### PR TITLE
fix: fail fast on schema backfill errors

### DIFF
--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -185,6 +185,37 @@ fn backfill_runs_even_when_migration_entries_exist() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn backfill_fails_when_alter_table_returns_non_duplicate_error() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA user_version = 10;")?;
+    conn.execute_batch(
+        "CREATE TABLE sdk_sessions (id INTEGER PRIMARY KEY, content_session_id TEXT UNIQUE NOT NULL, memory_session_id TEXT NOT NULL, project TEXT, user_prompt TEXT, started_at TEXT, started_at_epoch INTEGER, status TEXT DEFAULT 'active', prompt_counter INTEGER DEFAULT 1);
+         CREATE VIEW observations AS SELECT 1 AS id, '' AS memory_session_id, '' AS project, '' AS type, '' AS title, '' AS subtitle, '' AS narrative, '' AS facts, '' AS concepts, '' AS files_read, '' AS files_modified, 0 AS prompt_number, '' AS created_at, 0 AS created_at_epoch;
+         CREATE TABLE session_summaries (id INTEGER PRIMARY KEY, memory_session_id TEXT NOT NULL, project TEXT, request TEXT, completed TEXT, decisions TEXT, learned TEXT, next_steps TEXT, preferences TEXT, prompt_number INTEGER, created_at TEXT, created_at_epoch INTEGER);
+         CREATE TABLE pending_observations (id INTEGER PRIMARY KEY, session_id TEXT NOT NULL, project TEXT NOT NULL, tool_name TEXT NOT NULL, tool_input TEXT, tool_response TEXT, cwd TEXT, created_at_epoch INTEGER NOT NULL, updated_at_epoch INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'pending', attempt_count INTEGER NOT NULL DEFAULT 0, next_retry_epoch INTEGER, last_error TEXT, lease_owner TEXT, lease_expires_epoch INTEGER);
+         CREATE TABLE memories (id INTEGER PRIMARY KEY, session_id TEXT, project TEXT NOT NULL, topic_key TEXT, title TEXT NOT NULL, content TEXT NOT NULL, memory_type TEXT NOT NULL, files TEXT, created_at_epoch INTEGER NOT NULL, updated_at_epoch INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'active');
+         CREATE TABLE events (id INTEGER PRIMARY KEY, session_id TEXT NOT NULL, project TEXT NOT NULL, event_type TEXT NOT NULL, summary TEXT NOT NULL, detail TEXT, files TEXT, exit_code INTEGER, created_at_epoch INTEGER NOT NULL);
+         CREATE TABLE summarize_cooldown (project TEXT PRIMARY KEY, last_summarize_epoch INTEGER NOT NULL, last_message_hash TEXT);
+         CREATE TABLE summarize_locks (project TEXT PRIMARY KEY, lock_epoch INTEGER NOT NULL);",
+    )?;
+
+    let err = run_migrations(&conn)
+        .expect_err("backfill should fail on non-duplicate ALTER TABLE errors");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("backfill observations."),
+        "unexpected error: {err_msg}"
+    );
+
+    let applied = applied_versions(&conn)?;
+    assert!(
+        applied.is_empty(),
+        "baseline must not be marked applied after failed backfill"
+    );
+    Ok(())
+}
+
 /// Verify all columns in MEMORY_COLS are present after migrating from any starting state.
 #[test]
 fn memory_cols_all_present_after_migration() -> Result<()> {

--- a/src/migrate/transition.rs
+++ b/src/migrate/transition.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rusqlite::Connection;
+use rusqlite::Error::SqliteFailure;
 
 use super::state::{has_migration_table, mark_applied};
 use super::types::OLD_BASELINE_VERSION;
@@ -40,7 +41,7 @@ pub(super) fn transition_from_old_system(conn: &Connection) -> Result<()> {
 }
 
 /// Bring a pre-v13 database up to baseline by adding missing columns, tables,
-/// and indexes. Uses IF NOT EXISTS / ignores "duplicate column" errors so it is
+/// and indexes. Uses IF NOT EXISTS and ignores duplicate-column cases so it is
 /// safe to run on any v1-v12 schema.
 fn backfill_to_baseline(conn: &Connection) -> Result<()> {
     // --- missing columns on pending_observations (added between v10-v13) ---
@@ -52,7 +53,7 @@ fn backfill_to_baseline(conn: &Connection) -> Result<()> {
         ("last_error", "TEXT"),
     ];
     for (col, typedef) in &pending_cols {
-        add_column_if_missing(conn, "pending_observations", col, typedef);
+        add_column_if_missing(conn, "pending_observations", col, typedef)?;
     }
 
     // --- missing columns on observations ---
@@ -64,19 +65,19 @@ fn backfill_to_baseline(conn: &Connection) -> Result<()> {
         ("commit_sha", "TEXT"),
     ];
     for (col, typedef) in &obs_cols {
-        add_column_if_missing(conn, "observations", col, typedef);
+        add_column_if_missing(conn, "observations", col, typedef)?;
     }
 
     // --- missing columns on memories ---
     let mem_cols = [("branch", "TEXT"), ("scope", "TEXT DEFAULT 'project'")];
     for (col, typedef) in &mem_cols {
-        add_column_if_missing(conn, "memories", col, typedef);
+        add_column_if_missing(conn, "memories", col, typedef)?;
     }
 
     // --- missing columns on session_summaries ---
     let ss_cols = [("discovery_tokens", "INTEGER DEFAULT 0")];
     for (col, typedef) in &ss_cols {
-        add_column_if_missing(conn, "session_summaries", col, typedef);
+        add_column_if_missing(conn, "session_summaries", col, typedef)?;
     }
 
     // --- tables that may not exist in older schemas ---
@@ -179,17 +180,25 @@ fn backfill_to_baseline(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Try to add a column; silently ignore if it already exists.
-fn add_column_if_missing(conn: &Connection, table: &str, column: &str, typedef: &str) {
+/// Try to add a column; ignore duplicate-column errors but fail fast otherwise.
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    typedef: &str,
+) -> Result<()> {
     let sql = format!("ALTER TABLE {} ADD COLUMN {} {}", table, column, typedef);
-    if let Err(e) = conn.execute_batch(&sql) {
-        let msg = e.to_string();
-        if !msg.contains("duplicate column") {
-            crate::log::warn(
-                "migrate",
-                &format!("backfill {}.{}: {}", table, column, msg),
-            );
+    match conn.execute_batch(&sql) {
+        Ok(()) => Ok(()),
+        Err(SqliteFailure(err, maybe_msg)) if err.extended_code == 1 => {
+            let msg = maybe_msg.unwrap_or_default();
+            if msg.contains("duplicate column name") || msg.contains("duplicate column") {
+                return Ok(());
+            }
+
+            anyhow::bail!("backfill {}.{}: {}", table, column, msg);
         }
+        Err(err) => Err(err).with_context(|| format!("backfill {}.{} failed", table, column)),
     }
 }
 


### PR DESCRIPTION
## Summary
- fail baseline backfill on non-duplicate ALTER TABLE errors instead of warning and continuing
- keep duplicate-column cases idempotent while preventing partial migration state from being marked complete
- add a regression test covering backfill failure without advancing migration state

## Test plan
- [x] cargo fmt --all
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test