### PR TITLE
fix: fail schema backfill on real ALTER TABLE errors

### DIFF
--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use super::state::{applied_versions, has_migration_table};
+use super::transition::backfill_to_baseline;
 use super::types::{DryRunResult, Migration, MIGRATIONS, OLD_BASELINE_VERSION};
 
 pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
@@ -9,6 +10,19 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap_or(0);
     let applied = infer_applied_versions(real_conn, current_version)?;
+
+    let test_conn = Connection::open_in_memory()?;
+    clone_schema(real_conn, &test_conn)?;
+    if current_version >= OLD_BASELINE_VERSION || has_migration_table(real_conn) {
+        if let Err(error) = backfill_to_baseline(&test_conn) {
+            return Ok(DryRunResult {
+                current_version,
+                pending_count: applied_pending_count(&applied),
+                error: Some(format!("baseline backfill: {}", error)),
+            });
+        }
+    }
+
     let pending: Vec<&Migration> = MIGRATIONS
         .iter()
         .filter(|migration| !applied.contains(&migration.version))
@@ -22,8 +36,6 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
         });
     }
 
-    let test_conn = Connection::open_in_memory()?;
-    clone_schema(real_conn, &test_conn)?;
     for migration in &pending {
         if let Err(error) = test_conn.execute_batch(migration.sql) {
             return Ok(DryRunResult {
@@ -37,11 +49,26 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
         }
     }
 
+    if let Err(error) = backfill_to_baseline(&test_conn) {
+        return Ok(DryRunResult {
+            current_version,
+            pending_count: pending.len(),
+            error: Some(format!("baseline backfill: {}", error)),
+        });
+    }
+
     Ok(DryRunResult {
         current_version,
         pending_count: pending.len(),
         error: None,
     })
+}
+
+fn applied_pending_count(applied: &[i64]) -> usize {
+    MIGRATIONS
+        .iter()
+        .filter(|migration| !applied.contains(&migration.version))
+        .count()
 }
 
 fn infer_applied_versions(conn: &Connection, current_version: i64) -> Result<Vec<i64>> {

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -154,7 +154,61 @@ fn dry_run_pending_reports_pending_for_new_db() -> Result<()> {
 fn backfill_runs_even_when_migration_entries_exist() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     conn.execute_batch("PRAGMA user_version = 13;")?;
-    // Simulate old v13 schema WITHOUT scope column
+    create_v13_schema_without_scope(&conn)?;
+
+    // Pre-populate _schema_migrations so transition thinks it already ran
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at_epoch INTEGER NOT NULL);
+         INSERT INTO _schema_migrations VALUES (1, 'baseline', 1700000000);",
+    )?;
+
+    run_migrations(&conn)?;
+
+    // scope column must exist and be queryable
+    let has_scope: bool = conn.prepare("SELECT scope FROM memories LIMIT 0").is_ok();
+    assert!(has_scope, "memories.scope must exist after backfill");
+    Ok(())
+}
+
+#[test]
+fn backfill_fails_when_non_duplicate_alter_table_error_occurs() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA user_version = 13;")?;
+    create_v13_schema_without_scope(&conn)?;
+    conn.execute_batch("DROP TABLE pending_observations;")?;
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at_epoch INTEGER NOT NULL);
+         INSERT INTO _schema_migrations VALUES (1, 'baseline', 1700000000);",
+    )?;
+
+    let error = run_migrations(&conn).expect_err("missing table should fail backfill");
+    let message = error.to_string();
+    assert!(message.contains("backfill pending_observations.updated_at_epoch failed"));
+    Ok(())
+}
+
+#[test]
+fn dry_run_pending_reports_backfill_error_for_broken_schema() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA user_version = 13;")?;
+    create_v13_schema_without_scope(&conn)?;
+    conn.execute_batch("DROP TABLE pending_observations;")?;
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at_epoch INTEGER NOT NULL);
+         INSERT INTO _schema_migrations VALUES (1, 'baseline', 1700000000);",
+    )?;
+
+    let result = dry_run_pending(&conn)?;
+    assert_eq!(result.pending_count, 0);
+    let error = result
+        .error
+        .expect("broken schema should surface in dry-run");
+    assert!(error.contains("baseline backfill"));
+    assert!(error.contains("backfill pending_observations.updated_at_epoch failed"));
+    Ok(())
+}
+
+fn create_v13_schema_without_scope(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "CREATE TABLE memories (
             id INTEGER PRIMARY KEY, session_id TEXT, project TEXT NOT NULL,
@@ -171,17 +225,6 @@ fn backfill_runs_even_when_migration_entries_exist() -> Result<()> {
         CREATE TABLE summarize_cooldown (project TEXT PRIMARY KEY, last_summarize_epoch INTEGER NOT NULL, last_message_hash TEXT);
         CREATE TABLE summarize_locks (project TEXT PRIMARY KEY, lock_epoch INTEGER NOT NULL);",
     )?;
-    // Pre-populate _schema_migrations so transition thinks it already ran
-    conn.execute_batch(
-        "CREATE TABLE _schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at_epoch INTEGER NOT NULL);
-         INSERT INTO _schema_migrations VALUES (1, 'baseline', 1700000000);",
-    )?;
-
-    run_migrations(&conn)?;
-
-    // scope column must exist and be queryable
-    let has_scope: bool = conn.prepare("SELECT scope FROM memories LIMIT 0").is_ok();
-    assert!(has_scope, "memories.scope must exist after backfill");
     Ok(())
 }
 

--- a/src/migrate/transition.rs
+++ b/src/migrate/transition.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rusqlite::Connection;
 
 use super::state::{has_migration_table, mark_applied};
@@ -40,9 +40,9 @@ pub(super) fn transition_from_old_system(conn: &Connection) -> Result<()> {
 }
 
 /// Bring a pre-v13 database up to baseline by adding missing columns, tables,
-/// and indexes. Uses IF NOT EXISTS / ignores "duplicate column" errors so it is
+/// and indexes. Uses IF NOT EXISTS / ignores duplicate-column errors so it is
 /// safe to run on any v1-v12 schema.
-fn backfill_to_baseline(conn: &Connection) -> Result<()> {
+pub(super) fn backfill_to_baseline(conn: &Connection) -> Result<()> {
     // --- missing columns on pending_observations (added between v10-v13) ---
     let pending_cols = [
         ("updated_at_epoch", "INTEGER NOT NULL DEFAULT 0"),
@@ -52,7 +52,7 @@ fn backfill_to_baseline(conn: &Connection) -> Result<()> {
         ("last_error", "TEXT"),
     ];
     for (col, typedef) in &pending_cols {
-        add_column_if_missing(conn, "pending_observations", col, typedef);
+        add_column_if_missing(conn, "pending_observations", col, typedef)?;
     }
 
     // --- missing columns on observations ---
@@ -64,19 +64,19 @@ fn backfill_to_baseline(conn: &Connection) -> Result<()> {
         ("commit_sha", "TEXT"),
     ];
     for (col, typedef) in &obs_cols {
-        add_column_if_missing(conn, "observations", col, typedef);
+        add_column_if_missing(conn, "observations", col, typedef)?;
     }
 
     // --- missing columns on memories ---
     let mem_cols = [("branch", "TEXT"), ("scope", "TEXT DEFAULT 'project'")];
     for (col, typedef) in &mem_cols {
-        add_column_if_missing(conn, "memories", col, typedef);
+        add_column_if_missing(conn, "memories", col, typedef)?;
     }
 
     // --- missing columns on session_summaries ---
     let ss_cols = [("discovery_tokens", "INTEGER DEFAULT 0")];
     for (col, typedef) in &ss_cols {
-        add_column_if_missing(conn, "session_summaries", col, typedef);
+        add_column_if_missing(conn, "session_summaries", col, typedef)?;
     }
 
     // --- tables that may not exist in older schemas ---
@@ -179,18 +179,24 @@ fn backfill_to_baseline(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Try to add a column; silently ignore if it already exists.
-fn add_column_if_missing(conn: &Connection, table: &str, column: &str, typedef: &str) {
+/// Try to add a column; ignore only duplicate-column cases.
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    typedef: &str,
+) -> Result<()> {
     let sql = format!("ALTER TABLE {} ADD COLUMN {} {}", table, column, typedef);
-    if let Err(e) = conn.execute_batch(&sql) {
-        let msg = e.to_string();
-        if !msg.contains("duplicate column") {
-            crate::log::warn(
-                "migrate",
-                &format!("backfill {}.{}: {}", table, column, msg),
-            );
-        }
+    match conn.execute_batch(&sql) {
+        Ok(()) => Ok(()),
+        Err(error) if is_duplicate_column_error(&error.to_string()) => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("backfill {}.{} failed", table, column)),
     }
+}
+
+fn is_duplicate_column_error(message: &str) -> bool {
+    let normalized = message.to_ascii_lowercase();
+    normalized.contains("duplicate column") || normalized.contains("already exists")
 }
 
 fn has_existing_migration_entries(conn: &Connection) -> bool {


### PR DESCRIPTION
## Summary
- fail migration backfill on non-idempotent ALTER TABLE errors instead of warning and continuing
- keep duplicate-column replays idempotent while aligning dry-run with startup backfill behavior
- add regression tests for broken schemas with recorded migration entries

## Test plan
- [x] cargo fmt --all
- [x] cargo check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test