### PR TITLE
fix: confine default local note path

### DIFF
--- a/src/memory_service/local_copy.rs
+++ b/src/memory_service/local_copy.rs
@@ -94,7 +94,7 @@ fn normalize_path(path: &Path) -> PathBuf {
 /// If the parent directory already exists it is canonicalized to resolve
 /// symlinks before the prefix check, preventing symlink-based escapes.
 fn confine_to_base(abs: &Path) -> Result<PathBuf> {
-    let raw_base = {
+    let raw_base = normalize_path(&{
         let base = remem_data_dir();
         if base.is_absolute() {
             base
@@ -103,7 +103,7 @@ fn confine_to_base(abs: &Path) -> Result<PathBuf> {
                 .unwrap_or_else(|_| PathBuf::from("."))
                 .join(base)
         }
-    };
+    });
     // Canonicalize base if it exists so the prefix check is symlink-safe.
     let base = if raw_base.exists() {
         raw_base.canonicalize().unwrap_or_else(|_| raw_base.clone())

--- a/src/memory_service/local_copy.rs
+++ b/src/memory_service/local_copy.rs
@@ -59,7 +59,15 @@ pub fn resolve_local_note_path(
         };
         confine_to_base(&abs)
     } else {
-        confine_to_base(&default_local_note_path(project, title))
+        let default_path = default_local_note_path(project, title);
+        let abs = if default_path.is_absolute() {
+            default_path
+        } else {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(default_path)
+        };
+        confine_to_base(&abs)
     }
 }
 
@@ -86,7 +94,16 @@ fn normalize_path(path: &Path) -> PathBuf {
 /// If the parent directory already exists it is canonicalized to resolve
 /// symlinks before the prefix check, preventing symlink-based escapes.
 fn confine_to_base(abs: &Path) -> Result<PathBuf> {
-    let raw_base = remem_data_dir();
+    let raw_base = {
+        let base = remem_data_dir();
+        if base.is_absolute() {
+            base
+        } else {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(base)
+        }
+    };
     // Canonicalize base if it exists so the prefix check is symlink-safe.
     let base = if raw_base.exists() {
         raw_base.canonicalize().unwrap_or_else(|_| raw_base.clone())

--- a/src/memory_service/local_copy.rs
+++ b/src/memory_service/local_copy.rs
@@ -59,7 +59,7 @@ pub fn resolve_local_note_path(
         };
         confine_to_base(&abs)
     } else {
-        Ok(default_local_note_path(project, title))
+        confine_to_base(&default_local_note_path(project, title))
     }
 }
 

--- a/src/memory_service/tests.rs
+++ b/src/memory_service/tests.rs
@@ -135,3 +135,48 @@ fn resolve_empty_local_path_uses_confined_default() {
         "empty local_path should follow the same confined default branch"
     );
 }
+
+#[test]
+fn resolve_none_local_path_allows_relative_remem_data_dir_default() {
+    let _guard = ScopedTestDataDir::new("path-default-relative-data-dir");
+    let original_cwd = std::env::current_dir().expect("read cwd");
+    let temp_root = std::env::temp_dir().join(format!(
+        "remem-relative-data-dir-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos()
+    ));
+    let project_root = temp_root.join("workspace");
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let expected_base = project_root
+        .canonicalize()
+        .expect("canonicalize project root")
+        .join(".remem");
+    unsafe {
+        std::env::set_current_dir(&project_root).expect("enter project root");
+        std::env::set_var("REMEM_DATA_DIR", ".remem");
+        std::env::remove_var("REMEM_SAVE_MEMORY_LOCAL_DIR");
+    }
+
+    let got = resolve_local_note_path("proj", Some("title"), None);
+
+    unsafe {
+        std::env::set_current_dir(&original_cwd).expect("restore cwd");
+        std::env::remove_var("REMEM_DATA_DIR");
+    }
+    let _ = std::fs::remove_dir_all(&temp_root);
+
+    assert!(
+        got.is_ok(),
+        "relative REMEM_DATA_DIR default path should be allowed: {got:?}"
+    );
+    let path = got.unwrap();
+    assert!(path.is_absolute(), "resolved path should be absolute: {path:?}");
+    assert!(
+        path.starts_with(&expected_base),
+        "resolved path {path:?} should stay inside {:?}",
+        expected_base
+    );
+}

--- a/src/memory_service/tests.rs
+++ b/src/memory_service/tests.rs
@@ -173,7 +173,55 @@ fn resolve_none_local_path_allows_relative_remem_data_dir_default() {
         "relative REMEM_DATA_DIR default path should be allowed: {got:?}"
     );
     let path = got.unwrap();
-    assert!(path.is_absolute(), "resolved path should be absolute: {path:?}");
+    assert!(
+        path.is_absolute(),
+        "resolved path should be absolute: {path:?}"
+    );
+    assert!(
+        path.starts_with(&expected_base),
+        "resolved path {path:?} should stay inside {:?}",
+        expected_base
+    );
+}
+
+#[test]
+fn resolve_none_local_path_allows_relative_remem_data_dir_with_parent_segments() {
+    let _guard = ScopedTestDataDir::new("path-default-relative-data-dir-parent-segments");
+    let original_cwd = std::env::current_dir().expect("read cwd");
+    let temp_root = std::env::temp_dir().join(format!(
+        "remem-relative-parent-data-dir-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos()
+    ));
+    let workspace_root = temp_root.join("workspace");
+    let project_root = workspace_root.join("project");
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let expected_base = workspace_root
+        .canonicalize()
+        .expect("canonicalize workspace root")
+        .join(".remem");
+    unsafe {
+        std::env::set_current_dir(&project_root).expect("enter project root");
+        std::env::set_var("REMEM_DATA_DIR", "../.remem");
+        std::env::remove_var("REMEM_SAVE_MEMORY_LOCAL_DIR");
+    }
+
+    let got = resolve_local_note_path("proj", Some("title"), None);
+
+    unsafe {
+        std::env::set_current_dir(&original_cwd).expect("restore cwd");
+        std::env::remove_var("REMEM_DATA_DIR");
+    }
+    let _ = std::fs::remove_dir_all(&temp_root);
+
+    assert!(
+        got.is_ok(),
+        "relative REMEM_DATA_DIR with parent segments should be allowed: {got:?}"
+    );
+    let path = got.unwrap();
     assert!(
         path.starts_with(&expected_base),
         "resolved path {path:?} should stay inside {:?}",

--- a/src/memory_service/tests.rs
+++ b/src/memory_service/tests.rs
@@ -46,7 +46,6 @@ fn resolve_relative_traversal_is_rejected() {
 #[test]
 fn resolve_tilde_path_is_rejected() {
     let _dir = ScopedTestDataDir::new("path-tilde");
-    // PathBuf does not expand `~`; treated as literal dir name outside base
     let got = resolve_local_note_path("proj", Some("title"), Some("~/.ssh/authorized_keys"));
     assert!(got.is_err(), "tilde path should be rejected (not expanded)");
 }
@@ -65,16 +64,74 @@ fn resolve_base_dir_itself_is_rejected() {
 #[test]
 fn resolve_none_local_path_returns_default() {
     let _dir = ScopedTestDataDir::new("path-default");
+    unsafe { std::env::remove_var("REMEM_SAVE_MEMORY_LOCAL_DIR") };
+
     let got = resolve_local_note_path("proj", Some("title"), None);
     assert!(got.is_ok());
     let path = got.unwrap();
     assert!(path.is_absolute());
-    // Default path should be inside the data dir
     let base = crate::db::data_dir();
     assert!(
         path.starts_with(&base),
         "default path {:?} should be inside {:?}",
         path,
         base
+    );
+}
+
+#[test]
+fn resolve_none_local_path_allows_env_directory_inside_base() {
+    let _dir = ScopedTestDataDir::new("path-default-env-inside");
+    let base = crate::db::data_dir();
+    let env_dir = base.join("manual-notes-custom");
+    unsafe { std::env::set_var("REMEM_SAVE_MEMORY_LOCAL_DIR", &env_dir) };
+
+    let got = resolve_local_note_path("proj", Some("title"), None);
+    unsafe { std::env::remove_var("REMEM_SAVE_MEMORY_LOCAL_DIR") };
+
+    assert!(
+        got.is_ok(),
+        "env path inside base should be allowed: {got:?}"
+    );
+    let path = got.unwrap();
+    assert!(
+        path.starts_with(&env_dir),
+        "default path {:?} should be inside env dir {:?}",
+        path,
+        env_dir
+    );
+}
+
+#[test]
+fn resolve_none_local_path_rejects_env_directory_outside_base() {
+    let _dir = ScopedTestDataDir::new("path-default-env-outside");
+    let outside = std::env::temp_dir().join("remem-outside-manual-notes");
+    unsafe { std::env::set_var("REMEM_SAVE_MEMORY_LOCAL_DIR", &outside) };
+
+    let got = resolve_local_note_path("proj", Some("title"), None);
+    unsafe { std::env::remove_var("REMEM_SAVE_MEMORY_LOCAL_DIR") };
+
+    assert!(
+        got.is_err(),
+        "env path outside base should be rejected instead of bypassing confinement"
+    );
+    assert!(got
+        .unwrap_err()
+        .to_string()
+        .contains("outside the allowed directory"));
+}
+
+#[test]
+fn resolve_empty_local_path_uses_confined_default() {
+    let _dir = ScopedTestDataDir::new("path-default-empty");
+    let outside = std::env::temp_dir().join("remem-outside-empty-manual-notes");
+    unsafe { std::env::set_var("REMEM_SAVE_MEMORY_LOCAL_DIR", &outside) };
+
+    let got = resolve_local_note_path("proj", Some("title"), Some("   "));
+    unsafe { std::env::remove_var("REMEM_SAVE_MEMORY_LOCAL_DIR") };
+
+    assert!(
+        got.is_err(),
+        "empty local_path should follow the same confined default branch"
     );
 }


### PR DESCRIPTION
## Summary
- route the default `resolve_local_note_path()` branch through `confine_to_base()`
- reject `REMEM_SAVE_MEMORY_LOCAL_DIR` values outside `remem_data_dir()` instead of bypassing confinement
- add regression tests for default, in-base env override, out-of-base env override, and blank `local_path`

## Test Plan
- [x] cargo fmt --all
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo check
- [x] cargo test