### PR TITLE
fix(migrate): propagate non-duplicate ALTER TABLE errors from add_column_if_missing

### DIFF
--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -3,6 +3,7 @@ use rusqlite::Connection;
 
 use super::state::applied_versions;
 use super::{dry_run_pending, run_migrations, MIGRATIONS};
+use crate::db::test_support::ScopedTestDataDir;
 
 #[test]
 fn baseline_creates_all_tables() -> Result<()> {
@@ -83,6 +84,7 @@ fn transition_from_old_system_skips_baseline() -> Result<()> {
 
 #[test]
 fn auto_upgrades_old_schema_version() -> Result<()> {
+    let _test_dir = ScopedTestDataDir::new("migrate-auto-upgrade");
     let conn = Connection::open_in_memory()?;
     conn.execute_batch("PRAGMA user_version = 10;")?;
     // Simulate a v10 database with minimal tables
@@ -193,6 +195,7 @@ fn backfill_runs_even_when_migration_entries_exist() -> Result<()> {
 /// `run_migrations`.
 #[test]
 fn add_column_non_duplicate_error_propagates() -> Result<()> {
+    let _test_dir = ScopedTestDataDir::new("migrate-add-col-error");
     let conn = Connection::open_in_memory()?;
     // user_version = 13 triggers the transition/backfill path inside transition_from_old_system.
     conn.execute_batch("PRAGMA user_version = 13;")?;

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -185,6 +185,39 @@ fn backfill_runs_even_when_migration_entries_exist() -> Result<()> {
     Ok(())
 }
 
+/// Regression (issue #8): a failing ALTER TABLE that is NOT a duplicate-column error must
+/// propagate as an error rather than being silently logged and swallowed.
+/// Simulates a DB at OLD_BASELINE_VERSION where `pending_observations` is absent so that
+/// `ALTER TABLE pending_observations ADD COLUMN …` fails with "no such table" — a non-duplicate
+/// error that must bubble up through `backfill_to_baseline` → `transition_from_old_system` →
+/// `run_migrations`.
+#[test]
+fn add_column_non_duplicate_error_propagates() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    // user_version = 13 triggers the transition/backfill path inside transition_from_old_system.
+    conn.execute_batch("PRAGMA user_version = 13;")?;
+    // Intentionally omit `pending_observations` so ALTER TABLE fails with "no such table".
+    conn.execute_batch(
+        "CREATE TABLE sdk_sessions (id INTEGER PRIMARY KEY);
+         CREATE TABLE observations (id INTEGER PRIMARY KEY, memory_session_id TEXT NOT NULL);
+         CREATE TABLE session_summaries (id INTEGER PRIMARY KEY);
+         CREATE TABLE memories (
+             id INTEGER PRIMARY KEY, project TEXT NOT NULL, title TEXT NOT NULL,
+             content TEXT NOT NULL, memory_type TEXT NOT NULL,
+             created_at_epoch INTEGER NOT NULL, updated_at_epoch INTEGER NOT NULL,
+             status TEXT NOT NULL DEFAULT 'active'
+         );
+         CREATE TABLE events (id INTEGER PRIMARY KEY);",
+    )?;
+
+    let result = run_migrations(&conn);
+    assert!(
+        result.is_err(),
+        "run_migrations must return Err when ALTER TABLE fails with a non-duplicate-column error"
+    );
+    Ok(())
+}
+
 /// Verify all columns in MEMORY_COLS are present after migrating from any starting state.
 #[test]
 fn memory_cols_all_present_after_migration() -> Result<()> {

--- a/src/migrate/transition.rs
+++ b/src/migrate/transition.rs
@@ -52,7 +52,7 @@ fn backfill_to_baseline(conn: &Connection) -> Result<()> {
         ("last_error", "TEXT"),
     ];
     for (col, typedef) in &pending_cols {
-        add_column_if_missing(conn, "pending_observations", col, typedef);
+        add_column_if_missing(conn, "pending_observations", col, typedef)?;
     }
 
     // --- missing columns on observations ---
@@ -64,19 +64,19 @@ fn backfill_to_baseline(conn: &Connection) -> Result<()> {
         ("commit_sha", "TEXT"),
     ];
     for (col, typedef) in &obs_cols {
-        add_column_if_missing(conn, "observations", col, typedef);
+        add_column_if_missing(conn, "observations", col, typedef)?;
     }
 
     // --- missing columns on memories ---
     let mem_cols = [("branch", "TEXT"), ("scope", "TEXT DEFAULT 'project'")];
     for (col, typedef) in &mem_cols {
-        add_column_if_missing(conn, "memories", col, typedef);
+        add_column_if_missing(conn, "memories", col, typedef)?;
     }
 
     // --- missing columns on session_summaries ---
     let ss_cols = [("discovery_tokens", "INTEGER DEFAULT 0")];
     for (col, typedef) in &ss_cols {
-        add_column_if_missing(conn, "session_summaries", col, typedef);
+        add_column_if_missing(conn, "session_summaries", col, typedef)?;
     }
 
     // --- tables that may not exist in older schemas ---
@@ -179,18 +179,23 @@ fn backfill_to_baseline(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Try to add a column; silently ignore if it already exists.
-fn add_column_if_missing(conn: &Connection, table: &str, column: &str, typedef: &str) {
+/// Try to add a column; silently ignore if it already exists (duplicate column error).
+/// Any other error is propagated to the caller.
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    typedef: &str,
+) -> Result<()> {
     let sql = format!("ALTER TABLE {} ADD COLUMN {} {}", table, column, typedef);
     if let Err(e) = conn.execute_batch(&sql) {
         let msg = e.to_string();
-        if !msg.contains("duplicate column") {
-            crate::log::warn(
-                "migrate",
-                &format!("backfill {}.{}: {}", table, column, msg),
-            );
+        if msg.contains("duplicate column") {
+            return Ok(());
         }
+        return Err(e.into());
     }
+    Ok(())
 }
 
 fn has_existing_migration_entries(conn: &Connection) -> bool {


### PR DESCRIPTION
## Summary
- Changed `add_column_if_missing()` return type from `()` to `Result<()>`
- Non-duplicate-column errors are now propagated as `Err` instead of being silently logged as warnings
- Updated all call sites in `backfill_to_baseline()` to use `?` operator, so callers receive a hard failure when the schema is partially applied

## Test plan
- [ ] All 194 lib tests pass (`cargo test --lib -- --test-threads=1`)
- [ ] All 12 migrate-specific tests pass (`cargo test migrate`)
- [ ] `cargo clippy --all-targets -- -D warnings` passes clean
- [ ] `cargo fmt --all` produces no changes

Fixes issue #8 (silently swallowed non-duplicate ALTER TABLE errors).