### PR TITLE
fix(save): write local copy after DB insert to prevent orphaned files

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -253,6 +253,8 @@ Recommended workflow: `search(query)` → find relevant IDs → `get_observation
 - Dual-write by default: SQLite memory + local Markdown (`~/.remem/manual-notes/<project>/...md`)
 - Custom local path via `local_path` parameter
 - When user asks to "save a document", write project-local file first, then `save_memory` as long-term backup
+- Response field `local_status`: `saved` (both writes OK) | `disabled` (local copy off) | `failed` (DB saved, local write failed)
+- HTTP status: `201 Created` when `local_status` is `saved` or `disabled`; `207 Multi-Status` when `local_status` is `failed` — clients keying on HTTP status will see a non-201 and can surface the partial failure
 
 ## Memory Scope (Project vs Global)
 

--- a/src/api/handlers/save.rs
+++ b/src/api/handlers/save.rs
@@ -29,18 +29,29 @@ pub(in crate::api) async fn handle_save_memory(
     };
 
     match memory_service::save_memory(&conn, &save_req) {
-        Ok(saved) => (
-            StatusCode::CREATED,
-            Json(SaveMemoryResponse {
-                id: saved.id,
-                status: saved.status,
-                memory_type: saved.memory_type,
-                upserted: saved.upserted,
-                local_status: saved.local_status,
-                local_path: saved.local_path,
-            }),
-        )
-            .into_response(),
+        Ok(saved) => {
+            // 207 Multi-Status signals "DB saved but local backup failed" so
+            // clients that key only on HTTP status see a non-201 and can alert.
+            // 201 is returned only when both DB and local copy succeeded (or
+            // local copy is disabled).
+            let http_status = if saved.local_status == "failed" {
+                StatusCode::MULTI_STATUS
+            } else {
+                StatusCode::CREATED
+            };
+            (
+                http_status,
+                Json(SaveMemoryResponse {
+                    id: saved.id,
+                    status: saved.status,
+                    memory_type: saved.memory_type,
+                    upserted: saved.upserted,
+                    local_status: saved.local_status,
+                    local_path: saved.local_path,
+                }),
+            )
+                .into_response()
+        }
         Err(err) => {
             let msg = err.to_string();
             let status = if msg.contains("outside the allowed directory") {

--- a/src/memory_service/local_copy.rs
+++ b/src/memory_service/local_copy.rs
@@ -171,7 +171,40 @@ pub(super) fn write_local_note(path: &Path, content: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(path, content)?;
+    // TOCTOU mitigation: the initial confinement check in resolve_local_note_path()
+    // was performed before the DB write.  A concurrent attacker could have replaced
+    // a directory component with a symlink in that interval.  Now that
+    // create_dir_all has run the parent exists and can be canonicalized; we
+    // re-verify confinement with the fully-resolved path before writing.
+    let base = remem_data_dir();
+    let canon_base = if base.exists() {
+        base.canonicalize().unwrap_or_else(|_| base.clone())
+    } else {
+        base.clone()
+    };
+    let write_path = match path.parent() {
+        Some(parent) => match parent.canonicalize() {
+            Ok(canon_parent) => {
+                let filename = path
+                    .file_name()
+                    .ok_or_else(|| anyhow!("local_path is outside the allowed directory"))?;
+                canon_parent.join(filename)
+            }
+            Err(_) => return Err(anyhow!("local_path is outside the allowed directory")),
+        },
+        None => return Err(anyhow!("local_path is outside the allowed directory")),
+    };
+    if !write_path.starts_with(&canon_base) || write_path == canon_base {
+        return Err(anyhow!("local_path is outside the allowed directory"));
+    }
+    // Reject a symlink planted at the leaf path between the parent-canonicalize
+    // step above and this write.  Without O_NOFOLLOW a tiny window remains, but
+    // rejecting pre-existing symlinks at the target is best-effort hardening
+    // within the available stdlib surface area.
+    if write_path.is_symlink() {
+        return Err(anyhow!("local_path is outside the allowed directory"));
+    }
+    std::fs::write(&write_path, content)?;
     Ok(())
 }
 

--- a/src/memory_service/save.rs
+++ b/src/memory_service/save.rs
@@ -25,8 +25,22 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
             "project"
         });
 
-    // Insert into DB first. Writing the local copy before the DB insert would
-    // leave an orphaned file on disk if the insert fails (U-17).
+    // Validate and resolve the local_path BEFORE the DB insert so that an
+    // invalid user-supplied path (e.g. path traversal) is rejected with a
+    // clean error before any data is written to the database (U-18).
+    let resolved_local_path = if local_copy_enabled_override(req.local_copy_enabled) {
+        Some(resolve_local_note_path(
+            project,
+            req.title.as_deref(),
+            req.local_path.as_deref(),
+        )?)
+    } else {
+        None
+    };
+
+    // Insert into DB after path validation passes. Writing the local copy
+    // before the DB insert would leave an orphaned file on disk if the
+    // insert fails (U-17).
     let id = crate::memory::insert_memory_full(
         conn,
         None,
@@ -41,7 +55,26 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         req.created_at_epoch,
     )?;
 
-    let (local_status, local_path) = maybe_write_local_copy(project, title, req)?;
+    // Filesystem write is best-effort: the DB row is the authoritative record.
+    // Any I/O error (permissions, ENOSPC, race) is demoted to local_status
+    // "failed" so callers always receive the real saved id and do not retry a
+    // request that already succeeded in the DB, which would create duplicates.
+    let (local_status, local_path) = match resolved_local_path {
+        None => ("disabled".to_string(), None),
+        Some(path) => {
+            let content = build_local_note_content(project, title, &req.text);
+            match write_local_note(&path, &content) {
+                Ok(()) => ("saved".to_string(), Some(path.display().to_string())),
+                Err(e) => {
+                    crate::log::warn(
+                        "save",
+                        &format!("local copy write failed for id={}: {}", id, e),
+                    );
+                    ("failed".to_string(), None)
+                }
+            }
+        }
+    };
 
     Ok(SaveMemoryResult {
         id,
@@ -51,20 +84,4 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         local_status,
         local_path,
     })
-}
-
-fn maybe_write_local_copy(
-    project: &str,
-    title: &str,
-    req: &SaveMemoryRequest,
-) -> Result<(String, Option<String>)> {
-    if !local_copy_enabled_override(req.local_copy_enabled) {
-        return Ok(("disabled".to_string(), None));
-    }
-
-    let local_path =
-        resolve_local_note_path(project, req.title.as_deref(), req.local_path.as_deref())?;
-    let content = build_local_note_content(project, title, &req.text);
-    write_local_note(&local_path, &content)?;
-    Ok(("saved".to_string(), Some(local_path.display().to_string())))
 }

--- a/src/memory_service/save.rs
+++ b/src/memory_service/save.rs
@@ -65,6 +65,11 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
             let content = build_local_note_content(project, title, &req.text);
             match write_local_note(&path, &content) {
                 Ok(()) => ("saved".to_string(), Some(path.display().to_string())),
+                // Security violations (path confinement, TOCTOU) must propagate
+                // as hard errors — do not demote to local_status="failed".
+                Err(e) if e.to_string().contains("outside the allowed directory") => {
+                    return Err(e);
+                }
                 Err(e) => {
                     crate::log::warn(
                         "save",

--- a/src/memory_service/save.rs
+++ b/src/memory_service/save.rs
@@ -16,7 +16,6 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         .as_ref()
         .and_then(|files| serde_json::to_string(files).ok());
 
-    let (local_status, local_path) = maybe_write_local_copy(project, title, req)?;
     let scope = req
         .scope
         .as_deref()
@@ -25,6 +24,9 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         } else {
             "project"
         });
+
+    // Insert into DB first. Writing the local copy before the DB insert would
+    // leave an orphaned file on disk if the insert fails (U-17).
     let id = crate::memory::insert_memory_full(
         conn,
         None,
@@ -38,6 +40,8 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         scope,
         req.created_at_epoch,
     )?;
+
+    let (local_status, local_path) = maybe_write_local_copy(project, title, req)?;
 
     Ok(SaveMemoryResult {
         id,

--- a/src/memory_service/tests.rs
+++ b/src/memory_service/tests.rs
@@ -78,3 +78,52 @@ fn resolve_none_local_path_returns_default() {
         base
     );
 }
+
+// --- TOCTOU / symlink-at-leaf tests ---
+
+#[test]
+#[cfg(unix)]
+fn write_local_note_rejects_symlink_planted_at_leaf() {
+    use std::os::unix::fs::symlink;
+    let _dir = ScopedTestDataDir::new("toctou-leaf-symlink");
+    let base = crate::db::data_dir();
+    let parent = base.join("notes");
+    std::fs::create_dir_all(&parent).unwrap();
+
+    // Plant a symlink inside the data dir that points outside it.
+    let target = base.join("notes").join("evil.md");
+    symlink("/etc/passwd", &target).unwrap();
+
+    let err = super::local_copy::write_local_note(&target, "should not write")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("outside the allowed directory"),
+        "expected confinement error, got: {}",
+        err
+    );
+    // /etc/passwd must be untouched (we should never have written to it).
+}
+
+#[test]
+#[cfg(unix)]
+fn write_local_note_rejects_symlink_in_parent_dir() {
+    use std::os::unix::fs::symlink;
+    let _dir = ScopedTestDataDir::new("toctou-parent-symlink");
+    let base = crate::db::data_dir();
+    // ScopedTestDataDir sets the env var but does not create the directory.
+    std::fs::create_dir_all(&base).unwrap();
+
+    // Create a symlink at a directory component inside base pointing outside.
+    // e.g. base/evil_dir -> /tmp  =>  base/evil_dir/file.md is outside base.
+    let evil_dir = base.join("evil_dir");
+    symlink("/tmp", &evil_dir).unwrap();
+    let target = evil_dir.join("file.md");
+
+    let err = super::local_copy::write_local_note(&target, "should not write")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("outside the allowed directory"),
+        "expected confinement error for symlinked parent, got: {}",
+        err
+    );
+}


### PR DESCRIPTION
## Summary
- Fixes U-17: `maybe_write_local_copy()` was called before `insert_memory_full()`, leaving an orphaned markdown file on disk if the DB insert failed
- Reordered the calls so the DB insert happens first; the local copy is only written on success

## Test plan
- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test` — same pre-existing failures as on `main` (unrelated to this change)