### PR TITLE
test: harden test infrastructure against mutex poison and log-rotate races

### DIFF
--- a/src/db/test_support.rs
+++ b/src/db/test_support.rs
@@ -15,7 +15,7 @@ pub struct ScopedTestDataDir {
 
 impl ScopedTestDataDir {
     pub fn new(label: &str) -> Self {
-        let guard = env_lock().lock().expect("test env lock poisoned");
+        let guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var_os("REMEM_DATA_DIR");
         let unique = format!(
             "remem-test-{}-{}-{}",

--- a/src/log/tests.rs
+++ b/src/log/tests.rs
@@ -56,8 +56,11 @@ fn open_log_append_creates_log_file_in_data_dir() {
 
 #[test]
 fn rotate_if_needed_shifts_existing_files() {
-    let _data_dir = ScopedTestDataDir::new("log-rotate");
-    let path = log_path().expect("log path should resolve");
+    let data_dir = ScopedTestDataDir::new("log-rotate");
+    // Use a dedicated test path — NOT the real log path — so concurrent
+    // tests' log writes (e.g. migration auto-upgrade) cannot contaminate
+    // the file we are about to rotate.
+    let path = data_dir.path.join("logs").join("rotate-test.log");
     let parent = path.parent().expect("log file should have parent");
     std::fs::create_dir_all(parent).expect("log dir should create");
 

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -3,6 +3,7 @@ use rusqlite::Connection;
 
 use super::state::applied_versions;
 use super::{dry_run_pending, run_migrations, MIGRATIONS};
+use crate::db::test_support::ScopedTestDataDir;
 
 #[test]
 fn baseline_creates_all_tables() -> Result<()> {
@@ -83,6 +84,7 @@ fn transition_from_old_system_skips_baseline() -> Result<()> {
 
 #[test]
 fn auto_upgrades_old_schema_version() -> Result<()> {
+    let _test_dir = ScopedTestDataDir::new("migrate-auto-upgrade");
     let conn = Connection::open_in_memory()?;
     conn.execute_batch("PRAGMA user_version = 10;")?;
     // Simulate a v10 database with minimal tables
@@ -172,6 +174,7 @@ fn backfill_runs_even_when_migration_entries_exist() -> Result<()> {
 
 #[test]
 fn backfill_fails_when_non_duplicate_alter_table_error_occurs() -> Result<()> {
+    let _test_dir = ScopedTestDataDir::new("migrate-backfill-error");
     let conn = Connection::open_in_memory()?;
     conn.execute_batch("PRAGMA user_version = 13;")?;
     create_v13_schema_without_scope(&conn)?;


### PR DESCRIPTION
## Summary
- ScopedTestDataDir recovers from poisoned env lock (`unwrap_or_else`) instead of panicking, preventing cascade failures
- Log-rotate test uses a dedicated file path to avoid contamination from concurrent migration tests
- Migration tests (`auto_upgrades_old_schema_version`, `backfill_fails_when_non_duplicate_alter_table_error_occurs`) now acquire `ScopedTestDataDir` for env isolation

Cherry-picked from closed PRs #16 and #13 which had useful test infrastructure fixes alongside their (now-superseded) feature changes.

## Test plan
- [x] `cargo test` — all 237 tests pass
- [x] No production code changed

Signed-off-by: majiayu000 <1835304752@qq.com>