### PR TITLE
fix(migrate): surface clone_schema errors in DryRunResult

### DIFF
--- a/src/doctor/schema.rs
+++ b/src/doctor/schema.rs
@@ -31,20 +31,24 @@ pub(super) fn check_schema_migration() -> Check {
 
     match crate::migrate::dry_run_pending(&real_conn) {
         Ok(result) => {
-            if result.pending_count == 0 {
+            if let Some(err) = result.error {
+                Check {
+                    name: "Schema",
+                    status: Status::Fail,
+                    detail: if result.pending_count == 0 {
+                        format!("schema check failed: {}", err)
+                    } else {
+                        format!(
+                            "{} pending migration(s) will FAIL: {}",
+                            result.pending_count, err
+                        )
+                    },
+                }
+            } else if result.pending_count == 0 {
                 Check {
                     name: "Schema",
                     status: Status::Ok,
                     detail: format!("v{} (up to date)", result.current_version),
-                }
-            } else if let Some(err) = result.error {
-                Check {
-                    name: "Schema",
-                    status: Status::Fail,
-                    detail: format!(
-                        "{} pending migration(s) will FAIL: {}",
-                        result.pending_count, err
-                    ),
                 }
             } else {
                 Check {

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -12,7 +12,13 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
     let applied = infer_applied_versions(real_conn, current_version)?;
 
     let test_conn = Connection::open_in_memory()?;
-    clone_schema(real_conn, &test_conn)?;
+    if let Err(error) = clone_schema(real_conn, &test_conn) {
+        return Ok(DryRunResult {
+            current_version,
+            pending_count: applied_pending_count(&applied),
+            error: Some(format!("schema clone: {}", error)),
+        });
+    }
     if current_version >= OLD_BASELINE_VERSION || has_migration_table(real_conn) {
         if let Err(error) = backfill_to_baseline(&test_conn) {
             return Ok(DryRunResult {
@@ -97,9 +103,7 @@ fn clone_schema(src: &Connection, dst: &Connection) -> Result<()> {
         }
         let safe = sql.replace("CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ");
         let safe = safe.replace("CREATE INDEX ", "CREATE INDEX IF NOT EXISTS ");
-        if let Err(error) = dst.execute_batch(&safe) {
-            crate::log::debug("migrate", &format!("clone_schema skip: {}", error));
-        }
+        dst.execute_batch(&safe)?;
     }
     Ok(())
 }

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -90,7 +90,8 @@ fn infer_applied_versions(conn: &Connection, current_version: i64) -> Result<Vec
 fn clone_schema(src: &Connection, dst: &Connection) -> Result<()> {
     let mut stmt = src.prepare(
         "SELECT sql FROM sqlite_master
-         WHERE sql IS NOT NULL AND type IN ('table', 'index', 'trigger')",
+         WHERE sql IS NOT NULL AND type IN ('table', 'index', 'trigger')
+         ORDER BY CASE type WHEN 'table' THEN 0 WHEN 'index' THEN 1 WHEN 'trigger' THEN 2 ELSE 3 END, name",
     )?;
     let sqls: Vec<String> = stmt
         .query_map([], |row| row.get(0))?


### PR DESCRIPTION
## Summary

- `clone_schema` was silently dropping `execute_batch` errors with only a debug log (LOG-001)
- Tables that are neither FTS5 nor internal `_` tables now propagate errors via `?`
- `dry_run_pending` captures clone failures and surfaces them through `DryRunResult.error`, consistent with how backfill and migration errors are already reported
- Prevents false-positive 'no errors' results when the in-memory dry-run schema diverges from the real DB

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 201 unit tests + 36 integration/bench tests all pass
- [x] Existing `dry_run_pending_reports_backfill_error_for_broken_schema` and related migration tests continue to pass