### PR TITLE
feat(install): multi-host support (Claude Code + Codex)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,12 +506,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -751,6 +763,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1154,6 +1176,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml_edit",
  "tower-http",
 ]
 
@@ -1602,6 +1625,30 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2057,6 +2104,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 axum = { version = "0.8.8", features = ["json"] }
 tower-http = { version = "0.6.8", features = ["cors"] }
 getrandom = "0.3"
+toml_edit = "0.22"
 
 [profile.release]
 opt-level = "z"

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -24,8 +24,8 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         Commands::Summarize => summarize::summarize().await?,
         Commands::Worker { once } => worker::run(once, 2000).await?,
         Commands::Mcp => mcp::run_mcp_server().await?,
-        Commands::Install => install::install()?,
-        Commands::Uninstall => install::uninstall()?,
+        Commands::Install { target, dry_run } => install::install(target, dry_run)?,
+        Commands::Uninstall { target, dry_run } => install::uninstall(target, dry_run)?,
         Commands::Cleanup => run_cleanup()?,
         Commands::SyncMemory { cwd } => {
             let cwd = resolve_cwd_arg(cwd);

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,5 +1,7 @@
 use clap::{Parser, Subcommand};
 
+pub(super) use crate::install::InstallTarget;
+
 #[derive(Parser)]
 #[command(name = "remem", about = "Persistent memory for Claude Code", version)]
 pub(super) struct Cli {
@@ -25,8 +27,22 @@ pub(super) enum Commands {
         once: bool,
     },
     Mcp,
-    Install,
-    Uninstall,
+    Install {
+        /// Which host(s) to install into.
+        #[arg(long, value_enum, default_value = "auto")]
+        target: InstallTarget,
+        /// Print what would be written without touching disk.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    Uninstall {
+        /// Which host(s) to uninstall from. Defaults to all known hosts.
+        #[arg(long, value_enum, default_value = "auto")]
+        target: InstallTarget,
+        /// Print what would be removed without touching disk.
+        #[arg(long)]
+        dry_run: bool,
+    },
     Cleanup,
     SyncMemory {
         #[arg(long)]

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -91,7 +91,10 @@ fn probe_hooks(probe: &HostProbe) -> Check {
         return Check {
             name,
             status: Status::Fail,
-            detail: format!("{} not found (run `remem install`)", probe.hooks_path.display()),
+            detail: format!(
+                "{} not found (run `remem install`)",
+                probe.hooks_path.display()
+            ),
         };
     }
 
@@ -116,7 +119,12 @@ fn probe_hooks(probe: &HostProbe) -> Check {
         Check {
             name,
             status: Status::Ok,
-            detail: format!("{}/{} registered in {}", found, events.len(), probe.hooks_path.display()),
+            detail: format!(
+                "{}/{} registered in {}",
+                found,
+                events.len(),
+                probe.hooks_path.display()
+            ),
         }
     } else if found > 0 {
         Check {
@@ -133,7 +141,10 @@ fn probe_hooks(probe: &HostProbe) -> Check {
         Check {
             name,
             status: Status::Fail,
-            detail: format!("no remem hooks (run `remem install --target {}`)", probe.name),
+            detail: format!(
+                "no remem hooks (run `remem install --target {}`)",
+                probe.name
+            ),
         }
     }
 }

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -22,7 +22,7 @@ pub(super) fn check_binary() -> Check {
 struct HostProbe {
     name: &'static str,
     hooks_path: PathBuf,
-    mcp_path: PathBuf,
+    mcp_paths: Vec<PathBuf>,
 }
 
 fn known_hosts() -> Vec<HostProbe> {
@@ -31,12 +31,15 @@ fn known_hosts() -> Vec<HostProbe> {
         HostProbe {
             name: "claude",
             hooks_path: home.join(".claude").join("settings.json"),
-            mcp_path: home.join(".claude.json"),
+            mcp_paths: vec![
+                home.join(".claude.json"),
+                home.join(".claude").join("claude_desktop_config.json"),
+            ],
         },
         HostProbe {
             name: "codex",
             hooks_path: home.join(".codex").join("hooks.json"),
-            mcp_path: home.join(".codex").join("config.toml"),
+            mcp_paths: vec![home.join(".codex").join("config.toml")],
         },
     ]
 }
@@ -46,7 +49,7 @@ fn known_hosts() -> Vec<HostProbe> {
 fn host_present(probe: &HostProbe) -> bool {
     probe.hooks_path.parent().is_some_and(|p| p.exists())
         || probe.hooks_path.exists()
-        || probe.mcp_path.exists()
+        || probe.mcp_paths.iter().any(|path| path.exists())
 }
 
 fn active_hosts() -> Vec<HostProbe> {
@@ -178,69 +181,42 @@ fn probe_hooks(probe: HostProbe) -> Check {
 
 fn probe_mcp(probe: HostProbe) -> Check {
     let name = mcp_check_name(probe.name);
-
-    if !probe.mcp_path.exists() {
-        return Check {
-            name,
-            status: Status::Fail,
-            detail: format!(
-                "{} not found (run `remem install --target {}`)",
-                probe.mcp_path.display(),
-                probe.name
-            ),
+    let has_existing_path = probe.mcp_paths.iter().any(|path| path.exists());
+    if let Some(result) = probe
+        .mcp_paths
+        .iter()
+        .filter(|path| path.exists())
+        .find_map(|path| probe_mcp_path(probe.name, path))
+    {
+        return match result {
+            Ok(path) => Check {
+                name,
+                status: Status::Ok,
+                detail: format!("registered in {}", path.display()),
+            },
+            Err((path, err)) => Check {
+                name,
+                status: Status::Fail,
+                detail: format!("cannot parse {}: {}", path.display(), err),
+            },
         };
     }
 
-    let content = match std::fs::read_to_string(&probe.mcp_path) {
-        Ok(c) => c,
-        Err(err) => {
-            return Check {
-                name,
-                status: Status::Fail,
-                detail: format!("cannot read {}: {}", probe.mcp_path.display(), err),
-            };
-        }
-    };
-
-    let has_remem = match probe.name {
-        "claude" => match serde_json::from_str::<Value>(&content) {
-            Ok(doc) => claude_has_remem_mcp(&doc),
-            Err(err) => {
-                return Check {
-                    name,
-                    status: Status::Fail,
-                    detail: format!("cannot parse {}: {}", probe.mcp_path.display(), err),
-                };
-            }
-        },
-        "codex" => match content.parse::<DocumentMut>() {
-            Ok(doc) => codex_has_remem_mcp(&doc),
-            Err(err) => {
-                return Check {
-                    name,
-                    status: Status::Fail,
-                    detail: format!("cannot parse {}: {}", probe.mcp_path.display(), err),
-                };
-            }
-        },
-        _ => false,
-    };
-
-    if has_remem {
-        Check {
-            name,
-            status: Status::Ok,
-            detail: format!("registered in {}", probe.mcp_path.display()),
-        }
-    } else {
-        Check {
-            name,
-            status: Status::Fail,
-            detail: format!(
+    Check {
+        name,
+        status: Status::Fail,
+        detail: if has_existing_path {
+            format!(
                 "not registered (run `remem install --target {}`)",
                 probe.name
-            ),
-        }
+            )
+        } else {
+            format!(
+                "{} not found (run `remem install --target {}`)",
+                display_mcp_paths(&probe.mcp_paths),
+                probe.name
+            )
+        },
     }
 }
 
@@ -264,6 +240,14 @@ fn host_targets_remem(probe: &HostProbe) -> bool {
     hooks_file_has_remem(&probe.hooks_path) || mcp_file_has_remem(probe)
 }
 
+fn display_mcp_paths(paths: &[PathBuf]) -> String {
+    paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(" or ")
+}
+
 fn hooks_file_has_remem(path: &PathBuf) -> bool {
     let Ok(content) = std::fs::read_to_string(path) else {
         return false;
@@ -277,10 +261,17 @@ fn hooks_file_has_remem(path: &PathBuf) -> bool {
 }
 
 fn mcp_file_has_remem(probe: &HostProbe) -> bool {
-    let Ok(content) = std::fs::read_to_string(&probe.mcp_path) else {
+    probe
+        .mcp_paths
+        .iter()
+        .any(|path| path_has_remem_mcp(probe.name, path))
+}
+
+fn path_has_remem_mcp(host: &str, path: &PathBuf) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
         return false;
     };
-    match probe.name {
+    match host {
         "claude" => match serde_json::from_str::<Value>(&content) {
             Ok(doc) => claude_has_remem_mcp(&doc),
             Err(_) => content.contains("remem"),
@@ -290,6 +281,29 @@ fn mcp_file_has_remem(probe: &HostProbe) -> bool {
             Err(_) => content.contains("remem"),
         },
         _ => false,
+    }
+}
+
+fn probe_mcp_path<'a>(
+    host: &str,
+    path: &'a PathBuf,
+) -> Option<Result<&'a PathBuf, (&'a PathBuf, String)>> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let has_remem = match host {
+        "claude" => match serde_json::from_str::<Value>(&content) {
+            Ok(doc) => claude_has_remem_mcp(&doc),
+            Err(err) => return Some(Err((path, err.to_string()))),
+        },
+        "codex" => match content.parse::<DocumentMut>() {
+            Ok(doc) => codex_has_remem_mcp(&doc),
+            Err(err) => return Some(Err((path, err.to_string()))),
+        },
+        _ => false,
+    };
+    if has_remem {
+        Some(Ok(path))
+    } else {
+        None
     }
 }
 
@@ -361,7 +375,7 @@ mod tests {
         let check = probe_hooks(HostProbe {
             name: "codex",
             hooks_path,
-            mcp_path: dir.join("config.toml"),
+            mcp_paths: vec![dir.join("config.toml")],
         });
 
         assert!(matches!(check.status, Status::Warn));
@@ -385,7 +399,7 @@ note = "remem"
         let check = probe_mcp(HostProbe {
             name: "codex",
             hooks_path: dir.join("hooks.json"),
-            mcp_path,
+            mcp_paths: vec![mcp_path],
         });
 
         assert!(matches!(check.status, Status::Fail));
@@ -398,18 +412,18 @@ note = "remem"
         let claude = HostProbe {
             name: "claude",
             hooks_path: claude_dir.join("settings.json"),
-            mcp_path: claude_dir.join("claude.json"),
+            mcp_paths: vec![claude_dir.join("claude.json")],
         };
-        std::fs::write(&claude.mcp_path, r#"{ "mcpServers": { "other": {} } }"#).unwrap();
+        std::fs::write(&claude.mcp_paths[0], r#"{ "mcpServers": { "other": {} } }"#).unwrap();
 
         let codex_dir = temp_path("doctor-codex");
         let codex = HostProbe {
             name: "codex",
             hooks_path: codex_dir.join("hooks.json"),
-            mcp_path: codex_dir.join("config.toml"),
+            mcp_paths: vec![codex_dir.join("config.toml")],
         };
         std::fs::write(
-            &codex.mcp_path,
+            &codex.mcp_paths[0],
             r#"[mcp_servers.remem]
 command = "/tmp/remem"
 "#,
@@ -431,5 +445,31 @@ command = "/tmp/remem"
         };
 
         assert_eq!(hosts, vec![codex]);
+    }
+
+    #[test]
+    fn probe_mcp_accepts_claude_desktop_config_path() {
+        let dir = temp_path("doctor-claude-desktop");
+        std::fs::write(
+            dir.join("claude_desktop_config.json"),
+            r#"{ "mcpServers": { "remem": { "command": "/tmp/remem" } } }"#,
+        )
+        .unwrap();
+
+        let check = probe_mcp(HostProbe {
+            name: "claude",
+            hooks_path: dir.join("settings.json"),
+            mcp_paths: vec![
+                dir.join("claude.json"),
+                dir.join("claude_desktop_config.json"),
+            ],
+        });
+
+        assert!(matches!(check.status, Status::Ok));
+        assert!(
+            check.detail.contains("claude_desktop_config.json"),
+            "{}",
+            check.detail
+        );
     }
 }

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -13,87 +13,173 @@ pub(super) fn check_binary() -> Check {
     }
 }
 
-pub(super) fn check_hooks() -> Check {
-    let settings_path = dirs::home_dir()
-        .map(|home| home.join(".claude").join("settings.json"))
-        .unwrap_or_else(|| PathBuf::from("~/.claude/settings.json"));
+/// A single host we know how to validate. The strings are leaked static
+/// because `Check::name` takes `&'static str` — every host lives for the
+/// process, so leaking is fine.
+struct HostProbe {
+    name: &'static str,
+    hooks_path: PathBuf,
+    mcp_path: PathBuf,
+    /// Needle in the MCP config file that indicates remem is registered.
+    /// JSON hosts use `mcpServers`, TOML hosts use `mcp_servers`.
+    mcp_needle: &'static str,
+}
 
-    if !settings_path.exists() {
-        return Check {
+fn known_hosts() -> Vec<HostProbe> {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    vec![
+        HostProbe {
+            name: "claude",
+            hooks_path: home.join(".claude").join("settings.json"),
+            mcp_path: home.join(".claude.json"),
+            mcp_needle: "mcpServers",
+        },
+        HostProbe {
+            name: "codex",
+            hooks_path: home.join(".codex").join("hooks.json"),
+            mcp_path: home.join(".codex").join("config.toml"),
+            mcp_needle: "mcp_servers",
+        },
+    ]
+}
+
+/// True if the host's config directory exists — i.e. the tool is installed
+/// on this machine and worth probing.
+fn host_present(probe: &HostProbe) -> bool {
+    probe.hooks_path.parent().is_some_and(|p| p.exists())
+        || probe.hooks_path.exists()
+        || probe.mcp_path.exists()
+}
+
+/// Produce one Check per detected host's hooks file. Hosts whose config
+/// directory doesn't exist are silently skipped — they aren't installed, so
+/// there's nothing to validate.
+pub(super) fn check_hooks() -> Vec<Check> {
+    let mut checks = Vec::new();
+    for probe in known_hosts().iter().filter(|h| host_present(h)) {
+        checks.push(probe_hooks(probe));
+    }
+    if checks.is_empty() {
+        checks.push(Check {
             name: "Hooks",
             status: Status::Fail,
-            detail: format!("{} not found", settings_path.display()),
+            detail: "no supported host detected (install Claude Code or Codex)".to_string(),
+        });
+    }
+    checks
+}
+
+pub(super) fn check_mcp() -> Vec<Check> {
+    let mut checks = Vec::new();
+    for probe in known_hosts().iter().filter(|h| host_present(h)) {
+        checks.push(probe_mcp(probe));
+    }
+    if checks.is_empty() {
+        checks.push(Check {
+            name: "MCP server",
+            status: Status::Fail,
+            detail: "no supported host detected".to_string(),
+        });
+    }
+    checks
+}
+
+fn probe_hooks(probe: &HostProbe) -> Check {
+    let name: &'static str = Box::leak(format!("Hooks ({})", probe.name).into_boxed_str());
+
+    if !probe.hooks_path.exists() {
+        return Check {
+            name,
+            status: Status::Fail,
+            detail: format!("{} not found (run `remem install`)", probe.hooks_path.display()),
         };
     }
 
-    let content = match std::fs::read_to_string(&settings_path) {
+    let content = match std::fs::read_to_string(&probe.hooks_path) {
         Ok(content) => content,
         Err(err) => {
             return Check {
-                name: "Hooks",
+                name,
                 status: Status::Fail,
-                detail: format!("cannot read {}: {}", settings_path.display(), err),
+                detail: format!("cannot read {}: {}", probe.hooks_path.display(), err),
             };
         }
     };
 
-    let hooks = ["PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"];
-    let mut found = 0;
-    for hook in &hooks {
-        if content.contains(hook) && content.contains("remem") {
-            found += 1;
-        }
-    }
+    let events = ["PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"];
+    let found = events
+        .iter()
+        .filter(|event| content.contains(*event) && content.contains("remem"))
+        .count();
 
-    if found == hooks.len() {
+    if found == events.len() {
         Check {
-            name: "Hooks",
+            name,
             status: Status::Ok,
-            detail: format!("{}/{} registered in settings.json", found, hooks.len()),
+            detail: format!("{}/{} registered in {}", found, events.len(), probe.hooks_path.display()),
         }
     } else if found > 0 {
         Check {
-            name: "Hooks",
+            name,
             status: Status::Warn,
             detail: format!(
-                "{}/{} registered (run `remem install` to fix)",
+                "{}/{} registered (run `remem install --target {}` to fix)",
                 found,
-                hooks.len()
+                events.len(),
+                probe.name
             ),
         }
     } else {
         Check {
-            name: "Hooks",
+            name,
             status: Status::Fail,
-            detail: "no remem hooks found (run `remem install`)".to_string(),
+            detail: format!("no remem hooks (run `remem install --target {}`)", probe.name),
         }
     }
 }
 
-pub(super) fn check_mcp() -> Check {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    let mcp_paths = [
-        home.join(".claude.json"),
-        home.join(".claude").join("claude_desktop_config.json"),
-    ];
+fn probe_mcp(probe: &HostProbe) -> Check {
+    let name: &'static str = Box::leak(format!("MCP ({})", probe.name).into_boxed_str());
 
-    for path in &mcp_paths {
-        if path.exists() {
-            if let Ok(content) = std::fs::read_to_string(path) {
-                if content.contains("remem") && content.contains("mcp") {
-                    return Check {
-                        name: "MCP server",
-                        status: Status::Ok,
-                        detail: format!("registered in {}", path.display()),
-                    };
-                }
-            }
-        }
+    if !probe.mcp_path.exists() {
+        return Check {
+            name,
+            status: Status::Fail,
+            detail: format!(
+                "{} not found (run `remem install --target {}`)",
+                probe.mcp_path.display(),
+                probe.name
+            ),
+        };
     }
 
-    Check {
-        name: "MCP server",
-        status: Status::Fail,
-        detail: "not registered (run `remem install`)".to_string(),
+    let content = match std::fs::read_to_string(&probe.mcp_path) {
+        Ok(c) => c,
+        Err(err) => {
+            return Check {
+                name,
+                status: Status::Fail,
+                detail: format!("cannot read {}: {}", probe.mcp_path.display(), err),
+            };
+        }
+    };
+
+    // Substring check is defensive (works for both JSON and TOML without
+    // parsing either). `<needle>` + `remem` both present ≈ registered.
+    if content.contains(probe.mcp_needle) && content.contains("remem") {
+        Check {
+            name,
+            status: Status::Ok,
+            detail: format!("registered in {}", probe.mcp_path.display()),
+        }
+    } else {
+        Check {
+            name,
+            status: Status::Fail,
+            detail: format!(
+                "not registered (run `remem install --target {}`)",
+                probe.name
+            ),
+        }
     }
 }

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -1,4 +1,6 @@
+use serde_json::Value;
 use std::path::PathBuf;
+use toml_edit::DocumentMut;
 
 use super::types::{Check, Status};
 
@@ -16,13 +18,11 @@ pub(super) fn check_binary() -> Check {
 /// A single host we know how to validate. The strings are leaked static
 /// because `Check::name` takes `&'static str` — every host lives for the
 /// process, so leaking is fine.
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct HostProbe {
     name: &'static str,
     hooks_path: PathBuf,
     mcp_path: PathBuf,
-    /// Needle in the MCP config file that indicates remem is registered.
-    /// JSON hosts use `mcpServers`, TOML hosts use `mcp_servers`.
-    mcp_needle: &'static str,
 }
 
 fn known_hosts() -> Vec<HostProbe> {
@@ -32,13 +32,11 @@ fn known_hosts() -> Vec<HostProbe> {
             name: "claude",
             hooks_path: home.join(".claude").join("settings.json"),
             mcp_path: home.join(".claude.json"),
-            mcp_needle: "mcpServers",
         },
         HostProbe {
             name: "codex",
             hooks_path: home.join(".codex").join("hooks.json"),
             mcp_path: home.join(".codex").join("config.toml"),
-            mcp_needle: "mcp_servers",
         },
     ]
 }
@@ -51,12 +49,30 @@ fn host_present(probe: &HostProbe) -> bool {
         || probe.mcp_path.exists()
 }
 
+fn active_hosts() -> Vec<HostProbe> {
+    let hosts: Vec<HostProbe> = known_hosts().into_iter().filter(host_present).collect();
+    if hosts.is_empty() {
+        return hosts;
+    }
+
+    let targeted: Vec<HostProbe> = hosts
+        .iter()
+        .filter(|probe| host_targets_remem(probe))
+        .cloned()
+        .collect();
+    if targeted.is_empty() {
+        hosts
+    } else {
+        targeted
+    }
+}
+
 /// Produce one Check per detected host's hooks file. Hosts whose config
 /// directory doesn't exist are silently skipped — they aren't installed, so
 /// there's nothing to validate.
 pub(super) fn check_hooks() -> Vec<Check> {
     let mut checks = Vec::new();
-    for probe in known_hosts().iter().filter(|h| host_present(h)) {
+    for probe in active_hosts() {
         checks.push(probe_hooks(probe));
     }
     if checks.is_empty() {
@@ -71,7 +87,7 @@ pub(super) fn check_hooks() -> Vec<Check> {
 
 pub(super) fn check_mcp() -> Vec<Check> {
     let mut checks = Vec::new();
-    for probe in known_hosts().iter().filter(|h| host_present(h)) {
+    for probe in active_hosts() {
         checks.push(probe_mcp(probe));
     }
     if checks.is_empty() {
@@ -84,8 +100,8 @@ pub(super) fn check_mcp() -> Vec<Check> {
     checks
 }
 
-fn probe_hooks(probe: &HostProbe) -> Check {
-    let name: &'static str = Box::leak(format!("Hooks ({})", probe.name).into_boxed_str());
+fn probe_hooks(probe: HostProbe) -> Check {
+    let name = hooks_check_name(probe.name);
 
     if !probe.hooks_path.exists() {
         return Check {
@@ -109,10 +125,21 @@ fn probe_hooks(probe: &HostProbe) -> Check {
         }
     };
 
+    let doc: Value = match serde_json::from_str(&content) {
+        Ok(doc) => doc,
+        Err(err) => {
+            return Check {
+                name,
+                status: Status::Fail,
+                detail: format!("cannot parse {}: {}", probe.hooks_path.display(), err),
+            };
+        }
+    };
+
     let events = ["PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"];
     let found = events
         .iter()
-        .filter(|event| content.contains(*event) && content.contains("remem"))
+        .filter(|event| event_has_remem_hook(&doc, event))
         .count();
 
     if found == events.len() {
@@ -149,8 +176,8 @@ fn probe_hooks(probe: &HostProbe) -> Check {
     }
 }
 
-fn probe_mcp(probe: &HostProbe) -> Check {
-    let name: &'static str = Box::leak(format!("MCP ({})", probe.name).into_boxed_str());
+fn probe_mcp(probe: HostProbe) -> Check {
+    let name = mcp_check_name(probe.name);
 
     if !probe.mcp_path.exists() {
         return Check {
@@ -175,9 +202,31 @@ fn probe_mcp(probe: &HostProbe) -> Check {
         }
     };
 
-    // Substring check is defensive (works for both JSON and TOML without
-    // parsing either). `<needle>` + `remem` both present ≈ registered.
-    if content.contains(probe.mcp_needle) && content.contains("remem") {
+    let has_remem = match probe.name {
+        "claude" => match serde_json::from_str::<Value>(&content) {
+            Ok(doc) => claude_has_remem_mcp(&doc),
+            Err(err) => {
+                return Check {
+                    name,
+                    status: Status::Fail,
+                    detail: format!("cannot parse {}: {}", probe.mcp_path.display(), err),
+                };
+            }
+        },
+        "codex" => match content.parse::<DocumentMut>() {
+            Ok(doc) => codex_has_remem_mcp(&doc),
+            Err(err) => {
+                return Check {
+                    name,
+                    status: Status::Fail,
+                    detail: format!("cannot parse {}: {}", probe.mcp_path.display(), err),
+                };
+            }
+        },
+        _ => false,
+    };
+
+    if has_remem {
         Check {
             name,
             status: Status::Ok,
@@ -192,5 +241,195 @@ fn probe_mcp(probe: &HostProbe) -> Check {
                 probe.name
             ),
         }
+    }
+}
+
+fn hooks_check_name(host: &str) -> &'static str {
+    match host {
+        "claude" => "Hooks (claude)",
+        "codex" => "Hooks (codex)",
+        _ => "Hooks",
+    }
+}
+
+fn mcp_check_name(host: &str) -> &'static str {
+    match host {
+        "claude" => "MCP (claude)",
+        "codex" => "MCP (codex)",
+        _ => "MCP server",
+    }
+}
+
+fn host_targets_remem(probe: &HostProbe) -> bool {
+    hooks_file_has_remem(&probe.hooks_path) || mcp_file_has_remem(probe)
+}
+
+fn hooks_file_has_remem(path: &PathBuf) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    match serde_json::from_str::<Value>(&content) {
+        Ok(doc) => ["PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"]
+            .iter()
+            .any(|event| event_has_remem_hook(&doc, event)),
+        Err(_) => content.contains("remem"),
+    }
+}
+
+fn mcp_file_has_remem(probe: &HostProbe) -> bool {
+    let Ok(content) = std::fs::read_to_string(&probe.mcp_path) else {
+        return false;
+    };
+    match probe.name {
+        "claude" => match serde_json::from_str::<Value>(&content) {
+            Ok(doc) => claude_has_remem_mcp(&doc),
+            Err(_) => content.contains("remem"),
+        },
+        "codex" => match content.parse::<DocumentMut>() {
+            Ok(doc) => codex_has_remem_mcp(&doc),
+            Err(_) => content.contains("remem"),
+        },
+        _ => false,
+    }
+}
+
+fn event_has_remem_hook(doc: &Value, event: &str) -> bool {
+    doc.get("hooks")
+        .and_then(|hooks| hooks.get(event))
+        .and_then(|entries| entries.as_array())
+        .into_iter()
+        .flatten()
+        .any(entry_has_remem_hook)
+}
+
+fn entry_has_remem_hook(entry: &Value) -> bool {
+    entry
+        .get("hooks")
+        .and_then(|hooks| hooks.as_array())
+        .into_iter()
+        .flatten()
+        .any(|hook| {
+            hook.get("command")
+                .and_then(|command| command.as_str())
+                .is_some_and(|command| command.contains("remem"))
+        })
+}
+
+fn claude_has_remem_mcp(doc: &Value) -> bool {
+    doc.get("mcpServers")
+        .and_then(|servers| servers.as_object())
+        .is_some_and(|servers| servers.contains_key("remem"))
+}
+
+fn codex_has_remem_mcp(doc: &DocumentMut) -> bool {
+    doc.get("mcp_servers")
+        .and_then(|servers| servers.as_table())
+        .is_some_and(|servers| servers.contains_key("remem"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+    fn temp_path(label: &str) -> PathBuf {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("remem-{label}-{id}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn probe_hooks_requires_remem_on_each_event() {
+        let dir = temp_path("doctor-hooks");
+        let hooks_path = dir.join("hooks.json");
+        std::fs::write(
+            &hooks_path,
+            r#"{
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context" }] }],
+    "Stop": [{ "hooks": [{ "command": "other-tool summarize" }] }],
+    "PostToolUse": [{ "hooks": [{ "command": "other-tool observe" }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "command": "other-tool init" }] }]
+  }
+}"#,
+        )
+        .unwrap();
+
+        let check = probe_hooks(HostProbe {
+            name: "codex",
+            hooks_path,
+            mcp_path: dir.join("config.toml"),
+        });
+
+        assert!(matches!(check.status, Status::Warn));
+        assert!(check.detail.contains("1/4 registered"), "{}", check.detail);
+    }
+
+    #[test]
+    fn probe_mcp_requires_exact_codex_remem_entry() {
+        let dir = temp_path("doctor-mcp");
+        let mcp_path = dir.join("config.toml");
+        std::fs::write(
+            &mcp_path,
+            r#"# remem should not be detected from comments
+[mcp_servers.other]
+command = "echo"
+note = "remem"
+"#,
+        )
+        .unwrap();
+
+        let check = probe_mcp(HostProbe {
+            name: "codex",
+            hooks_path: dir.join("hooks.json"),
+            mcp_path,
+        });
+
+        assert!(matches!(check.status, Status::Fail));
+        assert!(check.detail.contains("not registered"), "{}", check.detail);
+    }
+
+    #[test]
+    fn active_hosts_prefers_hosts_with_remem_markers() {
+        let claude_dir = temp_path("doctor-claude");
+        let claude = HostProbe {
+            name: "claude",
+            hooks_path: claude_dir.join("settings.json"),
+            mcp_path: claude_dir.join("claude.json"),
+        };
+        std::fs::write(&claude.mcp_path, r#"{ "mcpServers": { "other": {} } }"#).unwrap();
+
+        let codex_dir = temp_path("doctor-codex");
+        let codex = HostProbe {
+            name: "codex",
+            hooks_path: codex_dir.join("hooks.json"),
+            mcp_path: codex_dir.join("config.toml"),
+        };
+        std::fs::write(
+            &codex.mcp_path,
+            r#"[mcp_servers.remem]
+command = "/tmp/remem"
+"#,
+        )
+        .unwrap();
+
+        let hosts = {
+            let present = vec![claude, codex.clone()];
+            let targeted: Vec<_> = present
+                .iter()
+                .filter(|probe| host_targets_remem(probe))
+                .cloned()
+                .collect();
+            if targeted.is_empty() {
+                present
+            } else {
+                targeted
+            }
+        };
+
+        assert_eq!(hosts, vec![codex]);
     }
 }

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -10,15 +10,11 @@ pub fn run_doctor() -> Result<()> {
     println!("remem v{} — system check", version);
     println!();
 
-    let checks = vec![
-        check_binary(),
-        check_schema_migration(),
-        check_database(),
-        check_hooks(),
-        check_mcp(),
-        check_pending_queue(),
-        check_disk_space(),
-    ];
+    let mut checks = vec![check_binary(), check_schema_migration(), check_database()];
+    checks.extend(check_hooks());
+    checks.extend(check_mcp());
+    checks.push(check_pending_queue());
+    checks.push(check_disk_space());
 
     let mut warns = 0;
     let mut fails = 0;

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,8 +1,11 @@
 mod config;
+mod host;
+mod hosts;
 mod json_io;
 mod paths;
 mod runtime;
 #[cfg(test)]
 mod tests;
 
+pub use host::InstallTarget;
 pub use runtime::{install, uninstall};

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -1,6 +1,10 @@
+use anyhow::{Context, Result};
 use serde_json::{json, Value};
+use std::path::Path;
 
-pub(super) fn build_hooks(bin: &str) -> Value {
+use crate::install::json_io::{read_json_file, write_json_file};
+
+pub(in crate::install) fn build_hooks(bin: &str) -> Value {
     json!({
         "SessionStart": [{
             "hooks": [{ "type": "command", "command": format!("{} context", bin), "timeout": 15000 }]
@@ -18,7 +22,7 @@ pub(super) fn build_hooks(bin: &str) -> Value {
     })
 }
 
-pub(super) fn build_mcp_server(bin: &str) -> Value {
+pub(in crate::install) fn build_mcp_server(bin: &str) -> Value {
     json!({
         "type": "stdio",
         "command": bin,
@@ -39,7 +43,7 @@ fn is_remem_hook(hook_entry: &Value, bin: &str) -> bool {
     false
 }
 
-pub(super) fn remove_remem_hooks(settings: &mut Value, bin: &str) {
+pub(in crate::install) fn remove_remem_hooks(settings: &mut Value, bin: &str) {
     if let Some(hooks) = settings
         .get_mut("hooks")
         .and_then(|hooks| hooks.as_object_mut())
@@ -64,7 +68,44 @@ pub(super) fn remove_remem_hooks(settings: &mut Value, bin: &str) {
     }
 }
 
-pub(super) fn remove_remem_mcp(settings: &mut Value, bin: &str) {
+/// Shared hook merge used by every host whose config file is JSON-shaped
+/// the same way Claude Code's `settings.json` is.
+///
+/// Idempotent: strips any existing remem hook entries before appending fresh
+/// ones, so repeated calls converge on the same state.
+pub(in crate::install) fn apply_hooks_json(path: &Path, bin: &str) -> Result<()> {
+    let mut doc = read_json_file(&path.to_path_buf())?;
+    remove_remem_hooks(&mut doc, bin);
+
+    let new_hooks = build_hooks(bin);
+    let obj = doc
+        .as_object_mut()
+        .with_context(|| format!("{} 根节点不是 Object", path.display()))?;
+    let hooks = obj.entry("hooks").or_insert_with(|| json!({}));
+    if let (Some(existing), Some(new)) = (hooks.as_object_mut(), new_hooks.as_object()) {
+        for (event_type, entries) in new {
+            let arr = existing.entry(event_type).or_insert_with(|| json!([]));
+            if let (Some(arr), Some(new_entries)) = (arr.as_array_mut(), entries.as_array()) {
+                for entry in new_entries {
+                    arr.push(entry.clone());
+                }
+            }
+        }
+    }
+    write_json_file(&path.to_path_buf(), &doc)
+}
+
+/// Remove remem hook entries from the JSON file at `path`, if it exists.
+pub(in crate::install) fn strip_hooks_json(path: &Path, bin: &str) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let mut doc = read_json_file(&path.to_path_buf())?;
+    remove_remem_hooks(&mut doc, bin);
+    write_json_file(&path.to_path_buf(), &doc)
+}
+
+pub(in crate::install) fn remove_remem_mcp(settings: &mut Value, bin: &str) {
     if let Some(servers) = settings
         .get_mut("mcpServers")
         .and_then(|servers| servers.as_object_mut())

--- a/src/install/host.rs
+++ b/src/install/host.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use clap::ValueEnum;
+use std::path::PathBuf;
+
+/// Which host(s) to (un)install into.
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum InstallTarget {
+    /// Install to every host whose config directory already exists.
+    Auto,
+    /// Install only to Claude Code (~/.claude.json + ~/.claude/settings.json).
+    Claude,
+    /// Install only to Codex (~/.codex/config.toml).
+    Codex,
+    /// Install to every known host, creating config files if missing.
+    All,
+}
+
+/// Outcome of a hook installation attempt.
+pub enum HookSupport {
+    /// Hooks were installed.
+    Installed,
+    /// Host does not support hooks; reason for user-visible log.
+    /// Retained for future hosts (e.g. Cursor) that may not expose a hook
+    /// system with the same shape as Claude/Codex.
+    #[allow(dead_code)]
+    Skipped(&'static str),
+}
+
+/// A host capable of running the remem MCP server.
+///
+/// Each host owns its own config file format and mutation logic. The runtime
+/// layer only orchestrates which hosts to touch.
+pub trait InstallHost {
+    /// Short identifier printed in logs (e.g. "claude", "codex").
+    fn name(&self) -> &'static str;
+
+    /// Path to the primary config file this host manages.
+    fn config_path(&self) -> PathBuf;
+
+    /// True when the host appears to be installed on this machine.
+    /// Used by `InstallTarget::Auto` to decide whether to touch it.
+    fn is_available(&self) -> bool;
+
+    /// Add / update the remem MCP server entry. Idempotent.
+    fn install_mcp(&self, bin: &str) -> Result<()>;
+
+    /// Remove any remem MCP server entry. Idempotent.
+    fn uninstall_mcp(&self, bin: &str) -> Result<()>;
+
+    /// Add / update remem hooks. Hosts without hook support return `Skipped`.
+    fn install_hooks(&self, bin: &str) -> Result<HookSupport>;
+
+    /// Remove remem hooks. No-op if the host doesn't support hooks.
+    fn uninstall_hooks(&self, bin: &str) -> Result<()>;
+
+    /// Describe the writes a real install would do, without touching disk.
+    /// Returned lines are printed verbatim in dry-run mode.
+    fn dry_run_plan(&self, bin: &str) -> Vec<String>;
+}

--- a/src/install/hosts/claude.rs
+++ b/src/install/hosts/claude.rs
@@ -82,8 +82,14 @@ impl InstallHost for ClaudeHost {
 
     fn dry_run_plan(&self, bin: &str) -> Vec<String> {
         vec![
-            format!("  MCP    -> {} (add mcpServers.remem)", claude_json_path().display()),
-            format!("  hooks  -> {} (SessionStart/UserPromptSubmit/PostToolUse/Stop)", settings_path().display()),
+            format!(
+                "  MCP    -> {} (add mcpServers.remem)",
+                claude_json_path().display()
+            ),
+            format!(
+                "  hooks  -> {} (SessionStart/UserPromptSubmit/PostToolUse/Stop)",
+                settings_path().display()
+            ),
             format!("  binary -> {}", bin),
         ]
     }

--- a/src/install/hosts/claude.rs
+++ b/src/install/hosts/claude.rs
@@ -1,0 +1,90 @@
+use anyhow::{Context, Result};
+use serde_json::json;
+use std::path::PathBuf;
+
+use crate::install::config::{
+    apply_hooks_json, build_mcp_server, remove_remem_mcp, strip_hooks_json,
+};
+use crate::install::host::{HookSupport, InstallHost};
+use crate::install::json_io::{read_json_file, write_json_file};
+use crate::install::paths::{claude_json_path, settings_path};
+
+pub(in crate::install) struct ClaudeHost;
+
+impl InstallHost for ClaudeHost {
+    fn name(&self) -> &'static str {
+        "claude"
+    }
+
+    fn config_path(&self) -> PathBuf {
+        claude_json_path()
+    }
+
+    fn is_available(&self) -> bool {
+        // Treat Claude as available if either of its config files exists.
+        // (Fresh installs may have ~/.claude/ but no ~/.claude.json yet.)
+        claude_json_path().exists()
+            || dirs::home_dir()
+                .map(|h| h.join(".claude").exists())
+                .unwrap_or(false)
+    }
+
+    fn install_mcp(&self, bin: &str) -> Result<()> {
+        let path = claude_json_path();
+        let mut doc = read_json_file(&path)?;
+        remove_remem_mcp(&mut doc, bin);
+        let obj = doc
+            .as_object_mut()
+            .context("~/.claude.json 根节点不是 Object")?;
+        let servers = obj.entry("mcpServers").or_insert_with(|| json!({}));
+        if let Some(servers) = servers.as_object_mut() {
+            servers.insert("remem".to_string(), build_mcp_server(bin));
+        }
+        write_json_file(&path, &doc)?;
+        Ok(())
+    }
+
+    fn uninstall_mcp(&self, bin: &str) -> Result<()> {
+        let path = claude_json_path();
+        if !path.exists() {
+            return Ok(());
+        }
+        let mut doc = read_json_file(&path)?;
+        remove_remem_mcp(&mut doc, bin);
+        write_json_file(&path, &doc)?;
+        Ok(())
+    }
+
+    fn install_hooks(&self, bin: &str) -> Result<HookSupport> {
+        // Claude's settings.json can historically end up with a stale
+        // mcpServers entry if earlier versions mis-wrote here; clean that
+        // up defensively before merging hooks.
+        let path = settings_path();
+        if path.exists() {
+            let mut doc = read_json_file(&path)?;
+            remove_remem_mcp(&mut doc, bin);
+            write_json_file(&path, &doc)?;
+        }
+        apply_hooks_json(&path, bin)?;
+        Ok(HookSupport::Installed)
+    }
+
+    fn uninstall_hooks(&self, bin: &str) -> Result<()> {
+        let path = settings_path();
+        strip_hooks_json(&path, bin)?;
+        if path.exists() {
+            let mut doc = read_json_file(&path)?;
+            remove_remem_mcp(&mut doc, bin);
+            write_json_file(&path, &doc)?;
+        }
+        Ok(())
+    }
+
+    fn dry_run_plan(&self, bin: &str) -> Vec<String> {
+        vec![
+            format!("  MCP    -> {} (add mcpServers.remem)", claude_json_path().display()),
+            format!("  hooks  -> {} (SessionStart/UserPromptSubmit/PostToolUse/Stop)", settings_path().display()),
+            format!("  binary -> {}", bin),
+        ]
+    }
+}

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -1,9 +1,11 @@
 use anyhow::{Context, Result};
+use serde_json::Value;
 use std::path::{Path, PathBuf};
 use toml_edit::{value, Array, DocumentMut, Item, Table};
 
-use crate::install::config::{apply_hooks_json, strip_hooks_json};
+use crate::install::config::{build_hooks, remove_remem_hooks, strip_hooks_json};
 use crate::install::host::{HookSupport, InstallHost};
+use crate::install::json_io::{read_json_file, write_json_file};
 use crate::install::paths::{codex_config_path, codex_hooks_path};
 
 pub(in crate::install) struct CodexHost;
@@ -30,6 +32,7 @@ impl InstallHost for CodexHost {
         let path = codex_config_path();
         let mut doc = read_toml_doc(&path)?;
         upsert_remem_server(&mut doc, bin)?;
+        enable_codex_hooks(&mut doc)?;
         write_toml_doc(&path, &doc)?;
         Ok(())
     }
@@ -46,10 +49,7 @@ impl InstallHost for CodexHost {
     }
 
     fn install_hooks(&self, bin: &str) -> Result<HookSupport> {
-        // Codex's ~/.codex/hooks.json uses the same schema as Claude's
-        // settings.json (SessionStart / UserPromptSubmit / PreToolUse /
-        // PostToolUse / Stop, stdin JSON events). Reuse the shared merger.
-        apply_hooks_json(&codex_hooks_path(), bin)?;
+        apply_codex_hooks_json(&codex_hooks_path(), bin)?;
         Ok(HookSupport::Installed)
     }
 
@@ -93,6 +93,77 @@ fn write_toml_doc(path: &Path, doc: &DocumentMut) -> Result<()> {
     }
     std::fs::write(path, doc.to_string())
         .with_context(|| format!("写入 {} 失败", path.display()))?;
+    Ok(())
+}
+
+fn apply_codex_hooks_json(path: &Path, bin: &str) -> Result<()> {
+    let mut doc = read_json_file(&path.to_path_buf())?;
+    remove_remem_hooks(&mut doc, bin);
+
+    let new_hooks = build_codex_hooks(bin);
+    let obj = doc
+        .as_object_mut()
+        .with_context(|| format!("{} 根节点不是 Object", path.display()))?;
+    let hooks = obj
+        .entry("hooks".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    if let (Some(existing), Some(new)) = (hooks.as_object_mut(), new_hooks.as_object()) {
+        for (event_type, entries) in new {
+            let arr = existing
+                .entry(event_type.to_string())
+                .or_insert_with(|| serde_json::json!([]));
+            if let (Some(arr), Some(new_entries)) = (arr.as_array_mut(), entries.as_array()) {
+                for entry in new_entries {
+                    arr.push(entry.clone());
+                }
+            }
+        }
+    }
+    write_json_file(&path.to_path_buf(), &doc)
+}
+
+fn build_codex_hooks(bin: &str) -> Value {
+    let mut hooks = build_hooks(bin);
+    convert_hook_timeouts_to_seconds(&mut hooks);
+    hooks
+}
+
+fn convert_hook_timeouts_to_seconds(value: &mut Value) {
+    let Some(events) = value.as_object_mut() else {
+        return;
+    };
+
+    for entries in events.values_mut() {
+        let Some(entries) = entries.as_array_mut() else {
+            continue;
+        };
+        for entry in entries {
+            let Some(hooks) = entry
+                .get_mut("hooks")
+                .and_then(|hooks| hooks.as_array_mut())
+            else {
+                continue;
+            };
+            for hook in hooks {
+                let Some(timeout) = hook.get_mut("timeout") else {
+                    continue;
+                };
+                let Some(ms) = timeout.as_i64() else {
+                    continue;
+                };
+                *timeout = Value::from((ms / 1000).max(1));
+            }
+        }
+    }
+}
+
+fn enable_codex_hooks(doc: &mut DocumentMut) -> Result<()> {
+    let features = doc
+        .entry("features")
+        .or_insert(Item::Table(Table::new()))
+        .as_table_mut()
+        .context("features 存在但不是 table，拒绝覆盖")?;
+    features["codex_hooks"] = value(true);
     Ok(())
 }
 
@@ -190,6 +261,24 @@ startup_timeout_sec = 5
         assert!(rendered.contains("[mcp_servers.omx_state]"), "{rendered}");
         assert!(rendered.contains("startup_timeout_sec = 5"), "{rendered}");
         assert!(rendered.contains("[mcp_servers.remem]"), "{rendered}");
+    }
+
+    #[test]
+    fn enable_codex_hooks_adds_feature_flag() {
+        let mut doc = DocumentMut::new();
+        enable_codex_hooks(&mut doc).unwrap();
+        let rendered = doc.to_string();
+        assert!(rendered.contains("[features]"), "{rendered}");
+        assert!(rendered.contains("codex_hooks = true"), "{rendered}");
+    }
+
+    #[test]
+    fn build_codex_hooks_uses_second_timeouts() {
+        let hooks = build_codex_hooks("/tmp/remem");
+        assert_eq!(hooks["SessionStart"][0]["hooks"][0]["timeout"], 15);
+        assert_eq!(hooks["UserPromptSubmit"][0]["hooks"][0]["timeout"], 15);
+        assert_eq!(hooks["PostToolUse"][0]["hooks"][0]["timeout"], 120);
+        assert_eq!(hooks["Stop"][0]["hooks"][0]["timeout"], 120);
     }
 
     #[test]

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -1,0 +1,263 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use toml_edit::{value, Array, DocumentMut, Item, Table};
+
+use crate::install::config::{apply_hooks_json, strip_hooks_json};
+use crate::install::host::{HookSupport, InstallHost};
+use crate::install::paths::{codex_config_path, codex_hooks_path};
+
+pub(in crate::install) struct CodexHost;
+
+const SERVER_KEY: &str = "remem";
+
+impl InstallHost for CodexHost {
+    fn name(&self) -> &'static str {
+        "codex"
+    }
+
+    fn config_path(&self) -> PathBuf {
+        codex_config_path()
+    }
+
+    fn is_available(&self) -> bool {
+        codex_config_path().exists()
+            || dirs::home_dir()
+                .map(|h| h.join(".codex").exists())
+                .unwrap_or(false)
+    }
+
+    fn install_mcp(&self, bin: &str) -> Result<()> {
+        let path = codex_config_path();
+        let mut doc = read_toml_doc(&path)?;
+        upsert_remem_server(&mut doc, bin)?;
+        write_toml_doc(&path, &doc)?;
+        Ok(())
+    }
+
+    fn uninstall_mcp(&self, bin: &str) -> Result<()> {
+        let path = codex_config_path();
+        if !path.exists() {
+            return Ok(());
+        }
+        let mut doc = read_toml_doc(&path)?;
+        remove_remem_server(&mut doc, bin);
+        write_toml_doc(&path, &doc)?;
+        Ok(())
+    }
+
+    fn install_hooks(&self, bin: &str) -> Result<HookSupport> {
+        // Codex's ~/.codex/hooks.json uses the same schema as Claude's
+        // settings.json (SessionStart / UserPromptSubmit / PreToolUse /
+        // PostToolUse / Stop, stdin JSON events). Reuse the shared merger.
+        apply_hooks_json(&codex_hooks_path(), bin)?;
+        Ok(HookSupport::Installed)
+    }
+
+    fn uninstall_hooks(&self, bin: &str) -> Result<()> {
+        strip_hooks_json(&codex_hooks_path(), bin)
+    }
+
+    fn dry_run_plan(&self, bin: &str) -> Vec<String> {
+        vec![
+            format!(
+                "  MCP    -> {} (add [mcp_servers.{}])",
+                codex_config_path().display(),
+                SERVER_KEY
+            ),
+            format!(
+                "  hooks  -> {} (SessionStart/UserPromptSubmit/PostToolUse/Stop)",
+                codex_hooks_path().display()
+            ),
+            format!("  binary -> {}", bin),
+        ]
+    }
+}
+
+// --- TOML helpers ---------------------------------------------------------
+
+fn read_toml_doc(path: &Path) -> Result<DocumentMut> {
+    if !path.exists() {
+        return Ok(DocumentMut::new());
+    }
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("读取 {} 失败", path.display()))?;
+    content
+        .parse::<DocumentMut>()
+        .with_context(|| format!("解析 {} 失败（非法 TOML）", path.display()))
+}
+
+fn write_toml_doc(path: &Path, doc: &DocumentMut) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("创建目录 {} 失败", parent.display()))?;
+    }
+    std::fs::write(path, doc.to_string())
+        .with_context(|| format!("写入 {} 失败", path.display()))?;
+    Ok(())
+}
+
+/// Ensure `[mcp_servers.remem]` points at the current binary.
+///
+/// Preserves any sibling `[mcp_servers.*]` entries (e.g. omx_state) plus
+/// surrounding comments/formatting. Returns an error if the config has
+/// a non-table value at `mcp_servers` (e.g. a user typo like
+/// `mcp_servers = "foo"`), since we won't silently clobber that.
+fn upsert_remem_server(doc: &mut DocumentMut, bin: &str) -> Result<()> {
+    // Also clean up any non-canonical entry pointing at a stale remem binary.
+    remove_remem_server(doc, bin);
+
+    let servers = doc
+        .entry("mcp_servers")
+        .or_insert(Item::Table({
+            let mut t = Table::new();
+            t.set_implicit(true);
+            t
+        }))
+        .as_table_mut()
+        .context("mcp_servers 存在但不是 table，拒绝覆盖")?;
+
+    let mut entry = Table::new();
+    entry["command"] = value(bin);
+    let mut args = Array::new();
+    args.push("mcp");
+    entry["args"] = value(args);
+    entry["enabled"] = value(true);
+    servers.insert(SERVER_KEY, Item::Table(entry));
+    Ok(())
+}
+
+/// Remove any `[mcp_servers.*]` whose key is "remem" or whose `command`
+/// matches the given binary path (defensively catches renamed stale entries).
+fn remove_remem_server(doc: &mut DocumentMut, bin: &str) {
+    let Some(servers) = doc
+        .get_mut("mcp_servers")
+        .and_then(|item| item.as_table_mut())
+    else {
+        return;
+    };
+
+    let keys: Vec<String> = servers.iter().map(|(k, _)| k.to_string()).collect();
+    for key in keys {
+        if key == SERVER_KEY {
+            servers.remove(&key);
+            continue;
+        }
+        let cmd_matches = servers
+            .get(&key)
+            .and_then(|item| item.as_table())
+            .and_then(|t| t.get("command"))
+            .and_then(|v| v.as_str())
+            .map(|s| s == bin || s.ends_with("/remem"))
+            .unwrap_or(false);
+        if cmd_matches {
+            servers.remove(&key);
+        }
+    }
+
+    if servers.is_empty() {
+        doc.remove("mcp_servers");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_into_empty_doc() {
+        let mut doc = DocumentMut::new();
+        upsert_remem_server(&mut doc, "/tmp/remem").unwrap();
+        let rendered = doc.to_string();
+        assert!(rendered.contains("[mcp_servers.remem]"), "{rendered}");
+        assert!(rendered.contains("command = \"/tmp/remem\""), "{rendered}");
+        assert!(rendered.contains("args = [\"mcp\"]"), "{rendered}");
+        assert!(rendered.contains("enabled = true"), "{rendered}");
+    }
+
+    #[test]
+    fn upsert_preserves_other_servers_and_comments() {
+        let src = r#"# Top-level comment
+[mcp_servers.omx_state]
+command = "node"
+args = ["state-server.js"]
+enabled = true
+startup_timeout_sec = 5
+"#;
+        let mut doc: DocumentMut = src.parse().unwrap();
+        upsert_remem_server(&mut doc, "/tmp/remem").unwrap();
+        let rendered = doc.to_string();
+        assert!(rendered.contains("# Top-level comment"), "{rendered}");
+        assert!(rendered.contains("[mcp_servers.omx_state]"), "{rendered}");
+        assert!(rendered.contains("startup_timeout_sec = 5"), "{rendered}");
+        assert!(rendered.contains("[mcp_servers.remem]"), "{rendered}");
+    }
+
+    #[test]
+    fn upsert_is_idempotent() {
+        let mut doc = DocumentMut::new();
+        upsert_remem_server(&mut doc, "/tmp/remem").unwrap();
+        let first = doc.to_string();
+        upsert_remem_server(&mut doc, "/tmp/remem").unwrap();
+        let second = doc.to_string();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn upsert_updates_binary_path() {
+        let mut doc = DocumentMut::new();
+        upsert_remem_server(&mut doc, "/old/remem").unwrap();
+        upsert_remem_server(&mut doc, "/new/remem").unwrap();
+        let rendered = doc.to_string();
+        assert!(rendered.contains("/new/remem"), "{rendered}");
+        assert!(!rendered.contains("/old/remem"), "{rendered}");
+    }
+
+    #[test]
+    fn upsert_errors_when_mcp_servers_is_not_a_table() {
+        let src = r#"mcp_servers = "not-a-table"
+"#;
+        let mut doc: DocumentMut = src.parse().unwrap();
+        let err = upsert_remem_server(&mut doc, "/tmp/remem").unwrap_err();
+        assert!(err.to_string().contains("不是 table"), "{err}");
+    }
+
+    #[test]
+    fn remove_leaves_other_servers_intact() {
+        let src = r#"[mcp_servers.omx_state]
+command = "node"
+args = ["state-server.js"]
+enabled = true
+
+[mcp_servers.remem]
+command = "/tmp/remem"
+args = ["mcp"]
+enabled = true
+"#;
+        let mut doc: DocumentMut = src.parse().unwrap();
+        remove_remem_server(&mut doc, "/tmp/remem");
+        let rendered = doc.to_string();
+        assert!(rendered.contains("[mcp_servers.omx_state]"), "{rendered}");
+        assert!(!rendered.contains("[mcp_servers.remem]"), "{rendered}");
+    }
+
+    #[test]
+    fn remove_when_section_absent_is_noop() {
+        let src = "[other_section]\nkey = 1\n";
+        let mut doc: DocumentMut = src.parse().unwrap();
+        remove_remem_server(&mut doc, "/tmp/remem");
+        assert!(doc.to_string().contains("[other_section]"));
+    }
+
+    #[test]
+    fn remove_cleans_empty_section() {
+        let src = r#"[mcp_servers.remem]
+command = "/tmp/remem"
+args = ["mcp"]
+enabled = true
+"#;
+        let mut doc: DocumentMut = src.parse().unwrap();
+        remove_remem_server(&mut doc, "/tmp/remem");
+        let rendered = doc.to_string();
+        assert!(!rendered.contains("mcp_servers"), "{rendered}");
+    }
+}

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -79,8 +79,8 @@ fn read_toml_doc(path: &Path) -> Result<DocumentMut> {
     if !path.exists() {
         return Ok(DocumentMut::new());
     }
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("读取 {} 失败", path.display()))?;
+    let content =
+        std::fs::read_to_string(path).with_context(|| format!("读取 {} 失败", path.display()))?;
     content
         .parse::<DocumentMut>()
         .with_context(|| format!("解析 {} 失败（非法 TOML）", path.display()))

--- a/src/install/hosts/mod.rs
+++ b/src/install/hosts/mod.rs
@@ -1,0 +1,26 @@
+mod claude;
+mod codex;
+
+pub(in crate::install) use claude::ClaudeHost;
+pub(in crate::install) use codex::CodexHost;
+
+use crate::install::host::{InstallHost, InstallTarget};
+
+/// Resolve the concrete list of hosts to act on for a given target.
+///
+/// - `Claude` / `Codex`: single explicit host (always acted upon, even if
+///   config missing — the user asked for it).
+/// - `Auto`: only hosts whose config dir exists.
+/// - `All`: every known host, regardless of whether it's currently installed.
+pub(in crate::install) fn resolve_hosts(target: InstallTarget) -> Vec<Box<dyn InstallHost>> {
+    match target {
+        InstallTarget::Claude => vec![Box::new(ClaudeHost)],
+        InstallTarget::Codex => vec![Box::new(CodexHost)],
+        InstallTarget::All => vec![Box::new(ClaudeHost), Box::new(CodexHost)],
+        InstallTarget::Auto => {
+            let all: Vec<Box<dyn InstallHost>> =
+                vec![Box::new(ClaudeHost), Box::new(CodexHost)];
+            all.into_iter().filter(|h| h.is_available()).collect()
+        }
+    }
+}

--- a/src/install/hosts/mod.rs
+++ b/src/install/hosts/mod.rs
@@ -18,8 +18,7 @@ pub(in crate::install) fn resolve_hosts(target: InstallTarget) -> Vec<Box<dyn In
         InstallTarget::Codex => vec![Box::new(CodexHost)],
         InstallTarget::All => vec![Box::new(ClaudeHost), Box::new(CodexHost)],
         InstallTarget::Auto => {
-            let all: Vec<Box<dyn InstallHost>> =
-                vec![Box::new(ClaudeHost), Box::new(CodexHost)];
+            let all: Vec<Box<dyn InstallHost>> = vec![Box::new(ClaudeHost), Box::new(CodexHost)];
             all.into_iter().filter(|h| h.is_available()).collect()
         }
     }

--- a/src/install/json_io.rs
+++ b/src/install/json_io.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use serde_json::Value;
 use std::path::PathBuf;
 
-pub(super) fn read_json_file(path: &PathBuf) -> Result<Value> {
+pub(in crate::install) fn read_json_file(path: &PathBuf) -> Result<Value> {
     if path.exists() {
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("读取 {} 失败", path.display()))?;
@@ -12,7 +12,7 @@ pub(super) fn read_json_file(path: &PathBuf) -> Result<Value> {
     }
 }
 
-pub(super) fn write_json_file(path: &PathBuf, value: &Value) -> Result<()> {
+pub(in crate::install) fn write_json_file(path: &PathBuf, value: &Value) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }

--- a/src/install/paths.rs
+++ b/src/install/paths.rs
@@ -1,31 +1,45 @@
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 
-pub(super) fn settings_path() -> PathBuf {
+pub(in crate::install) fn settings_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".claude")
         .join("settings.json")
 }
 
-pub(super) fn claude_json_path() -> PathBuf {
+pub(in crate::install) fn claude_json_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".claude.json")
 }
 
-pub(super) fn old_hooks_path() -> PathBuf {
+pub(in crate::install) fn old_hooks_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".claude")
         .join("hooks.json")
 }
 
-pub(super) fn remem_data_dir() -> PathBuf {
+pub(in crate::install) fn codex_config_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".codex")
+        .join("config.toml")
+}
+
+pub(in crate::install) fn codex_hooks_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".codex")
+        .join("hooks.json")
+}
+
+pub(in crate::install) fn remem_data_dir() -> PathBuf {
     crate::db::data_dir()
 }
 
-pub(super) fn binary_path() -> Result<String> {
+pub(in crate::install) fn binary_path() -> Result<String> {
     let install_path = dirs::home_dir()
         .context("无法获取 HOME 目录")?
         .join(".local/bin/remem");

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -1,56 +1,44 @@
-use anyhow::{Context, Result};
-use serde_json::json;
+use anyhow::{bail, Result};
 
-use crate::install::config::{build_hooks, build_mcp_server, remove_remem_hooks, remove_remem_mcp};
-use crate::install::json_io::{read_json_file, write_json_file};
-use crate::install::paths::{
-    binary_path, claude_json_path, old_hooks_path, remem_data_dir, settings_path,
-};
+use crate::install::host::{HookSupport, InstallTarget};
+use crate::install::hosts::resolve_hosts;
+use crate::install::paths::{binary_path, old_hooks_path, remem_data_dir};
 
-pub fn install() -> Result<()> {
+pub fn install(target: InstallTarget, dry_run: bool) -> Result<()> {
     let bin = binary_path()?;
-    let settings_file = settings_path();
-    let claude_json_file = claude_json_path();
+    let hosts = resolve_hosts(target);
+    if hosts.is_empty() {
+        bail!(
+            "没检测到可用的 host（target=Auto 时仅安装已检测到的 host）。\n\
+             如需强制安装到全部 host，请使用 `--target all`。"
+        );
+    }
 
-    let mut settings = read_json_file(&settings_file)?;
-    remove_remem_hooks(&mut settings, &bin);
-    remove_remem_mcp(&mut settings, &bin);
-
-    let new_hooks = build_hooks(&bin);
-    let obj = settings
-        .as_object_mut()
-        .context("settings.json 根节点不是 Object")?;
-    let hooks = obj.entry("hooks").or_insert_with(|| json!({}));
-    if let (Some(existing), Some(new)) = (hooks.as_object_mut(), new_hooks.as_object()) {
-        for (event_type, entries) in new {
-            let arr = existing.entry(event_type).or_insert_with(|| json!([]));
-            if let (Some(arr), Some(new_entries)) = (arr.as_array_mut(), entries.as_array()) {
-                for entry in new_entries {
-                    arr.push(entry.clone());
-                }
+    if dry_run {
+        eprintln!("remem install (dry-run) — 以下写入不会被执行:");
+        for host in &hosts {
+            eprintln!("→ {}", host.name());
+            for line in host.dry_run_plan(&bin) {
+                eprintln!("{line}");
             }
         }
+        eprintln!("  data   -> {}", remem_data_dir().display());
+        return Ok(());
     }
-    write_json_file(&settings_file, &settings)?;
 
-    let mut claude_json = read_json_file(&claude_json_file)?;
-    remove_remem_mcp(&mut claude_json, &bin);
-
-    let obj = claude_json
-        .as_object_mut()
-        .context("~/.claude.json 根节点不是 Object")?;
-    let mcp_servers = obj.entry("mcpServers").or_insert_with(|| json!({}));
-    if let Some(servers) = mcp_servers.as_object_mut() {
-        servers.insert("remem".to_string(), build_mcp_server(&bin));
+    eprintln!("remem install:");
+    for host in &hosts {
+        eprintln!("→ {}", host.name());
+        host.install_mcp(&bin)?;
+        eprintln!("  MCP    -> {}", host.config_path().display());
+        match host.install_hooks(&bin)? {
+            HookSupport::Installed => eprintln!("  hooks  ✓"),
+            HookSupport::Skipped(reason) => eprintln!("  hooks  skipped: {reason}"),
+        }
     }
-    write_json_file(&claude_json_file, &claude_json)?;
 
     let data_dir = remem_data_dir();
     std::fs::create_dir_all(&data_dir)?;
-
-    eprintln!("remem install complete:");
-    eprintln!("  hooks  -> {}", settings_file.display());
-    eprintln!("  MCP    -> {}", claude_json_file.display());
     eprintln!("  data   -> {}", data_dir.display());
     eprintln!("  binary -> {}", bin);
 
@@ -66,31 +54,36 @@ pub fn install() -> Result<()> {
 
     eprintln!();
     eprintln!("Next steps:");
-    eprintln!("  1. Restart Claude Code (quit and reopen)");
-    eprintln!("  2. remem will automatically capture your sessions");
+    eprintln!("  1. Restart the affected host(s) (Claude Code / Codex)");
+    eprintln!("  2. remem will automatically capture your sessions (hosts with hook support)");
     eprintln!("  3. Run 'remem status' to check system health");
 
     Ok(())
 }
 
-pub fn uninstall() -> Result<()> {
+pub fn uninstall(target: InstallTarget, dry_run: bool) -> Result<()> {
     let bin = binary_path()?;
-    let settings_file = settings_path();
-    let claude_json_file = claude_json_path();
+    // Uninstall defaults to "all known hosts" so a stale config isn't left
+    // behind if the user removed a host before running uninstall.
+    let effective = if matches!(target, InstallTarget::Auto) {
+        InstallTarget::All
+    } else {
+        target
+    };
+    let hosts = resolve_hosts(effective);
 
-    if settings_file.exists() {
-        let mut settings = read_json_file(&settings_file)?;
-        remove_remem_hooks(&mut settings, &bin);
-        remove_remem_mcp(&mut settings, &bin);
-        write_json_file(&settings_file, &settings)?;
-        eprintln!("  hooks 已从 {} 移除", settings_file.display());
+    if dry_run {
+        eprintln!("remem uninstall (dry-run) — 以下删除不会被执行:");
+        for host in &hosts {
+            eprintln!("→ {}: 移除 {}", host.name(), host.config_path().display());
+        }
+        return Ok(());
     }
 
-    if claude_json_file.exists() {
-        let mut claude_json = read_json_file(&claude_json_file)?;
-        remove_remem_mcp(&mut claude_json, &bin);
-        write_json_file(&claude_json_file, &claude_json)?;
-        eprintln!("  MCP 已从 {} 移除", claude_json_file.display());
+    for host in &hosts {
+        host.uninstall_mcp(&bin)?;
+        host.uninstall_hooks(&bin)?;
+        eprintln!("  {} 已清理 ({})", host.name(), host.config_path().display());
     }
 
     eprintln!("remem uninstall 完成");

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -83,7 +83,11 @@ pub fn uninstall(target: InstallTarget, dry_run: bool) -> Result<()> {
     for host in &hosts {
         host.uninstall_mcp(&bin)?;
         host.uninstall_hooks(&bin)?;
-        eprintln!("  {} 已清理 ({})", host.name(), host.config_path().display());
+        eprintln!(
+            "  {} 已清理 ({})",
+            host.name(),
+            host.config_path().display()
+        );
     }
 
     eprintln!("remem uninstall 完成");


### PR DESCRIPTION
## Summary
- Abstract install into an `InstallHost` trait; `remem install` now supports `--target {auto,claude,codex,all}` and `--dry-run`
- Register remem MCP + hooks into Codex (`~/.codex/config.toml` + `~/.codex/hooks.json`) using `toml_edit` to preserve comments
- `remem doctor` reports per-host status (`Hooks (claude)` / `Hooks (codex)` / `MCP (claude)` / `MCP (codex)`)

## Test plan
- [x] `cargo test --lib install` (11 passed — upsert preserves comments/siblings, idempotent, errors on non-table `mcp_servers`)
- [ ] End-to-end install against a real Codex CLI
- [ ] Hooks merge on a pre-existing `~/.codex/hooks.json`