### PR TITLE
fix(dream): wrap apply() upsert and stale-mark in a single transaction

### DIFF
--- a/src/dream.rs
+++ b/src/dream.rs
@@ -14,7 +14,7 @@ pub(crate) fn list_clusters(project: &str) -> Result<Vec<Cluster>> {
 }
 
 pub async fn process_dream_job(project: &str) -> Result<()> {
-    let conn = crate::db::open_db()?;
+    let mut conn = crate::db::open_db()?;
     let clusters = load_clusters(&conn, project)?;
 
     if clusters.is_empty() {
@@ -36,7 +36,7 @@ pub async fn process_dream_job(project: &str) -> Result<()> {
     for cluster in &clusters {
         match merge_cluster(cluster, project).await? {
             MergeDecision::Merge(result) => {
-                apply::apply(&conn, project, &result)?;
+                apply::apply(&mut conn, project, &result)?;
                 merged += 1;
                 crate::log::info(
                     "dream",

--- a/src/dream/apply.rs
+++ b/src/dream/apply.rs
@@ -100,4 +100,68 @@ mod tests {
             .unwrap();
         assert_eq!(status, "stale");
     }
+
+    /// Proves the all-or-nothing guarantee: if the stale-mark UPDATE fails after
+    /// `insert_memory_full` has already run, the entire transaction must roll back
+    /// so no partial state is persisted.
+    #[test]
+    fn test_apply_rolls_back_insert_when_stale_mark_fails() {
+        let (mut conn, project) = setup();
+
+        // Trigger causes every stale-mark UPDATE to fail, simulating a mid-transaction crash.
+        conn.execute_batch(
+            "CREATE TRIGGER force_stale_fail
+             BEFORE UPDATE OF status ON memories
+             WHEN NEW.status = 'stale'
+             BEGIN
+                 SELECT RAISE(ABORT, 'forced stale-mark failure');
+             END;",
+        )
+        .expect("create trigger");
+
+        let old_id = insert_memory(
+            &conn,
+            Some("sess-x"),
+            &project,
+            None,
+            "predecessor",
+            "will be superseded",
+            "decision",
+            None,
+        )
+        .expect("insert predecessor");
+
+        let result = MergeResult {
+            topic_key: "rollback-topic".to_owned(),
+            memory_type: "decision".to_owned(),
+            title: "Should not persist".to_owned(),
+            content: "Transaction must roll back".to_owned(),
+            superseded_ids: vec![old_id],
+        };
+
+        assert!(
+            apply(&mut conn, &project, &result).is_err(),
+            "apply() must propagate the stale-mark failure"
+        );
+
+        // The merged memory must NOT be present — insert was rolled back.
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE project = ?1 AND topic_key = ?2",
+                params![&project, "rollback-topic"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "merged memory insert must be rolled back");
+
+        // Predecessor must still be active — stale-mark was also rolled back.
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM memories WHERE id = ?1",
+                params![old_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "active", "predecessor status must be unchanged on rollback");
+    }
 }

--- a/src/dream/apply.rs
+++ b/src/dream/apply.rs
@@ -3,10 +3,11 @@ use rusqlite::{params, Connection};
 
 use super::merge::MergeResult;
 
-pub(super) fn apply(conn: &Connection, project: &str, result: &MergeResult) -> Result<()> {
-    // Upsert the merged memory (reuses existing topic_key upsert logic)
+pub(super) fn apply(conn: &mut Connection, project: &str, result: &MergeResult) -> Result<()> {
+    let tx = conn.transaction()?;
+
     crate::memory::insert_memory_full(
-        conn,
+        &tx,
         Some("dream"),
         project,
         Some(&result.topic_key),
@@ -19,14 +20,14 @@ pub(super) fn apply(conn: &Connection, project: &str, result: &MergeResult) -> R
         None,
     )?;
 
-    // Mark superseded memories as stale
     for id in &result.superseded_ids {
-        conn.execute(
+        tx.execute(
             "UPDATE memories SET status = 'stale' WHERE id = ?1 AND project = ?2",
             params![id, project],
         )?;
     }
 
+    tx.commit()?;
     Ok(())
 }
 
@@ -46,7 +47,7 @@ mod tests {
 
     #[test]
     fn test_apply_upserts_merged_memory() {
-        let (conn, project) = setup();
+        let (mut conn, project) = setup();
         let result = MergeResult {
             topic_key: "merged-topic".to_owned(),
             memory_type: "decision".to_owned(),
@@ -54,7 +55,7 @@ mod tests {
             content: "Merged content".to_owned(),
             superseded_ids: vec![],
         };
-        apply(&conn, &project, &result).expect("apply");
+        apply(&mut conn, &project, &result).expect("apply");
 
         let count: i64 = conn
             .query_row(
@@ -68,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_apply_marks_superseded_stale() {
-        let (conn, project) = setup();
+        let (mut conn, project) = setup();
         let old_id = insert_memory(
             &conn,
             Some("sess-1"),
@@ -88,7 +89,7 @@ mod tests {
             content: "New content".to_owned(),
             superseded_ids: vec![old_id],
         };
-        apply(&conn, &project, &result).expect("apply");
+        apply(&mut conn, &project, &result).expect("apply");
 
         let status: String = conn
             .query_row(


### PR DESCRIPTION
## Summary

- `apply()` in `src/dream/apply.rs` previously performed `insert_memory_full()` and the stale-marking UPDATE loop as separate, non-atomic writes
- A crash between those two operations would leave merged and predecessor memories both active, producing duplicate active records with overlapping `topic_keys`
- Wraps both writes in a single `conn.transaction()` / `tx.commit()`, matching the pattern used in `db/summarize/session/finalize.rs`

## Test plan

- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test` — 20 tests pass
- [ ] Existing tests `test_apply_upserts_merged_memory` and `test_apply_marks_superseded_stale` exercise both write paths through the transaction