### PR TITLE
fix(flush): warn on build_existing_context failure in single-item path

### DIFF
--- a/src/observe_flush/task.rs
+++ b/src/observe_flush/task.rs
@@ -29,7 +29,14 @@ pub(crate) async fn flush_single_task(
         return Ok(0);
     }
 
-    let existing_context = build_existing_context(conn, project).unwrap_or_default();
+    let existing_context = build_existing_context(conn, project)
+        .map_err(|err| {
+            crate::log::warn(
+                "flush",
+                &format!("existing context failed (continuing): {}", err),
+            );
+        })
+        .unwrap_or_default();
     let events = build_session_events_xml(std::slice::from_ref(pending));
     let user_message = format!(
         "{}<session_events>\n{}</session_events>",

--- a/src/observe_flush/task.rs
+++ b/src/observe_flush/task.rs
@@ -138,7 +138,8 @@ mod tests {
         let mut conn = Connection::open_in_memory()?;
         let pending = make_pending("A".repeat(200)); // > MIN_TASK_RESPONSE_LEN (100)
 
-        let result = flush_single_task(&mut conn, "sess-test", "test-proj", "owner", &pending).await;
+        let result =
+            flush_single_task(&mut conn, "sess-test", "test-proj", "owner", &pending).await;
 
         // The SQLite context error must NOT propagate as the returned Err.
         if let Err(ref e) = result {

--- a/src/observe_flush/task.rs
+++ b/src/observe_flush/task.rs
@@ -85,3 +85,61 @@ pub(crate) async fn flush_single_task(
 
     Ok(observations.len())
 }
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use crate::db::PendingObservation;
+
+    use super::flush_single_task;
+
+    /// Regression guard for https://github.com/majiayu000/remem/issues/30.
+    ///
+    /// When the DB is missing the context tables, `build_existing_context` returns
+    /// `Err`.  The fix at task.rs:32 must swallow that error as a warning and
+    /// continue — not propagate it.  We verify by checking that the error returned
+    /// (which will be from the downstream AI call, not from SQLite) does NOT
+    /// contain the SQLite "no such table" sentinel that would indicate the context
+    /// error leaked through.
+    #[tokio::test]
+    async fn flush_single_task_continues_when_context_tables_missing() -> anyhow::Result<()> {
+        // Empty in-memory DB — no tables at all, so build_existing_context fails.
+        let mut conn = Connection::open_in_memory()?;
+
+        let long_response = "A".repeat(200); // > MIN_TASK_RESPONSE_LEN (100)
+        let pending = PendingObservation {
+            id: 1,
+            session_id: "sess-test".to_string(),
+            project: "test-proj".to_string(),
+            tool_name: "Bash".to_string(),
+            tool_input: Some("echo hello".to_string()),
+            tool_response: Some(long_response),
+            cwd: None,
+            created_at_epoch: 0,
+            updated_at_epoch: 0,
+            status: "claimed".to_string(),
+            attempt_count: 1,
+            next_retry_epoch: None,
+            last_error: None,
+        };
+
+        let result = flush_single_task(&mut conn, "sess-test", "test-proj", "owner", &pending).await;
+
+        // build_existing_context queries `observations` and `memories`.  If its
+        // error leaks through, the returned Err will contain one of those table
+        // names.  Any other error (AI call failure, missing pending_observations
+        // table, etc.) is irrelevant to this regression guard.
+        if let Err(ref e) = result {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("no such table: observations")
+                    && !msg.contains("no such table: memories"),
+                "build_existing_context error leaked into flush_single_task: {}",
+                e
+            );
+        }
+        // Ok(_) is also acceptable (e.g. if the full pipeline completes in CI).
+        Ok(())
+    }
+}

--- a/src/observe_flush/task.rs
+++ b/src/observe_flush/task.rs
@@ -90,25 +90,13 @@ pub(crate) async fn flush_single_task(
 mod tests {
     use rusqlite::Connection;
 
+    use crate::db::test_support::ScopedTestDataDir;
     use crate::db::PendingObservation;
 
     use super::flush_single_task;
 
-    /// Regression guard for https://github.com/majiayu000/remem/issues/30.
-    ///
-    /// When the DB is missing the context tables, `build_existing_context` returns
-    /// `Err`.  The fix at task.rs:32 must swallow that error as a warning and
-    /// continue — not propagate it.  We verify by checking that the error returned
-    /// (which will be from the downstream AI call, not from SQLite) does NOT
-    /// contain the SQLite "no such table" sentinel that would indicate the context
-    /// error leaked through.
-    #[tokio::test]
-    async fn flush_single_task_continues_when_context_tables_missing() -> anyhow::Result<()> {
-        // Empty in-memory DB — no tables at all, so build_existing_context fails.
-        let mut conn = Connection::open_in_memory()?;
-
-        let long_response = "A".repeat(200); // > MIN_TASK_RESPONSE_LEN (100)
-        let pending = PendingObservation {
+    fn make_pending(long_response: String) -> PendingObservation {
+        PendingObservation {
             id: 1,
             session_id: "sess-test".to_string(),
             project: "test-proj".to_string(),
@@ -122,14 +110,37 @@ mod tests {
             attempt_count: 1,
             next_retry_epoch: None,
             last_error: None,
-        };
+        }
+    }
+
+    /// Regression guard for https://github.com/majiayu000/remem/issues/30.
+    ///
+    /// When `build_existing_context` fails (e.g. "no such table: observations"),
+    /// the fix at task.rs:32 must emit a WARN log entry and then continue —
+    /// not propagate the error.  This test verifies the warning was actually
+    /// written to the log file.  A bare `.unwrap_or_default()` (the pre-fix
+    /// regression) produces no log output and would therefore fail this assertion,
+    /// distinguishing it from the fixed `.map_err(warn).unwrap_or_default()` path.
+    // ScopedTestDataDir holds a std::sync::MutexGuard (!Send) to serialize env-var
+    // access. Holding it across .await is intentional here: the warning fires
+    // before the first await, and the guard must stay alive until we read the log
+    // file after the call returns. #[tokio::test] uses a current-thread runtime
+    // so the future need not be Send.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn flush_single_task_warns_on_context_build_failure() -> anyhow::Result<()> {
+        // Redirect REMEM_DATA_DIR so we can read the log file and assert the
+        // warning was emitted.
+        let data_dir = ScopedTestDataDir::new("flush-single-warn");
+        let log_path = data_dir.path.join("remem.log");
+
+        // Empty in-memory DB — no tables at all, so build_existing_context fails.
+        let mut conn = Connection::open_in_memory()?;
+        let pending = make_pending("A".repeat(200)); // > MIN_TASK_RESPONSE_LEN (100)
 
         let result = flush_single_task(&mut conn, "sess-test", "test-proj", "owner", &pending).await;
 
-        // build_existing_context queries `observations` and `memories`.  If its
-        // error leaks through, the returned Err will contain one of those table
-        // names.  Any other error (AI call failure, missing pending_observations
-        // table, etc.) is irrelevant to this regression guard.
+        // The SQLite context error must NOT propagate as the returned Err.
         if let Err(ref e) = result {
             let msg = e.to_string();
             assert!(
@@ -139,7 +150,16 @@ mod tests {
                 e
             );
         }
-        // Ok(_) is also acceptable (e.g. if the full pipeline completes in CI).
+
+        // Core regression guard: the WARN line must be present in the log file.
+        // The pre-fix code (bare .unwrap_or_default()) never wrote this line,
+        // so this assertion fails on the old implementation and passes on the fix.
+        let log_content = std::fs::read_to_string(&log_path).unwrap_or_default();
+        assert!(
+            log_content.contains("existing context failed (continuing)"),
+            "expected WARN 'existing context failed (continuing)' in {log_path:?}, got:\n{log_content}"
+        );
+
         Ok(())
     }
 }

--- a/src/observe_flush/task.rs
+++ b/src/observe_flush/task.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use std::future::Future;
+use std::pin::Pin;
 
 use crate::db;
 use crate::memory_format;
@@ -14,6 +16,40 @@ pub(crate) async fn flush_single_task(
     lease_owner: &str,
     pending: &db::PendingObservation,
 ) -> Result<usize> {
+    flush_single_task_with_ai(
+        conn,
+        session_id,
+        project,
+        lease_owner,
+        pending,
+        |user_message, project| {
+            Box::pin(async move {
+                crate::ai::call_ai(
+                    TASK_OBSERVATION_PROMPT,
+                    &user_message,
+                    crate::ai::UsageContext {
+                        project: Some(project),
+                        operation: "flush-task",
+                    },
+                )
+                .await
+            })
+        },
+    )
+    .await
+}
+
+async fn flush_single_task_with_ai<F>(
+    conn: &mut rusqlite::Connection,
+    session_id: &str,
+    project: &str,
+    lease_owner: &str,
+    pending: &db::PendingObservation,
+    call_ai: F,
+) -> Result<usize>
+where
+    F: for<'a> FnOnce(String, &'a str) -> Pin<Box<dyn Future<Output = Result<String>> + 'a>>,
+{
     let response_text = pending.tool_response.as_deref().unwrap_or("");
     if response_text.len() < MIN_TASK_RESPONSE_LEN {
         let reason = format!(
@@ -44,15 +80,7 @@ pub(crate) async fn flush_single_task(
     );
 
     let ai_start = std::time::Instant::now();
-    let response = crate::ai::call_ai(
-        TASK_OBSERVATION_PROMPT,
-        &user_message,
-        crate::ai::UsageContext {
-            project: Some(project),
-            operation: "flush-task",
-        },
-    )
-    .await?;
+    let response = call_ai(user_message, project).await?;
     let ai_ms = ai_start.elapsed().as_millis();
 
     crate::log::info(
@@ -88,12 +116,37 @@ pub(crate) async fn flush_single_task(
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::{OsStr, OsString};
+
     use rusqlite::Connection;
 
     use crate::db::test_support::ScopedTestDataDir;
     use crate::db::PendingObservation;
 
-    use super::flush_single_task;
+    use super::flush_single_task_with_ai;
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.as_ref() {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
 
     fn make_pending(long_response: String) -> PendingObservation {
         PendingObservation {
@@ -116,11 +169,9 @@ mod tests {
     /// Regression guard for https://github.com/majiayu000/remem/issues/30.
     ///
     /// When `build_existing_context` fails (e.g. "no such table: observations"),
-    /// the fix at task.rs:32 must emit a WARN log entry and then continue —
-    /// not propagate the error.  This test verifies the warning was actually
-    /// written to the log file.  A bare `.unwrap_or_default()` (the pre-fix
-    /// regression) produces no log output and would therefore fail this assertion,
-    /// distinguishing it from the fixed `.map_err(warn).unwrap_or_default()` path.
+    /// the flush should emit a WARN log entry and continue to the AI step instead
+    /// of leaking the SQLite error. This test injects a stub AI caller so the
+    /// assertion stays unit-local and never touches the live CLI or HTTP path.
     // ScopedTestDataDir holds a std::sync::MutexGuard (!Send) to serialize env-var
     // access. Holding it across .await is intentional here: the warning fires
     // before the first await, and the guard must stay alive until we read the log
@@ -129,17 +180,27 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn flush_single_task_warns_on_context_build_failure() -> anyhow::Result<()> {
-        // Redirect REMEM_DATA_DIR so we can read the log file and assert the
-        // warning was emitted.
         let data_dir = ScopedTestDataDir::new("flush-single-warn");
         let log_path = data_dir.path.join("remem.log");
+        let _executor = ScopedEnvVar::set("REMEM_EXECUTOR", "cli");
+        let missing_claude = data_dir.path.join("missing-claude");
+        let _claude_path = ScopedEnvVar::set("REMEM_CLAUDE_PATH", &missing_claude);
 
         // Empty in-memory DB — no tables at all, so build_existing_context fails.
         let mut conn = Connection::open_in_memory()?;
         let pending = make_pending("A".repeat(200)); // > MIN_TASK_RESPONSE_LEN (100)
 
-        let result =
-            flush_single_task(&mut conn, "sess-test", "test-proj", "owner", &pending).await;
+        let result = flush_single_task_with_ai(
+            &mut conn,
+            "sess-test",
+            "test-proj",
+            "owner",
+            &pending,
+            |_user_message, _project| {
+                Box::pin(async { Err(anyhow::anyhow!("stub ai failure after context build")) })
+            },
+        )
+        .await;
 
         // The SQLite context error must NOT propagate as the returned Err.
         if let Err(ref e) = result {
@@ -150,11 +211,15 @@ mod tests {
                 "build_existing_context error leaked into flush_single_task: {}",
                 e
             );
+            assert!(
+                msg.contains("stub ai failure after context build"),
+                "expected injected AI stub failure, got: {}",
+                e
+            );
+        } else {
+            anyhow::bail!("expected injected AI stub failure");
         }
 
-        // Core regression guard: the WARN line must be present in the log file.
-        // The pre-fix code (bare .unwrap_or_default()) never wrote this line,
-        // so this assertion fails on the old implementation and passes on the fix.
         let log_content = std::fs::read_to_string(&log_path).unwrap_or_default();
         assert!(
             log_content.contains("existing context failed (continuing)"),


### PR DESCRIPTION
## Summary

- `src/observe_flush/task.rs:32` silently swallowed errors from `build_existing_context()` via `.unwrap_or_default()`, violating U-29
- Applied the same `warn`-level log already used by the batch flush path in `runner.rs`, making the failure observable in logs
- No behaviour change on the success path; error path now emits a warning and continues with empty context (same as before, but visible)

Closes #30

## Test plan

- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test` — 208 tests pass, 0 failures