### PR TITLE
fix(migrate): propagate row errors in applied_versions (U-29)

### DIFF
--- a/src/migrate/state.rs
+++ b/src/migrate/state.rs
@@ -23,10 +23,9 @@ pub(super) fn has_migration_table(conn: &Connection) -> bool {
 
 pub(super) fn applied_versions(conn: &Connection) -> Result<Vec<i64>> {
     let mut stmt = conn.prepare("SELECT version FROM _schema_migrations ORDER BY version")?;
-    let versions = stmt
+    let versions: Vec<i64> = stmt
         .query_map([], |row| row.get(0))?
-        .filter_map(|row| row.ok())
-        .collect();
+        .collect::<rusqlite::Result<Vec<i64>>>()?;
     Ok(versions)
 }
 

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -266,6 +266,22 @@ fn dry_run_skips_schema_migrations_regardless_of_sql_quoting() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn applied_versions_propagates_row_error() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    // TEXT column so we can insert a non-numeric value that fails i64 deserialization.
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (version TEXT, name TEXT NOT NULL, applied_at_epoch INTEGER NOT NULL);
+         INSERT INTO _schema_migrations VALUES ('1', 'baseline', 1700000000);
+         INSERT INTO _schema_migrations VALUES ('not-a-number', 'bad', 1700000001);",
+    )?;
+    assert!(
+        applied_versions(&conn).is_err(),
+        "applied_versions must propagate row deserialization errors instead of silently dropping them"
+    );
+    Ok(())
+}
+
 fn create_v13_schema_without_scope(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "CREATE TABLE memories (


### PR DESCRIPTION
## Summary

- Replace `filter_map(|row| row.ok())` with `collect::<rusqlite::Result<Vec<i64>>>()?` in `applied_versions()` (`src/migrate/state.rs`)
- A deserialization failure in any row (e.g. NULL or wrong type in the `version` column) now propagates as an error instead of silently excluding that version and triggering a re-apply of the migration
- Add `applied_versions_propagates_row_error` test that inserts a non-numeric version string and asserts `applied_versions` returns `Err`

## Test plan

- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test` — 209 passed, 0 failed (including new test `migrate::tests::applied_versions_propagates_row_error`)

Closes #28