### PR TITLE
feat(raw-archive): decouple raw capture from curated memory

### DIFF
--- a/SPEC-raw-archive-vs-curated-memory-2026-04-22.md
+++ b/SPEC-raw-archive-vs-curated-memory-2026-04-22.md
@@ -1,0 +1,157 @@
+---
+spec: raw-archive-vs-curated-memory
+status: active
+date: 2026-04-22
+owner: remem
+---
+
+# Raw Archive vs Curated Memory（采集与提炼解耦）
+
+## 问题
+
+当前 remem 的写入链路是：
+`hook → summarize（AI 提炼 + cooldown/duplicate/skip 判断）→ promote（长度阈值 + 类型过滤）→ memories`。
+
+结果：一段实际发生过的对话，只要在 summarize/promote 的任一步被跳过或过滤，就在 remem 里**彻底不可检索**。
+已复现用例：trainer-hub 项目下的 VPS 采购对话存在于 `.claude/history.jsonl`（见行号 3727-3743），但
+- `session_summaries` 里没有对应条目
+- `memories` 里搜不到 RackNerd / OVHcloud / Hetzner 这些关键词
+
+CLAUDE.md 已经记录了这是**致命设计缺陷**。本 spec 定义修复方案。
+
+## 目标
+
+把单层管道拆成两层：
+
+1. **Raw archive（采集保证层）**
+   - 每一条用户 prompt 和每一条 assistant 回复都必须落库。
+   - 允许噪音，允许重复，允许低价值。
+   - 唯一保证：**发生过的 → 可回忆**。
+
+2. **Curated memory（提炼精选层）**
+   - 只存 decision / discovery / preference / bugfix / architecture。
+   - 由现有 summarize → promote 管道产出。
+   - 允许跳过、去重、过滤。
+   - 唯一保证：**高信号、低噪音**。
+
+## 非目标
+
+- 不保留 tool_input / tool_response 原文（已在 `pending_observations` / `events` 里）。
+- 不替代 `session_summaries`，summary 依旧是人类可读的总结层。
+- 不改 save_memory 语义。
+
+## 数据模型
+
+新表 `raw_messages`（schema v2）：
+
+```sql
+CREATE TABLE IF NOT EXISTS raw_messages (
+    id INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    project TEXT NOT NULL,
+    role TEXT NOT NULL,                 -- 'user' | 'assistant'
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,         -- FNV64 hex of content
+    source TEXT NOT NULL,               -- 'transcript' | 'hook' | 'manual'
+    branch TEXT,
+    cwd TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    UNIQUE(project, role, content_hash)
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS raw_messages_fts USING fts5(
+    content,
+    content='raw_messages',
+    content_rowid='id',
+    tokenize='trigram'
+);
+-- + AI/AD/AU triggers analogous to memories_fts
+
+CREATE INDEX idx_raw_messages_project_created
+    ON raw_messages(project, created_at_epoch DESC);
+CREATE INDEX idx_raw_messages_session
+    ON raw_messages(session_id, created_at_epoch);
+```
+
+UNIQUE 做的是**项目内 role+content 去重**，同一段内容多次聊天只存一份，但时间戳按首次出现记录。
+
+## 写入入口
+
+只改 `Stop` hook（`remem summarize`）：
+
+```
+process_summary_job_input(input):
+    parse SummarizeInput
+    ----- NEW -----
+    if transcript_path:
+        drain_transcript_into_raw_archive(
+            transcript_path, session_id, project, branch, cwd
+        )
+    elif last_assistant_message:
+        insert_raw_message(
+            session_id, project, 'assistant', last_assistant_message, 'hook'
+        )
+    ----- 原有逻辑 -----
+    cooldown / duplicate / length guard ...
+    AI summarize → promote
+```
+
+要点：
+- Raw 写入**发生在所有 summary 短路之前**。summarize 被 cooldown、duplicate、AI skip、长度不足跳过，都不影响 raw 落库。
+- Transcript drain 顺序扫描 jsonl，对每条 `type=user` 和 `type=assistant` 抽文本插入；UNIQUE 约束保证幂等，跨多次 Stop hook 重复 drain 不会膨胀。
+- 写入失败只 `log::warn`，**不 propagate**——raw 落库是 best-effort，不能拖垮 summarize 主流程。
+
+## 检索入口
+
+### 新 MCP 工具：`search_raw`
+
+```
+search_raw(query, project?, role?, limit?, offset?, include_stale?) -> [RawHit]
+```
+
+- 纯 FTS5 查询 `raw_messages_fts`
+- 返回字段：id, session_id, project, role, content (300-char preview), created_at, branch
+- 文档中明确说明：这是**原始聊天内容**，可能含噪音，但保证"聊过的一定能搜到"。
+
+### 修改 `search` 行为
+
+`memory_service::search_memories` 在 curated 结果 < 3 条时，**自动 fallback** 查 raw_messages 并把结果以 `raw_hits` 字段一起返回（而不是替换 curated 结果）。MCP `search` 工具响应结构：
+
+```json
+{
+  "results": [...],
+  "raw_hits": [...],        // only present when fallback triggered
+  "multi_hop": {...}        // optional, as today
+}
+```
+
+前端提示词更新：当 curated 空但 raw_hits 非空时，agent 应说"这段内容只存在于 raw archive，没有被提炼为长期记忆"。
+
+## 运维 / CLI
+
+- `remem status` 增加一行 `raw_messages` 计数（和 sessions/summaries/memories 并列）。
+- 不提供独立的 `remem raw` CLI 子命令（最小化改动；用 MCP `search_raw` 即可）。
+- 不提供 GC（暂）；后续按 `created_at_epoch` 做按项目/时间窗裁剪时再加。
+
+## 迁移
+
+新增 migration `v002_raw_messages.sql`。不回填历史 transcript——历史就是历史，raw archive 从启用之日起生效。
+不做兼容：任何旧读路径都不会触碰新表。
+
+## 不做的事（显式拒绝）
+
+- **不做 raw → memory 自动 promote**。Raw archive 的作用是兜底检索，不是 curated 层的输入源。如果要把 VPS 这类聊天升格为 preference，走 save_memory。
+- **不用 raw_messages 做上下文注入**。只在显式 search_raw 时可见。
+- **不加密 content**。现有 DB 已有可选加密，复用同一路径。
+
+## 验证
+
+1. 启用后，在 `/Users/lifcc/Desktop/code/AI/tools/trainer-hub` 项目发一条含 "VPS RackNerd" 的对话。
+2. Stop hook 触发 → `raw_messages` 至少新增 1 条 role=user 记录。
+3. 即便该会话 summary 被 cooldown/duplicate/skip 跳过，`search_raw("VPS RackNerd")` 也能命中。
+4. `search("VPS")` 在 curated 无命中时，自动带回 raw_hits。
+
+## 相关记忆
+
+- decision#40469 `raw-archive-vs-curated-memory`（本 spec 的原始决策）
+- CLAUDE.md 错误 2：save_memory 不会被调用

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -29,6 +29,7 @@ pub(in crate::cli) fn run_status() -> Result<()> {
     println!("  Memories:      {:>6}", stats.active_memories);
     println!("  Observations:  {:>6}", stats.active_observations);
     println!("  Sessions:      {:>6}", stats.session_summaries);
+    println!("  Raw messages:  {:>6}", stats.raw_messages);
     println!("  Pending:       {:>6}", stats.pending_observations);
     println!("  Pending failed:{:>6}", stats.failed_pending_observations);
     println!();

--- a/src/db_query/stats.rs
+++ b/src/db_query/stats.rs
@@ -8,6 +8,7 @@ pub struct SystemStats {
     pub active_memories: i64,
     pub active_observations: i64,
     pub session_summaries: i64,
+    pub raw_messages: i64,
     pub pending_observations: i64,
     pub failed_pending_observations: i64,
     pub stuck_jobs: i64,
@@ -40,6 +41,7 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
         session_summaries: conn.query_row("SELECT COUNT(*) FROM session_summaries", [], |row| {
             row.get(0)
         })?,
+        raw_messages: conn.query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))?,
         pending_observations: conn.query_row(
             "SELECT COUNT(*) FROM pending_observations WHERE status = 'pending'",
             [],

--- a/src/db_query/stats/tests.rs
+++ b/src/db_query/stats/tests.rs
@@ -20,6 +20,9 @@ fn setup_stats_schema(conn: &Connection) {
         CREATE TABLE session_summaries (
             id INTEGER PRIMARY KEY
         );
+        CREATE TABLE raw_messages (
+            id INTEGER PRIMARY KEY
+        );
         CREATE TABLE pending_observations (
             id INTEGER PRIMARY KEY,
             status TEXT NOT NULL
@@ -88,6 +91,7 @@ fn query_system_stats_and_related_views_share_one_definition() {
             active_memories: 2,
             active_observations: 1,
             session_summaries: 1,
+            raw_messages: 0,
             pending_observations: 1,
             failed_pending_observations: 1,
             stuck_jobs: 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod pending_admin;
 pub mod preference;
 pub mod project_id;
 pub mod query_expand;
+pub mod raw_archive;
 pub mod search;
 pub mod search_multihop;
 pub mod summarize;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,4 +1,5 @@
 mod context_tools;
+mod raw_tools;
 mod runtime;
 mod search_tools;
 #[cfg(test)]
@@ -20,7 +21,8 @@ impl MemoryServer {
             tool_router: Self::tool_router_search()
                 + Self::tool_router_context()
                 + Self::tool_router_write()
-                + Self::tool_router_workstream(),
+                + Self::tool_router_workstream()
+                + Self::tool_router_raw(),
         })
     }
 

--- a/src/mcp/server/raw_tools.rs
+++ b/src/mcp/server/raw_tools.rs
@@ -1,0 +1,74 @@
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{tool, tool_router};
+
+use super::super::types::{RawSearchHit, SearchRawParams};
+use super::MemoryServer;
+use crate::raw_archive;
+
+const PREVIEW_CHARS: usize = 300;
+
+#[tool_router(router = tool_router_raw, vis = "pub(super)")]
+impl MemoryServer {
+    #[tool(
+        description = "Search the raw archive (every user/assistant turn captured by the Stop hook). \
+        Use this when `search` returns no curated match or you need to recall a literal phrase from past chats. \
+        Returns the untreated conversation content — expect noise. \
+        The raw archive is what guarantees 'what was said remains searchable' even when summarize/promote skip a turn."
+    )]
+    pub(super) fn search_raw(
+        &self,
+        Parameters(params): Parameters<SearchRawParams>,
+    ) -> Result<String, String> {
+        let start = std::time::Instant::now();
+        crate::log::info(
+            "mcp",
+            &format!(
+                "search_raw called query={:?} project={:?} role={:?} limit={} offset={}",
+                params.query,
+                params.project,
+                params.role,
+                params.limit.unwrap_or(20),
+                params.offset.unwrap_or(0),
+            ),
+        );
+        self.with_conn(|conn| {
+            let req = raw_archive::RawSearchRequest {
+                query: params.query.clone(),
+                project: params.project.clone(),
+                role: params.role.clone(),
+                limit: params.limit.unwrap_or(20),
+                offset: params.offset.unwrap_or(0),
+            };
+            let hits = raw_archive::search_raw_messages(conn, &req).map_err(|e| {
+                crate::log::warn("mcp", &format!("search_raw failed: {}", e));
+                e.to_string()
+            })?;
+
+            let results: Vec<RawSearchHit> = hits
+                .into_iter()
+                .map(|msg| RawSearchHit {
+                    id: msg.id,
+                    session_id: msg.session_id,
+                    project: msg.project,
+                    role: msg.role,
+                    preview: msg.content.chars().take(PREVIEW_CHARS).collect(),
+                    source: msg.source,
+                    branch: msg.branch,
+                    created_at: chrono::DateTime::from_timestamp(msg.created_at_epoch, 0)
+                        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+                        .unwrap_or_default(),
+                })
+                .collect();
+
+            crate::log::info(
+                "mcp",
+                &format!(
+                    "search_raw done count={} {}ms",
+                    results.len(),
+                    start.elapsed().as_millis()
+                ),
+            );
+            serde_json::to_string_pretty(&results).map_err(|e| e.to_string())
+        })
+    }
+}

--- a/src/mcp/server/runtime.rs
+++ b/src/mcp/server/runtime.rs
@@ -13,6 +13,7 @@ const SERVER_INSTRUCTIONS: &str = r#"Persistent memory for Claude Code sessions.
 3. Then: `get_observations(ids)` → full narrative, facts, concepts, files
 4. Use `timeline(anchor/query)` to understand chronological context around a change
 5. Use `save_memory(text)` to persist important decisions or discoveries (and local markdown backup)
+6. If curated `search` is empty/sparse, it auto-attaches `raw_hits` from the raw archive (every user/assistant turn captured at Stop time). Call `search_raw(query)` directly when you need to recall a literal phrase that was never summarized or promoted.
 
 ## Local document rule
 - If user asks to save/write/update a document, create or edit a local file first

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -119,8 +119,8 @@ impl MemoryServer {
                     });
                 }
                 if !raw_hits_json.is_empty() {
-                    response["raw_hits"] = serde_json::to_value(&raw_hits_json)
-                        .map_err(|e| e.to_string())?;
+                    response["raw_hits"] =
+                        serde_json::to_value(&raw_hits_json).map_err(|e| e.to_string())?;
                 }
                 serde_json::to_string_pretty(&response).map_err(|e| e.to_string())
             } else {

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -1,9 +1,11 @@
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::{tool, tool_router};
 
-use super::super::types::{SearchParams, SearchResult};
+use super::super::types::{RawSearchHit, SearchParams, SearchResult};
 use super::MemoryServer;
 use crate::memory_service;
+
+const RAW_PREVIEW_CHARS: usize = 300;
 
 #[tool_router(router = tool_router_search, vis = "pub(super)")]
 impl MemoryServer {
@@ -48,6 +50,7 @@ impl MemoryServer {
                 memories,
                 multi_hop,
                 has_more: _,
+                raw_hits,
             } = search_set;
 
             let search_results: Vec<SearchResult> = memories
@@ -71,6 +74,22 @@ impl MemoryServer {
                 })
                 .collect();
 
+            let raw_hits_json: Vec<RawSearchHit> = raw_hits
+                .into_iter()
+                .map(|msg| RawSearchHit {
+                    id: msg.id,
+                    session_id: msg.session_id,
+                    project: msg.project,
+                    role: msg.role,
+                    preview: msg.content.chars().take(RAW_PREVIEW_CHARS).collect(),
+                    source: msg.source,
+                    branch: msg.branch,
+                    created_at: chrono::DateTime::from_timestamp(msg.created_at_epoch, 0)
+                        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+                        .unwrap_or_default(),
+                })
+                .collect();
+
             let hop_info = if let Some(meta) = &multi_hop {
                 format!(
                     " hops={} entities_discovered={}",
@@ -83,21 +102,26 @@ impl MemoryServer {
             crate::log::info(
                 "mcp",
                 &format!(
-                    "search done count={} {}ms{}",
+                    "search done count={} raw_fallback={} {}ms{}",
                     search_results.len(),
+                    raw_hits_json.len(),
                     start.elapsed().as_millis(),
                     hop_info,
                 ),
             );
 
-            if let Some(meta) = multi_hop {
-                let response = serde_json::json!({
-                    "results": search_results,
-                    "multi_hop": {
+            if multi_hop.is_some() || !raw_hits_json.is_empty() {
+                let mut response = serde_json::json!({ "results": search_results });
+                if let Some(meta) = multi_hop {
+                    response["multi_hop"] = serde_json::json!({
                         "hops": meta.hops,
                         "entities_discovered": meta.entities_discovered,
-                    }
-                });
+                    });
+                }
+                if !raw_hits_json.is_empty() {
+                    response["raw_hits"] = serde_json::to_value(&raw_hits_json)
+                        .map_err(|e| e.to_string())?;
+                }
                 serde_json::to_string_pretty(&response).map_err(|e| e.to_string())
             } else {
                 serde_json::to_string_pretty(&search_results).map_err(|e| e.to_string())

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -119,3 +119,32 @@ pub(super) struct SearchResult {
     pub project: String,
     pub status: String,
 }
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(super) struct SearchRawParams {
+    #[schemars(
+        description = "Raw FTS query across every user/assistant turn captured by the raw archive. Unlike `search`, this bypasses all curation and returns literal chat content. Use when `search` comes back empty or you need to recall an exact phrase from past conversations."
+    )]
+    pub query: String,
+    #[schemars(description = "Project name filter")]
+    pub project: Option<String>,
+    #[schemars(description = "Role filter: 'user' or 'assistant' (default: both)")]
+    pub role: Option<String>,
+    #[schemars(description = "Max results to return (default 20)")]
+    pub limit: Option<i64>,
+    #[schemars(description = "Result offset for pagination")]
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct RawSearchHit {
+    pub id: i64,
+    pub session_id: String,
+    pub project: String,
+    pub role: String,
+    pub preview: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    pub created_at: String,
+}

--- a/src/memory_service/search.rs
+++ b/src/memory_service/search.rs
@@ -3,12 +3,18 @@ use rusqlite::Connection;
 
 use super::types::{MultiHopMeta, SearchRequest, SearchResultSet};
 
+/// Curated hits below this count trigger a raw archive fallback so the caller
+/// always has *something* to show when the conversation happened but was
+/// never promoted.
+const RAW_FALLBACK_THRESHOLD: usize = 3;
+const RAW_FALLBACK_LIMIT: i64 = 10;
+
 pub fn search_memories(conn: &Connection, req: &SearchRequest) -> Result<SearchResultSet> {
     let limit = req.limit.max(1);
     let query = req.query.as_deref();
 
     if req.multi_hop {
-        return multi_hop_search(conn, query, req.project.as_deref(), limit);
+        return multi_hop_search(conn, query, req.project.as_deref(), limit, req);
     }
 
     let mut memories = crate::search::search_with_branch(
@@ -23,10 +29,12 @@ pub fn search_memories(conn: &Connection, req: &SearchRequest) -> Result<SearchR
     )?;
     let has_more = memories.len() as i64 > limit;
     memories.truncate(limit as usize);
+    let raw_hits = maybe_fallback_raw(conn, req, memories.len());
     Ok(SearchResultSet {
         memories,
         multi_hop: None,
         has_more,
+        raw_hits,
     })
 }
 
@@ -35,12 +43,14 @@ fn multi_hop_search(
     query: Option<&str>,
     project: Option<&str>,
     limit: i64,
+    req: &SearchRequest,
 ) -> Result<SearchResultSet> {
     if let Some(query_text) = query.filter(|query_text| !query_text.is_empty()) {
         let mut result =
             crate::search_multihop::search_multi_hop(conn, query_text, project, limit + 1)?;
         let has_more = result.memories.len() as i64 > limit;
         result.memories.truncate(limit as usize);
+        let raw_hits = maybe_fallback_raw(conn, req, result.memories.len());
         Ok(SearchResultSet {
             memories: result.memories,
             multi_hop: Some(MultiHopMeta {
@@ -48,6 +58,7 @@ fn multi_hop_search(
                 entities_discovered: result.entities_discovered,
             }),
             has_more,
+            raw_hits,
         })
     } else {
         Ok(SearchResultSet {
@@ -57,6 +68,42 @@ fn multi_hop_search(
                 entities_discovered: vec![],
             }),
             has_more: false,
+            raw_hits: vec![],
         })
+    }
+}
+
+fn maybe_fallback_raw(
+    conn: &Connection,
+    req: &SearchRequest,
+    curated_len: usize,
+) -> Vec<crate::raw_archive::RawMessage> {
+    if curated_len >= RAW_FALLBACK_THRESHOLD {
+        return vec![];
+    }
+    let Some(query) = req
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|q| !q.is_empty())
+    else {
+        return vec![];
+    };
+    let raw_req = crate::raw_archive::RawSearchRequest {
+        query: query.to_string(),
+        project: req.project.clone(),
+        role: None,
+        limit: RAW_FALLBACK_LIMIT,
+        offset: 0,
+    };
+    match crate::raw_archive::search_raw_messages(conn, &raw_req) {
+        Ok(hits) => hits,
+        Err(error) => {
+            crate::log::warn(
+                "search",
+                &format!("raw archive fallback failed: {}", error),
+            );
+            vec![]
+        }
     }
 }

--- a/src/memory_service/search.rs
+++ b/src/memory_service/search.rs
@@ -99,10 +99,7 @@ fn maybe_fallback_raw(
     match crate::raw_archive::search_raw_messages(conn, &raw_req) {
         Ok(hits) => hits,
         Err(error) => {
-            crate::log::warn(
-                "search",
-                &format!("raw archive fallback failed: {}", error),
-            );
+            crate::log::warn("search", &format!("raw archive fallback failed: {}", error));
             vec![]
         }
     }

--- a/src/memory_service/types.rs
+++ b/src/memory_service/types.rs
@@ -21,6 +21,8 @@ pub struct SearchResultSet {
     pub memories: Vec<crate::memory::Memory>,
     pub multi_hop: Option<MultiHopMeta>,
     pub has_more: bool,
+    /// Raw archive hits attached as fallback when curated memories are sparse.
+    pub raw_hits: Vec<crate::raw_archive::RawMessage>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -62,10 +62,10 @@ fn full_migration_on_empty_db() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1]);
+    assert_eq!(applied, vec![1, 2]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 13);
+    assert_eq!(user_version, 14);
     Ok(())
 }
 
@@ -78,7 +78,7 @@ fn transition_from_old_system_skips_baseline() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1]);
+    assert_eq!(applied, vec![1, 2]);
     Ok(())
 }
 
@@ -101,12 +101,12 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
 
     run_migrations(&conn)?;
 
-    // Should have auto-upgraded and marked baseline as applied
+    // Should have auto-upgraded and marked baseline + raw_messages as applied
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1]);
+    assert_eq!(applied, vec![1, 2]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 13);
+    assert_eq!(user_version, 14);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -145,7 +145,7 @@ fn dry_run_pending_reports_pending_for_new_db() -> Result<()> {
     let result = dry_run_pending(&conn)?;
 
     assert_eq!(result.current_version, 0);
-    assert_eq!(result.pending_count, 1);
+    assert_eq!(result.pending_count, 2);
     assert!(result.error.is_none());
     Ok(())
 }
@@ -202,7 +202,9 @@ fn dry_run_pending_reports_backfill_error_for_broken_schema() -> Result<()> {
     )?;
 
     let result = dry_run_pending(&conn)?;
-    assert_eq!(result.pending_count, 0);
+    // After broken baseline backfill fails, dry_run reports the still-unapplied
+    // migrations (v2 raw_messages is not yet in _schema_migrations).
+    assert_eq!(result.pending_count, 1);
     let error = result
         .error
         .expect("broken schema should surface in dry-run");

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -4,11 +4,18 @@ pub(crate) struct Migration {
     pub sql: &'static str,
 }
 
-pub(crate) const MIGRATIONS: &[Migration] = &[Migration {
-    version: 1,
-    name: "baseline",
-    sql: include_str!("../migrations/v001_baseline.sql"),
-}];
+pub(crate) const MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        name: "baseline",
+        sql: include_str!("../migrations/v001_baseline.sql"),
+    },
+    Migration {
+        version: 2,
+        name: "raw_messages",
+        sql: include_str!("../migrations/v002_raw_messages.sql"),
+    },
+];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;
 

--- a/src/migrations/v002_raw_messages.sql
+++ b/src/migrations/v002_raw_messages.sql
@@ -1,0 +1,43 @@
+-- v002_raw_messages: introduce raw archive layer (spec: SPEC-raw-archive-vs-curated-memory-2026-04-22)
+
+CREATE TABLE IF NOT EXISTS raw_messages (
+    id INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    project TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    source TEXT NOT NULL,
+    branch TEXT,
+    cwd TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    UNIQUE(project, role, content_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_raw_messages_project_created
+    ON raw_messages(project, created_at_epoch DESC);
+
+CREATE INDEX IF NOT EXISTS idx_raw_messages_session
+    ON raw_messages(session_id, created_at_epoch);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS raw_messages_fts USING fts5(
+    content,
+    content='raw_messages',
+    content_rowid='id',
+    tokenize='trigram'
+);
+
+CREATE TRIGGER IF NOT EXISTS raw_messages_ai AFTER INSERT ON raw_messages BEGIN
+    INSERT INTO raw_messages_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS raw_messages_ad AFTER DELETE ON raw_messages BEGIN
+    INSERT INTO raw_messages_fts(raw_messages_fts, rowid, content)
+    VALUES ('delete', old.id, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS raw_messages_au AFTER UPDATE ON raw_messages BEGIN
+    INSERT INTO raw_messages_fts(raw_messages_fts, rowid, content)
+    VALUES ('delete', old.id, old.content);
+    INSERT INTO raw_messages_fts(rowid, content) VALUES (new.id, new.content);
+END;

--- a/src/raw_archive.rs
+++ b/src/raw_archive.rs
@@ -30,10 +30,7 @@ pub struct RawMessage {
 /// `memory_promote::slug::content_hash`, which normalizes whitespace/case for
 /// semantic dedup of curated memories.
 fn exact_content_hash(content: &str) -> String {
-    format!(
-        "{:016x}",
-        crate::db::deterministic_hash(content.as_bytes())
-    )
+    format!("{:016x}", crate::db::deterministic_hash(content.as_bytes()))
 }
 
 /// Insert one raw message. UNIQUE(project, role, content_hash) makes this
@@ -172,10 +169,7 @@ pub struct RawSearchRequest {
     pub offset: i64,
 }
 
-pub fn search_raw_messages(
-    conn: &Connection,
-    req: &RawSearchRequest,
-) -> Result<Vec<RawMessage>> {
+pub fn search_raw_messages(conn: &Connection, req: &RawSearchRequest) -> Result<Vec<RawMessage>> {
     let limit = req.limit.max(1);
     let offset = req.offset.max(0);
     let query = req.query.trim();
@@ -209,19 +203,22 @@ pub fn search_raw_messages(
     ));
 
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(rusqlite::params_from_iter(crate::db::to_sql_refs(&binds)), |row| {
-        Ok(RawMessage {
-            id: row.get(0)?,
-            session_id: row.get(1)?,
-            project: row.get(2)?,
-            role: row.get(3)?,
-            content: row.get(4)?,
-            source: row.get(5)?,
-            branch: row.get(6)?,
-            cwd: row.get(7)?,
-            created_at_epoch: row.get(8)?,
-        })
-    })?;
+    let rows = stmt.query_map(
+        rusqlite::params_from_iter(crate::db::to_sql_refs(&binds)),
+        |row| {
+            Ok(RawMessage {
+                id: row.get(0)?,
+                session_id: row.get(1)?,
+                project: row.get(2)?,
+                role: row.get(3)?,
+                content: row.get(4)?,
+                source: row.get(5)?,
+                branch: row.get(6)?,
+                cwd: row.get(7)?,
+                created_at_epoch: row.get(8)?,
+            })
+        },
+    )?;
 
     let mut out = Vec::new();
     for row in rows {

--- a/src/raw_archive.rs
+++ b/src/raw_archive.rs
@@ -1,0 +1,335 @@
+//! Raw archive layer — captures every user/assistant turn regardless of
+//! whether summarize/promote choose to keep it.
+//!
+//! Spec: SPEC-raw-archive-vs-curated-memory-2026-04-22.md
+
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+pub const ROLE_USER: &str = "user";
+pub const ROLE_ASSISTANT: &str = "assistant";
+
+pub const SOURCE_TRANSCRIPT: &str = "transcript";
+pub const SOURCE_HOOK: &str = "hook";
+pub const SOURCE_MANUAL: &str = "manual";
+
+#[derive(Debug, Clone)]
+pub struct RawMessage {
+    pub id: i64,
+    pub session_id: String,
+    pub project: String,
+    pub role: String,
+    pub content: String,
+    pub source: String,
+    pub branch: Option<String>,
+    pub cwd: Option<String>,
+    pub created_at_epoch: i64,
+}
+
+/// Exact byte-for-byte hash of the raw message content. Distinct from
+/// `memory_promote::slug::content_hash`, which normalizes whitespace/case for
+/// semantic dedup of curated memories.
+fn exact_content_hash(content: &str) -> String {
+    format!(
+        "{:016x}",
+        crate::db::deterministic_hash(content.as_bytes())
+    )
+}
+
+/// Insert one raw message. UNIQUE(project, role, content_hash) makes this
+/// idempotent across repeated Stop-hook drains of the same transcript.
+/// Returns the row id of the existing or newly inserted message, or None
+/// when the content is empty.
+pub fn insert_raw_message(
+    conn: &Connection,
+    session_id: &str,
+    project: &str,
+    role: &str,
+    content: &str,
+    source: &str,
+    branch: Option<&str>,
+    cwd: Option<&str>,
+) -> Result<Option<i64>> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let hash = exact_content_hash(trimmed);
+    let now = chrono::Utc::now().timestamp();
+
+    let inserted = conn.execute(
+        "INSERT INTO raw_messages \
+         (session_id, project, role, content, content_hash, source, branch, cwd, created_at_epoch) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) \
+         ON CONFLICT(project, role, content_hash) DO NOTHING",
+        params![session_id, project, role, trimmed, hash, source, branch, cwd, now],
+    )?;
+
+    if inserted > 0 {
+        Ok(Some(conn.last_insert_rowid()))
+    } else {
+        let existing: i64 = conn.query_row(
+            "SELECT id FROM raw_messages WHERE project = ?1 AND role = ?2 AND content_hash = ?3",
+            params![project, role, hash],
+            |row| row.get(0),
+        )?;
+        Ok(Some(existing))
+    }
+}
+
+/// Drain a Claude Code transcript JSONL file into raw_messages.
+/// Best-effort: any parse error on a single line is skipped.
+pub fn drain_transcript(
+    conn: &Connection,
+    transcript_path: &str,
+    session_id: &str,
+    project: &str,
+    branch: Option<&str>,
+    cwd: Option<&str>,
+) -> Result<usize> {
+    let content = match std::fs::read_to_string(transcript_path) {
+        Ok(content) => content,
+        Err(error) => {
+            crate::log::warn(
+                "raw-archive",
+                &format!("read transcript {} failed: {}", transcript_path, error),
+            );
+            return Ok(0);
+        }
+    };
+
+    let mut new_rows = 0usize;
+    for line in content.lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let role = match value["type"].as_str() {
+            Some("user") => ROLE_USER,
+            Some("assistant") => ROLE_ASSISTANT,
+            _ => continue,
+        };
+        let text = extract_message_text(&value);
+        if text.trim().is_empty() {
+            continue;
+        }
+
+        let before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))
+            .unwrap_or(0);
+        if let Err(error) = insert_raw_message(
+            conn,
+            session_id,
+            project,
+            role,
+            &text,
+            SOURCE_TRANSCRIPT,
+            branch,
+            cwd,
+        ) {
+            crate::log::warn(
+                "raw-archive",
+                &format!("insert raw message failed: {}", error),
+            );
+            continue;
+        }
+        let after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))
+            .unwrap_or(before);
+        if after > before {
+            new_rows += 1;
+        }
+    }
+    Ok(new_rows)
+}
+
+fn extract_message_text(value: &serde_json::Value) -> String {
+    let content = &value["message"]["content"];
+    if let Some(array) = content.as_array() {
+        let parts: Vec<String> = array
+            .iter()
+            .filter_map(|entry| {
+                match entry["type"].as_str() {
+                    Some("text") => entry["text"].as_str().map(|s| s.to_string()),
+                    // user messages can carry plain strings under `content` too
+                    _ => None,
+                }
+            })
+            .collect();
+        return parts.join("\n");
+    }
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    String::new()
+}
+
+#[derive(Debug, Clone)]
+pub struct RawSearchRequest {
+    pub query: String,
+    pub project: Option<String>,
+    pub role: Option<String>,
+    pub limit: i64,
+    pub offset: i64,
+}
+
+pub fn search_raw_messages(
+    conn: &Connection,
+    req: &RawSearchRequest,
+) -> Result<Vec<RawMessage>> {
+    let limit = req.limit.max(1);
+    let offset = req.offset.max(0);
+    let query = req.query.trim();
+    if query.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut sql = String::from(
+        "SELECT r.id, r.session_id, r.project, r.role, r.content, r.source, \
+                r.branch, r.cwd, r.created_at_epoch \
+         FROM raw_messages r \
+         JOIN raw_messages_fts f ON f.rowid = r.id \
+         WHERE raw_messages_fts MATCH ?1",
+    );
+    let mut binds: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(fts_query(query))];
+
+    if let Some(project) = req.project.as_deref() {
+        sql.push_str(" AND r.project = ?");
+        sql.push_str(&(binds.len() + 1).to_string());
+        binds.push(Box::new(project.to_string()));
+    }
+    if let Some(role) = req.role.as_deref() {
+        sql.push_str(" AND r.role = ?");
+        sql.push_str(&(binds.len() + 1).to_string());
+        binds.push(Box::new(role.to_string()));
+    }
+
+    sql.push_str(&format!(
+        " ORDER BY r.created_at_epoch DESC LIMIT {} OFFSET {}",
+        limit, offset
+    ));
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(crate::db::to_sql_refs(&binds)), |row| {
+        Ok(RawMessage {
+            id: row.get(0)?,
+            session_id: row.get(1)?,
+            project: row.get(2)?,
+            role: row.get(3)?,
+            content: row.get(4)?,
+            source: row.get(5)?,
+            branch: row.get(6)?,
+            cwd: row.get(7)?,
+            created_at_epoch: row.get(8)?,
+        })
+    })?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+fn fts_query(query: &str) -> String {
+    // Wrap each token in quotes so we use phrase matching (robust against
+    // punctuation that trigram tokenizer would otherwise choke on).
+    let cleaned: Vec<String> = query
+        .split_whitespace()
+        .filter(|token| !token.is_empty())
+        .map(|token| format!("\"{}\"", token.replace('\"', "\"\"")))
+        .collect();
+    if cleaned.is_empty() {
+        format!("\"{}\"", query.replace('\"', "\"\""))
+    } else {
+        cleaned.join(" ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::migrate::run_migrations(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn insert_is_idempotent_per_project_role_content() {
+        let conn = setup_conn();
+        let id1 = insert_raw_message(
+            &conn,
+            "s1",
+            "/proj",
+            ROLE_USER,
+            "hello world",
+            SOURCE_HOOK,
+            None,
+            None,
+        )
+        .unwrap();
+        let id2 = insert_raw_message(
+            &conn,
+            "s2",
+            "/proj",
+            ROLE_USER,
+            "hello world",
+            SOURCE_HOOK,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(id1, id2);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn empty_content_is_skipped() {
+        let conn = setup_conn();
+        let id = insert_raw_message(
+            &conn,
+            "s1",
+            "/proj",
+            ROLE_USER,
+            "   \n\t  ",
+            SOURCE_HOOK,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(id.is_none());
+    }
+
+    #[test]
+    fn fts_finds_inserted_content() {
+        let conn = setup_conn();
+        insert_raw_message(
+            &conn,
+            "s1",
+            "/proj",
+            ROLE_USER,
+            "帮我看看 VPS RackNerd 的价格",
+            SOURCE_HOOK,
+            None,
+            None,
+        )
+        .unwrap();
+        let hits = search_raw_messages(
+            &conn,
+            &RawSearchRequest {
+                query: "RackNerd".to_string(),
+                project: Some("/proj".to_string()),
+                role: None,
+                limit: 10,
+                offset: 0,
+            },
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].content.contains("RackNerd"));
+    }
+}

--- a/src/summarize/summary_job/process.rs
+++ b/src/summarize/summary_job/process.rs
@@ -12,14 +12,21 @@ use super::persist::{build_existing_summary_context, finalize_summary, sync_nati
 
 pub async fn process_summary_job_input(input: &str) -> Result<()> {
     let hook: SummarizeInput = serde_json::from_str(input)?;
-    let Some(session_id) = hook.session_id else {
+    let Some(session_id) = hook.session_id.clone() else {
         return Ok(());
     };
     let cwd = hook.cwd.as_deref().unwrap_or(".");
     let project = project_from_cwd(cwd);
 
+    let mut conn = db::open_db()?;
+
+    // Raw archive ingest happens BEFORE every summarize short-circuit so that
+    // "what was said is searchable" is independent of curation outcome.
+    capture_raw_archive(&conn, &hook, &session_id, &project, cwd);
+
     let assistant_msg = hook
         .last_assistant_message
+        .clone()
         .or_else(|| {
             hook.transcript_path
                 .as_deref()
@@ -30,7 +37,6 @@ pub async fn process_summary_job_input(input: &str) -> Result<()> {
         return Ok(());
     };
 
-    let mut conn = db::open_db()?;
     if db::is_summarize_on_cooldown(&conn, &project, SUMMARIZE_COOLDOWN_SECS)? {
         crate::log::info(
             "summary-job",
@@ -95,6 +101,56 @@ fn prepare_assistant_message(message: String) -> Option<String> {
         Some(crate::db::truncate_str(&message, 12000).to_string())
     } else {
         Some(message)
+    }
+}
+
+fn capture_raw_archive(
+    conn: &rusqlite::Connection,
+    hook: &SummarizeInput,
+    session_id: &str,
+    project: &str,
+    cwd: &str,
+) {
+    let branch = db::detect_git_branch(cwd);
+    let cwd_opt = Some(cwd);
+
+    if let Some(transcript_path) = hook.transcript_path.as_deref() {
+        match crate::raw_archive::drain_transcript(
+            conn,
+            transcript_path,
+            session_id,
+            project,
+            branch.as_deref(),
+            cwd_opt,
+        ) {
+            Ok(new_rows) => crate::log::info(
+                "summary-job",
+                &format!(
+                    "raw archive drained transcript new_rows={} project={}",
+                    new_rows, project
+                ),
+            ),
+            Err(error) => crate::log::warn(
+                "summary-job",
+                &format!("raw archive drain failed: {}", error),
+            ),
+        }
+    } else if let Some(last) = hook.last_assistant_message.as_deref() {
+        if let Err(error) = crate::raw_archive::insert_raw_message(
+            conn,
+            session_id,
+            project,
+            crate::raw_archive::ROLE_ASSISTANT,
+            last,
+            crate::raw_archive::SOURCE_HOOK,
+            branch.as_deref(),
+            cwd_opt,
+        ) {
+            crate::log::warn(
+                "summary-job",
+                &format!("raw archive insert failed: {}", error),
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a raw archive layer so every user/assistant turn is persisted at Stop time, independent of summarize/promote curation.
- Introduces migration `v002_raw_messages` (table + FTS5 + triggers), module `raw_archive`, MCP tool `search_raw`, auto `raw_hits` fallback in `search` when curated results < 3.
- Full spec: `SPEC-raw-archive-vs-curated-memory-2026-04-22.md`.

## Why
A verified case (trainer-hub VPS research) was dropped entirely because the turn hit a summarize short-circuit (cooldown / duplicate hash / AI `<skip_summary>` / length floor). Raw capture was coupled to curation, so "skipped" meant "gone". This PR splits the two concerns: raw captures everything, curated stays high-signal.

## Test plan
- [x] `cargo check --lib`
- [x] `cargo test --lib` — 214 passed, 0 failed
- [x] `raw_archive` unit tests: idempotent insert, empty-content skip, FTS round-trip
- [x] `migrate` tests updated for v002 (pending_count, user_version)
- [ ] End-to-end Stop hook drain against a live Claude Code session