### PR TITLE
refactor(memory): unify project visibility to project+global overlay

### DIFF
--- a/src/entity/search/sql.rs
+++ b/src/entity/search/sql.rs
@@ -1,5 +1,5 @@
 pub(super) fn project_filter_sql(param_idx: usize) -> String {
-    format!("m.project = ?{param_idx}")
+    crate::memory_search::project_or_global_clause("m.project", param_idx)
 }
 
 pub(super) fn branch_filter_sql(param_idx: usize) -> String {

--- a/src/entity/tests/search.rs
+++ b/src/entity/tests/search.rs
@@ -89,6 +89,35 @@ fn expand_via_entity_graph_filtered_respects_branch_and_status() {
 }
 
 #[test]
+fn search_by_entity_project_filter_includes_global_scope_records() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_entity_schema(&conn);
+    conn.execute(
+        "INSERT INTO memories (id, project, memory_type, status, scope) VALUES (?1, ?2, 'decision', 'active', 'project')",
+        params![1_i64, "proj"],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO memories (id, project, memory_type, status, scope) VALUES (?1, ?2, 'preference', 'active', 'global')",
+        params![2_i64, "other-proj"],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO memories (id, project, memory_type, status, scope) VALUES (?1, ?2, 'decision', 'active', 'project')",
+        params![3_i64, "other-proj"],
+    )
+    .unwrap();
+    link_entities(&conn, 1, &["SQLite".to_string()]).unwrap();
+    link_entities(&conn, 2, &["SQLite".to_string()]).unwrap();
+    link_entities(&conn, 3, &["SQLite".to_string()]).unwrap();
+
+    let ids = search_by_entity(&conn, "SQLite", Some("proj"), 10).unwrap();
+    assert!(ids.contains(&1));
+    assert!(ids.contains(&2));
+    assert!(!ids.contains(&3));
+}
+
+#[test]
 fn search_by_entity_filtered_respects_branch_and_status() {
     let conn = Connection::open_in_memory().unwrap();
     setup_entity_schema(&conn);

--- a/src/entity/tests/support.rs
+++ b/src/entity/tests/support.rs
@@ -9,7 +9,8 @@ pub(super) fn setup_entity_schema(conn: &Connection) {
             text TEXT,
             memory_type TEXT NOT NULL DEFAULT 'discovery',
             branch TEXT,
-            status TEXT NOT NULL DEFAULT 'active'
+            status TEXT NOT NULL DEFAULT 'active',
+            scope TEXT NOT NULL DEFAULT 'project'
         );
         CREATE TABLE entities (
             id INTEGER PRIMARY KEY,

--- a/src/memory/store/read.rs
+++ b/src/memory/store/read.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::memory::types::{map_memory_row, Memory, MEMORY_COLS};
+use crate::memory_search::push_project_filter_required;
 
 pub fn get_recent_memories(conn: &Connection, project: &str, limit: i64) -> Result<Vec<Memory>> {
     list_memories(conn, project, None, limit, 0, false, None)
@@ -25,9 +26,10 @@ pub fn list_memories(
     include_inactive: bool,
     branch: Option<&str>,
 ) -> Result<Vec<Memory>> {
-    let mut conditions = vec!["(project = ?1 OR scope = 'global')".to_string()];
-    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(project.to_string())];
-    let mut idx = 2;
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    idx = push_project_filter_required("project", project, idx, &mut conditions, &mut params);
 
     if !include_inactive {
         conditions.push("status = 'active'".to_string());
@@ -77,7 +79,8 @@ pub fn get_memories_by_ids(
         .collect();
 
     if let Some(project) = project {
-        conditions.push(format!("project = ?{}", ids.len() + 1));
+        let idx = ids.len() + 1;
+        conditions.push(format!("(project = ?{idx} OR scope = 'global')"));
         params.push(Box::new(project.to_string()));
     }
 

--- a/src/memory_search.rs
+++ b/src/memory_search.rs
@@ -4,6 +4,6 @@ mod like;
 #[cfg(test)]
 mod tests;
 
-pub use filters::push_project_filter;
+pub use filters::{project_or_global_clause, push_project_filter, push_project_filter_required};
 pub use fts::{search_memories_fts, search_memories_fts_filtered};
 pub use like::{search_memories_like, search_memories_like_filtered};

--- a/src/memory_search/filters.rs
+++ b/src/memory_search/filters.rs
@@ -1,4 +1,5 @@
-/// Push exact project filter into SQL conditions.
+/// Push memory project visibility filter into SQL conditions.
+/// When a project is provided, memory queries use project + global overlay.
 /// Returns the next parameter index.
 pub fn push_project_filter(
     column: &str,
@@ -8,12 +9,28 @@ pub fn push_project_filter(
     params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
 ) -> usize {
     if let Some(project) = project {
-        let (clause, next_idx) =
-            crate::project_id::push_project_filter(column, project, idx, params);
-        conditions.push(clause);
-        idx = next_idx;
+        conditions.push(project_or_global_clause(column, idx));
+        params.push(Box::new(project.to_string()));
+        idx += 1;
     }
     idx
+}
+
+pub fn push_project_filter_required(
+    column: &str,
+    project: &str,
+    mut idx: usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) -> usize {
+    conditions.push(project_or_global_clause(column, idx));
+    params.push(Box::new(project.to_string()));
+    idx += 1;
+    idx
+}
+
+pub fn project_or_global_clause(column: &str, param_idx: usize) -> String {
+    format!("({column} = ?{param_idx} OR scope = 'global')")
 }
 
 pub(super) fn push_branch_filter(

--- a/src/temporal/search.rs
+++ b/src/temporal/search.rs
@@ -34,7 +34,9 @@ pub fn search_by_time_filtered(
         conditions.push("status = 'active'".to_string());
     }
     if let Some(project) = project {
-        conditions.push(crate::memory_search::project_or_global_clause("project", idx));
+        conditions.push(crate::memory_search::project_or_global_clause(
+            "project", idx,
+        ));
         params_vec.push(Box::new(project.to_string()));
         idx += 1;
     }

--- a/src/temporal/search.rs
+++ b/src/temporal/search.rs
@@ -34,7 +34,7 @@ pub fn search_by_time_filtered(
         conditions.push("status = 'active'".to_string());
     }
     if let Some(project) = project {
-        conditions.push(format!("project = ?{idx}"));
+        conditions.push(crate::memory_search::project_or_global_clause("project", idx));
         params_vec.push(Box::new(project.to_string()));
         idx += 1;
     }


### PR DESCRIPTION
## Summary
- Memory read paths (list/by-id/FTS/LIKE/entity/temporal) disagreed on what a project filter means: list overlaid global scope, by-id/query paths applied strict project equality. Same data visible in one entrypoint was invisible in another.
- This PR introduces a shared helper \`memory_search::filters::project_or_global_clause\` and routes all memory read paths through it. A project filter now consistently means \"rows in this project OR rows with scope='global'\".
- Observations keep strict project semantics and are intentionally not touched.

## Changes
- \`memory_search/filters.rs\`: add \`project_or_global_clause\` + \`push_project_filter_required\`; \`push_project_filter\` now emits the overlay clause.
- \`memory_search.rs\`: re-export the new helpers.
- \`memory/store/read.rs\`: \`list_memories\` and \`get_memories_by_ids\` both apply overlay.
- \`entity/search/sql.rs\`: \`project_filter_sql\` delegates to the shared helper.
- \`temporal/search.rs\`: project branch uses the shared helper.
- Tests: regression for entity overlay + \`scope\` column in the entity test schema.

## Test plan
- [x] \`cargo test --lib\` → 204 passed, 0 failed