### PR TITLE
[codex] Fix noisy context memory selection

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,5 @@
 mod format;
+mod memory_traits;
 mod query;
 mod render;
 mod sections;

--- a/src/context/memory_traits.rs
+++ b/src/context/memory_traits.rs
@@ -2,6 +2,11 @@ use crate::memory::Memory;
 
 pub(in crate::context) fn is_memory_self_diagnostic(memory: &Memory) -> bool {
     let haystack = format!("{} {}", memory.title, memory.text).to_ascii_lowercase();
+    is_self_diagnostic_text(&haystack)
+}
+
+pub(in crate::context) fn is_self_diagnostic_text(text: &str) -> bool {
+    let haystack = text.to_ascii_lowercase();
     [
         "sessionstart",
         "memory injection",

--- a/src/context/memory_traits.rs
+++ b/src/context/memory_traits.rs
@@ -1,0 +1,14 @@
+use crate::memory::Memory;
+
+pub(in crate::context) fn is_memory_self_diagnostic(memory: &Memory) -> bool {
+    let haystack = format!("{} {}", memory.title, memory.text).to_ascii_lowercase();
+    [
+        "sessionstart",
+        "memory injection",
+        "memories loaded",
+        "remem context",
+        "loaded memories",
+    ]
+    .iter()
+    .any(|needle| haystack.contains(needle))
+}

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -14,7 +14,6 @@ const BASENAME_SEARCH_LIMIT: i64 = 20;
 const MAX_SELF_DIAGNOSTIC_MEMORIES: usize = 2;
 const SUMMARY_FETCH_BATCH_SIZE: usize = 25;
 const SUMMARY_MAX_SCAN: usize = 200;
-const STALE_DESIGN_SUMMARY_DAYS: i64 = 7;
 
 pub(super) fn load_context_data(
     conn: &Connection,
@@ -286,10 +285,8 @@ pub(super) fn query_recent_summaries(
         return Ok(Vec::new());
     }
 
-    let now_epoch = chrono::Utc::now().timestamp();
     let scan_limit = SUMMARY_MAX_SCAN.max(limit);
     let mut selected = Vec::new();
-    let mut fallback = Vec::new();
     let mut seen_clusters = HashSet::new();
     let mut offset = 0usize;
 
@@ -309,11 +306,6 @@ pub(super) fn query_recent_summaries(
                 continue;
             }
 
-            if is_stale_design_prototype_summary(&summary, now_epoch) {
-                fallback.push(summary);
-                continue;
-            }
-
             selected.push(summary);
             if selected.len() >= limit {
                 break;
@@ -321,10 +313,6 @@ pub(super) fn query_recent_summaries(
         }
 
         offset += fetch_limit;
-    }
-
-    if selected.is_empty() {
-        selected.extend(fallback.into_iter().take(limit));
     }
 
     Ok(selected)
@@ -356,24 +344,8 @@ fn query_summary_batch(
 }
 
 fn is_session_summary_self_diagnostic(summary: &SessionSummaryBrief) -> bool {
-    let haystack = format!(
-        "{} {}",
-        summary.request,
-        summary.completed.as_deref().unwrap_or_default()
-    );
-    is_self_diagnostic_text(&haystack)
-}
-
-fn is_stale_design_prototype_summary(summary: &SessionSummaryBrief, now_epoch: i64) -> bool {
-    let age_days = (now_epoch - summary.created_at_epoch) / 86400;
-    if age_days <= STALE_DESIGN_SUMMARY_DAYS {
-        return false;
-    }
-
     let haystack = session_summary_haystack(summary);
-    ["landing page", "wireframe", "starfield"]
-        .iter()
-        .any(|needle| haystack.contains(needle))
+    is_self_diagnostic_text(&haystack)
 }
 
 fn summary_cluster_key(summary: &SessionSummaryBrief) -> String {

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -14,6 +14,7 @@ const BASENAME_SEARCH_LIMIT: i64 = 20;
 const MAX_SELF_DIAGNOSTIC_MEMORIES: usize = 2;
 const SUMMARY_FETCH_BATCH_SIZE: usize = 25;
 const SUMMARY_MAX_SCAN: usize = 200;
+const STALE_DESIGN_SUMMARY_DAYS: i64 = 7;
 
 pub(super) fn load_context_data(
     conn: &Connection,
@@ -286,7 +287,9 @@ pub(super) fn query_recent_summaries(
     }
 
     let scan_limit = SUMMARY_MAX_SCAN.max(limit);
+    let now_epoch = chrono::Utc::now().timestamp();
     let mut selected = Vec::new();
+    let mut low_signal_fallback = Vec::new();
     let mut seen_clusters = HashSet::new();
     let mut offset = 0usize;
 
@@ -302,10 +305,17 @@ pub(super) fn query_recent_summaries(
                 continue;
             }
 
-            if !seen_clusters.insert(summary_cluster_key(&summary)) {
+            let cluster_key = summary_cluster_key(&summary);
+            if seen_clusters.contains(&cluster_key) {
                 continue;
             }
 
+            if is_stale_design_prototype_summary(&summary, now_epoch) {
+                low_signal_fallback.push((cluster_key, summary));
+                continue;
+            }
+
+            seen_clusters.insert(cluster_key);
             selected.push(summary);
             if selected.len() >= limit {
                 break;
@@ -313,6 +323,17 @@ pub(super) fn query_recent_summaries(
         }
 
         offset += fetch_limit;
+    }
+
+    if selected.is_empty() {
+        for (cluster_key, summary) in low_signal_fallback {
+            if seen_clusters.insert(cluster_key) {
+                selected.push(summary);
+            }
+            if selected.len() >= limit {
+                break;
+            }
+        }
     }
 
     Ok(selected)
@@ -346,6 +367,18 @@ fn query_summary_batch(
 fn is_session_summary_self_diagnostic(summary: &SessionSummaryBrief) -> bool {
     let haystack = session_summary_haystack(summary);
     is_self_diagnostic_text(&haystack)
+}
+
+fn is_stale_design_prototype_summary(summary: &SessionSummaryBrief, now_epoch: i64) -> bool {
+    let age_days = (now_epoch - summary.created_at_epoch) / 86400;
+    if age_days <= STALE_DESIGN_SUMMARY_DAYS {
+        return false;
+    }
+
+    let haystack = session_summary_haystack(summary);
+    ["landing page", "wireframe", "starfield"]
+        .iter()
+        .any(|needle| haystack.contains(needle))
 }
 
 fn summary_cluster_key(summary: &SessionSummaryBrief) -> String {

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -12,7 +12,9 @@ const CONTEXT_MEMORY_LIMIT: usize = 50;
 const RECENT_MEMORY_FETCH_LIMIT: i64 = 100;
 const BASENAME_SEARCH_LIMIT: i64 = 20;
 const MAX_SELF_DIAGNOSTIC_MEMORIES: usize = 2;
-const SUMMARY_FETCH_MULTIPLIER: usize = 3;
+const SUMMARY_FETCH_BATCH_SIZE: usize = 25;
+const SUMMARY_MAX_SCAN: usize = 200;
+const STALE_DESIGN_SUMMARY_DAYS: i64 = 7;
 
 pub(super) fn load_context_data(
     conn: &Connection,
@@ -280,25 +282,77 @@ pub(super) fn query_recent_summaries(
     project: &str,
     limit: usize,
 ) -> Result<Vec<SessionSummaryBrief>> {
-    let fetch_limit = limit.saturating_mul(SUMMARY_FETCH_MULTIPLIER).max(limit);
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let now_epoch = chrono::Utc::now().timestamp();
+    let scan_limit = SUMMARY_MAX_SCAN.max(limit);
+    let mut selected = Vec::new();
+    let mut fallback = Vec::new();
+    let mut seen_clusters = HashSet::new();
+    let mut offset = 0usize;
+
+    while selected.len() < limit && offset < scan_limit {
+        let fetch_limit = SUMMARY_FETCH_BATCH_SIZE.min(scan_limit - offset);
+        let batch = query_summary_batch(conn, project, fetch_limit, offset)?;
+        if batch.is_empty() {
+            break;
+        }
+
+        for summary in batch {
+            if is_session_summary_self_diagnostic(&summary) {
+                continue;
+            }
+
+            if !seen_clusters.insert(summary_cluster_key(&summary)) {
+                continue;
+            }
+
+            if is_stale_design_prototype_summary(&summary, now_epoch) {
+                fallback.push(summary);
+                continue;
+            }
+
+            selected.push(summary);
+            if selected.len() >= limit {
+                break;
+            }
+        }
+
+        offset += fetch_limit;
+    }
+
+    if selected.is_empty() {
+        selected.extend(fallback.into_iter().take(limit));
+    }
+
+    Ok(selected)
+}
+
+fn query_summary_batch(
+    conn: &Connection,
+    project: &str,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<SessionSummaryBrief>> {
     let mut stmt = conn.prepare(
         "SELECT request, completed, created_at_epoch \
          FROM session_summaries \
          WHERE project = ?1 AND request IS NOT NULL AND request != '' \
-         ORDER BY created_at_epoch DESC LIMIT ?2",
+         ORDER BY created_at_epoch DESC LIMIT ?2 OFFSET ?3",
     )?;
-    let rows = stmt.query_map(rusqlite::params![project, fetch_limit as i64], |row| {
-        Ok(SessionSummaryBrief {
-            request: row.get(0)?,
-            completed: row.get(1)?,
-            created_at_epoch: row.get(2)?,
-        })
-    })?;
-    Ok(rows
-        .flatten()
-        .filter(|summary| !is_session_summary_self_diagnostic(summary))
-        .take(limit)
-        .collect())
+    let rows = stmt.query_map(
+        rusqlite::params![project, limit as i64, offset as i64],
+        |row| {
+            Ok(SessionSummaryBrief {
+                request: row.get(0)?,
+                completed: row.get(1)?,
+                created_at_epoch: row.get(2)?,
+            })
+        },
+    )?;
+    crate::db_query::collect_rows(rows)
 }
 
 fn is_session_summary_self_diagnostic(summary: &SessionSummaryBrief) -> bool {
@@ -308,4 +362,34 @@ fn is_session_summary_self_diagnostic(summary: &SessionSummaryBrief) -> bool {
         summary.completed.as_deref().unwrap_or_default()
     );
     is_self_diagnostic_text(&haystack)
+}
+
+fn is_stale_design_prototype_summary(summary: &SessionSummaryBrief, now_epoch: i64) -> bool {
+    let age_days = (now_epoch - summary.created_at_epoch) / 86400;
+    if age_days <= STALE_DESIGN_SUMMARY_DAYS {
+        return false;
+    }
+
+    let haystack = session_summary_haystack(summary);
+    ["landing page", "wireframe", "starfield"]
+        .iter()
+        .any(|needle| haystack.contains(needle))
+}
+
+fn summary_cluster_key(summary: &SessionSummaryBrief) -> String {
+    let request = normalize_cluster_text(&summary.request);
+    let tokens: Vec<&str> = request.split_whitespace().collect();
+    if let Some(reference_key) = reference_cluster_key(&tokens) {
+        return reference_key;
+    }
+    context_cluster_suffix(&request)
+}
+
+fn session_summary_haystack(summary: &SessionSummaryBrief) -> String {
+    format!(
+        "{} {}",
+        summary.request,
+        summary.completed.as_deref().unwrap_or_default()
+    )
+    .to_ascii_lowercase()
 }

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -1,18 +1,24 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::memory::{self, Memory};
 
+use super::memory_traits::is_memory_self_diagnostic;
 use super::types::{LoadedContext, SessionSummaryBrief};
+
+const CONTEXT_MEMORY_LIMIT: usize = 50;
+const RECENT_MEMORY_FETCH_LIMIT: i64 = 100;
+const BASENAME_SEARCH_LIMIT: i64 = 20;
+const MAX_SELF_DIAGNOSTIC_MEMORIES: usize = 2;
 
 pub(super) fn load_context_data(
     conn: &Connection,
     project: &str,
     current_branch: Option<&str>,
 ) -> LoadedContext {
-    let mut memories = load_project_memories(conn, project);
+    let mut memories = load_project_memories(conn, project, current_branch);
     sort_memories_by_branch(&mut memories, current_branch);
 
     let summaries = query_recent_summaries(conn, project, 5).unwrap_or_default();
@@ -26,29 +32,43 @@ pub(super) fn load_context_data(
     }
 }
 
-fn load_project_memories(conn: &Connection, project: &str) -> Vec<Memory> {
+fn load_project_memories(
+    conn: &Connection,
+    project: &str,
+    current_branch: Option<&str>,
+) -> Vec<Memory> {
     let mut memories = Vec::new();
     let mut seen_ids = HashSet::new();
 
-    let project_query = project.rsplit('/').next().unwrap_or(project);
-    if let Ok(searched) =
-        crate::search::search(conn, Some(project_query), Some(project), None, 20, 0, false)
-    {
-        for memory in searched {
-            seen_ids.insert(memory.id);
-            memories.push(memory);
-        }
-    }
-
-    let recent = memory::get_recent_memories(conn, project, 50).unwrap_or_default();
+    let recent =
+        memory::get_recent_memories(conn, project, RECENT_MEMORY_FETCH_LIMIT).unwrap_or_default();
     for memory in recent {
         if seen_ids.insert(memory.id) {
             memories.push(memory);
         }
     }
 
-    memories.truncate(50);
-    memories
+    let project_query = project.rsplit('/').next().unwrap_or(project);
+    if let Ok(searched) = crate::search::search(
+        conn,
+        Some(project_query),
+        Some(project),
+        None,
+        BASENAME_SEARCH_LIMIT,
+        0,
+        false,
+    ) {
+        for memory in searched {
+            if seen_ids.insert(memory.id) {
+                memories.push(memory);
+            }
+        }
+    }
+
+    limit_self_diagnostic_memories(deduplicate_memory_clusters(memories, current_branch))
+        .into_iter()
+        .take(CONTEXT_MEMORY_LIMIT)
+        .collect()
 }
 
 fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {
@@ -68,6 +88,190 @@ fn branch_sort_score(memory: &Memory, current_branch: &str) -> u8 {
         Some("main") | Some("master") => 2,
         _ => 3,
     }
+}
+
+struct ClusterRepresentative {
+    first_index: usize,
+    memory: Memory,
+}
+
+fn deduplicate_memory_clusters(memories: Vec<Memory>, current_branch: Option<&str>) -> Vec<Memory> {
+    let mut representatives: HashMap<String, ClusterRepresentative> = HashMap::new();
+
+    for (index, memory) in memories.into_iter().enumerate() {
+        let cluster_key = memory_cluster_key(&memory);
+        match representatives.get_mut(&cluster_key) {
+            Some(representative) => {
+                if is_better_cluster_representative(&memory, &representative.memory, current_branch)
+                {
+                    representative.memory = memory;
+                }
+            }
+            None => {
+                representatives.insert(
+                    cluster_key,
+                    ClusterRepresentative {
+                        first_index: index,
+                        memory,
+                    },
+                );
+            }
+        }
+    }
+
+    let mut deduped: Vec<ClusterRepresentative> = representatives.into_values().collect();
+    deduped.sort_by_key(|representative| representative.first_index);
+    deduped
+        .into_iter()
+        .map(|representative| representative.memory)
+        .collect()
+}
+
+fn is_better_cluster_representative(
+    candidate: &Memory,
+    incumbent: &Memory,
+    current_branch: Option<&str>,
+) -> bool {
+    let candidate_branch_score = current_branch
+        .map(|branch| branch_sort_score(candidate, branch))
+        .unwrap_or(0);
+    let incumbent_branch_score = current_branch
+        .map(|branch| branch_sort_score(incumbent, branch))
+        .unwrap_or(0);
+
+    candidate_branch_score < incumbent_branch_score
+        || (candidate_branch_score == incumbent_branch_score
+            && candidate.updated_at_epoch > incumbent.updated_at_epoch)
+}
+
+fn limit_self_diagnostic_memories(memories: Vec<Memory>) -> Vec<Memory> {
+    let mut retained = Vec::new();
+    let mut self_diagnostic_count = 0;
+
+    for memory in memories {
+        if is_memory_self_diagnostic(&memory) {
+            if self_diagnostic_count >= MAX_SELF_DIAGNOSTIC_MEMORIES {
+                continue;
+            }
+            self_diagnostic_count += 1;
+        }
+        retained.push(memory);
+    }
+
+    retained
+}
+
+fn memory_cluster_key(memory: &Memory) -> String {
+    if let Some(topic_key) = stable_topic_key(memory.topic_key.as_deref(), &memory.memory_type) {
+        return format!("topic:{topic_key}");
+    }
+
+    if let Some(context) = context_prefix(&memory.text) {
+        return format!(
+            "context:{}:{}",
+            memory.memory_type,
+            context_cluster_suffix(&normalize_cluster_text(&context))
+        );
+    }
+
+    format!(
+        "title:{}:{}",
+        memory.memory_type,
+        normalize_cluster_text(&memory.title)
+    )
+}
+
+fn stable_topic_key<'a>(topic_key: Option<&'a str>, memory_type: &str) -> Option<&'a str> {
+    let key = topic_key?.trim();
+    if key.is_empty() || looks_generated_topic_key(key, memory_type) {
+        return None;
+    }
+    Some(key)
+}
+
+fn looks_generated_topic_key(key: &str, memory_type: &str) -> bool {
+    let Some(suffix) = key.strip_prefix(&format!("{memory_type}-")) else {
+        return false;
+    };
+    suffix.len() >= 12 && suffix.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn context_prefix(text: &str) -> Option<String> {
+    let trimmed = text.trim_start();
+    let rest = trimmed.strip_prefix("[Context:")?;
+    let end = rest.find(']')?;
+    Some(rest[..end].trim().to_string())
+}
+
+fn normalize_cluster_text(text: &str) -> String {
+    let mut folded = String::new();
+    for ch in text.chars() {
+        if ch.is_alphanumeric() {
+            folded.extend(ch.to_lowercase());
+        } else {
+            folded.push(' ');
+        }
+    }
+
+    let normalized = folded.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    normalized.chars().take(96).collect()
+}
+
+fn context_cluster_suffix(normalized_context: &str) -> String {
+    let tokens: Vec<&str> = normalized_context.split_whitespace().collect();
+    if let Some(reference_key) = reference_cluster_key(&tokens) {
+        return reference_key;
+    }
+
+    let ascii_tokens: Vec<&str> = tokens
+        .iter()
+        .copied()
+        .filter(|token| token.chars().all(|ch| ch.is_ascii_alphanumeric()))
+        .filter(|token| !is_context_stop_token(token))
+        .take(5)
+        .collect();
+    if ascii_tokens.len() >= 2 {
+        return format!("tokens:{}", ascii_tokens.join("-"));
+    }
+
+    normalized_context.chars().take(96).collect()
+}
+
+fn reference_cluster_key(tokens: &[&str]) -> Option<String> {
+    for window in tokens.windows(2) {
+        let label = window[0];
+        let value = window[1];
+        if matches!(label, "pr" | "pull" | "pullrequest")
+            && value.chars().all(|ch| ch.is_ascii_digit())
+        {
+            return Some(format!("pr:{value}"));
+        }
+        if matches!(label, "issue" | "issues") && value.chars().all(|ch| ch.is_ascii_digit()) {
+            return Some(format!("issue:{value}"));
+        }
+    }
+    None
+}
+
+fn is_context_stop_token(token: &str) -> bool {
+    matches!(
+        token,
+        "a" | "an"
+            | "and"
+            | "by"
+            | "for"
+            | "from"
+            | "in"
+            | "of"
+            | "on"
+            | "the"
+            | "to"
+            | "with"
+            | "context"
+            | "skills"
+            | "skill"
+    )
 }
 
 pub(super) fn query_recent_summaries(

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -5,13 +5,14 @@ use rusqlite::Connection;
 
 use crate::memory::{self, Memory};
 
-use super::memory_traits::is_memory_self_diagnostic;
+use super::memory_traits::{is_memory_self_diagnostic, is_self_diagnostic_text};
 use super::types::{LoadedContext, SessionSummaryBrief};
 
 const CONTEXT_MEMORY_LIMIT: usize = 50;
 const RECENT_MEMORY_FETCH_LIMIT: i64 = 100;
 const BASENAME_SEARCH_LIMIT: i64 = 20;
 const MAX_SELF_DIAGNOSTIC_MEMORIES: usize = 2;
+const SUMMARY_FETCH_MULTIPLIER: usize = 3;
 
 pub(super) fn load_context_data(
     conn: &Connection,
@@ -65,10 +66,10 @@ fn load_project_memories(
         }
     }
 
-    limit_self_diagnostic_memories(deduplicate_memory_clusters(memories, current_branch))
-        .into_iter()
-        .take(CONTEXT_MEMORY_LIMIT)
-        .collect()
+    let mut selected =
+        limit_self_diagnostic_memories(deduplicate_memory_clusters(memories, current_branch));
+    sort_memories_by_branch(&mut selected, current_branch);
+    selected.into_iter().take(CONTEXT_MEMORY_LIMIT).collect()
 }
 
 fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {
@@ -279,18 +280,32 @@ pub(super) fn query_recent_summaries(
     project: &str,
     limit: usize,
 ) -> Result<Vec<SessionSummaryBrief>> {
+    let fetch_limit = limit.saturating_mul(SUMMARY_FETCH_MULTIPLIER).max(limit);
     let mut stmt = conn.prepare(
         "SELECT request, completed, created_at_epoch \
          FROM session_summaries \
          WHERE project = ?1 AND request IS NOT NULL AND request != '' \
          ORDER BY created_at_epoch DESC LIMIT ?2",
     )?;
-    let rows = stmt.query_map(rusqlite::params![project, limit as i64], |row| {
+    let rows = stmt.query_map(rusqlite::params![project, fetch_limit as i64], |row| {
         Ok(SessionSummaryBrief {
             request: row.get(0)?,
             completed: row.get(1)?,
             created_at_epoch: row.get(2)?,
         })
     })?;
-    Ok(rows.flatten().collect())
+    Ok(rows
+        .flatten()
+        .filter(|summary| !is_session_summary_self_diagnostic(summary))
+        .take(limit)
+        .collect())
+}
+
+fn is_session_summary_self_diagnostic(summary: &SessionSummaryBrief) -> bool {
+    let haystack = format!(
+        "{} {}",
+        summary.request,
+        summary.completed.as_deref().unwrap_or_default()
+    );
+    is_self_diagnostic_text(&haystack)
 }

--- a/src/context/sections/core.rs
+++ b/src/context/sections/core.rs
@@ -1,10 +1,14 @@
 use crate::memory::Memory;
+use std::collections::HashMap;
 
 use super::super::format::format_epoch_short;
+use super::super::memory_traits::is_memory_self_diagnostic;
 
 const MAX_CHARS: usize = 3000;
 const MAX_ITEMS: usize = 6;
 const PREVIEW_LEN: usize = 200;
+const MAX_PRIMARY_ITEMS_PER_TYPE: usize = 2;
+const MIN_ADDITIONAL_CORE_SCORE: f64 = 1.3;
 
 pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Memory]) {
     let now = chrono::Utc::now().timestamp();
@@ -19,16 +23,42 @@ pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Me
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let mut selected = Vec::new();
+    let mut selected: Vec<(&Memory, String)> = Vec::new();
     let mut total_chars = 0;
-    for (memory, _score) in scored.iter().take(MAX_ITEMS) {
-        let preview: String = memory.text.chars().take(PREVIEW_LEN).collect();
-        let item_len = preview.len() + memory.title.len() + 20;
-        if total_chars + item_len > MAX_CHARS && !selected.is_empty() {
+    let mut selected_ids = std::collections::HashSet::new();
+    let mut type_counts: HashMap<&str, usize> = HashMap::new();
+
+    for (memory, score) in &scored {
+        if selected.len() >= MAX_ITEMS {
             break;
         }
-        selected.push((memory, preview));
-        total_chars += item_len;
+        if *score < MIN_ADDITIONAL_CORE_SCORE && !selected.is_empty() {
+            break;
+        }
+        let count = type_counts
+            .get(memory.memory_type.as_str())
+            .copied()
+            .unwrap_or_default();
+        if count >= MAX_PRIMARY_ITEMS_PER_TYPE {
+            continue;
+        }
+        if push_selected_memory(&mut selected, &mut total_chars, memory) {
+            selected_ids.insert(memory.id);
+            *type_counts.entry(memory.memory_type.as_str()).or_default() += 1;
+        }
+    }
+
+    for (memory, score) in &scored {
+        if selected.len() >= MAX_ITEMS {
+            break;
+        }
+        if *score < MIN_ADDITIONAL_CORE_SCORE && !selected.is_empty() {
+            break;
+        }
+        if selected_ids.contains(&memory.id) {
+            continue;
+        }
+        push_selected_memory(&mut selected, &mut total_chars, memory);
     }
 
     if selected.is_empty() {
@@ -51,13 +81,29 @@ pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Me
     output.push('\n');
 }
 
+fn push_selected_memory<'a>(
+    selected: &mut Vec<(&'a Memory, String)>,
+    total_chars: &mut usize,
+    memory: &'a Memory,
+) -> bool {
+    let preview: String = memory.text.chars().take(PREVIEW_LEN).collect();
+    let item_len = preview.len() + memory.title.len() + 20;
+    if *total_chars + item_len > MAX_CHARS && !selected.is_empty() {
+        return false;
+    }
+
+    selected.push((memory, preview));
+    *total_chars += item_len;
+    true
+}
+
 fn calculate_memory_score(memory: &Memory, now_epoch: i64) -> f64 {
     let type_weight = match memory.memory_type.as_str() {
-        "decision" => 3.0,
-        "bugfix" => 2.5,
-        "architecture" => 2.0,
-        "discovery" => 1.0,
-        "preference" => 1.5,
+        "bugfix" => 3.0,
+        "architecture" => 2.6,
+        "decision" => 2.2,
+        "discovery" => 1.8,
+        "preference" => 1.4,
         _ => 0.5,
     };
 
@@ -65,10 +111,16 @@ fn calculate_memory_score(memory: &Memory, now_epoch: i64) -> f64 {
     let time_decay = if age_days <= 7 {
         1.0
     } else if age_days <= 30 {
-        0.7
+        0.55
     } else {
         0.4
     };
 
-    type_weight * time_decay
+    let meta_penalty = if is_memory_self_diagnostic(memory) {
+        0.35
+    } else {
+        1.0
+    };
+
+    type_weight * time_decay * meta_penalty
 }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -3,7 +3,7 @@ use crate::memory::Memory;
 use crate::workstream::{WorkStream, WorkStreamStatus};
 use rusqlite::{params, Connection};
 
-use super::query::load_context_data;
+use super::query::{load_context_data, query_recent_summaries};
 use super::sections::{
     render_core_memory, render_memory_index, render_recent_sessions, render_workstreams,
 };
@@ -260,6 +260,46 @@ fn load_context_data_prefers_current_branch_within_dedup_cluster() {
 }
 
 #[test]
+fn load_context_data_keeps_current_branch_memories_before_limit() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    for idx in 0..55 {
+        insert_memory(
+            &conn,
+            idx + 1,
+            project,
+            Some(&format!("branchless-topic-{idx}")),
+            "decision",
+            &format!("Branchless decision {idx}"),
+            "Recent branchless decision body",
+            now - idx,
+        );
+    }
+    insert_memory_with_branch(
+        &conn,
+        200,
+        project,
+        Some("current-branch-topic"),
+        "bugfix",
+        "Current branch operational fix",
+        "Older but branch-specific fix body",
+        now - 1_000,
+        Some("fix/context-selection"),
+    );
+
+    let loaded = load_context_data(&conn, project, Some("fix/context-selection"));
+
+    assert_eq!(loaded.memories.len(), 50);
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Current branch operational fix"));
+}
+
+#[test]
 fn load_context_data_limits_memory_self_diagnostics_before_index_rendering() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);
@@ -301,6 +341,71 @@ fn load_context_data_limits_memory_self_diagnostics_before_index_rendering() {
         .memories
         .iter()
         .any(|memory| memory.title == "Fix guard path source selection"));
+}
+
+#[test]
+fn query_recent_summaries_filters_self_diagnostics_and_backfills() {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE session_summaries (
+            project TEXT,
+            request TEXT,
+            completed TEXT,
+            created_at_epoch INTEGER
+        );",
+    )
+    .unwrap();
+    let project = "/tmp/vibeguard";
+
+    insert_session_summary(
+        &conn,
+        project,
+        "Debug remem context memory injection",
+        Some("SessionStart memories loaded investigation"),
+        300,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Fix runtime hook",
+        Some("Validated hook behavior"),
+        299,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Analyze SessionStart memories loaded",
+        None,
+        298,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Review PR install paths",
+        Some("Checked install scripts"),
+        297,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Memory injection follow-up",
+        Some("remem context smoke test"),
+        296,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Repair guard source path",
+        Some("Added source path evidence"),
+        295,
+    );
+
+    let summaries = query_recent_summaries(&conn, project, 3).unwrap();
+
+    assert_eq!(summaries.len(), 3);
+    assert_eq!(summaries[0].request, "Fix runtime hook");
+    assert_eq!(summaries[1].request, "Review PR install paths");
+    assert_eq!(summaries[2].request, "Repair guard source path");
 }
 
 fn sample_memory(id: i64, memory_type: &str, title: &str) -> Memory {
@@ -379,6 +484,21 @@ fn insert_memory_with_branch(
             updated_at_epoch,
             branch
         ],
+    )
+    .unwrap();
+}
+
+fn insert_session_summary(
+    conn: &Connection,
+    project: &str,
+    request: &str,
+    completed: Option<&str>,
+    created_at_epoch: i64,
+) {
+    conn.execute(
+        "INSERT INTO session_summaries (project, request, completed, created_at_epoch)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![project, request, completed, created_at_epoch],
     )
     .unwrap();
 }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -408,6 +408,102 @@ fn query_recent_summaries_filters_self_diagnostics_and_backfills() {
     assert_eq!(summaries[2].request, "Repair guard source path");
 }
 
+#[test]
+fn query_recent_summaries_scans_past_self_diagnostic_burst() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_session_summary_schema(&conn);
+    let project = "/tmp/vibeguard";
+
+    for idx in 0..30 {
+        insert_session_summary(
+            &conn,
+            project,
+            &format!("Debug remem context memory injection {idx}"),
+            Some("SessionStart memories loaded investigation"),
+            1_000 - idx,
+        );
+    }
+    insert_session_summary(
+        &conn,
+        project,
+        "Fix runtime hook",
+        Some("Validated hook behavior"),
+        100,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Repair guard source path",
+        Some("Added source path evidence"),
+        99,
+    );
+
+    let summaries = query_recent_summaries(&conn, project, 2).unwrap();
+
+    assert_eq!(summaries.len(), 2);
+    assert_eq!(summaries[0].request, "Fix runtime hook");
+    assert_eq!(summaries[1].request, "Repair guard source path");
+}
+
+#[test]
+fn query_recent_summaries_suppresses_stale_design_prototype_noise() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_session_summary_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_session_summary(
+        &conn,
+        project,
+        "Build landing page and wireframe variants",
+        Some("Starfield prototype shipped"),
+        now - 8 * 86400,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Generate VibeGuard wireframe prototype",
+        Some("Landing page assets updated"),
+        now - 9 * 86400,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Fix runtime hook",
+        Some("Validated hook behavior"),
+        now - 10 * 86400,
+    );
+
+    let summaries = query_recent_summaries(&conn, project, 5).unwrap();
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].request, "Fix runtime hook");
+}
+
+#[test]
+fn query_recent_summaries_keeps_stale_design_summary_as_last_resort() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_session_summary_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_session_summary(
+        &conn,
+        project,
+        "Build landing page and wireframe variants",
+        Some("Starfield prototype shipped"),
+        now - 8 * 86400,
+    );
+
+    let summaries = query_recent_summaries(&conn, project, 5).unwrap();
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries[0].request,
+        "Build landing page and wireframe variants"
+    );
+}
+
 fn sample_memory(id: i64, memory_type: &str, title: &str) -> Memory {
     sample_memory_with_epoch(id, memory_type, title, 1_710_000_000)
 }
@@ -499,6 +595,18 @@ fn insert_session_summary(
         "INSERT INTO session_summaries (project, request, completed, created_at_epoch)
          VALUES (?1, ?2, ?3, ?4)",
         params![project, request, completed, created_at_epoch],
+    )
+    .unwrap();
+}
+
+fn create_session_summary_schema(conn: &Connection) {
+    conn.execute_batch(
+        "CREATE TABLE session_summaries (
+            project TEXT,
+            request TEXT,
+            completed TEXT,
+            created_at_epoch INTEGER
+        );",
     )
     .unwrap();
 }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -1,6 +1,9 @@
+use crate::memory::types::tests_helper::setup_memory_schema;
 use crate::memory::Memory;
 use crate::workstream::{WorkStream, WorkStreamStatus};
+use rusqlite::{params, Connection};
 
+use super::query::load_context_data;
 use super::sections::{
     render_core_memory, render_memory_index, render_recent_sessions, render_workstreams,
 };
@@ -79,6 +82,227 @@ fn render_core_memory_prioritizes_higher_score_memories() {
     assert!(high_pos < low_pos);
 }
 
+#[test]
+fn render_core_memory_keeps_type_diversity_before_filling_same_type() {
+    let mut output = String::new();
+    let now = chrono::Utc::now().timestamp();
+    let memories = vec![
+        sample_memory_with_epoch(1, "decision", "Decision one", now),
+        sample_memory_with_epoch(2, "decision", "Decision two", now),
+        sample_memory_with_epoch(3, "decision", "Decision three", now),
+        sample_memory_with_epoch(4, "discovery", "Operational discovery", now),
+    ];
+
+    render_core_memory(&mut output, &memories);
+
+    let discovery_pos = output.find("**#4 Operational discovery**").unwrap();
+    let third_decision_pos = output.find("**#3 Decision three**").unwrap();
+    assert!(discovery_pos < third_decision_pos);
+}
+
+#[test]
+fn render_core_memory_does_not_backfill_with_memory_self_diagnostics() {
+    let mut output = String::new();
+    let now = chrono::Utc::now().timestamp();
+    let memories = vec![
+        sample_memory_with_epoch(1, "decision", "Memory injection diagnosis", now),
+        sample_memory_with_epoch(2, "discovery", "Runtime hook finding", now),
+    ];
+
+    render_core_memory(&mut output, &memories);
+
+    let runtime_pos = output.find("**#2 Runtime hook finding**").unwrap();
+    assert!(runtime_pos < output.len());
+    assert!(!output.contains("Memory injection diagnosis"));
+}
+
+#[test]
+fn render_core_memory_keeps_stale_decision_out_when_recent_context_is_available() {
+    let mut output = String::new();
+    let now = chrono::Utc::now().timestamp();
+    let stale_epoch = now - 8 * 86400;
+    let memories = vec![
+        sample_memory_with_epoch(1, "decision", "Recent decision one", now),
+        sample_memory_with_epoch(3, "discovery", "Recent discovery one", now),
+        sample_memory_with_epoch(4, "discovery", "Recent discovery two", now),
+        sample_memory_with_epoch(5, "preference", "Recent preference one", now),
+        sample_memory_with_epoch(6, "preference", "Recent preference two", now),
+        sample_memory_with_epoch(7, "decision", "Stale landing page decision", stale_epoch),
+    ];
+
+    render_core_memory(&mut output, &memories);
+
+    assert!(!output.contains("Stale landing page decision"));
+}
+
+#[test]
+fn load_context_data_dedupes_generated_topic_keys_by_workstream_context() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    for idx in 0..6 {
+        insert_memory(
+            &conn,
+            idx + 1,
+            project,
+            Some(&format!("decision-{:016x}", idx)),
+            "decision",
+            &format!("Landing page decision {idx}"),
+            "[Context: Build VibeGuard landing page and wireframe variants]\nDecision body",
+            now - idx,
+        );
+    }
+    insert_memory(
+        &conn,
+        99,
+        project,
+        Some("post-write-hook-worktree-hang"),
+        "bugfix",
+        "Fix post-write hook worktree hang",
+        "Handle .git files when resolving worktree roots",
+        now - 100,
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+    let landing_count = loaded
+        .memories
+        .iter()
+        .filter(|memory| memory.title.contains("Landing page decision"))
+        .count();
+
+    assert_eq!(landing_count, 1);
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Fix post-write hook worktree hang"));
+}
+
+#[test]
+fn load_context_data_clusters_contexts_by_pr_reference() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("decision-1111111111111111"),
+        "decision",
+        "Skill install decision A",
+        "[Context: Review VibeGuard PR #116 added agentsmd-audit and trajectory-review skills]\nBody",
+        now,
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("decision-2222222222222222"),
+        "decision",
+        "Skill install decision B",
+        "[Context: Review VibeGuard PR 116 new skill installation contract]\nBody",
+        now - 1,
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+    let pr_decision_count = loaded
+        .memories
+        .iter()
+        .filter(|memory| memory.title.starts_with("Skill install decision"))
+        .count();
+
+    assert_eq!(pr_decision_count, 1);
+}
+
+#[test]
+fn load_context_data_prefers_current_branch_within_dedup_cluster() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory_with_branch(
+        &conn,
+        1,
+        project,
+        Some("decision-1111111111111111"),
+        "decision",
+        "Main branch landing decision",
+        "[Context: Build VibeGuard landing page and wireframe variants]\nMain body",
+        now,
+        Some("main"),
+    );
+    insert_memory_with_branch(
+        &conn,
+        2,
+        project,
+        Some("decision-2222222222222222"),
+        "decision",
+        "Feature branch landing decision",
+        "[Context: Build VibeGuard landing page and wireframe variants]\nFeature body",
+        now - 10,
+        Some("fix/context-selection"),
+    );
+
+    let loaded = load_context_data(&conn, project, Some("fix/context-selection"));
+
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Feature branch landing decision"));
+    assert!(!loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Main branch landing decision"));
+}
+
+#[test]
+fn load_context_data_limits_memory_self_diagnostics_before_index_rendering() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    for idx in 0..8 {
+        insert_memory(
+            &conn,
+            idx + 1,
+            project,
+            Some(&format!("decision-{:016x}", idx)),
+            "decision",
+            &format!("Memory injection diagnosis {idx}"),
+            "Debug remem context SessionStart memories loaded behavior",
+            now - idx,
+        );
+    }
+    insert_memory(
+        &conn,
+        100,
+        project,
+        Some("guard-paths-source-path"),
+        "bugfix",
+        "Fix guard path source selection",
+        "Use source path evidence in guard output",
+        now - 20,
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+    let self_diagnostic_count = loaded
+        .memories
+        .iter()
+        .filter(|memory| memory.title.contains("Memory injection diagnosis"))
+        .count();
+
+    assert_eq!(self_diagnostic_count, 2);
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Fix guard path source selection"));
+}
+
 fn sample_memory(id: i64, memory_type: &str, title: &str) -> Memory {
     sample_memory_with_epoch(id, memory_type, title, 1_710_000_000)
 }
@@ -104,4 +328,57 @@ fn sample_memory_with_epoch(
         branch: None,
         scope: "project".to_string(),
     }
+}
+
+fn insert_memory(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    topic_key: Option<&str>,
+    memory_type: &str,
+    title: &str,
+    content: &str,
+    updated_at_epoch: i64,
+) {
+    insert_memory_with_branch(
+        conn,
+        id,
+        project,
+        topic_key,
+        memory_type,
+        title,
+        content,
+        updated_at_epoch,
+        None,
+    );
+}
+
+fn insert_memory_with_branch(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    topic_key: Option<&str>,
+    memory_type: &str,
+    title: &str,
+    content: &str,
+    updated_at_epoch: i64,
+    branch: Option<&str>,
+) {
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope)
+         VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?7, 'active', ?8, 'project')",
+        params![
+            id,
+            project,
+            topic_key,
+            title,
+            content,
+            memory_type,
+            updated_at_epoch,
+            branch
+        ],
+    )
+    .unwrap();
 }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -445,65 +445,6 @@ fn query_recent_summaries_scans_past_self_diagnostic_burst() {
     assert_eq!(summaries[1].request, "Repair guard source path");
 }
 
-#[test]
-fn query_recent_summaries_suppresses_stale_design_prototype_noise() {
-    let conn = Connection::open_in_memory().unwrap();
-    create_session_summary_schema(&conn);
-    let project = "/tmp/vibeguard";
-    let now = chrono::Utc::now().timestamp();
-
-    insert_session_summary(
-        &conn,
-        project,
-        "Build landing page and wireframe variants",
-        Some("Starfield prototype shipped"),
-        now - 8 * 86400,
-    );
-    insert_session_summary(
-        &conn,
-        project,
-        "Generate VibeGuard wireframe prototype",
-        Some("Landing page assets updated"),
-        now - 9 * 86400,
-    );
-    insert_session_summary(
-        &conn,
-        project,
-        "Fix runtime hook",
-        Some("Validated hook behavior"),
-        now - 10 * 86400,
-    );
-
-    let summaries = query_recent_summaries(&conn, project, 5).unwrap();
-
-    assert_eq!(summaries.len(), 1);
-    assert_eq!(summaries[0].request, "Fix runtime hook");
-}
-
-#[test]
-fn query_recent_summaries_keeps_stale_design_summary_as_last_resort() {
-    let conn = Connection::open_in_memory().unwrap();
-    create_session_summary_schema(&conn);
-    let project = "/tmp/vibeguard";
-    let now = chrono::Utc::now().timestamp();
-
-    insert_session_summary(
-        &conn,
-        project,
-        "Build landing page and wireframe variants",
-        Some("Starfield prototype shipped"),
-        now - 8 * 86400,
-    );
-
-    let summaries = query_recent_summaries(&conn, project, 5).unwrap();
-
-    assert_eq!(summaries.len(), 1);
-    assert_eq!(
-        summaries[0].request,
-        "Build landing page and wireframe variants"
-    );
-}
-
 fn sample_memory(id: i64, memory_type: &str, title: &str) -> Memory {
     sample_memory_with_epoch(id, memory_type, title, 1_710_000_000)
 }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -445,6 +445,96 @@ fn query_recent_summaries_scans_past_self_diagnostic_burst() {
     assert_eq!(summaries[1].request, "Repair guard source path");
 }
 
+#[test]
+fn query_recent_summaries_suppresses_stale_design_prototype_noise() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_session_summary_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_session_summary(
+        &conn,
+        project,
+        "Build landing page and wireframe variants",
+        Some("Starfield prototype shipped"),
+        now - 8 * 86400,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Generate VibeGuard wireframe prototype",
+        Some("Landing page assets updated"),
+        now - 9 * 86400,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Fix runtime hook",
+        Some("Validated hook behavior"),
+        now - 10 * 86400,
+    );
+
+    let summaries = query_recent_summaries(&conn, project, 5).unwrap();
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].request, "Fix runtime hook");
+}
+
+#[test]
+fn query_recent_summaries_keeps_stale_design_summary_as_last_resort() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_session_summary_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_session_summary(
+        &conn,
+        project,
+        "Build landing page and wireframe variants",
+        Some("Starfield prototype shipped"),
+        now - 8 * 86400,
+    );
+
+    let summaries = query_recent_summaries(&conn, project, 5).unwrap();
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries[0].request,
+        "Build landing page and wireframe variants"
+    );
+}
+
+#[test]
+fn query_recent_summaries_allows_normal_summary_after_low_signal_same_cluster() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_session_summary_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_session_summary(
+        &conn,
+        project,
+        "Review release work",
+        Some("Starfield prototype shipped"),
+        now - 8 * 86400,
+    );
+    insert_session_summary(
+        &conn,
+        project,
+        "Review release work",
+        Some("Validated current runtime hook behavior"),
+        now - 9 * 86400,
+    );
+
+    let summaries = query_recent_summaries(&conn, project, 5).unwrap();
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries[0].completed.as_deref(),
+        Some("Validated current runtime hook behavior")
+    );
+}
+
 fn sample_memory(id: i64, memory_type: &str, title: &str) -> Memory {
     sample_memory_with_epoch(id, memory_type, title, 1_710_000_000)
 }


### PR DESCRIPTION
## Summary

Fixes noisy SessionStart context injection by making memory selection cluster-aware and branch-aware before truncation.

Changes:
- Prefer exact-project recent memories before basename search, then dedupe by stable topic/context/PR/issue cluster.
- Pick the current-branch representative inside a dedup cluster before falling back to branchless/main/other records.
- Sort by branch before the 50-memory truncation so older current-branch context is not evicted by branchless/main records.
- Limit memory self-diagnostic records before rendering.
- Filter self-diagnostic session summaries and page through older summaries to backfill normal sessions.
- Keep Core from backfilling with low-score stale or self-diagnostic memories when stronger context exists.

Closes #42.

## Validation

- `cargo fmt --check`
- `cargo test context::tests -- --nocapture`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`