### PR TITLE
[codex] isolate hook AI executor routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,20 @@ Restart your AI coding tool after installation.
 
 ## How It Works
 
-remem runs through host hooks:
+remem uses host-specific hook strategies:
 
 ```
-Your normal Claude Code/Codex workflow
+Claude Code workflow
         |
         |- SessionStart      -> Inject memories + preferences
         |- UserPromptSubmit  -> Register session, flush stale queues
         |- PostToolUse       -> Capture tool operations (queued, <1ms)
         '- Stop              -> Summarize in background (~6ms return)
+
+Codex workflow
+        |
+        |- SessionStart      -> Inject memories + preferences
+        '- Stop              -> Summarize in background with Codex CLI
 ```
 
 No manual capture is required.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Language: **English** | [简体中文](README.zh-CN.md)
 
-Persistent memory for Claude Code. A single Rust binary that automatically captures, distills, and injects project context across sessions: decisions, patterns, preferences, and learnings.
+Persistent memory for Claude Code and Codex. A single Rust binary that automatically captures, distills, and injects project context across sessions: decisions, patterns, preferences, and learnings.
 
 [![CI](https://github.com/majiayu000/remem/actions/workflows/ci.yml/badge.svg)](https://github.com/majiayu000/remem/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -41,18 +41,18 @@ cargo build --release
 cp target/release/remem ~/.local/bin/
 codesign -s - -f ~/.local/bin/remem  # required on macOS ARM
 
-# Configure Claude Code hooks + MCP
+# Configure detected Claude Code/Codex hooks + MCP
 remem install
 ```
 
-Restart Claude Code after installation.
+Restart your AI coding tool after installation.
 
 ## How It Works
 
-remem runs through Claude Code hooks:
+remem runs through host hooks:
 
 ```
-Your normal Claude Code workflow
+Your normal Claude Code/Codex workflow
         |
         |- SessionStart      -> Inject memories + preferences
         |- UserPromptSubmit  -> Register session, flush stale queues

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 语言： [English](README.md) | **简体中文**
 
-`remem` 是面向 Claude Code 的持久记忆工具。它是一个 Rust 单二进制程序，会在会话间自动捕获、提炼并注入项目上下文，包括决策、模式、偏好和经验。
+`remem` 是面向 Claude Code 和 Codex 的持久记忆工具。它是一个 Rust 单二进制程序，会在会话间自动捕获、提炼并注入项目上下文，包括决策、模式、偏好和经验。
 
 [![CI](https://github.com/majiayu000/remem/actions/workflows/ci.yml/badge.svg)](https://github.com/majiayu000/remem/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -41,18 +41,18 @@ cargo build --release
 cp target/release/remem ~/.local/bin/
 codesign -s - -f ~/.local/bin/remem  # macOS ARM 必须签名
 
-# 配置 Claude Code hooks + MCP
+# 配置检测到的 Claude Code/Codex hooks + MCP
 remem install
 ```
 
-安装后重启 Claude Code。
+安装后重启对应的 AI 编程工具。
 
 ## 工作机制
 
-`remem` 通过 Claude Code Hooks 自动运行：
+`remem` 通过 host hooks 自动运行：
 
 ```
-你的 Claude Code 正常工作流
+你的 Claude Code/Codex 正常工作流
         |
         |- SessionStart      -> 注入记忆与偏好
         |- UserPromptSubmit  -> 注册会话、刷新旧队列

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,15 +49,20 @@ remem install
 
 ## 工作机制
 
-`remem` 通过 host hooks 自动运行：
+`remem` 使用 host-specific hook 策略自动运行：
 
 ```
-你的 Claude Code/Codex 正常工作流
+Claude Code 正常工作流
         |
         |- SessionStart      -> 注入记忆与偏好
         |- UserPromptSubmit  -> 注册会话、刷新旧队列
         |- PostToolUse       -> 捕获工具操作（入队，<1ms）
         '- Stop              -> 后台总结（返回约 6ms）
+
+Codex 正常工作流
+        |
+        |- SessionStart      -> 注入记忆与偏好
+        '- Stop              -> 使用 Codex CLI 后台总结
 ```
 
 全程自动，不需要手动保存记忆。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ```
 ┌───────────────────────────────────────────────────────────┐
-│                    Claude Code Hooks                       │
+│                 Claude Code / Codex Hooks                  │
 │                                                            │
 │  SessionStart ──────→ context       (inject memories)      │
 │  UserPromptSubmit ──→ session-init  (register + flush)     │
@@ -289,7 +289,7 @@ Project key = `last two path segments + canonical absolute path hash`, balancing
 |----------|---------|-------------|
 | `REMEM_DATA_DIR` | `~/.remem` | Data directory (DB + logs) |
 | `REMEM_MODEL` | `haiku` | AI model (haiku/sonnet/opus or full model ID) |
-| `REMEM_EXECUTOR` | `auto` | AI executor: `auto` (HTTP first) / `http` / `cli` |
+| `REMEM_EXECUTOR` | `auto` | AI executor: `auto` (HTTP first) / `http` / `claude-cli` / `codex-cli` |
 | `ANTHROPIC_API_KEY` | - | Required for HTTP mode (also supports `ANTHROPIC_AUTH_TOKEN`) |
 | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | Custom API endpoint |
 | `REMEM_DEBUG` | - | Enable debug logging |
@@ -302,6 +302,8 @@ Project key = `last two path segments + canonical absolute path hash`, balancing
 | `REMEM_CONTEXT_SHOW_WORK_TOKENS` | `true` | Show work token statistics |
 | `REMEM_CONTEXT_SHOW_LAST_SUMMARY` | `true` | Show last session summary |
 | `REMEM_CLAUDE_PATH` | `claude` | Claude CLI path |
+| `REMEM_CODEX_PATH` | `codex` | Codex CLI path |
+| `REMEM_CODEX_MODEL` | - | Optional Codex CLI model override |
 | `REMEM_LOG_MAX_BYTES` | `10485760` | Log file size limit (bytes), auto-rotated |
 | `REMEM_SAVE_MEMORY_LOCAL_COPY` | `true` | Enable local Markdown backup for save_memory |
 | `REMEM_SAVE_MEMORY_LOCAL_DIR` | `~/.remem/manual-notes` | Local backup directory |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -289,7 +289,11 @@ Project key = `last two path segments + canonical absolute path hash`, balancing
 |----------|---------|-------------|
 | `REMEM_DATA_DIR` | `~/.remem` | Data directory (DB + logs) |
 | `REMEM_MODEL` | `haiku` | AI model (haiku/sonnet/opus or full model ID) |
-| `REMEM_EXECUTOR` | `auto` | AI executor: `auto` (HTTP first) / `http` / `claude-cli` / `codex-cli` |
+| `REMEM_EXECUTOR` | `auto` | Legacy/general AI executor fallback for summaries and unspecified operations: `auto` / `http` / `claude-cli` / `codex-cli` |
+| `REMEM_SUMMARY_EXECUTOR` | `REMEM_EXECUTOR` | Summary executor override, used by Stop hooks (`claude-cli` for Claude Code, `codex-cli` for Codex) |
+| `REMEM_FLUSH_EXECUTOR` | `auto` | Flush/background observation executor override |
+| `REMEM_COMPRESS_EXECUTOR` | `auto` | Memory compression executor override |
+| `REMEM_DREAM_EXECUTOR` | `auto` | Dream executor override |
 | `ANTHROPIC_API_KEY` | - | Required for HTTP mode (also supports `ANTHROPIC_AUTH_TOKEN`) |
 | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | Custom API endpoint |
 | `REMEM_DEBUG` | - | Enable debug logging |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,11 +4,14 @@
 
 ```
 ┌───────────────────────────────────────────────────────────┐
-│                 Claude Code / Codex Hooks                  │
+│              Host Hooks (Claude Code / Codex)              │
+│                                                            │
+│  Claude Code: SessionStart/UserPromptSubmit/PostToolUse/Stop│
+│  Codex:       SessionStart/Stop                            │
 │                                                            │
 │  SessionStart ──────→ context       (inject memories)      │
-│  UserPromptSubmit ──→ session-init  (register + flush)     │
-│  PostToolUse ───────→ observe       (filter + queue)       │
+│  UserPromptSubmit ──→ session-init  (Claude Code only)     │
+│  PostToolUse ───────→ observe       (Claude Code only)     │
 │  Stop ──────────────→ summarize     (3-gate + worker)      │
 └──────────────┬──────────────────────┬──────────────────────┘
                │                      │
@@ -73,7 +76,7 @@
 
 ## Data Flow
 
-### 1. Observation Capture (PostToolUse → observe)
+### 1. Observation Capture (Claude Code PostToolUse → observe)
 
 ```
 Tool call ──→ Type check ──→ Bash filter ──→ Queue to SQLite
@@ -157,7 +160,7 @@ New session starts
        └─ Recent session summaries (request/completed)
 ```
 
-### 4. Stale Queue Recovery (UserPromptSubmit → session_init)
+### 4. Stale Queue Recovery (Claude Code UserPromptSubmit → session_init)
 
 ```
 New message submitted
@@ -377,7 +380,7 @@ memories_fts (title, content)                                    -- FTS5 trigram
 - **HTTP-first AI calls**: HTTP API direct 2-5s vs `claude -p` CLI 30+s, 6-12x performance gap
 - **Stop hook async**: Dispatcher returns in 6ms, `std::process::Command` spawns independent worker
 - **SQLite single-file + WAL**: Zero dependencies, FTS5 full-text search, WAL concurrent read/write
-- **Queue batch processing**: PostToolUse only queues (<1ms), Stop processes ≤15 events in one AI call
+- **Queue batch processing**: Claude Code PostToolUse only queues (<1ms), Stop processes ≤15 events in one AI call
 - **Decision priority**: Summary fields ordered decisions > completed > learned, architectural knowledge most valuable
 - **Schema version control**: `PRAGMA user_version` skips repeated migration, reduces per-hook DB overhead
 - **Stable project key**: `parent/dirname@hash12`, readable prefix + canonical path hash, eliminates same-name directory collisions

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -71,9 +71,9 @@ fn executor_for_operation(operation: &str) -> Option<AiExecutor> {
 fn executor_env_keys(operation: &str) -> &'static [&'static str] {
     match operation {
         "summarize" => &["REMEM_SUMMARY_EXECUTOR", "REMEM_EXECUTOR"],
-        "flush" | "flush-task" => &["REMEM_FLUSH_EXECUTOR", "REMEM_EXECUTOR"],
-        "compress" => &["REMEM_COMPRESS_EXECUTOR", "REMEM_EXECUTOR"],
-        "dream" => &["REMEM_DREAM_EXECUTOR", "REMEM_EXECUTOR"],
+        "flush" | "flush-task" => &["REMEM_FLUSH_EXECUTOR"],
+        "compress" => &["REMEM_COMPRESS_EXECUTOR"],
+        "dream" => &["REMEM_DREAM_EXECUTOR"],
         _ => &["REMEM_EXECUTOR"],
     }
 }

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod codex_cli;
 mod config;
 mod http;
 mod pricing;
@@ -8,6 +9,7 @@ mod types;
 mod usage;
 
 use cli::call_cli;
+use codex_cli::call_codex_cli;
 use http::call_http;
 use pricing::estimate_tokens;
 use usage::record_usage;
@@ -21,8 +23,11 @@ pub async fn call_ai(
     ctx: UsageContext<'_>,
 ) -> anyhow::Result<String> {
     let result = match std::env::var("REMEM_EXECUTOR").ok().as_deref() {
-        Some("http") => call_http(system, user_message).await,
-        Some("cli") => call_cli(system, user_message).await,
+        Some("http") | Some("anthropic-http") | Some("anthropic") => {
+            call_http(system, user_message).await
+        }
+        Some("cli") | Some("claude-cli") | Some("claude") => call_cli(system, user_message).await,
+        Some("codex-cli") | Some("codex") => call_codex_cli(system, user_message).await,
         _ => {
             if std::env::var("ANTHROPIC_API_KEY").is_ok()
                 || std::env::var("ANTHROPIC_AUTH_TOKEN").is_ok()

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -16,40 +16,73 @@ use usage::record_usage;
 
 pub use types::UsageContext;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AiExecutor {
+    Http,
+    ClaudeCli,
+    CodexCli,
+}
+
 /// AI call with timeout. HTTP first (fast, ~2-5s), CLI fallback (slow, ~30-60s).
 pub async fn call_ai(
     system: &str,
     user_message: &str,
     ctx: UsageContext<'_>,
 ) -> anyhow::Result<String> {
-    let result = match std::env::var("REMEM_EXECUTOR").ok().as_deref() {
-        Some("http") | Some("anthropic-http") | Some("anthropic") => {
-            call_http(system, user_message).await
-        }
-        Some("cli") | Some("claude-cli") | Some("claude") => call_cli(system, user_message).await,
-        Some("codex-cli") | Some("codex") => call_codex_cli(system, user_message).await,
-        _ => {
-            if std::env::var("ANTHROPIC_API_KEY").is_ok()
-                || std::env::var("ANTHROPIC_AUTH_TOKEN").is_ok()
-            {
-                match call_http(system, user_message).await {
-                    Ok(result) => Ok(result),
-                    Err(http_err) => {
-                        crate::log::warn(
-                            "ai",
-                            &format!("HTTP failed, falling back to CLI: {}", http_err),
-                        );
-                        call_cli(system, user_message).await
-                    }
-                }
-            } else {
-                call_cli(system, user_message).await
-            }
-        }
+    let result = match executor_for_operation(ctx.operation) {
+        Some(AiExecutor::Http) => call_http(system, user_message).await,
+        Some(AiExecutor::ClaudeCli) => call_cli(system, user_message).await,
+        Some(AiExecutor::CodexCli) => call_codex_cli(system, user_message).await,
+        None => call_auto(system, user_message).await,
     }?;
 
     let input_tokens = estimate_tokens(system) + estimate_tokens(user_message);
     let output_tokens = estimate_tokens(&result.text);
     record_usage(ctx, &result, input_tokens, output_tokens);
     Ok(result.text)
+}
+
+async fn call_auto(system: &str, user_message: &str) -> anyhow::Result<types::AiCallResult> {
+    if std::env::var("ANTHROPIC_API_KEY").is_ok() || std::env::var("ANTHROPIC_AUTH_TOKEN").is_ok() {
+        match call_http(system, user_message).await {
+            Ok(result) => Ok(result),
+            Err(http_err) => {
+                crate::log::warn(
+                    "ai",
+                    &format!("HTTP failed, falling back to CLI: {}", http_err),
+                );
+                call_cli(system, user_message).await
+            }
+        }
+    } else {
+        call_cli(system, user_message).await
+    }
+}
+
+fn executor_for_operation(operation: &str) -> Option<AiExecutor> {
+    for key in executor_env_keys(operation) {
+        if let Some(executor) = executor_from_env(key) {
+            return Some(executor);
+        }
+    }
+    None
+}
+
+fn executor_env_keys(operation: &str) -> &'static [&'static str] {
+    match operation {
+        "summarize" => &["REMEM_SUMMARY_EXECUTOR", "REMEM_EXECUTOR"],
+        "flush" | "flush-task" => &["REMEM_FLUSH_EXECUTOR", "REMEM_EXECUTOR"],
+        "compress" => &["REMEM_COMPRESS_EXECUTOR", "REMEM_EXECUTOR"],
+        "dream" => &["REMEM_DREAM_EXECUTOR", "REMEM_EXECUTOR"],
+        _ => &["REMEM_EXECUTOR"],
+    }
+}
+
+fn executor_from_env(key: &str) -> Option<AiExecutor> {
+    match std::env::var(key).ok()?.as_str() {
+        "http" | "anthropic-http" | "anthropic" => Some(AiExecutor::Http),
+        "cli" | "claude-cli" | "claude" => Some(AiExecutor::ClaudeCli),
+        "codex-cli" | "codex" => Some(AiExecutor::CodexCli),
+        _ => None,
+    }
 }

--- a/src/ai/codex_cli.rs
+++ b/src/ai/codex_cli.rs
@@ -1,0 +1,132 @@
+use std::ffi::OsString;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+use crate::ai::config::{get_codex_model, get_codex_path};
+use crate::ai::types::{AiCallResult, AI_TIMEOUT_SECS};
+
+pub(super) async fn call_codex_cli(system: &str, user_message: &str) -> Result<AiCallResult> {
+    let codex = get_codex_path();
+    let model = get_codex_model();
+    let output_path = std::env::temp_dir().join(format!(
+        "remem-codex-summary-{}-{}.txt",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    let prompt = build_prompt(system, user_message);
+
+    let mut command = Command::new(&codex);
+    command.args(build_codex_args(&output_path, model.as_deref()));
+    command
+        .env("REMEM_DISABLE_HOOKS", "1")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("failed to spawn '{}' - is Codex CLI installed?", codex))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        stdin.write_all(prompt.as_bytes()).await?;
+    }
+
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(AI_TIMEOUT_SECS),
+        child.wait_with_output(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("codex CLI timed out after {}s", AI_TIMEOUT_SECS))??;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let _ = std::fs::remove_file(&output_path);
+        anyhow::bail!("codex CLI exited {}: {}", output.status, stderr);
+    }
+
+    let text = std::fs::read_to_string(&output_path)
+        .with_context(|| format!("failed to read Codex output {}", output_path.display()))?
+        .trim()
+        .to_string();
+    let _ = std::fs::remove_file(&output_path);
+    if text.is_empty() {
+        anyhow::bail!("codex CLI returned empty response");
+    }
+
+    Ok(AiCallResult {
+        text,
+        executor: "codex-cli",
+        model: model.unwrap_or_else(|| "codex-default".to_string()),
+    })
+}
+
+fn build_codex_args(output_path: &Path, model: Option<&str>) -> Vec<OsString> {
+    let mut args: Vec<OsString> = [
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--ephemeral",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "read-only",
+        "--output-last-message",
+    ]
+    .into_iter()
+    .map(OsString::from)
+    .collect();
+
+    args.push(output_path.as_os_str().to_owned());
+    if let Some(model) = model {
+        args.push(OsString::from("--model"));
+        args.push(OsString::from(model));
+    }
+    args.push(OsString::from("-"));
+    args
+}
+
+fn build_prompt(system: &str, user_message: &str) -> String {
+    format!(
+        "You are running as remem's Codex CLI summarization backend.\n\
+         Follow the system instructions exactly and return only the requested output.\n\n\
+         <system>\n{}\n</system>\n\n\
+         <input>\n{}\n</input>\n",
+        system, user_message
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::build_codex_args;
+
+    #[test]
+    fn codex_args_put_global_approval_before_exec() {
+        let args = build_codex_args(Path::new("/tmp/remem-out.txt"), Some("gpt-test"));
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(&rendered[..3], ["--ask-for-approval", "never", "exec"]);
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair[0] == "--output-last-message" && pair[1] == "/tmp/remem-out.txt"),
+            "{rendered:?}"
+        );
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair[0] == "--model" && pair[1] == "gpt-test"),
+            "{rendered:?}"
+        );
+        assert_eq!(rendered.last().map(String::as_str), Some("-"));
+    }
+}

--- a/src/ai/codex_cli.rs
+++ b/src/ai/codex_cli.rs
@@ -35,12 +35,22 @@ pub(super) async fn call_codex_cli(system: &str, user_message: &str) -> Result<A
         stdin.write_all(prompt.as_bytes()).await?;
     }
 
-    let output = tokio::time::timeout(
+    let output = match tokio::time::timeout(
         std::time::Duration::from_secs(AI_TIMEOUT_SECS),
         child.wait_with_output(),
     )
     .await
-    .map_err(|_| anyhow::anyhow!("codex CLI timed out after {}s", AI_TIMEOUT_SECS))??;
+    {
+        Ok(Ok(output)) => output,
+        Ok(Err(error)) => {
+            let _ = std::fs::remove_file(&output_path);
+            return Err(error.into());
+        }
+        Err(_) => {
+            let _ = std::fs::remove_file(&output_path);
+            anyhow::bail!("codex CLI timed out after {}s", AI_TIMEOUT_SECS);
+        }
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/ai/config.rs
+++ b/src/ai/config.rs
@@ -16,3 +16,13 @@ pub(super) fn resolve_model_for_api(short: &str) -> &str {
 pub(super) fn get_claude_path() -> String {
     std::env::var("REMEM_CLAUDE_PATH").unwrap_or_else(|_| "claude".to_string())
 }
+
+pub(super) fn get_codex_path() -> String {
+    std::env::var("REMEM_CODEX_PATH").unwrap_or_else(|_| "codex".to_string())
+}
+
+pub(super) fn get_codex_model() -> Option<String> {
+    std::env::var("REMEM_CODEX_MODEL")
+        .ok()
+        .filter(|model| !model.trim().is_empty())
+}

--- a/src/ai/tests.rs
+++ b/src/ai/tests.rs
@@ -108,7 +108,7 @@ fn summary_executor_override_does_not_leak_to_flush() {
 }
 
 #[test]
-fn operation_executor_overrides_global_fallback() {
+fn operation_executor_overrides_do_not_use_global_fallback_for_background_jobs() {
     with_env_vars(
         &[
             ("REMEM_EXECUTOR", Some("claude-cli")),
@@ -123,11 +123,32 @@ fn operation_executor_overrides_global_fallback() {
                 Some(AiExecutor::CodexCli)
             );
             assert_eq!(executor_for_operation("flush"), Some(AiExecutor::Http));
-            assert_eq!(
-                executor_for_operation("compress"),
-                Some(AiExecutor::ClaudeCli)
-            );
+            assert_eq!(executor_for_operation("compress"), None);
+            assert_eq!(executor_for_operation("dream"), None);
             assert_eq!(executor_for_operation("other"), Some(AiExecutor::ClaudeCli));
+        },
+    );
+}
+
+#[test]
+fn legacy_global_executor_only_affects_summary() {
+    with_env_vars(
+        &[
+            ("REMEM_EXECUTOR", Some("codex-cli")),
+            ("REMEM_SUMMARY_EXECUTOR", None),
+            ("REMEM_FLUSH_EXECUTOR", None),
+            ("REMEM_COMPRESS_EXECUTOR", None),
+            ("REMEM_DREAM_EXECUTOR", None),
+        ],
+        || {
+            assert_eq!(
+                executor_for_operation("summarize"),
+                Some(AiExecutor::CodexCli)
+            );
+            assert_eq!(executor_for_operation("flush"), None);
+            assert_eq!(executor_for_operation("flush-task"), None);
+            assert_eq!(executor_for_operation("compress"), None);
+            assert_eq!(executor_for_operation("dream"), None);
         },
     );
 }

--- a/src/ai/tests.rs
+++ b/src/ai/tests.rs
@@ -2,6 +2,7 @@ use std::sync::Mutex;
 
 use super::config::resolve_model_for_api;
 use super::pricing::{estimate_cost_usd, pricing_for_model};
+use super::{executor_for_operation, AiExecutor};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -80,6 +81,53 @@ fn estimate_cost_usd_combines_input_and_output_prices() {
         || {
             let cost = estimate_cost_usd("any-model", 500_000, 250_000);
             assert!((cost - 3.0).abs() < f64::EPSILON);
+        },
+    );
+}
+
+#[test]
+fn summary_executor_override_does_not_leak_to_flush() {
+    with_env_vars(
+        &[
+            ("REMEM_EXECUTOR", None),
+            ("REMEM_SUMMARY_EXECUTOR", Some("codex-cli")),
+            ("REMEM_FLUSH_EXECUTOR", None),
+            ("REMEM_COMPRESS_EXECUTOR", None),
+            ("REMEM_DREAM_EXECUTOR", None),
+        ],
+        || {
+            assert_eq!(
+                executor_for_operation("summarize"),
+                Some(AiExecutor::CodexCli)
+            );
+            assert_eq!(executor_for_operation("flush"), None);
+            assert_eq!(executor_for_operation("flush-task"), None);
+            assert_eq!(executor_for_operation("compress"), None);
+        },
+    );
+}
+
+#[test]
+fn operation_executor_overrides_global_fallback() {
+    with_env_vars(
+        &[
+            ("REMEM_EXECUTOR", Some("claude-cli")),
+            ("REMEM_SUMMARY_EXECUTOR", Some("codex-cli")),
+            ("REMEM_FLUSH_EXECUTOR", Some("http")),
+            ("REMEM_COMPRESS_EXECUTOR", None),
+            ("REMEM_DREAM_EXECUTOR", None),
+        ],
+        || {
+            assert_eq!(
+                executor_for_operation("summarize"),
+                Some(AiExecutor::CodexCli)
+            );
+            assert_eq!(executor_for_operation("flush"), Some(AiExecutor::Http));
+            assert_eq!(
+                executor_for_operation("compress"),
+                Some(AiExecutor::ClaudeCli)
+            );
+            assert_eq!(executor_for_operation("other"), Some(AiExecutor::ClaudeCli));
         },
     );
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -16,12 +16,30 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             session_id,
             color,
         } => {
+            if remem_hooks_disabled() {
+                return Ok(());
+            }
             let cwd = resolve_cwd_arg(cwd);
             context::generate_context(&cwd, session_id.as_deref(), color)?;
         }
-        Commands::SessionInit => observe::session_init().await?,
-        Commands::Observe => observe::observe().await?,
-        Commands::Summarize => summarize::summarize().await?,
+        Commands::SessionInit => {
+            if remem_hooks_disabled() {
+                return Ok(());
+            }
+            observe::session_init().await?;
+        }
+        Commands::Observe => {
+            if remem_hooks_disabled() {
+                return Ok(());
+            }
+            observe::observe().await?;
+        }
+        Commands::Summarize => {
+            if remem_hooks_disabled() {
+                return Ok(());
+            }
+            summarize::summarize().await?;
+        }
         Commands::Worker { once } => worker::run(once, 2000).await?,
         Commands::Mcp => mcp::run_mcp_server().await?,
         Commands::Install { target, dry_run } => install::install(target, dry_run)?,
@@ -54,4 +72,10 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn remem_hooks_disabled() -> bool {
+    std::env::var("REMEM_DISABLE_HOOKS")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
 }

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -3,7 +3,11 @@ use clap::{Parser, Subcommand};
 pub(super) use crate::install::InstallTarget;
 
 #[derive(Parser)]
-#[command(name = "remem", about = "Persistent memory for Claude Code", version)]
+#[command(
+    name = "remem",
+    about = "Persistent memory for Claude Code and Codex",
+    version
+)]
 pub(super) struct Cli {
     #[command(subcommand)]
     pub(super) command: Commands,

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -139,7 +139,7 @@ fn probe_hooks(probe: HostProbe) -> Check {
         }
     };
 
-    let events = ["PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"];
+    let events = expected_hook_events(probe.name);
     let found = events
         .iter()
         .filter(|event| event_has_remem_hook(&doc, event))
@@ -253,10 +253,18 @@ fn hooks_file_has_remem(path: &PathBuf) -> bool {
         return false;
     };
     match serde_json::from_str::<Value>(&content) {
-        Ok(doc) => ["PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"]
+        Ok(doc) => ["claude", "codex"]
             .iter()
+            .flat_map(|host| expected_hook_events(host).iter())
             .any(|event| event_has_remem_hook(&doc, event)),
         Err(_) => content.contains("remem"),
+    }
+}
+
+fn expected_hook_events(host: &str) -> &'static [&'static str] {
+    match host {
+        "codex" => &["SessionStart", "Stop"],
+        _ => &["PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"],
     }
 }
 
@@ -379,7 +387,32 @@ mod tests {
         });
 
         assert!(matches!(check.status, Status::Warn));
-        assert!(check.detail.contains("1/4 registered"), "{}", check.detail);
+        assert!(check.detail.contains("1/2 registered"), "{}", check.detail);
+    }
+
+    #[test]
+    fn probe_hooks_accepts_codex_summary_strategy() {
+        let dir = temp_path("doctor-codex-hooks");
+        let hooks_path = dir.join("hooks.json");
+        std::fs::write(
+            &hooks_path,
+            r#"{
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context" }] }],
+    "Stop": [{ "hooks": [{ "command": "REMEM_SUMMARY_EXECUTOR=codex-cli /tmp/remem summarize" }] }]
+  }
+}"#,
+        )
+        .unwrap();
+
+        let check = probe_hooks(HostProbe {
+            name: "codex",
+            hooks_path,
+            mcp_paths: vec![dir.join("config.toml")],
+        });
+
+        assert!(matches!(check.status, Status::Ok));
+        assert!(check.detail.contains("2/2 registered"), "{}", check.detail);
     }
 
     #[test]

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -11,7 +11,7 @@ pub(in crate::install) enum HookExecutor {
 }
 
 impl HookExecutor {
-    fn env_value(self) -> &'static str {
+    fn summary_executor(self) -> &'static str {
         match self {
             Self::ClaudeCli => "claude-cli",
             Self::CodexCli => "codex-cli",
@@ -20,12 +20,16 @@ impl HookExecutor {
 }
 
 fn hook_command(bin: &str, executor: HookExecutor, subcommand: &str) -> String {
-    format!(
-        "REMEM_EXECUTOR={} {} {}",
-        executor.env_value(),
-        bin,
-        subcommand
-    )
+    if subcommand == "summarize" {
+        format!(
+            "REMEM_SUMMARY_EXECUTOR={} {} {}",
+            executor.summary_executor(),
+            bin,
+            subcommand
+        )
+    } else {
+        format!("{} {}", bin, subcommand)
+    }
 }
 
 pub(in crate::install) fn build_hooks(bin: &str, executor: HookExecutor) -> Value {

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -5,25 +5,33 @@ use std::path::Path;
 use crate::install::json_io::{read_json_file, write_json_file};
 
 #[derive(Clone, Copy)]
-pub(in crate::install) enum HookExecutor {
-    ClaudeCli,
-    CodexCli,
+pub(in crate::install) enum HookStrategy {
+    ClaudeCode,
+    Codex,
 }
 
-impl HookExecutor {
+impl HookStrategy {
     fn summary_executor(self) -> &'static str {
         match self {
-            Self::ClaudeCli => "claude-cli",
-            Self::CodexCli => "codex-cli",
+            Self::ClaudeCode => "claude-cli",
+            Self::Codex => "codex-cli",
         }
+    }
+
+    fn include_session_init(self) -> bool {
+        matches!(self, Self::ClaudeCode)
+    }
+
+    fn include_observe(self) -> bool {
+        matches!(self, Self::ClaudeCode)
     }
 }
 
-fn hook_command(bin: &str, executor: HookExecutor, subcommand: &str) -> String {
+fn hook_command(bin: &str, strategy: HookStrategy, subcommand: &str) -> String {
     if subcommand == "summarize" {
         format!(
             "REMEM_SUMMARY_EXECUTOR={} {} {}",
-            executor.summary_executor(),
+            strategy.summary_executor(),
             bin,
             subcommand
         )
@@ -32,22 +40,43 @@ fn hook_command(bin: &str, executor: HookExecutor, subcommand: &str) -> String {
     }
 }
 
-pub(in crate::install) fn build_hooks(bin: &str, executor: HookExecutor) -> Value {
-    json!({
-        "SessionStart": [{
-            "hooks": [{ "type": "command", "command": hook_command(bin, executor, "context"), "timeout": 15000 }]
-        }],
-        "UserPromptSubmit": [{
-            "hooks": [{ "type": "command", "command": hook_command(bin, executor, "session-init"), "timeout": 15000 }]
-        }],
-        "PostToolUse": [{
-            "matcher": "Write|Edit|NotebookEdit|Bash|Task",
-            "hooks": [{ "type": "command", "command": hook_command(bin, executor, "observe"), "timeout": 120000 }]
-        }],
-        "Stop": [{
-            "hooks": [{ "type": "command", "command": hook_command(bin, executor, "summarize"), "timeout": 120000 }]
-        }]
-    })
+pub(in crate::install) fn build_hooks(bin: &str, strategy: HookStrategy) -> Value {
+    let mut hooks = serde_json::Map::new();
+
+    hooks.insert(
+        "SessionStart".to_string(),
+        json!([{
+            "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "context"), "timeout": 15000 }]
+        }]),
+    );
+
+    if strategy.include_session_init() {
+        hooks.insert(
+            "UserPromptSubmit".to_string(),
+            json!([{
+                "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "session-init"), "timeout": 15000 }]
+            }]),
+        );
+    }
+
+    if strategy.include_observe() {
+        hooks.insert(
+            "PostToolUse".to_string(),
+            json!([{
+                "matcher": "Write|Edit|NotebookEdit|Bash|Task",
+                "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "observe"), "timeout": 120000 }]
+            }]),
+        );
+    }
+
+    hooks.insert(
+        "Stop".to_string(),
+        json!([{
+            "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "summarize"), "timeout": 120000 }]
+        }]),
+    );
+
+    Value::Object(hooks)
 }
 
 pub(in crate::install) fn build_mcp_server(bin: &str) -> Value {
@@ -104,12 +133,12 @@ pub(in crate::install) fn remove_remem_hooks(settings: &mut Value, bin: &str) {
 pub(in crate::install) fn apply_hooks_json(
     path: &Path,
     bin: &str,
-    executor: HookExecutor,
+    strategy: HookStrategy,
 ) -> Result<()> {
     let mut doc = read_json_file(&path.to_path_buf())?;
     remove_remem_hooks(&mut doc, bin);
 
-    let new_hooks = build_hooks(bin, executor);
+    let new_hooks = build_hooks(bin, strategy);
     let obj = doc
         .as_object_mut()
         .with_context(|| format!("{} 根节点不是 Object", path.display()))?;

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -4,20 +4,44 @@ use std::path::Path;
 
 use crate::install::json_io::{read_json_file, write_json_file};
 
-pub(in crate::install) fn build_hooks(bin: &str) -> Value {
+#[derive(Clone, Copy)]
+pub(in crate::install) enum HookExecutor {
+    ClaudeCli,
+    CodexCli,
+}
+
+impl HookExecutor {
+    fn env_value(self) -> &'static str {
+        match self {
+            Self::ClaudeCli => "claude-cli",
+            Self::CodexCli => "codex-cli",
+        }
+    }
+}
+
+fn hook_command(bin: &str, executor: HookExecutor, subcommand: &str) -> String {
+    format!(
+        "REMEM_EXECUTOR={} {} {}",
+        executor.env_value(),
+        bin,
+        subcommand
+    )
+}
+
+pub(in crate::install) fn build_hooks(bin: &str, executor: HookExecutor) -> Value {
     json!({
         "SessionStart": [{
-            "hooks": [{ "type": "command", "command": format!("{} context", bin), "timeout": 15000 }]
+            "hooks": [{ "type": "command", "command": hook_command(bin, executor, "context"), "timeout": 15000 }]
         }],
         "UserPromptSubmit": [{
-            "hooks": [{ "type": "command", "command": format!("{} session-init", bin), "timeout": 15000 }]
+            "hooks": [{ "type": "command", "command": hook_command(bin, executor, "session-init"), "timeout": 15000 }]
         }],
         "PostToolUse": [{
             "matcher": "Write|Edit|NotebookEdit|Bash|Task",
-            "hooks": [{ "type": "command", "command": format!("{} observe", bin), "timeout": 120000 }]
+            "hooks": [{ "type": "command", "command": hook_command(bin, executor, "observe"), "timeout": 120000 }]
         }],
         "Stop": [{
-            "hooks": [{ "type": "command", "command": format!("{} summarize", bin), "timeout": 120000 }]
+            "hooks": [{ "type": "command", "command": hook_command(bin, executor, "summarize"), "timeout": 120000 }]
         }]
     })
 }
@@ -73,11 +97,15 @@ pub(in crate::install) fn remove_remem_hooks(settings: &mut Value, bin: &str) {
 ///
 /// Idempotent: strips any existing remem hook entries before appending fresh
 /// ones, so repeated calls converge on the same state.
-pub(in crate::install) fn apply_hooks_json(path: &Path, bin: &str) -> Result<()> {
+pub(in crate::install) fn apply_hooks_json(
+    path: &Path,
+    bin: &str,
+    executor: HookExecutor,
+) -> Result<()> {
     let mut doc = read_json_file(&path.to_path_buf())?;
     remove_remem_hooks(&mut doc, bin);
 
-    let new_hooks = build_hooks(bin);
+    let new_hooks = build_hooks(bin, executor);
     let obj = doc
         .as_object_mut()
         .with_context(|| format!("{} 根节点不是 Object", path.display()))?;

--- a/src/install/hosts/claude.rs
+++ b/src/install/hosts/claude.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 use std::path::PathBuf;
 
 use crate::install::config::{
-    apply_hooks_json, build_mcp_server, remove_remem_mcp, strip_hooks_json,
+    apply_hooks_json, build_mcp_server, remove_remem_mcp, strip_hooks_json, HookExecutor,
 };
 use crate::install::host::{HookSupport, InstallHost};
 use crate::install::json_io::{read_json_file, write_json_file};
@@ -65,7 +65,7 @@ impl InstallHost for ClaudeHost {
             remove_remem_mcp(&mut doc, bin);
             write_json_file(&path, &doc)?;
         }
-        apply_hooks_json(&path, bin)?;
+        apply_hooks_json(&path, bin, HookExecutor::ClaudeCli)?;
         Ok(HookSupport::Installed)
     }
 

--- a/src/install/hosts/claude.rs
+++ b/src/install/hosts/claude.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 use std::path::PathBuf;
 
 use crate::install::config::{
-    apply_hooks_json, build_mcp_server, remove_remem_mcp, strip_hooks_json, HookExecutor,
+    apply_hooks_json, build_mcp_server, remove_remem_mcp, strip_hooks_json, HookStrategy,
 };
 use crate::install::host::{HookSupport, InstallHost};
 use crate::install::json_io::{read_json_file, write_json_file};
@@ -65,7 +65,7 @@ impl InstallHost for ClaudeHost {
             remove_remem_mcp(&mut doc, bin);
             write_json_file(&path, &doc)?;
         }
-        apply_hooks_json(&path, bin, HookExecutor::ClaudeCli)?;
+        apply_hooks_json(&path, bin, HookStrategy::ClaudeCode)?;
         Ok(HookSupport::Installed)
     }
 

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use toml_edit::{value, Array, DocumentMut, Item, Table};
 
-use crate::install::config::{build_hooks, remove_remem_hooks, strip_hooks_json, HookExecutor};
+use crate::install::config::{build_hooks, remove_remem_hooks, strip_hooks_json, HookStrategy};
 use crate::install::host::{HookSupport, InstallHost};
 use crate::install::json_io::{read_json_file, write_json_file};
 use crate::install::paths::{codex_config_path, codex_hooks_path};
@@ -65,7 +65,7 @@ impl InstallHost for CodexHost {
                 SERVER_KEY
             ),
             format!(
-                "  hooks  -> {} (SessionStart/UserPromptSubmit/PostToolUse/Stop)",
+                "  hooks  -> {} (SessionStart/Stop)",
                 codex_hooks_path().display()
             ),
             format!("  binary -> {}", bin),
@@ -123,7 +123,7 @@ fn apply_codex_hooks_json(path: &Path, bin: &str) -> Result<()> {
 }
 
 fn build_codex_hooks(bin: &str) -> Value {
-    let mut hooks = build_hooks(bin, HookExecutor::CodexCli);
+    let mut hooks = build_hooks(bin, HookStrategy::Codex);
     convert_hook_timeouts_to_seconds(&mut hooks);
     hooks
 }
@@ -276,9 +276,9 @@ startup_timeout_sec = 5
     fn build_codex_hooks_uses_second_timeouts() {
         let hooks = build_codex_hooks("/tmp/remem");
         assert_eq!(hooks["SessionStart"][0]["hooks"][0]["timeout"], 15);
-        assert_eq!(hooks["UserPromptSubmit"][0]["hooks"][0]["timeout"], 15);
-        assert_eq!(hooks["PostToolUse"][0]["hooks"][0]["timeout"], 120);
         assert_eq!(hooks["Stop"][0]["hooks"][0]["timeout"], 120);
+        assert!(hooks.get("UserPromptSubmit").is_none());
+        assert!(hooks.get("PostToolUse").is_none());
         assert_eq!(
             hooks["Stop"][0]["hooks"][0]["command"],
             "REMEM_SUMMARY_EXECUTOR=codex-cli /tmp/remem summarize"

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -281,7 +281,7 @@ startup_timeout_sec = 5
         assert_eq!(hooks["Stop"][0]["hooks"][0]["timeout"], 120);
         assert_eq!(
             hooks["Stop"][0]["hooks"][0]["command"],
-            "REMEM_EXECUTOR=codex-cli /tmp/remem summarize"
+            "REMEM_SUMMARY_EXECUTOR=codex-cli /tmp/remem summarize"
         );
     }
 

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use toml_edit::{value, Array, DocumentMut, Item, Table};
 
-use crate::install::config::{build_hooks, remove_remem_hooks, strip_hooks_json};
+use crate::install::config::{build_hooks, remove_remem_hooks, strip_hooks_json, HookExecutor};
 use crate::install::host::{HookSupport, InstallHost};
 use crate::install::json_io::{read_json_file, write_json_file};
 use crate::install::paths::{codex_config_path, codex_hooks_path};
@@ -123,7 +123,7 @@ fn apply_codex_hooks_json(path: &Path, bin: &str) -> Result<()> {
 }
 
 fn build_codex_hooks(bin: &str) -> Value {
-    let mut hooks = build_hooks(bin);
+    let mut hooks = build_hooks(bin, HookExecutor::CodexCli);
     convert_hook_timeouts_to_seconds(&mut hooks);
     hooks
 }
@@ -279,6 +279,10 @@ startup_timeout_sec = 5
         assert_eq!(hooks["UserPromptSubmit"][0]["hooks"][0]["timeout"], 15);
         assert_eq!(hooks["PostToolUse"][0]["hooks"][0]["timeout"], 120);
         assert_eq!(hooks["Stop"][0]["hooks"][0]["timeout"], 120);
+        assert_eq!(
+            hooks["Stop"][0]["hooks"][0]["command"],
+            "REMEM_EXECUTOR=codex-cli /tmp/remem summarize"
+        );
     }
 
     #[test]

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -1,25 +1,46 @@
 use serde_json::json;
 
-use super::config::{build_hooks, remove_remem_hooks, remove_remem_mcp};
+use super::config::{build_hooks, remove_remem_hooks, remove_remem_mcp, HookExecutor};
 
 #[test]
-fn build_hooks_contains_expected_commands() {
-    let hooks = build_hooks("/tmp/remem");
+fn build_hooks_contains_expected_claude_commands() {
+    let hooks = build_hooks("/tmp/remem", HookExecutor::ClaudeCli);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
-        "/tmp/remem context"
+        "REMEM_EXECUTOR=claude-cli /tmp/remem context"
     );
     assert_eq!(
         hooks["UserPromptSubmit"][0]["hooks"][0]["command"],
-        "/tmp/remem session-init"
+        "REMEM_EXECUTOR=claude-cli /tmp/remem session-init"
     );
     assert_eq!(
         hooks["PostToolUse"][0]["hooks"][0]["command"],
-        "/tmp/remem observe"
+        "REMEM_EXECUTOR=claude-cli /tmp/remem observe"
     );
     assert_eq!(
         hooks["Stop"][0]["hooks"][0]["command"],
-        "/tmp/remem summarize"
+        "REMEM_EXECUTOR=claude-cli /tmp/remem summarize"
+    );
+}
+
+#[test]
+fn build_hooks_contains_expected_codex_commands() {
+    let hooks = build_hooks("/tmp/remem", HookExecutor::CodexCli);
+    assert_eq!(
+        hooks["SessionStart"][0]["hooks"][0]["command"],
+        "REMEM_EXECUTOR=codex-cli /tmp/remem context"
+    );
+    assert_eq!(
+        hooks["UserPromptSubmit"][0]["hooks"][0]["command"],
+        "REMEM_EXECUTOR=codex-cli /tmp/remem session-init"
+    );
+    assert_eq!(
+        hooks["PostToolUse"][0]["hooks"][0]["command"],
+        "REMEM_EXECUTOR=codex-cli /tmp/remem observe"
+    );
+    assert_eq!(
+        hooks["Stop"][0]["hooks"][0]["command"],
+        "REMEM_EXECUTOR=codex-cli /tmp/remem summarize"
     );
 }
 

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -1,10 +1,10 @@
 use serde_json::json;
 
-use super::config::{build_hooks, remove_remem_hooks, remove_remem_mcp, HookExecutor};
+use super::config::{build_hooks, remove_remem_hooks, remove_remem_mcp, HookStrategy};
 
 #[test]
 fn build_hooks_contains_expected_claude_commands() {
-    let hooks = build_hooks("/tmp/remem", HookExecutor::ClaudeCli);
+    let hooks = build_hooks("/tmp/remem", HookStrategy::ClaudeCode);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
         "/tmp/remem context"
@@ -25,19 +25,13 @@ fn build_hooks_contains_expected_claude_commands() {
 
 #[test]
 fn build_hooks_contains_expected_codex_commands() {
-    let hooks = build_hooks("/tmp/remem", HookExecutor::CodexCli);
+    let hooks = build_hooks("/tmp/remem", HookStrategy::Codex);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
         "/tmp/remem context"
     );
-    assert_eq!(
-        hooks["UserPromptSubmit"][0]["hooks"][0]["command"],
-        "/tmp/remem session-init"
-    );
-    assert_eq!(
-        hooks["PostToolUse"][0]["hooks"][0]["command"],
-        "/tmp/remem observe"
-    );
+    assert!(hooks.get("UserPromptSubmit").is_none());
+    assert!(hooks.get("PostToolUse").is_none());
     assert_eq!(
         hooks["Stop"][0]["hooks"][0]["command"],
         "REMEM_SUMMARY_EXECUTOR=codex-cli /tmp/remem summarize"

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -7,19 +7,19 @@ fn build_hooks_contains_expected_claude_commands() {
     let hooks = build_hooks("/tmp/remem", HookExecutor::ClaudeCli);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
-        "REMEM_EXECUTOR=claude-cli /tmp/remem context"
+        "/tmp/remem context"
     );
     assert_eq!(
         hooks["UserPromptSubmit"][0]["hooks"][0]["command"],
-        "REMEM_EXECUTOR=claude-cli /tmp/remem session-init"
+        "/tmp/remem session-init"
     );
     assert_eq!(
         hooks["PostToolUse"][0]["hooks"][0]["command"],
-        "REMEM_EXECUTOR=claude-cli /tmp/remem observe"
+        "/tmp/remem observe"
     );
     assert_eq!(
         hooks["Stop"][0]["hooks"][0]["command"],
-        "REMEM_EXECUTOR=claude-cli /tmp/remem summarize"
+        "REMEM_SUMMARY_EXECUTOR=claude-cli /tmp/remem summarize"
     );
 }
 
@@ -28,19 +28,19 @@ fn build_hooks_contains_expected_codex_commands() {
     let hooks = build_hooks("/tmp/remem", HookExecutor::CodexCli);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
-        "REMEM_EXECUTOR=codex-cli /tmp/remem context"
+        "/tmp/remem context"
     );
     assert_eq!(
         hooks["UserPromptSubmit"][0]["hooks"][0]["command"],
-        "REMEM_EXECUTOR=codex-cli /tmp/remem session-init"
+        "/tmp/remem session-init"
     );
     assert_eq!(
         hooks["PostToolUse"][0]["hooks"][0]["command"],
-        "REMEM_EXECUTOR=codex-cli /tmp/remem observe"
+        "/tmp/remem observe"
     );
     assert_eq!(
         hooks["Stop"][0]["hooks"][0]["command"],
-        "REMEM_EXECUTOR=codex-cli /tmp/remem summarize"
+        "REMEM_SUMMARY_EXECUTOR=codex-cli /tmp/remem summarize"
     );
 }
 

--- a/src/mcp/server/runtime.rs
+++ b/src/mcp/server/runtime.rs
@@ -5,7 +5,7 @@ use rmcp::{tool_handler, ServerHandler, ServiceExt};
 use super::MemoryServer;
 use crate::db;
 
-const SERVER_INSTRUCTIONS: &str = r#"Persistent memory for Claude Code sessions.
+const SERVER_INSTRUCTIONS: &str = r#"Persistent memory for Claude Code and Codex sessions.
 
 ## Workflow
 1. **Context index** is auto-injected at session start (titles + types, ~50 tokens each)

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -76,13 +76,87 @@ fn spawn_worker_once() -> Result<()> {
         Some(file) => std::process::Stdio::from(file),
         None => std::process::Stdio::null(),
     };
-    let _child = std::process::Command::new(&exe)
+    let mut command = std::process::Command::new(&exe);
+    command
         .arg("worker")
         .arg("--once")
         .env("REMEM_STDERR_TO_LOG", "1")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(stderr_cfg)
-        .spawn()?;
+        .stderr(stderr_cfg);
+    configure_worker_executor_env(&mut command);
+    let _child = command.spawn()?;
     Ok(())
+}
+
+fn configure_worker_executor_env(command: &mut std::process::Command) {
+    if std::env::var_os("REMEM_SUMMARY_EXECUTOR").is_none() {
+        if let Some(executor) = std::env::var_os("REMEM_EXECUTOR") {
+            command.env("REMEM_SUMMARY_EXECUTOR", executor);
+        }
+    }
+    command.env_remove("REMEM_EXECUTOR");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::sync::Mutex;
+
+    use super::configure_worker_executor_env;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env_vars<T>(vars: &[(&str, Option<&str>)], f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().expect("env lock should acquire");
+        let old_values = vars
+            .iter()
+            .map(|(key, _)| ((*key).to_string(), std::env::var(key).ok()))
+            .collect::<Vec<_>>();
+
+        for (key, value) in vars {
+            match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+
+        let result = f();
+
+        for (key, value) in old_values {
+            match value {
+                Some(value) => unsafe { std::env::set_var(&key, value) },
+                None => unsafe { std::env::remove_var(&key) },
+            }
+        }
+
+        result
+    }
+
+    fn command_env<'a>(command: &'a std::process::Command, key: &str) -> Option<Option<&'a OsStr>> {
+        command
+            .get_envs()
+            .find(|(name, _)| *name == OsStr::new(key))
+            .map(|(_, value)| value)
+    }
+
+    #[test]
+    fn worker_env_translates_legacy_global_executor_to_summary_only() {
+        with_env_vars(
+            &[
+                ("REMEM_EXECUTOR", Some("codex-cli")),
+                ("REMEM_SUMMARY_EXECUTOR", None),
+            ],
+            || {
+                let mut command = std::process::Command::new("remem");
+                configure_worker_executor_env(&mut command);
+
+                assert_eq!(
+                    command_env(&command, "REMEM_SUMMARY_EXECUTOR"),
+                    Some(Some(OsStr::new("codex-cli")))
+                );
+                assert_eq!(command_env(&command, "REMEM_EXECUTOR"), Some(None));
+            },
+        );
+    }
 }

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -95,7 +95,6 @@ fn configure_worker_executor_env(command: &mut std::process::Command) {
             command.env("REMEM_SUMMARY_EXECUTOR", executor);
         }
     }
-    command.env_remove("REMEM_EXECUTOR");
 }
 
 #[cfg(test)]
@@ -141,7 +140,7 @@ mod tests {
     }
 
     #[test]
-    fn worker_env_translates_legacy_global_executor_to_summary_only() {
+    fn worker_env_translates_legacy_global_executor_without_removing_it() {
         with_env_vars(
             &[
                 ("REMEM_EXECUTOR", Some("codex-cli")),
@@ -155,7 +154,24 @@ mod tests {
                     command_env(&command, "REMEM_SUMMARY_EXECUTOR"),
                     Some(Some(OsStr::new("codex-cli")))
                 );
-                assert_eq!(command_env(&command, "REMEM_EXECUTOR"), Some(None));
+                assert_eq!(command_env(&command, "REMEM_EXECUTOR"), None);
+            },
+        );
+    }
+
+    #[test]
+    fn worker_env_preserves_explicit_summary_override_and_global_executor() {
+        with_env_vars(
+            &[
+                ("REMEM_EXECUTOR", Some("http")),
+                ("REMEM_SUMMARY_EXECUTOR", Some("codex-cli")),
+            ],
+            || {
+                let mut command = std::process::Command::new("remem");
+                configure_worker_executor_env(&mut command);
+
+                assert_eq!(command_env(&command, "REMEM_SUMMARY_EXECUTOR"), None);
+                assert_eq!(command_env(&command, "REMEM_EXECUTOR"), None);
             },
         );
     }


### PR DESCRIPTION
## Summary

- add host-specific summary executor support and Codex CLI routing
- install `REMEM_SUMMARY_EXECUTOR` only on Stop/summarize hooks, leaving context/session-init/observe hooks executor-neutral
- prevent legacy `REMEM_EXECUTOR=codex-cli` from leaking into flush/compress/dream background jobs
- keep explicit operation-specific overrides available through `REMEM_FLUSH_EXECUTOR`, `REMEM_COMPRESS_EXECUTOR`, and `REMEM_DREAM_EXECUTOR`

## Root Cause

Codex Stop hooks previously used a global `REMEM_EXECUTOR=codex-cli`. The Stop hook then spawned `remem worker --once`, and the worker inherited that global executor. As a result, non-summary background jobs such as observation flush and compression could also run through Codex CLI, making hooks slow and causing visible nested Codex runs.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- rebuilt release binary and replaced local `~/.local/bin/remem`; verified binary hash matches `target/release/remem`
