### PR TITLE
Fix Codex flush executor fallback

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -295,7 +295,7 @@ Project key = `last two path segments + canonical absolute path hash`, balancing
 | `REMEM_MODEL` | `haiku` | AI model (haiku/sonnet/opus or full model ID) |
 | `REMEM_EXECUTOR` | `auto` | Legacy/general AI executor fallback for summaries and unspecified operations: `auto` / `http` / `claude-cli` / `codex-cli` |
 | `REMEM_SUMMARY_EXECUTOR` | `REMEM_EXECUTOR` | Summary executor override, used by Stop hooks (`claude-cli` for Claude Code, `codex-cli` for Codex) |
-| `REMEM_FLUSH_EXECUTOR` | `auto` | Flush/background observation executor override |
+| `REMEM_FLUSH_EXECUTOR` | `auto` | Flush/background observation executor override. If unset, `flush` / `flush-task` reuse `REMEM_SUMMARY_EXECUTOR` only when it resolves to Codex, so older Codex installs keep working without broadening Claude behavior |
 | `REMEM_COMPRESS_EXECUTOR` | `auto` | Memory compression executor override |
 | `REMEM_DREAM_EXECUTOR` | `auto` | Dream executor override |
 | `ANTHROPIC_API_KEY` | - | Required for HTTP mode (also supports `ANTHROPIC_AUTH_TOKEN`) |

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -60,6 +60,10 @@ async fn call_auto(system: &str, user_message: &str) -> anyhow::Result<types::Ai
 }
 
 fn executor_for_operation(operation: &str) -> Option<AiExecutor> {
+    if matches!(operation, "flush" | "flush-task") {
+        return flush_executor();
+    }
+
     for key in executor_env_keys(operation) {
         if let Some(executor) = executor_from_env(key) {
             return Some(executor);
@@ -76,6 +80,13 @@ fn executor_env_keys(operation: &str) -> &'static [&'static str] {
         "dream" => &["REMEM_DREAM_EXECUTOR"],
         _ => &["REMEM_EXECUTOR"],
     }
+}
+
+fn flush_executor() -> Option<AiExecutor> {
+    executor_from_env("REMEM_FLUSH_EXECUTOR").or_else(|| {
+        executor_from_env("REMEM_SUMMARY_EXECUTOR")
+            .filter(|executor| *executor == AiExecutor::CodexCli)
+    })
 }
 
 fn executor_from_env(key: &str) -> Option<AiExecutor> {

--- a/src/ai/tests.rs
+++ b/src/ai/tests.rs
@@ -86,7 +86,7 @@ fn estimate_cost_usd_combines_input_and_output_prices() {
 }
 
 #[test]
-fn summary_executor_override_does_not_leak_to_flush() {
+fn codex_summary_executor_falls_back_for_flush_operations() {
     with_env_vars(
         &[
             ("REMEM_EXECUTOR", None),
@@ -100,15 +100,18 @@ fn summary_executor_override_does_not_leak_to_flush() {
                 executor_for_operation("summarize"),
                 Some(AiExecutor::CodexCli)
             );
-            assert_eq!(executor_for_operation("flush"), None);
-            assert_eq!(executor_for_operation("flush-task"), None);
+            assert_eq!(executor_for_operation("flush"), Some(AiExecutor::CodexCli));
+            assert_eq!(
+                executor_for_operation("flush-task"),
+                Some(AiExecutor::CodexCli)
+            );
             assert_eq!(executor_for_operation("compress"), None);
         },
     );
 }
 
 #[test]
-fn operation_executor_overrides_do_not_use_global_fallback_for_background_jobs() {
+fn explicit_flush_executor_override_wins_over_codex_fallback() {
     with_env_vars(
         &[
             ("REMEM_EXECUTOR", Some("claude-cli")),
@@ -123,6 +126,7 @@ fn operation_executor_overrides_do_not_use_global_fallback_for_background_jobs()
                 Some(AiExecutor::CodexCli)
             );
             assert_eq!(executor_for_operation("flush"), Some(AiExecutor::Http));
+            assert_eq!(executor_for_operation("flush-task"), Some(AiExecutor::Http));
             assert_eq!(executor_for_operation("compress"), None);
             assert_eq!(executor_for_operation("dream"), None);
             assert_eq!(executor_for_operation("other"), Some(AiExecutor::ClaudeCli));
@@ -131,7 +135,28 @@ fn operation_executor_overrides_do_not_use_global_fallback_for_background_jobs()
 }
 
 #[test]
-fn legacy_global_executor_only_affects_summary() {
+fn claude_summary_executor_does_not_broaden_flush_resolution() {
+    with_env_vars(
+        &[
+            ("REMEM_EXECUTOR", None),
+            ("REMEM_SUMMARY_EXECUTOR", Some("claude-cli")),
+            ("REMEM_FLUSH_EXECUTOR", None),
+            ("REMEM_COMPRESS_EXECUTOR", None),
+            ("REMEM_DREAM_EXECUTOR", None),
+        ],
+        || {
+            assert_eq!(
+                executor_for_operation("summarize"),
+                Some(AiExecutor::ClaudeCli)
+            );
+            assert_eq!(executor_for_operation("flush"), None);
+            assert_eq!(executor_for_operation("flush-task"), None);
+        },
+    );
+}
+
+#[test]
+fn legacy_global_executor_still_only_affects_summary_directly() {
     with_env_vars(
         &[
             ("REMEM_EXECUTOR", Some("codex-cli")),

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -18,6 +18,13 @@ impl HookStrategy {
         }
     }
 
+    fn flush_executor(self) -> Option<&'static str> {
+        match self {
+            Self::ClaudeCode => None,
+            Self::Codex => Some("codex-cli"),
+        }
+    }
+
     fn include_session_init(self) -> bool {
         matches!(self, Self::ClaudeCode)
     }
@@ -50,12 +57,21 @@ impl HookStrategy {
 
 fn hook_command(bin: &str, strategy: HookStrategy, subcommand: &str) -> String {
     if subcommand == "summarize" {
-        format!(
-            "REMEM_SUMMARY_EXECUTOR={} {} {}",
-            strategy.summary_executor(),
-            bin,
-            subcommand
-        )
+        match strategy.flush_executor() {
+            Some(flush_executor) => format!(
+                "REMEM_SUMMARY_EXECUTOR={} REMEM_FLUSH_EXECUTOR={} {} {}",
+                strategy.summary_executor(),
+                flush_executor,
+                bin,
+                subcommand
+            ),
+            None => format!(
+                "REMEM_SUMMARY_EXECUTOR={} {} {}",
+                strategy.summary_executor(),
+                bin,
+                subcommand
+            ),
+        }
     } else if subcommand == "observe" {
         format!(
             "REMEM_HOOK_ADAPTER={} {} {}",

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -286,7 +286,7 @@ startup_timeout_sec = 5
         assert!(hooks.get("UserPromptSubmit").is_none());
         assert_eq!(
             hooks["Stop"][0]["hooks"][0]["command"],
-            "REMEM_SUMMARY_EXECUTOR=codex-cli /tmp/remem summarize"
+            "REMEM_SUMMARY_EXECUTOR=codex-cli REMEM_FLUSH_EXECUTOR=codex-cli /tmp/remem summarize"
         );
     }
 

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -39,7 +39,7 @@ fn build_hooks_contains_expected_codex_commands() {
     assert_eq!(hooks["PostToolUse"][0]["hooks"][0]["timeout"], 3000);
     assert_eq!(
         hooks["Stop"][0]["hooks"][0]["command"],
-        "REMEM_SUMMARY_EXECUTOR=codex-cli /tmp/remem summarize"
+        "REMEM_SUMMARY_EXECUTOR=codex-cli REMEM_FLUSH_EXECUTOR=codex-cli /tmp/remem summarize"
     );
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -110,7 +110,7 @@ pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use std::ffi::OsString;
     use std::os::unix::fs::PermissionsExt;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -109,3 +109,178 @@ pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
     crate::log::info("worker", "stopped");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::{Mutex, MutexGuard};
+
+    use rusqlite::params;
+
+    use crate::db::{self, test_support::ScopedTestDataDir};
+
+    use super::run;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let previous = std::env::var_os(key);
+            match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            match self.previous.as_ref() {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    struct ScopedEnv {
+        _guard: MutexGuard<'static, ()>,
+        _vars: Vec<ScopedEnvVar>,
+    }
+
+    impl ScopedEnv {
+        fn set(vars: &[(&'static str, Option<&str>)]) -> Self {
+            let guard = ENV_LOCK.lock().expect("env lock should acquire");
+            let vars = vars
+                .iter()
+                .map(|(key, value)| ScopedEnvVar::set(key, *value))
+                .collect();
+            Self {
+                _guard: guard,
+                _vars: vars,
+            }
+        }
+    }
+
+    fn install_stub_codex(path: &std::path::Path) {
+        let script = r#"#!/bin/sh
+prev=""
+output_path=""
+for arg in "$@"; do
+  if [ "$prev" = "--output-last-message" ]; then
+    output_path="$arg"
+    break
+  fi
+  prev="$arg"
+done
+cat >/dev/null
+if [ -z "$output_path" ]; then
+  echo "missing output path" >&2
+  exit 1
+fi
+cat <<'EOF' > "$output_path"
+<observation>
+  <type>decision</type>
+  <title>Codex worker flush</title>
+  <narrative>Queued Codex observation persisted.</narrative>
+</observation>
+EOF
+"#;
+        std::fs::write(path, script).expect("stub codex script should be written");
+        let mut perms = std::fs::metadata(path)
+            .expect("stub codex metadata should load")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).expect("stub codex permissions should be set");
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn worker_processes_observation_job_on_codex_only_env() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-codex-flush");
+        let stub_codex = std::env::temp_dir().join(format!(
+            "remem-test-codex-{}-{}.sh",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        install_stub_codex(&stub_codex);
+        let stub_codex_str = stub_codex
+            .as_os_str()
+            .to_str()
+            .expect("stub codex path should be valid utf-8");
+        let _env = ScopedEnv::set(&[
+            ("REMEM_EXECUTOR", None),
+            ("REMEM_SUMMARY_EXECUTOR", Some("codex-cli")),
+            ("REMEM_FLUSH_EXECUTOR", None),
+            ("REMEM_CODEX_PATH", Some(stub_codex_str)),
+            ("REMEM_CLAUDE_PATH", Some("/definitely/missing/claude")),
+            ("ANTHROPIC_API_KEY", None),
+            ("ANTHROPIC_AUTH_TOKEN", None),
+        ]);
+
+        let conn = db::open_db()?;
+        db::enqueue_pending(
+            &conn,
+            "sess-codex",
+            "proj-codex",
+            "Bash",
+            Some("echo codex"),
+            Some("codex output"),
+            None,
+        )?;
+        let job_id = db::enqueue_job(
+            &conn,
+            db::JobType::Observation,
+            "proj-codex",
+            Some("sess-codex"),
+            r#"{"session_id":"sess-codex","project":"proj-codex"}"#,
+            50,
+        )?;
+
+        let test_result = async {
+            run(true, 10).await?;
+
+            let conn = db::open_db()?;
+            let observation_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM observations WHERE project = ?1",
+                params!["proj-codex"],
+                |row| row.get(0),
+            )?;
+            let pending_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM pending_observations WHERE session_id = ?1",
+                params!["sess-codex"],
+                |row| row.get(0),
+            )?;
+            let job_state: String = conn.query_row(
+                "SELECT state FROM jobs WHERE id = ?1",
+                params![job_id],
+                |row| row.get(0),
+            )?;
+            let flush_executor: String = conn.query_row(
+                "SELECT executor FROM ai_usage_events WHERE operation = 'flush' ORDER BY created_at_epoch DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )?;
+
+            anyhow::ensure!(observation_count > 0, "expected persisted observations");
+            anyhow::ensure!(pending_count == 0, "expected pending queue to be drained");
+            anyhow::ensure!(job_state == "done", "expected observation job done, got {job_state}");
+            anyhow::ensure!(
+                flush_executor == "codex-cli",
+                "expected codex flush executor, got {flush_executor}"
+            );
+
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+
+        let _ = std::fs::remove_file(&stub_codex);
+        test_result
+    }
+}


### PR DESCRIPTION
## Summary
- make `flush` and `flush-task` reuse Codex when `REMEM_FLUSH_EXECUTOR` is unset but the worker/Stop path already selected Codex
- export `REMEM_FLUSH_EXECUTOR=codex-cli` in generated Codex Stop hooks for fresh installs
- add regression coverage for executor precedence and a worker test that persists observations on a Codex-only machine

## Testing
- cargo check
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test

Closes #52