### PR TITLE
[codex] add host-aware context compiler

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -301,14 +301,19 @@ Project key = `last two path segments + canonical absolute path hash`, balancing
 | `ANTHROPIC_API_KEY` | - | Required for HTTP mode (also supports `ANTHROPIC_AUTH_TOKEN`) |
 | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | Custom API endpoint |
 | `REMEM_DEBUG` | - | Enable debug logging |
-| `REMEM_CONTEXT_OBSERVATIONS` | `50` | Max observations loaded in context |
-| `REMEM_CONTEXT_FULL_COUNT` | `10` | Observations shown with full narrative |
-| `REMEM_CONTEXT_SESSION_COUNT` | `10` | Session summaries shown |
-| `REMEM_CONTEXT_OBSERVATION_TYPES` | `bugfix,feature,...` | Observation types to load |
-| `REMEM_CONTEXT_FULL_FIELD` | `narrative` | Field for full display (narrative/facts) |
-| `REMEM_CONTEXT_SHOW_READ_TOKENS` | `true` | Show read token statistics |
-| `REMEM_CONTEXT_SHOW_WORK_TOKENS` | `true` | Show work token statistics |
-| `REMEM_CONTEXT_SHOW_LAST_SUMMARY` | `true` | Show last session summary |
+| `REMEM_CONTEXT_HOST` | `auto` | Context host profile override: `claude-code`, `codex-cli`, or `unknown` |
+| `REMEM_CONTEXT_TOTAL_CHAR_LIMIT` | `12000` | Soft character cap for rendered context |
+| `REMEM_CONTEXT_CANDIDATE_FETCH_LIMIT` | `120` | Candidate memories fetched before section selection |
+| `REMEM_CONTEXT_MEMORY_INDEX_LIMIT` | `50` | Non-preference memories shown in the main memory index |
+| `REMEM_CONTEXT_OBSERVATIONS` | `50` | Deprecated alias for `REMEM_CONTEXT_MEMORY_INDEX_LIMIT` |
+| `REMEM_CONTEXT_MEMORY_INDEX_CHAR_LIMIT` | `4000` | Main memory index character budget |
+| `REMEM_CONTEXT_CORE_ITEM_LIMIT` | `6` | Core memory item budget |
+| `REMEM_CONTEXT_CORE_CHAR_LIMIT` | `3000` | Core memory character budget |
+| `REMEM_CONTEXT_SESSION_COUNT` | `5` | Session summaries shown |
+| `REMEM_CONTEXT_SELF_DIAGNOSTIC_LIMIT` | `2` | Self-diagnostic memory cap |
+| `REMEM_CONTEXT_PREFERENCE_PROJECT_LIMIT` | `20` | Project preference query limit |
+| `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` | `10` | Global preference query limit |
+| `REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT` | `1500` | Preference section character budget |
 | `REMEM_CLAUDE_PATH` | `claude` | Claude CLI path |
 | `REMEM_CODEX_PATH` | `codex` | Codex CLI path |
 | `REMEM_CODEX_MODEL` | - | Optional Codex CLI model override |

--- a/docs/context-budget-design-2026-04-29.md
+++ b/docs/context-budget-design-2026-04-29.md
@@ -1,0 +1,221 @@
+# Context Budget Design Note (2026-04-29)
+
+## 背景
+
+用户在 Codex `SessionStart` context 中看到：
+
+```text
+50 memories loaded.
+```
+
+这不是数据库里的总记忆数，而是 `remem context` 在 SessionStart 时从候选记忆中筛选后注入的上限。当前实现把偏好、决策、发现等记忆放进同一个 `memories` 池，再统一截断为 50 条。
+
+一次本机复现：
+
+```bash
+cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/computer
+```
+
+关键结果：
+
+```text
+[context] DONE 1120ms project=/Users/lifcc/Desktop/code/AI/tools/computer memories=50 summaries=2 workstreams=0
+```
+
+最终 index 组成：
+
+```text
+Preferences (46)
+Decisions (2)
+Discoveries (2)
+```
+
+这说明 `50` 作为性能上限暂时可接受，但作为单一内容预算不合理：偏好已经有独立 `Your Preferences` section，却又占满主 memory index，导致 decision / bugfix / discovery 等任务记忆被挤出。
+
+## 当前代码边界
+
+- `src/context/query.rs`
+  - `CONTEXT_MEMORY_LIMIT: usize = 50`
+  - `RECENT_MEMORY_FETCH_LIMIT = 100`
+  - `BASENAME_SEARCH_LIMIT = 20`
+  - `MAX_SELF_DIAGNOSTIC_MEMORIES = 2`
+  - `load_project_memories()` 从 recent + basename search 合并、去重、限制自诊断记忆，然后 `take(50)`。
+- `src/preference/render.rs`
+  - 项目偏好上限 20。
+  - 全局偏好上限 10。
+  - 输出到独立 `## Your Preferences (always apply these)` section。
+  - 输出字符预算 `MAX_CHARS = 1500`。
+- `src/context/render.rs`
+  - 先渲染 preferences，再渲染 core/index/sessions。
+  - 末尾显示 `loaded.memories.len()`。
+- `docs/ARCHITECTURE.md`
+  - 仍记录 `REMEM_CONTEXT_OBSERVATIONS` 等 env vars。
+  - 当前代码没有读取这些 context env vars，属于文档和实现漂移。
+
+## multi-ai-research 初步结论
+
+2026-04-29 使用 `multi-ai-research` 外部交叉调研：
+
+- Gemini: 成功。
+- Grok: 成功。
+- DeepSeek: 成功。
+- ChatGPT web adapter: 失败，原因是没有找到 send button。
+- Claude CLI: 失败，原因是未登录。
+
+三路有效结果一致：
+
+1. 不建议保留单一硬编码 `CONTEXT_MEMORY_LIMIT = 50` 作为所有记忆类型的共同预算。
+2. 偏好应该由独立 preference section 管理，不应继续占用 main memory index/core 的主要名额。
+3. 应该引入 typed/section budgets，至少拆分 main memory、core、session、self-diagnostic、preference project/global/char limit。
+4. 应该提供 env override，并让 `docs/ARCHITECTURE.md` 与代码保持一致。
+5. 需要用测试覆盖 preference flood、env override、dedupe/no-starvation。
+
+## 建议设计
+
+第一阶段不做复杂重排，先修正当前明显问题：
+
+```rust
+struct ContextLimits {
+    candidate_fetch_limit: usize,       // default 120
+    memory_index_limit: usize,          // default 50, non-preference memories only
+    core_item_limit: usize,             // default 6
+    core_char_limit: usize,             // default 3000
+    session_limit: usize,               // default 5
+    self_diagnostic_limit: usize,       // default 2
+    preference_project_limit: usize,    // default 20
+    preference_global_limit: usize,     // default 10
+    preference_char_limit: usize,       // default 1500
+}
+```
+
+默认策略：
+
+- `preference` 从 main memory index/core 的候选池中排除。
+- `Your Preferences` section 继续独立渲染，但预算由 `ContextLimits` 控制。
+- 候选召回可以比最终注入更宽，默认 120 条；最终 main index 仍只注入 50 条非 preference 记忆。
+- main memory index 默认保留 50 条非 preference 记忆。
+- core 默认保留 6 条高分记忆，并受字符预算限制。
+- sessions 默认保留 5 条最近 session summary。
+- self-diagnostic 默认最多 2 条。
+- 类型软预算作为第二阶段：decision / bugfix / architecture / discovery 至少有展示机会，剩余额度再按当前分数回填。
+
+环境变量建议：
+
+| New variable | Default | Notes |
+| --- | ---: | --- |
+| `REMEM_CONTEXT_CANDIDATE_FETCH_LIMIT` | `120` | 候选召回上限，最终仍会按 section budget 裁剪 |
+| `REMEM_CONTEXT_MEMORY_INDEX_LIMIT` | `50` | main index 非 preference 记忆上限 |
+| `REMEM_CONTEXT_CORE_ITEM_LIMIT` | `6` | core section 条数上限 |
+| `REMEM_CONTEXT_CORE_CHAR_LIMIT` | `3000` | core section 字符预算 |
+| `REMEM_CONTEXT_SESSION_COUNT` | `5` | session summary 上限 |
+| `REMEM_CONTEXT_SELF_DIAGNOSTIC_LIMIT` | `2` | self-diagnostic 记忆上限 |
+| `REMEM_CONTEXT_PREFERENCE_PROJECT_LIMIT` | `20` | 项目偏好查询上限 |
+| `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` | `10` | 全局偏好查询上限 |
+| `REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT` | `1500` | preference section 字符预算 |
+
+兼容策略：
+
+- `REMEM_CONTEXT_OBSERVATIONS` 保留为 deprecated alias，映射到 `REMEM_CONTEXT_MEMORY_INDEX_LIMIT`。
+- `docs/ARCHITECTURE.md` 删除或标注已经不存在的 `REMEM_CONTEXT_FULL_COUNT`、`REMEM_CONTEXT_OBSERVATION_TYPES`、`REMEM_CONTEXT_FULL_FIELD`、token display vars，除非先补实现。
+
+## 第一阶段验收
+
+建议最小测试集：
+
+- `preference_flood_does_not_starve_core_memories`
+  - 构造大量 preference 和少量 decision/discovery。
+  - 断言 preference 只出现在 `Your Preferences`，main index/core 仍保留 decision/discovery。
+- `context_limits_env_override_is_respected`
+  - 设置 env override。
+  - 断言 memory/session/preference budget 都按 override 生效。
+- `preferences_rendered_separately_not_in_index`
+  - 断言同一 preference 不重复进入 main memory index。
+- `deprecated_context_observations_alias_still_works`
+  - 断言旧 env alias 仍能控制 main index limit。
+
+建议 smoke：
+
+```bash
+cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/computer
+```
+
+验收重点不是只看 `memories=N`，而是看类型构成：
+
+- `Your Preferences` 仍存在。
+- `## Core` 不被 preference flood 占满。
+- `## Index` 中 decision / bugfix / discovery 不被 preference 挤出。
+
+## 开源项目对照
+
+2026-04-29 开 3 个子 agent 做只读调研：
+
+- Agent A: 通用 agent memory 框架，覆盖 Mem0、Zep/Graphiti、Letta/MemGPT、LangMem/LangGraph memory。
+- Agent B: 编程助手 / SessionStart / MCP memory，覆盖 Claude Code auto memory、Claude-Mem、Engram、Basic Memory、Supermemory MCP、OpenAI Agents SDK Memory。
+- Agent C: RAG / 本地知识库 / 长期记忆检索，覆盖 Chroma、LlamaIndex、LangChain/TimeWeighted/MMR、Letta archival/core split。
+
+三条线的共同结论：
+
+1. 主流系统不把启动上下文设计成一个所有类型共享的 flat item limit。
+2. 小量高价值内容常驻：profile、preferences、core memory、summary、index。
+3. 长尾记忆按需检索：search / timeline / get details / topic files / rollout summaries。
+4. 预算按 section、类型、字符/token、scope/filter 拆开。
+5. 启动注入偏向 compact index，不默认注入全文。
+6. 检索链路通常是先宽召回，再 rerank/filter/compress，最后按最终 prompt budget 裁剪。
+
+## 代表项目做法
+
+| 项目 | 关键做法 | 对 remem 的启发 |
+| --- | --- | --- |
+| Mem0 | `search` 使用 scoped filters、`top_k`、threshold、rerank；由应用把结果注入 prompt，不是全量常驻。 | main context 应该是 scoped retrieval/index，不是所有 memory 的扁平 dump。 |
+| Zep / Graphiti | context template 支持 `%{edges limit=10}`、`%{entities limit=5}`、`%{user_summary}`；事实、实体、summary 分 section。 | 直接借鉴 section limit，把 preference/profile 和 facts/decisions 拆池。 |
+| Letta / MemGPT | core memory blocks 常驻；archival memory 按需 search；memory blocks/files/archival/external RAG 有不同 size/count 建议。 | `Your Preferences` 类似 core/profile；decision/discovery 更接近 archival/index，不能互相抢预算。 |
+| LangMem / LangGraph | long-term memory 用 namespace/store；agent 可用 manage/search tools；后台 manager 可异步抽取和合并。 | 保留 SessionStart 小索引，同时鼓励工具链按需 `search -> get_observations`。 |
+| Claude Code auto memory | 每个项目有 `MEMORY.md` entrypoint 和 topic files；启动只加载 `MEMORY.md` 前 200 行或 25KB，topic files 不启动全量加载。 | remem 的 SessionStart 输出应该是入口地图，不是百科全书。 |
+| Claude-Mem | MCP search tools 是三层 workflow：`search` 紧凑索引、`timeline` 上下文、`get_observations` 详情。 | remem 已有相同工具，应把 SessionStart 更明确地定位为索引入口。 |
+| Basic Memory | Markdown + SQLite knowledge graph；通过 `search_notes`、`build_context(memory://...)`、`read_note` 按需展开。 | 可以借鉴 knowledge graph / path-oriented context，但不需要启动时塞入全部。 |
+| OpenAI Agents SDK Memory | 启动注入小 `memory_summary.md`，再搜索 `MEMORY.md`，需要时才打开 rollout summaries。 | 与 remem 的 `Core + Index + Sessions` 结构一致，但应保持 compact 和可追溯。 |
+| Chroma / LlamaIndex / LangChain | 候选召回后做 metadata filter、similarity cutoff、rerank、MMR/diversity、time-weighted rerank、contextual compression。 | 第二阶段可以增加轻量 MMR/topic diversity，避免同一主题重复占满 50 条。 |
+
+## Primary Sources
+
+- Mem0 search: https://docs.mem0.ai/core-concepts/memory-operations/search
+- Zep context templates: https://help.getzep.com/context-templates
+- Letta context hierarchy: https://docs.letta.com/guides/core-concepts/memory/context-hierarchy
+- LangMem README: https://github.com/langchain-ai/langmem
+- Claude Code memory: https://code.claude.com/docs/en/memory
+- Claude-Mem README: https://github.com/thedotmack/claude-mem
+- Basic Memory README: https://github.com/basicmachines-co/basic-memory
+- OpenAI Agents SDK memory: https://openai.github.io/openai-agents-python/sandbox/memory/
+- Chroma agentic memory: https://docs.trychroma.com/guides/build/agentic-memory
+- LlamaIndex node postprocessors: https://developers.llamaindex.ai/python/framework/module_guides/querying/node_postprocessors/
+
+## 最终建议
+
+`CONTEXT_MEMORY_LIMIT = 50` 可以保留为兼容语义，但应降级为“main non-preference index limit”的默认值。真正的模型应该是：
+
+```text
+SessionStart context
+  ├─ Preferences/Profile: 独立预算，始终 apply
+  ├─ Core: 6 条左右最高价值非 preference 记忆，受字符预算限制
+  ├─ Memory Index: 50 条以内非 preference 紧凑索引
+  ├─ Workstreams: 当前 active workstream
+  └─ Sessions: 5 条左右 recent session summary
+
+Details
+  └─ search -> timeline -> get_observations 按需展开
+```
+
+第一阶段实施顺序：
+
+1. 增加 `ContextLimits` 和 env parsing。
+2. `load_project_memories()` 默认排除 `preference`。
+3. `render_preferences()` 改为读取 `ContextLimits`。
+4. `render_core()` / `query_recent_summaries()` 改为读取 `core_item_limit`、`core_char_limit`、`session_limit`。
+5. 同步 `docs/ARCHITECTURE.md`，清理未实现 env。
+6. 加 preference flood / env override / deprecated alias / UTF-8 char budget 测试。
+
+第二阶段再评估：
+
+1. 类型软预算：decision / bugfix / architecture / discovery。
+2. 轻量 MMR/topic diversity：同 topic/cluster 默认最多 1-2 条。
+3. Token cost 或字符 cost 显示，避免只看 item count。

--- a/docs/spec-context-compiler.md
+++ b/docs/spec-context-compiler.md
@@ -363,10 +363,10 @@ The existing footer:
 should become more precise after section splitting:
 
 ```text
-50 indexed memories loaded. 6 core memories. 5 sessions.
+120 context memories loaded. 6 core memories. 50 indexed memories. 5 sessions.
 ```
 
-This avoids implying that preferences or total DB rows are included in the same number.
+This separates the candidate pool from section counts so a compact index does not imply a smaller Core pool.
 
 ## 10. Migration Plan
 

--- a/docs/spec-context-compiler.md
+++ b/docs/spec-context-compiler.md
@@ -1,0 +1,502 @@
+# Spec: Host-Aware Context Compiler
+
+**Status**: Draft
+**Date**: 2026-04-29
+**Related**: `docs/context-budget-design-2026-04-29.md`
+
+---
+
+## 1. Background
+
+`remem context` currently behaves like a renderer over one shared memory pool:
+
+```text
+load project memories
+  -> dedupe / branch sort / self-diagnostic cap
+  -> take(CONTEXT_MEMORY_LIMIT = 50)
+  -> render preferences separately
+  -> render core + index + workstreams + sessions
+```
+
+This caused a real Codex SessionStart case where the main index was dominated by:
+
+```text
+Preferences (46)
+Decisions (2)
+Discoveries (2)
+```
+
+The problem is not that `50` is too high or too low. The problem is that one flat limit is carrying unrelated context responsibilities:
+
+- profile/preferences that should always apply;
+- high-value core project memory;
+- a compact non-preference memory index;
+- recent session summaries;
+- active workstreams;
+- host-specific retrieval instructions.
+
+Open-source memory systems converge on the same shape: small always-on profile/core context plus compact indexes, with details loaded on demand. remem already has the retrieval tools (`search`, `timeline`, `get_observations`), but SessionStart should become an entrypoint map rather than a flat memory dump.
+
+## 2. Goals
+
+- Introduce a host-aware `ContextCompiler` boundary.
+- Make Claude Code and Codex context behavior explicit and configurable.
+- Split context into stable sections with independent budgets.
+- Treat preferences/profile as first-class always-on context, not ordinary index entries.
+- Keep SessionStart compact and push full details to MCP/CLI retrieval.
+- Preserve current behavior as much as possible during the first implementation slice.
+- Make context limits testable via scoped Rust tests and live `remem context` smoke checks.
+
+## 3. Non-Goals
+
+- No vector database or graph database dependency.
+- No rewrite of memory storage, promotion, dream, or lifecycle logic.
+- No per-section plugin system in the first implementation.
+- No change to MCP tool contracts.
+- No broad `cargo test --workspace` requirement for this work; targeted package/module tests are enough.
+- No automatic deletion of noisy memories as part of context compilation.
+
+## 4. Design Principle
+
+The long-term abstraction should be:
+
+```text
+ContextRequest
+  -> Candidate Retrieval
+  -> HostProfile.default_policy()
+  -> ContextCompiler
+  -> SectionPlan[]
+  -> RenderedContext
+```
+
+The important distinction:
+
+- **Host variation exists now**, so host profiles should be modeled now.
+- **Section algorithms are still mostly shared**, so section behavior should start as enum + policy data, not a trait/plugin system.
+
+## 5. Existing Boundaries
+
+remem already has two host-related abstractions:
+
+| Existing boundary | Responsibility |
+| --- | --- |
+| `InstallHost` | Mutate host config files and install/uninstall MCP/hooks. |
+| `ToolAdapter` | Parse and normalize hook JSON from a host. |
+
+This spec adds a third boundary:
+
+| New boundary | Responsibility |
+| --- | --- |
+| `ContextHostProfile` | Choose default context policy, retrieval hints, and output style for a host. |
+
+These boundaries should align on a shared `HostKind`, but they should not be collapsed into one giant trait.
+
+## 6. Core Types
+
+### 6.1 HostKind
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostKind {
+    ClaudeCode,
+    CodexCli,
+    Unknown,
+}
+```
+
+Source of host selection:
+
+1. `--host` CLI arg on `remem context` if present.
+2. `REMEM_CONTEXT_HOST` env var.
+3. Auto-detection fallback from environment/config.
+4. `Unknown` default policy.
+
+Install hooks should eventually set this explicitly:
+
+```text
+REMEM_CONTEXT_HOST=claude-code remem context
+REMEM_CONTEXT_HOST=codex-cli remem context
+```
+
+### 6.2 ContextRequest
+
+```rust
+pub struct ContextRequest {
+    pub cwd: String,
+    pub project: String,
+    pub session_id: Option<String>,
+    pub current_branch: Option<String>,
+    pub host: HostKind,
+    pub use_colors: bool,
+}
+```
+
+`generate_context()` should become a thin CLI entry that builds `ContextRequest` and delegates to the compiler.
+
+### 6.3 ContextHostProfile
+
+```rust
+pub trait ContextHostProfile {
+    fn host(&self) -> HostKind;
+    fn capabilities(&self) -> HostCapabilities;
+    fn default_policy(&self) -> ContextPolicy;
+    fn retrieval_hints(&self) -> RetrievalHints;
+}
+```
+
+Expected initial profiles:
+
+| Profile | Notes |
+| --- | --- |
+| `ClaudeCodeContextProfile` | Claude has broader hooks and UserPromptSubmit. It can mention Claude-facing hook behavior and the same MCP retrieval tools. |
+| `CodexCliContextProfile` | Codex currently observes mainly Bash through hooks. Its hints should emphasize `search` / `get_observations` and avoid implying full tool coverage. |
+| `UnknownContextProfile` | Conservative defaults, no host-specific claims. |
+
+### 6.4 HostCapabilities
+
+```rust
+pub struct HostCapabilities {
+    pub has_mcp_tools: bool,
+    pub has_session_start_hook: bool,
+    pub has_user_prompt_submit_hook: bool,
+    pub observes_native_file_edits: bool,
+    pub observes_bash: bool,
+    pub supports_context_colors: bool,
+}
+```
+
+These are for context rendering and diagnostics. They do not replace `InstallHost` or `ToolAdapter`.
+
+### 6.5 ContextPolicy
+
+```rust
+pub struct ContextPolicy {
+    pub total_char_limit: usize,
+    pub candidate_fetch_limit: usize,
+    pub sections: Vec<SectionPolicy>,
+}
+```
+
+The policy is declarative. It says what sections exist and what budget each section gets.
+
+### 6.6 SectionPolicy
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectionKind {
+    Preferences,
+    Core,
+    Workstreams,
+    MemoryIndex,
+    Sessions,
+    RetrievalHints,
+}
+
+pub struct SectionPolicy {
+    pub kind: SectionKind,
+    pub item_limit: usize,
+    pub char_limit: usize,
+    pub include_types: Vec<MemoryType>,
+    pub exclude_types: Vec<MemoryType>,
+    pub per_type_soft_limit: Vec<(MemoryType, usize)>,
+}
+```
+
+Use enum-driven rendering first:
+
+```rust
+match section.kind {
+    SectionKind::Preferences => render_preferences_section(...),
+    SectionKind::Core => render_core_section(...),
+    SectionKind::MemoryIndex => render_memory_index_section(...),
+    SectionKind::Workstreams => render_workstreams_section(...),
+    SectionKind::Sessions => render_sessions_section(...),
+    SectionKind::RetrievalHints => render_retrieval_hints_section(...),
+}
+```
+
+Do not introduce a `ContextSection` trait in the first slice. Add it later only if section behavior becomes genuinely host-specific or externally extensible.
+
+## 7. Default Policy
+
+### 7.1 Shared Defaults
+
+```rust
+ContextPolicy {
+    total_char_limit: 12_000,
+    candidate_fetch_limit: 120,
+    sections: vec![
+        Preferences { item_limit: 30, char_limit: 1500 },
+        Core { item_limit: 6, char_limit: 3000 },
+        Workstreams { item_limit: 5, char_limit: 1200 },
+        MemoryIndex { item_limit: 50, char_limit: 4000 },
+        Sessions { item_limit: 5, char_limit: 2200 },
+        RetrievalHints { item_limit: 1, char_limit: 500 },
+    ],
+}
+```
+
+### 7.2 Section Type Rules
+
+| Section | Include | Exclude |
+| --- | --- | --- |
+| `Preferences` | `preference` | all others |
+| `Core` | `bugfix`, `architecture`, `decision`, `discovery` | `preference`, `session_activity` |
+| `MemoryIndex` | all project memory types except preference | `preference` |
+| `Sessions` | session summaries | memories |
+| `Workstreams` | active workstreams | memories |
+| `RetrievalHints` | host profile text | memories |
+
+The key invariant:
+
+```text
+preference must not enter Core or MemoryIndex by default.
+```
+
+### 7.3 Host Differences
+
+Initial host differences should stay small:
+
+| Setting | Claude Code | Codex CLI |
+| --- | ---: | ---: |
+| `candidate_fetch_limit` | 120 | 120 |
+| `MemoryIndex.item_limit` | 50 | 50 |
+| `Core.item_limit` | 6 | 6 |
+| `Sessions.item_limit` | 5 | 5 |
+| `RetrievalHints` | Claude hook/MCP wording | Codex hook/MCP wording |
+
+Future differences may include lower total char limit for a host, different retrieval hint wording, or hiding sections a host cannot use.
+
+## 8. Environment Variables
+
+New env names:
+
+| Variable | Default | Meaning |
+| --- | ---: | --- |
+| `REMEM_CONTEXT_HOST` | auto | `claude-code`, `codex-cli`, or `unknown` |
+| `REMEM_CONTEXT_TOTAL_CHAR_LIMIT` | `12000` | whole rendered context soft cap |
+| `REMEM_CONTEXT_CANDIDATE_FETCH_LIMIT` | `120` | candidate memories fetched before section selection |
+| `REMEM_CONTEXT_MEMORY_INDEX_LIMIT` | `50` | non-preference memory index item cap |
+| `REMEM_CONTEXT_MEMORY_INDEX_CHAR_LIMIT` | `4000` | non-preference memory index char cap |
+| `REMEM_CONTEXT_CORE_ITEM_LIMIT` | `6` | core memory item cap |
+| `REMEM_CONTEXT_CORE_CHAR_LIMIT` | `3000` | core memory char cap |
+| `REMEM_CONTEXT_SESSION_COUNT` | `5` | recent session summary cap |
+| `REMEM_CONTEXT_PREFERENCE_PROJECT_LIMIT` | `20` | project preference query cap |
+| `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` | `10` | global preference query cap |
+| `REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT` | `1500` | rendered preference char cap |
+| `REMEM_CONTEXT_SELF_DIAGNOSTIC_LIMIT` | `2` | self-diagnostic memory cap |
+
+Compatibility:
+
+- Keep `REMEM_CONTEXT_OBSERVATIONS` as a deprecated alias for `REMEM_CONTEXT_MEMORY_INDEX_LIMIT`.
+- If both old and new vars are set, the new var wins.
+- Update `docs/ARCHITECTURE.md` so it no longer lists unimplemented context env vars as active behavior.
+
+## 9. Compiler Flow
+
+```text
+ContextRequest
+  -> resolve_host_profile(request.host)
+  -> policy = host_profile.default_policy().with_env_overrides()
+  -> candidates = load_context_candidates(policy.candidate_fetch_limit)
+  -> plan = build_section_plan(policy, candidates, summaries, workstreams)
+  -> output = render_context_header()
+  -> output += render_sections(plan)
+  -> output += render_context_footer(plan.stats)
+```
+
+### 9.1 Candidate Retrieval
+
+Replace `load_context_data()` with a clearer split:
+
+```rust
+pub struct ContextCandidates {
+    pub memories: Vec<Memory>,
+    pub summaries: Vec<SessionSummaryBrief>,
+    pub workstreams: Vec<WorkStream>,
+}
+
+fn load_context_candidates(
+    conn: &Connection,
+    request: &ContextRequest,
+    policy: &ContextPolicy,
+) -> ContextCandidates;
+```
+
+Candidate retrieval may still use existing logic:
+
+- recent memories;
+- basename search;
+- dedup clusters;
+- branch-aware ordering;
+- self-diagnostic cap.
+
+But final section inclusion must be controlled by section policies.
+
+### 9.2 Section Planning
+
+```rust
+pub struct SectionPlan {
+    pub kind: SectionKind,
+    pub selected_memories: Vec<Memory>,
+    pub selected_summaries: Vec<SessionSummaryBrief>,
+    pub rendered_char_estimate: usize,
+}
+```
+
+Rules:
+
+- `Preferences` pulls from preference query path, not the main memory index path.
+- `Core` and `MemoryIndex` use non-preference memory candidates by default.
+- `Sessions` uses session summaries and its own limit.
+- `Workstreams` uses active workstreams and its own limit.
+- `RetrievalHints` comes from the host profile.
+
+### 9.3 Footer Stats
+
+The existing footer:
+
+```text
+50 memories loaded.
+```
+
+should become more precise after section splitting:
+
+```text
+50 indexed memories loaded. 6 core memories. 5 sessions.
+```
+
+This avoids implying that preferences or total DB rows are included in the same number.
+
+## 10. Migration Plan
+
+### Phase 1: Host-aware request and policy shell
+
+- Add `HostKind`.
+- Add `--host` to `remem context`.
+- Add `REMEM_CONTEXT_HOST`.
+- Make install hooks set `REMEM_CONTEXT_HOST`.
+- Add `ContextRequest`, `ContextPolicy`, `SectionPolicy`.
+- Keep rendered output mostly unchanged.
+
+Validation:
+
+```bash
+cargo test context:: --lib
+cargo test install:: --lib
+```
+
+### Phase 2: Split Preferences from Main Memory Pool
+
+- Move preference selection fully into `Preferences` section.
+- Exclude `preference` from `Core` and `MemoryIndex`.
+- Make preference limits env-driven.
+
+Validation:
+
+```bash
+cargo test context:: --lib preference
+cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/computer
+```
+
+Expected live smoke shape:
+
+```text
+## Your Preferences
+...
+## Core
+decision / discovery / bugfix / architecture items
+## Index
+Decisions (...)
+Discoveries (...)
+```
+
+The main index should no longer be dominated by `Preferences (46)`.
+
+### Phase 3: Section Budgets
+
+- Apply item and char caps per section.
+- Add `core_item_limit`, `core_char_limit`, `memory_index_char_limit`, `session_limit`.
+- Update footer stats.
+- Update `docs/ARCHITECTURE.md`.
+
+Validation:
+
+```bash
+cargo test context:: --lib env
+cargo test context:: --lib budget
+```
+
+### Phase 4: Type Diversity
+
+- Add soft limits for `decision`, `bugfix`, `architecture`, `discovery`.
+- Keep branch relevance and recent high-score behavior.
+- Ensure old but high-value decisions are not permanently starved.
+
+Validation:
+
+```bash
+cargo test context:: --lib diversity
+```
+
+### Phase 5: Optional Retrieval Quality
+
+Only after the above is stable:
+
+- Lightweight topic diversity using existing `topic_key` / cluster keys.
+- Token or char cost estimates in logs.
+- Optional host-specific policy tuning.
+
+Do not block Phase 1-3 on MMR, embeddings, or graph retrieval.
+
+## 11. Acceptance Tests
+
+Minimum tests for the full spec:
+
+- `context_host_env_overrides_auto_detection`
+- `install_hooks_set_context_host_for_claude_and_codex`
+- `preference_flood_does_not_starve_core_memories`
+- `preferences_rendered_separately_not_in_index`
+- `context_limits_env_override_is_respected`
+- `deprecated_context_observations_alias_still_works`
+- `core_char_budget_does_not_split_utf8`
+- `codex_profile_uses_codex_retrieval_hints`
+- `claude_profile_uses_claude_retrieval_hints`
+- `footer_reports_indexed_memory_count_not_total_db_count`
+
+Live smoke:
+
+```bash
+cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/computer
+REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/computer
+REMEM_CONTEXT_HOST=claude-code cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/computer
+```
+
+Review the section composition, not just the final item count.
+
+## 12. Open Questions
+
+1. Should `--host` be exposed as public CLI API, or should hooks only use `REMEM_CONTEXT_HOST`?
+2. Should footer stats include rendered char estimates?
+3. Should `ContextPolicy` be serialized later for user config, or remain env-only?
+4. Should `PreferenceSection` eventually promote stable preferences into a profile document rather than rendering raw memory rows?
+5. Should context output include explicit `search` examples, or only tool names?
+
+## 13. Recommended First PR
+
+First PR should be structural but narrow:
+
+1. Add `HostKind`, `ContextRequest`, `ContextPolicy`, `SectionPolicy`.
+2. Add env parsing with old alias compatibility.
+3. Add `REMEM_CONTEXT_HOST` to installed SessionStart hook commands.
+4. Keep current section rendering as much as possible.
+5. Add tests for host/env parsing and hook command generation.
+
+Second PR should change behavior:
+
+1. Exclude `preference` from main memory candidates.
+2. Make preference rendering use policy limits.
+3. Add preference flood tests.
+4. Run the `computer` live smoke.
+
+This split keeps the architectural boundary reviewable before changing the user-visible context composition.

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -14,13 +14,14 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         Commands::Context {
             cwd,
             session_id,
+            host,
             color,
         } => {
             if remem_hooks_disabled() {
                 return Ok(());
             }
             let cwd = resolve_cwd_arg(cwd);
-            context::generate_context(&cwd, session_id.as_deref(), color)?;
+            context::generate_context(&cwd, session_id.as_deref(), color, host.as_deref())?;
         }
         Commands::SessionInit => {
             if remem_hooks_disabled() {

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -21,6 +21,8 @@ pub(super) enum Commands {
         #[arg(long)]
         session_id: Option<String>,
         #[arg(long)]
+        host: Option<String>,
+        #[arg(long)]
         color: bool,
     },
     SessionInit,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,7 @@
 mod format;
+mod host;
 mod memory_traits;
+mod policy;
 mod query;
 mod render;
 mod sections;

--- a/src/context/host.rs
+++ b/src/context/host.rs
@@ -1,0 +1,170 @@
+use super::policy::ContextPolicy;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostKind {
+    ClaudeCode,
+    CodexCli,
+    Unknown,
+}
+
+impl HostKind {
+    pub fn as_env_value(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude-code",
+            Self::CodexCli => "codex-cli",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "claude" | "claude-code" | "claudecode" => Some(Self::ClaudeCode),
+            "codex" | "codex-cli" | "codexcli" => Some(Self::CodexCli),
+            "unknown" => Some(Self::Unknown),
+            _ => None,
+        }
+    }
+}
+
+pub(super) struct HostCapabilities {
+    pub has_mcp_tools: bool,
+    pub has_session_start_hook: bool,
+    pub has_user_prompt_submit_hook: bool,
+    pub observes_native_file_edits: bool,
+    pub observes_bash: bool,
+}
+
+pub(super) struct RetrievalHints {
+    pub line: &'static str,
+}
+
+pub(super) trait ContextHostProfile {
+    fn host(&self) -> HostKind;
+    fn capabilities(&self) -> HostCapabilities;
+    fn default_policy(&self) -> ContextPolicy;
+    fn retrieval_hints(&self) -> RetrievalHints;
+}
+
+pub(super) struct ClaudeCodeContextProfile;
+pub(super) struct CodexCliContextProfile;
+pub(super) struct UnknownContextProfile;
+
+impl ContextHostProfile for ClaudeCodeContextProfile {
+    fn host(&self) -> HostKind {
+        HostKind::ClaudeCode
+    }
+
+    fn capabilities(&self) -> HostCapabilities {
+        HostCapabilities {
+            has_mcp_tools: true,
+            has_session_start_hook: true,
+            has_user_prompt_submit_hook: true,
+            observes_native_file_edits: true,
+            observes_bash: true,
+        }
+    }
+
+    fn default_policy(&self) -> ContextPolicy {
+        ContextPolicy::from_env()
+    }
+
+    fn retrieval_hints(&self) -> RetrievalHints {
+        RetrievalHints {
+            line: "Use `search`/`get_observations` for details. `save_memory` after decisions/bugfixes.",
+        }
+    }
+}
+
+impl ContextHostProfile for CodexCliContextProfile {
+    fn host(&self) -> HostKind {
+        HostKind::CodexCli
+    }
+
+    fn capabilities(&self) -> HostCapabilities {
+        HostCapabilities {
+            has_mcp_tools: true,
+            has_session_start_hook: true,
+            has_user_prompt_submit_hook: false,
+            observes_native_file_edits: false,
+            observes_bash: true,
+        }
+    }
+
+    fn default_policy(&self) -> ContextPolicy {
+        ContextPolicy::from_env()
+    }
+
+    fn retrieval_hints(&self) -> RetrievalHints {
+        RetrievalHints {
+            line: "Use `search`/`get_observations` for details. Codex hook capture is Bash-focused, so save explicit decisions/bugfixes when they matter.",
+        }
+    }
+}
+
+impl ContextHostProfile for UnknownContextProfile {
+    fn host(&self) -> HostKind {
+        HostKind::Unknown
+    }
+
+    fn capabilities(&self) -> HostCapabilities {
+        HostCapabilities {
+            has_mcp_tools: true,
+            has_session_start_hook: true,
+            has_user_prompt_submit_hook: false,
+            observes_native_file_edits: false,
+            observes_bash: true,
+        }
+    }
+
+    fn default_policy(&self) -> ContextPolicy {
+        ContextPolicy::from_env()
+    }
+
+    fn retrieval_hints(&self) -> RetrievalHints {
+        RetrievalHints {
+            line: "Use `search`/`get_observations` for details. `save_memory` after decisions/bugfixes.",
+        }
+    }
+}
+
+pub(super) fn resolve_host_kind(host_arg: Option<&str>) -> HostKind {
+    host_arg
+        .and_then(HostKind::parse)
+        .or_else(|| {
+            std::env::var("REMEM_CONTEXT_HOST")
+                .ok()
+                .and_then(|value| HostKind::parse(&value))
+        })
+        .unwrap_or(HostKind::Unknown)
+}
+
+pub(super) fn resolve_profile(host: HostKind) -> Box<dyn ContextHostProfile> {
+    match host {
+        HostKind::ClaudeCode => Box::new(ClaudeCodeContextProfile),
+        HostKind::CodexCli => Box::new(CodexCliContextProfile),
+        HostKind::Unknown => Box::new(UnknownContextProfile),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_supported_host_names() {
+        assert_eq!(HostKind::parse("claude-code"), Some(HostKind::ClaudeCode));
+        assert_eq!(HostKind::parse("codex-cli"), Some(HostKind::CodexCli));
+        assert_eq!(HostKind::parse("unknown"), Some(HostKind::Unknown));
+        assert_eq!(HostKind::parse("missing"), None);
+    }
+
+    #[test]
+    fn codex_profile_reports_bash_focused_capture() {
+        let profile = CodexCliContextProfile;
+        let capabilities = profile.capabilities();
+        assert!(capabilities.has_mcp_tools);
+        assert!(capabilities.observes_bash);
+        assert!(!capabilities.observes_native_file_edits);
+        assert!(profile.retrieval_hints().line.contains("Bash-focused"));
+    }
+}

--- a/src/context/policy.rs
+++ b/src/context/policy.rs
@@ -190,18 +190,10 @@ impl ContextPolicy {
         let Some(section) = self.section(kind) else {
             return true;
         };
-        if section
-            .exclude_types
-            .iter()
-            .any(|excluded| *excluded == memory_type)
-        {
+        if section.exclude_types.contains(&memory_type) {
             return false;
         }
-        section.include_types.is_empty()
-            || section
-                .include_types
-                .iter()
-                .any(|included| *included == memory_type)
+        section.include_types.is_empty() || section.include_types.contains(&memory_type)
     }
 
     pub(super) fn section_item_limit(&self, kind: SectionKind, fallback: usize) -> usize {

--- a/src/context/policy.rs
+++ b/src/context/policy.rs
@@ -1,0 +1,243 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SectionKind {
+    Preferences,
+    Core,
+    Workstreams,
+    MemoryIndex,
+    Sessions,
+    RetrievalHints,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct SectionPolicy {
+    pub kind: SectionKind,
+    pub item_limit: usize,
+    pub char_limit: usize,
+    pub include_types: Vec<&'static str>,
+    pub exclude_types: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ContextLimits {
+    pub total_char_limit: usize,
+    pub candidate_fetch_limit: usize,
+    pub memory_index_limit: usize,
+    pub memory_index_char_limit: usize,
+    pub core_item_limit: usize,
+    pub core_char_limit: usize,
+    pub session_limit: usize,
+    pub self_diagnostic_limit: usize,
+    pub preference_project_limit: usize,
+    pub preference_global_limit: usize,
+    pub preference_char_limit: usize,
+}
+
+impl Default for ContextLimits {
+    fn default() -> Self {
+        Self {
+            total_char_limit: 12_000,
+            candidate_fetch_limit: 120,
+            memory_index_limit: 50,
+            memory_index_char_limit: 4_000,
+            core_item_limit: 6,
+            core_char_limit: 3_000,
+            session_limit: 5,
+            self_diagnostic_limit: 2,
+            preference_project_limit: 20,
+            preference_global_limit: 10,
+            preference_char_limit: 1_500,
+        }
+    }
+}
+
+impl ContextLimits {
+    pub(super) fn from_env() -> Self {
+        Self::from_env_reader(|key| std::env::var(key).ok())
+    }
+
+    pub(super) fn from_env_reader<F>(mut read: F) -> Self
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        let defaults = Self::default();
+        Self {
+            total_char_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_TOTAL_CHAR_LIMIT",
+                defaults.total_char_limit,
+            ),
+            candidate_fetch_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_CANDIDATE_FETCH_LIMIT",
+                defaults.candidate_fetch_limit,
+            ),
+            memory_index_limit: read_usize_with_alias(
+                &mut read,
+                "REMEM_CONTEXT_MEMORY_INDEX_LIMIT",
+                "REMEM_CONTEXT_OBSERVATIONS",
+                defaults.memory_index_limit,
+            ),
+            memory_index_char_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_MEMORY_INDEX_CHAR_LIMIT",
+                defaults.memory_index_char_limit,
+            ),
+            core_item_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_CORE_ITEM_LIMIT",
+                defaults.core_item_limit,
+            ),
+            core_char_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_CORE_CHAR_LIMIT",
+                defaults.core_char_limit,
+            ),
+            session_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_SESSION_COUNT",
+                defaults.session_limit,
+            ),
+            self_diagnostic_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_SELF_DIAGNOSTIC_LIMIT",
+                defaults.self_diagnostic_limit,
+            ),
+            preference_project_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_PREFERENCE_PROJECT_LIMIT",
+                defaults.preference_project_limit,
+            ),
+            preference_global_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT",
+                defaults.preference_global_limit,
+            ),
+            preference_char_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT",
+                defaults.preference_char_limit,
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ContextPolicy {
+    pub limits: ContextLimits,
+    pub sections: Vec<SectionPolicy>,
+}
+
+impl ContextPolicy {
+    pub(super) fn from_env() -> Self {
+        Self::from_limits(ContextLimits::from_env())
+    }
+
+    pub(super) fn from_limits(limits: ContextLimits) -> Self {
+        Self {
+            limits,
+            sections: vec![
+                SectionPolicy {
+                    kind: SectionKind::Preferences,
+                    item_limit: limits.preference_project_limit + limits.preference_global_limit,
+                    char_limit: limits.preference_char_limit,
+                    include_types: vec!["preference"],
+                    exclude_types: vec![],
+                },
+                SectionPolicy {
+                    kind: SectionKind::Core,
+                    item_limit: limits.core_item_limit,
+                    char_limit: limits.core_char_limit,
+                    include_types: vec!["bugfix", "architecture", "decision", "discovery"],
+                    exclude_types: vec!["preference", "session_activity"],
+                },
+                SectionPolicy {
+                    kind: SectionKind::Workstreams,
+                    item_limit: 5,
+                    char_limit: 1_200,
+                    include_types: vec![],
+                    exclude_types: vec![],
+                },
+                SectionPolicy {
+                    kind: SectionKind::MemoryIndex,
+                    item_limit: limits.memory_index_limit,
+                    char_limit: limits.memory_index_char_limit,
+                    include_types: vec![],
+                    exclude_types: vec!["preference"],
+                },
+                SectionPolicy {
+                    kind: SectionKind::Sessions,
+                    item_limit: limits.session_limit,
+                    char_limit: 2_200,
+                    include_types: vec![],
+                    exclude_types: vec![],
+                },
+                SectionPolicy {
+                    kind: SectionKind::RetrievalHints,
+                    item_limit: 1,
+                    char_limit: 500,
+                    include_types: vec![],
+                    exclude_types: vec![],
+                },
+            ],
+        }
+    }
+
+    pub(super) fn section(&self, kind: SectionKind) -> Option<&SectionPolicy> {
+        self.sections.iter().find(|section| section.kind == kind)
+    }
+
+    pub(super) fn allows_memory_type(&self, kind: SectionKind, memory_type: &str) -> bool {
+        let Some(section) = self.section(kind) else {
+            return true;
+        };
+        if section
+            .exclude_types
+            .iter()
+            .any(|excluded| *excluded == memory_type)
+        {
+            return false;
+        }
+        section.include_types.is_empty()
+            || section
+                .include_types
+                .iter()
+                .any(|included| *included == memory_type)
+    }
+
+    pub(super) fn section_item_limit(&self, kind: SectionKind, fallback: usize) -> usize {
+        self.section(kind)
+            .map(|section| section.item_limit)
+            .unwrap_or(fallback)
+    }
+
+    pub(super) fn section_char_limit(&self, kind: SectionKind, fallback: usize) -> usize {
+        self.section(kind)
+            .map(|section| section.char_limit)
+            .unwrap_or(fallback)
+    }
+}
+
+fn read_usize<F>(read: &mut F, key: &str, default: usize) -> usize
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    parse_usize(read(key)).unwrap_or(default)
+}
+
+fn read_usize_with_alias<F>(read: &mut F, key: &str, alias: &str, default: usize) -> usize
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    parse_usize(read(key))
+        .or_else(|| parse_usize(read(alias)))
+        .unwrap_or(default)
+}
+
+fn parse_usize(value: Option<String>) -> Option<usize> {
+    let parsed = value?.trim().parse::<usize>().ok()?;
+    if parsed == 0 {
+        None
+    } else {
+        Some(parsed)
+    }
+}

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -54,9 +54,17 @@ fn load_project_memories(
     let mut memories = Vec::new();
     let mut seen_ids = HashSet::new();
 
-    let recent =
-        memory::get_recent_memories(conn, project, policy.limits.candidate_fetch_limit as i64)
-            .unwrap_or_default();
+    let excluded_types = policy
+        .section(SectionKind::MemoryIndex)
+        .map(|section| section.exclude_types.as_slice())
+        .unwrap_or(&[]);
+    let recent = memory::get_recent_memories_excluding_types(
+        conn,
+        project,
+        excluded_types,
+        policy.limits.candidate_fetch_limit as i64,
+    )
+    .unwrap_or_default();
     for memory in recent {
         if seen_ids.insert(memory.id) {
             memories.push(memory);
@@ -80,12 +88,12 @@ fn load_project_memories(
         }
     }
 
+    memories
+        .retain(|memory| policy.allows_memory_type(SectionKind::MemoryIndex, &memory.memory_type));
     let mut selected = limit_self_diagnostic_memories(
         deduplicate_memory_clusters(memories, current_branch),
         policy.limits.self_diagnostic_limit,
     );
-    selected
-        .retain(|memory| policy.allows_memory_type(SectionKind::MemoryIndex, &memory.memory_type));
     sort_memories_by_branch(&mut selected, current_branch);
     selected
         .into_iter()

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -6,25 +6,35 @@ use rusqlite::Connection;
 use crate::memory::{self, Memory};
 
 use super::memory_traits::{is_memory_self_diagnostic, is_self_diagnostic_text};
+use super::policy::{ContextPolicy, SectionKind};
 use super::types::{LoadedContext, SessionSummaryBrief};
 
-const CONTEXT_MEMORY_LIMIT: usize = 50;
-const RECENT_MEMORY_FETCH_LIMIT: i64 = 100;
 const BASENAME_SEARCH_LIMIT: i64 = 20;
-const MAX_SELF_DIAGNOSTIC_MEMORIES: usize = 2;
 const SUMMARY_FETCH_BATCH_SIZE: usize = 25;
 const SUMMARY_MAX_SCAN: usize = 200;
 const STALE_DESIGN_SUMMARY_DAYS: i64 = 7;
 
+#[cfg(test)]
 pub(super) fn load_context_data(
     conn: &Connection,
     project: &str,
     current_branch: Option<&str>,
 ) -> LoadedContext {
-    let mut memories = load_project_memories(conn, project, current_branch);
+    let policy = ContextPolicy::from_limits(super::policy::ContextLimits::default());
+    load_context_data_with_policy(conn, project, current_branch, &policy)
+}
+
+pub(super) fn load_context_data_with_policy(
+    conn: &Connection,
+    project: &str,
+    current_branch: Option<&str>,
+    policy: &ContextPolicy,
+) -> LoadedContext {
+    let mut memories = load_project_memories(conn, project, current_branch, policy);
     sort_memories_by_branch(&mut memories, current_branch);
 
-    let summaries = query_recent_summaries(conn, project, 5).unwrap_or_default();
+    let summaries =
+        query_recent_summaries(conn, project, policy.limits.session_limit).unwrap_or_default();
     let workstreams =
         crate::workstream::query_active_workstreams(conn, project).unwrap_or_default();
 
@@ -39,12 +49,14 @@ fn load_project_memories(
     conn: &Connection,
     project: &str,
     current_branch: Option<&str>,
+    policy: &ContextPolicy,
 ) -> Vec<Memory> {
     let mut memories = Vec::new();
     let mut seen_ids = HashSet::new();
 
     let recent =
-        memory::get_recent_memories(conn, project, RECENT_MEMORY_FETCH_LIMIT).unwrap_or_default();
+        memory::get_recent_memories(conn, project, policy.limits.candidate_fetch_limit as i64)
+            .unwrap_or_default();
     for memory in recent {
         if seen_ids.insert(memory.id) {
             memories.push(memory);
@@ -68,10 +80,17 @@ fn load_project_memories(
         }
     }
 
-    let mut selected =
-        limit_self_diagnostic_memories(deduplicate_memory_clusters(memories, current_branch));
+    let mut selected = limit_self_diagnostic_memories(
+        deduplicate_memory_clusters(memories, current_branch),
+        policy.limits.self_diagnostic_limit,
+    );
+    selected
+        .retain(|memory| policy.allows_memory_type(SectionKind::MemoryIndex, &memory.memory_type));
     sort_memories_by_branch(&mut selected, current_branch);
-    selected.into_iter().take(CONTEXT_MEMORY_LIMIT).collect()
+    selected
+        .into_iter()
+        .take(policy.limits.memory_index_limit)
+        .collect()
 }
 
 fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {
@@ -147,13 +166,13 @@ fn is_better_cluster_representative(
             && candidate.updated_at_epoch > incumbent.updated_at_epoch)
 }
 
-fn limit_self_diagnostic_memories(memories: Vec<Memory>) -> Vec<Memory> {
+fn limit_self_diagnostic_memories(memories: Vec<Memory>, limit: usize) -> Vec<Memory> {
     let mut retained = Vec::new();
     let mut self_diagnostic_count = 0;
 
     for memory in memories {
         if is_memory_self_diagnostic(&memory) {
-            if self_diagnostic_count >= MAX_SELF_DIAGNOSTIC_MEMORIES {
+            if self_diagnostic_count >= limit {
                 continue;
             }
             self_diagnostic_count += 1;

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -96,9 +96,6 @@ fn load_project_memories(
     );
     sort_memories_by_branch(&mut selected, current_branch);
     selected
-        .into_iter()
-        .take(policy.limits.memory_index_limit)
-        .collect()
 }
 
 fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -9,7 +9,7 @@ use super::policy::{ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
     render_core_memory_with_limits, render_empty_state, render_memory_index_with_limits,
-    render_recent_sessions, render_workstreams_with_limits,
+    render_recent_sessions_with_limit, render_workstreams_with_limits,
 };
 use super::types::ContextRequest;
 
@@ -100,7 +100,11 @@ pub fn generate_context(
         );
     }
     if !loaded.summaries.is_empty() {
-        render_recent_sessions(&mut output, &loaded.summaries);
+        render_recent_sessions_with_limit(
+            &mut output,
+            &loaded.summaries,
+            policy.section_char_limit(SectionKind::Sessions, 2_200),
+        );
     }
 
     output.push_str(&format!(

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -9,7 +9,7 @@ use super::policy::{ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
     render_core_memory_with_limits, render_empty_state, render_memory_index_with_limits,
-    render_recent_sessions, render_workstreams,
+    render_recent_sessions, render_workstreams_with_limits,
 };
 use super::types::ContextRequest;
 
@@ -90,7 +90,12 @@ pub fn generate_context(
         render_memory_index_with_limits(&mut output, &loaded.memories, &render_limits);
     }
     if !loaded.workstreams.is_empty() {
-        render_workstreams(&mut output, &loaded.workstreams);
+        render_workstreams_with_limits(
+            &mut output,
+            &loaded.workstreams,
+            policy.section_item_limit(SectionKind::Workstreams, 5),
+            policy.section_char_limit(SectionKind::Workstreams, 1_200),
+        );
     }
     if !loaded.summaries.is_empty() {
         render_recent_sessions(&mut output, &loaded.summaries);
@@ -103,6 +108,7 @@ pub fn generate_context(
         preference_count,
         loaded.summaries.len()
     ));
+    enforce_total_char_limit(&mut output, policy.limits.total_char_limit);
     print!("{}", output);
 
     timer.done(&format!(
@@ -155,6 +161,24 @@ fn render_preferences_to_buffer(
         limits.preference_char_limit,
     )?;
     Ok((output, count))
+}
+
+pub(in crate::context) fn enforce_total_char_limit(output: &mut String, char_limit: usize) {
+    if char_limit == 0 || output.chars().count() <= char_limit {
+        return;
+    }
+
+    let marker = "\n[remem context truncated to REMEM_CONTEXT_TOTAL_CHAR_LIMIT]\n";
+    let marker_chars = marker.chars().count();
+    if marker_chars >= char_limit {
+        *output = output.chars().take(char_limit).collect();
+        return;
+    }
+
+    let keep_chars = char_limit - marker_chars;
+    let mut truncated: String = output.chars().take(keep_chars).collect();
+    truncated.push_str(marker);
+    *output = truncated;
 }
 
 fn build_context_header(project: &str, current_branch: Option<&str>) -> String {

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -84,10 +84,12 @@ pub fn generate_context(
     output.push_str(&preference_output);
 
     let mut core_count = 0;
+    let mut index_count = 0;
     if !loaded.memories.is_empty() {
         let render_limits = section_render_limits(&policy);
         core_count = render_core_memory_with_limits(&mut output, &loaded.memories, &render_limits);
-        render_memory_index_with_limits(&mut output, &loaded.memories, &render_limits);
+        index_count =
+            render_memory_index_with_limits(&mut output, &loaded.memories, &render_limits);
     }
     if !loaded.workstreams.is_empty() {
         render_workstreams_with_limits(
@@ -102,9 +104,10 @@ pub fn generate_context(
     }
 
     output.push_str(&format!(
-        "{} indexed memories loaded. {} core memories. {} preferences. {} sessions.\n",
+        "{} context memories loaded. {} core memories. {} indexed memories. {} preferences. {} sessions.\n",
         loaded.memories.len(),
         core_count,
+        index_count,
         preference_count,
         loaded.summaries.len()
     ));
@@ -112,7 +115,7 @@ pub fn generate_context(
     print!("{}", output);
 
     timer.done(&format!(
-        "project={} cwd={} session={} host={} colors={} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] indexed_memories={} core={} preferences={} summaries={} workstreams={}",
+        "project={} cwd={} session={} host={} colors={} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] context_memories={} core={} index={} preferences={} summaries={} workstreams={}",
         request.project,
         request.cwd,
         request.session_id.as_deref().unwrap_or("-"),
@@ -125,6 +128,7 @@ pub fn generate_context(
         capabilities.observes_bash,
         loaded.memories.len(),
         core_count,
+        index_count,
         preference_count,
         loaded.summaries.len(),
         loaded.workstreams.len(),

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -4,16 +4,36 @@ use crate::db;
 use crate::db::project_from_cwd;
 
 use super::format::format_header_datetime;
-use super::query::load_context_data;
+use super::host::{resolve_host_kind, resolve_profile};
+use super::policy::{ContextPolicy, SectionKind};
+use super::query::load_context_data_with_policy;
 use super::sections::{
-    render_core_memory, render_empty_state, render_memory_index, render_recent_sessions,
-    render_workstreams,
+    render_core_memory_with_limits, render_empty_state, render_memory_index_with_limits,
+    render_recent_sessions, render_workstreams,
 };
+use super::types::ContextRequest;
 
-pub fn generate_context(cwd: &str, _session_id: Option<&str>, _use_colors: bool) -> Result<()> {
+pub fn generate_context(
+    cwd: &str,
+    session_id: Option<&str>,
+    use_colors: bool,
+    host_arg: Option<&str>,
+) -> Result<()> {
     let timer = crate::log::Timer::start("context", &format!("cwd={}", cwd));
     let project = project_from_cwd(cwd);
     let current_branch = db::detect_git_branch(cwd);
+    let host = resolve_host_kind(host_arg);
+    let profile = resolve_profile(host);
+    let policy = profile.default_policy();
+    let request = ContextRequest {
+        cwd: cwd.to_string(),
+        project: project.clone(),
+        session_id: session_id.map(str::to_string),
+        current_branch: current_branch.clone(),
+        host: profile.host(),
+        use_colors,
+    };
+    let capabilities = profile.capabilities();
 
     let conn = match db::open_db() {
         Ok(connection) => connection,
@@ -28,26 +48,46 @@ pub fn generate_context(cwd: &str, _session_id: Option<&str>, _use_colors: bool)
         }
     };
 
-    let loaded = load_context_data(&conn, &project, current_branch.as_deref());
-    if loaded.memories.is_empty() && loaded.summaries.is_empty() && loaded.workstreams.is_empty() {
+    let loaded = load_context_data_with_policy(
+        &conn,
+        &request.project,
+        request.current_branch.as_deref(),
+        &policy,
+    );
+    let (preference_output, preference_count) =
+        match render_preferences_to_buffer(&conn, &project, cwd, &policy) {
+            Ok(rendered) => rendered,
+            Err(error) => {
+                crate::log::warn("context", &format!("render_preferences failed: {}", error));
+                (String::new(), 0)
+            }
+        };
+
+    if preference_count == 0
+        && loaded.memories.is_empty()
+        && loaded.summaries.is_empty()
+        && loaded.workstreams.is_empty()
+    {
         render_empty_state(&project);
         timer.done("empty (no data)");
         return Ok(());
     }
 
     let mut output = String::new();
-    output.push_str(&build_context_header(&project, current_branch.as_deref()));
-    output.push_str(
-        "Use `search`/`get_observations` for details. `save_memory` after decisions/bugfixes.\n\n",
-    );
+    output.push_str(&build_context_header(
+        &request.project,
+        request.current_branch.as_deref(),
+    ));
+    output.push_str(profile.retrieval_hints().line);
+    output.push_str("\n\n");
 
-    if let Err(error) = crate::preference::render_preferences(&mut output, &conn, &project, cwd) {
-        crate::log::warn("context", &format!("render_preferences failed: {}", error));
-    }
+    output.push_str(&preference_output);
 
+    let mut core_count = 0;
     if !loaded.memories.is_empty() {
-        render_core_memory(&mut output, &loaded.memories);
-        render_memory_index(&mut output, &loaded.memories);
+        let render_limits = section_render_limits(&policy);
+        core_count = render_core_memory_with_limits(&mut output, &loaded.memories, &render_limits);
+        render_memory_index_with_limits(&mut output, &loaded.memories, &render_limits);
     }
     if !loaded.workstreams.is_empty() {
         render_workstreams(&mut output, &loaded.workstreams);
@@ -56,17 +96,65 @@ pub fn generate_context(cwd: &str, _session_id: Option<&str>, _use_colors: bool)
         render_recent_sessions(&mut output, &loaded.summaries);
     }
 
-    output.push_str(&format!("{} memories loaded.\n", loaded.memories.len()));
+    output.push_str(&format!(
+        "{} indexed memories loaded. {} core memories. {} preferences. {} sessions.\n",
+        loaded.memories.len(),
+        core_count,
+        preference_count,
+        loaded.summaries.len()
+    ));
     print!("{}", output);
 
     timer.done(&format!(
-        "project={} memories={} summaries={} workstreams={}",
-        project,
+        "project={} cwd={} session={} host={} colors={} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] indexed_memories={} core={} preferences={} summaries={} workstreams={}",
+        request.project,
+        request.cwd,
+        request.session_id.as_deref().unwrap_or("-"),
+        request.host.as_env_value(),
+        request.use_colors,
+        capabilities.has_mcp_tools,
+        capabilities.has_session_start_hook,
+        capabilities.has_user_prompt_submit_hook,
+        capabilities.observes_native_file_edits,
+        capabilities.observes_bash,
         loaded.memories.len(),
+        core_count,
+        preference_count,
         loaded.summaries.len(),
         loaded.workstreams.len(),
     ));
     Ok(())
+}
+
+fn section_render_limits(policy: &ContextPolicy) -> super::policy::ContextLimits {
+    let mut limits = policy.limits;
+    limits.core_item_limit = policy.section_item_limit(SectionKind::Core, limits.core_item_limit);
+    limits.core_char_limit = policy.section_char_limit(SectionKind::Core, limits.core_char_limit);
+    limits.memory_index_limit =
+        policy.section_item_limit(SectionKind::MemoryIndex, limits.memory_index_limit);
+    limits.memory_index_char_limit =
+        policy.section_char_limit(SectionKind::MemoryIndex, limits.memory_index_char_limit);
+    limits
+}
+
+fn render_preferences_to_buffer(
+    conn: &rusqlite::Connection,
+    project: &str,
+    cwd: &str,
+    policy: &ContextPolicy,
+) -> Result<(String, usize)> {
+    let mut output = String::new();
+    let limits = &policy.limits;
+    let count = crate::preference::render_preferences_with_limits(
+        &mut output,
+        conn,
+        project,
+        cwd,
+        limits.preference_project_limit,
+        limits.preference_global_limit,
+        limits.preference_char_limit,
+    )?;
+    Ok((output, count))
 }
 
 fn build_context_header(project: &str, current_branch: Option<&str>) -> String {

--- a/src/context/sections.rs
+++ b/src/context/sections.rs
@@ -11,7 +11,9 @@ pub(super) use empty::render_empty_state;
 #[cfg(test)]
 pub(super) use index::render_memory_index;
 pub(super) use index::render_memory_index_with_limits;
+#[cfg(test)]
 pub(super) use sessions::render_recent_sessions;
+pub(super) use sessions::render_recent_sessions_with_limit;
 #[cfg(test)]
 pub(super) use workstreams::render_workstreams;
 pub(super) use workstreams::render_workstreams_with_limits;

--- a/src/context/sections.rs
+++ b/src/context/sections.rs
@@ -4,8 +4,12 @@ mod index;
 mod sessions;
 mod workstreams;
 
+#[cfg(test)]
 pub(super) use core::render_core_memory;
+pub(super) use core::render_core_memory_with_limits;
 pub(super) use empty::render_empty_state;
+#[cfg(test)]
 pub(super) use index::render_memory_index;
+pub(super) use index::render_memory_index_with_limits;
 pub(super) use sessions::render_recent_sessions;
 pub(super) use workstreams::render_workstreams;

--- a/src/context/sections.rs
+++ b/src/context/sections.rs
@@ -12,4 +12,6 @@ pub(super) use empty::render_empty_state;
 pub(super) use index::render_memory_index;
 pub(super) use index::render_memory_index_with_limits;
 pub(super) use sessions::render_recent_sessions;
+#[cfg(test)]
 pub(super) use workstreams::render_workstreams;
+pub(super) use workstreams::render_workstreams_with_limits;

--- a/src/context/sections/core.rs
+++ b/src/context/sections/core.rs
@@ -3,17 +3,26 @@ use std::collections::HashMap;
 
 use super::super::format::format_epoch_short;
 use super::super::memory_traits::is_memory_self_diagnostic;
+use super::super::policy::ContextLimits;
 
-const MAX_CHARS: usize = 3000;
-const MAX_ITEMS: usize = 6;
 const PREVIEW_LEN: usize = 200;
 const MAX_PRIMARY_ITEMS_PER_TYPE: usize = 2;
 const MIN_ADDITIONAL_CORE_SCORE: f64 = 1.3;
 
+#[cfg(test)]
 pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Memory]) {
+    render_core_memory_with_limits(output, memories, &ContextLimits::default());
+}
+
+pub(in crate::context) fn render_core_memory_with_limits(
+    output: &mut String,
+    memories: &[Memory],
+    limits: &ContextLimits,
+) -> usize {
     let now = chrono::Utc::now().timestamp();
     let mut scored: Vec<(&Memory, f64)> = memories
         .iter()
+        .filter(|memory| is_core_memory_type(&memory.memory_type))
         .map(|memory| (memory, calculate_memory_score(memory, now)))
         .collect();
     scored.sort_by(|left, right| {
@@ -29,7 +38,7 @@ pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Me
     let mut type_counts: HashMap<&str, usize> = HashMap::new();
 
     for (memory, score) in &scored {
-        if selected.len() >= MAX_ITEMS {
+        if selected.len() >= limits.core_item_limit {
             break;
         }
         if *score < MIN_ADDITIONAL_CORE_SCORE && !selected.is_empty() {
@@ -42,14 +51,19 @@ pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Me
         if count >= MAX_PRIMARY_ITEMS_PER_TYPE {
             continue;
         }
-        if push_selected_memory(&mut selected, &mut total_chars, memory) {
+        if push_selected_memory(
+            &mut selected,
+            &mut total_chars,
+            memory,
+            limits.core_char_limit,
+        ) {
             selected_ids.insert(memory.id);
             *type_counts.entry(memory.memory_type.as_str()).or_default() += 1;
         }
     }
 
     for (memory, score) in &scored {
-        if selected.len() >= MAX_ITEMS {
+        if selected.len() >= limits.core_item_limit {
             break;
         }
         if *score < MIN_ADDITIONAL_CORE_SCORE && !selected.is_empty() {
@@ -58,14 +72,20 @@ pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Me
         if selected_ids.contains(&memory.id) {
             continue;
         }
-        push_selected_memory(&mut selected, &mut total_chars, memory);
+        push_selected_memory(
+            &mut selected,
+            &mut total_chars,
+            memory,
+            limits.core_char_limit,
+        );
     }
 
     if selected.is_empty() {
-        return;
+        return 0;
     }
 
     output.push_str("## Core\n");
+    let selected_count = selected.len();
     for (memory, preview) in selected {
         let date = format_epoch_short(memory.updated_at_epoch);
         output.push_str(&format!(
@@ -79,16 +99,18 @@ pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Me
         output.push('\n');
     }
     output.push('\n');
+    selected_count
 }
 
 fn push_selected_memory<'a>(
     selected: &mut Vec<(&'a Memory, String)>,
     total_chars: &mut usize,
     memory: &'a Memory,
+    max_chars: usize,
 ) -> bool {
     let preview: String = memory.text.chars().take(PREVIEW_LEN).collect();
     let item_len = preview.len() + memory.title.len() + 20;
-    if *total_chars + item_len > MAX_CHARS && !selected.is_empty() {
+    if *total_chars + item_len > max_chars && !selected.is_empty() {
         return false;
     }
 
@@ -97,13 +119,19 @@ fn push_selected_memory<'a>(
     true
 }
 
+fn is_core_memory_type(memory_type: &str) -> bool {
+    matches!(
+        memory_type,
+        "bugfix" | "architecture" | "decision" | "discovery"
+    )
+}
+
 fn calculate_memory_score(memory: &Memory, now_epoch: i64) -> f64 {
     let type_weight = match memory.memory_type.as_str() {
         "bugfix" => 3.0,
         "architecture" => 2.6,
         "decision" => 2.2,
         "discovery" => 1.8,
-        "preference" => 1.4,
         _ => 0.5,
     };
 

--- a/src/context/sections/core.rs
+++ b/src/context/sections/core.rs
@@ -19,6 +19,16 @@ pub(in crate::context) fn render_core_memory_with_limits(
     memories: &[Memory],
     limits: &ContextLimits,
 ) -> usize {
+    if limits.core_item_limit == 0 || limits.core_char_limit == 0 {
+        return 0;
+    }
+    let header = "## Core\n";
+    let trailer_chars = 1;
+    let header_chars = header.chars().count();
+    if header_chars + trailer_chars >= limits.core_char_limit {
+        return 0;
+    }
+
     let now = chrono::Utc::now().timestamp();
     let mut scored: Vec<(&Memory, f64)> = memories
         .iter()
@@ -33,7 +43,7 @@ pub(in crate::context) fn render_core_memory_with_limits(
     });
 
     let mut selected: Vec<(&Memory, String)> = Vec::new();
-    let mut total_chars = 0;
+    let mut total_chars = header_chars + trailer_chars;
     let mut selected_ids = std::collections::HashSet::new();
     let mut type_counts: HashMap<&str, usize> = HashMap::new();
 
@@ -84,7 +94,7 @@ pub(in crate::context) fn render_core_memory_with_limits(
         return 0;
     }
 
-    output.push_str("## Core\n");
+    output.push_str(header);
     let selected_count = selected.len();
     for (memory, preview) in selected {
         let date = format_epoch_short(memory.updated_at_epoch);
@@ -93,9 +103,6 @@ pub(in crate::context) fn render_core_memory_with_limits(
             memory.id, memory.title, memory.memory_type, date
         ));
         output.push_str(&preview);
-        if memory.text.len() > PREVIEW_LEN {
-            output.push_str("...");
-        }
         output.push('\n');
     }
     output.push('\n');
@@ -108,15 +115,43 @@ fn push_selected_memory<'a>(
     memory: &'a Memory,
     max_chars: usize,
 ) -> bool {
-    let preview: String = memory.text.chars().take(PREVIEW_LEN).collect();
-    let item_len = preview.len() + memory.title.len() + 20;
-    if *total_chars + item_len > max_chars && !selected.is_empty() {
+    let header = format!(
+        "**#{} {}** ({}, {})\n",
+        memory.id,
+        memory.title,
+        memory.memory_type,
+        format_epoch_short(memory.updated_at_epoch)
+    );
+    let fixed_chars = header.chars().count() + 1;
+    if *total_chars + fixed_chars >= max_chars {
         return false;
     }
 
+    let remaining_chars = max_chars - *total_chars - fixed_chars;
+    let preview_limit = remaining_chars.min(PREVIEW_LEN);
+    let preview = truncate_to_chars(&memory.text, preview_limit);
+    if preview.is_empty() {
+        return false;
+    }
+    let item_len = preview.chars().count() + fixed_chars;
     selected.push((memory, preview));
     *total_chars += item_len;
     true
+}
+
+fn truncate_to_chars(value: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    if max_chars <= 3 {
+        return value.chars().take(max_chars).collect();
+    }
+    let mut truncated: String = value.chars().take(max_chars - 3).collect();
+    truncated.push_str("...");
+    truncated
 }
 
 fn is_core_memory_type(memory_type: &str) -> bool {

--- a/src/context/sections/index.rs
+++ b/src/context/sections/index.rs
@@ -6,15 +6,19 @@ use super::super::format::{format_epoch_short, type_label};
 use super::super::policy::ContextLimits;
 
 #[cfg(test)]
-pub(in crate::context) fn render_memory_index(output: &mut String, memories: &[Memory]) {
-    render_memory_index_with_limits(output, memories, &ContextLimits::default());
+pub(in crate::context) fn render_memory_index(output: &mut String, memories: &[Memory]) -> usize {
+    render_memory_index_with_limits(output, memories, &ContextLimits::default())
 }
 
 pub(in crate::context) fn render_memory_index_with_limits(
     output: &mut String,
     memories: &[Memory],
     limits: &ContextLimits,
-) {
+) -> usize {
+    if limits.memory_index_limit == 0 || limits.memory_index_char_limit == 0 {
+        return 0;
+    }
+
     let mut by_type: HashMap<&str, Vec<&Memory>> = HashMap::new();
     for memory in memories
         .iter()
@@ -27,7 +31,7 @@ pub(in crate::context) fn render_memory_index_with_limits(
             .push(memory);
     }
     if by_type.is_empty() {
-        return;
+        return 0;
     }
 
     let display_order = [
@@ -38,15 +42,16 @@ pub(in crate::context) fn render_memory_index_with_limits(
         "session_activity",
     ];
 
-    output.push_str("## Index\n");
+    let mut body = String::new();
     let mut total_chars = 0usize;
+    let mut rendered_count = 0usize;
     for memory_type in &display_order {
         if let Some(memories_for_type) = by_type.get(memory_type) {
             if total_chars >= limits.memory_index_char_limit {
                 break;
             }
-            push_memory_index_line(
-                output,
+            rendered_count += push_memory_index_line(
+                &mut body,
                 type_label(memory_type),
                 memory_type,
                 memories_for_type,
@@ -58,8 +63,8 @@ pub(in crate::context) fn render_memory_index_with_limits(
 
     for (memory_type, memories_for_type) in &by_type {
         if !display_order.contains(memory_type) && total_chars < limits.memory_index_char_limit {
-            push_memory_index_line(
-                output,
+            rendered_count += push_memory_index_line(
+                &mut body,
                 memory_type,
                 memory_type,
                 memories_for_type,
@@ -68,7 +73,13 @@ pub(in crate::context) fn render_memory_index_with_limits(
             );
         }
     }
+    if rendered_count == 0 {
+        return 0;
+    }
+    output.push_str("## Index\n");
+    output.push_str(&body);
     output.push('\n');
+    rendered_count
 }
 
 fn push_memory_index_line(
@@ -78,33 +89,76 @@ fn push_memory_index_line(
     memories: &[&Memory],
     max_chars: usize,
     total_chars: &mut usize,
-) {
+) -> usize {
     let section_label = if label == memory_type {
         memory_type.to_string()
     } else {
         label.to_string()
     };
     let prefix = format!("**{}** ({}): ", section_label, memories.len());
-    if *total_chars + prefix.len() > max_chars && *total_chars > 0 {
-        return;
+    let prefix_len = char_len(&prefix);
+    if *total_chars + prefix_len >= max_chars {
+        return 0;
     }
-    output.push_str(&prefix);
-    *total_chars += prefix.len();
+    let mut line = prefix;
+    let mut line_chars = prefix_len;
 
+    let mut rendered = 0usize;
     let mut first = true;
     for memory in memories.iter().take(10) {
         let date = format_epoch_short(memory.updated_at_epoch);
         let item = format!("#{} {} ({})", memory.id, memory.title, date);
         let separator = if first { "" } else { " | " };
-        let next_len = separator.len() + item.len();
-        if *total_chars + next_len > max_chars && !first {
+        let next_len = char_len(separator) + char_len(&item);
+        if *total_chars + line_chars + next_len > max_chars {
+            if !first {
+                break;
+            }
+            let remaining =
+                max_chars.saturating_sub(*total_chars + line_chars + char_len(separator));
+            if remaining == 0 {
+                break;
+            }
+            let truncated = truncate_to_chars(&item, remaining);
+            if truncated.is_empty() {
+                break;
+            }
+            line.push_str(separator);
+            line.push_str(&truncated);
+            line_chars += char_len(separator) + char_len(&truncated);
+            rendered += 1;
             break;
         }
-        output.push_str(separator);
-        output.push_str(&item);
-        *total_chars += next_len;
+        line.push_str(separator);
+        line.push_str(&item);
+        line_chars += next_len;
+        rendered += 1;
         first = false;
     }
-    output.push('\n');
-    *total_chars += 1;
+    if rendered == 0 {
+        return 0;
+    }
+    if *total_chars + line_chars < max_chars {
+        line.push('\n');
+        line_chars += 1;
+    }
+    output.push_str(&line);
+    *total_chars += line_chars;
+    rendered
+}
+
+fn char_len(value: &str) -> usize {
+    value.chars().count()
+}
+
+fn truncate_to_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    if max_chars <= 3 {
+        return value.chars().take(max_chars).collect();
+    }
+    let mut truncated: String = value.chars().take(max_chars - 3).collect();
+    truncated.push_str("...");
+    truncated
 }

--- a/src/context/sections/index.rs
+++ b/src/context/sections/index.rs
@@ -3,14 +3,31 @@ use std::collections::HashMap;
 use crate::memory::Memory;
 
 use super::super::format::{format_epoch_short, type_label};
+use super::super::policy::ContextLimits;
 
+#[cfg(test)]
 pub(in crate::context) fn render_memory_index(output: &mut String, memories: &[Memory]) {
+    render_memory_index_with_limits(output, memories, &ContextLimits::default());
+}
+
+pub(in crate::context) fn render_memory_index_with_limits(
+    output: &mut String,
+    memories: &[Memory],
+    limits: &ContextLimits,
+) {
     let mut by_type: HashMap<&str, Vec<&Memory>> = HashMap::new();
-    for memory in memories {
+    for memory in memories
+        .iter()
+        .filter(|memory| memory.memory_type != "preference")
+        .take(limits.memory_index_limit)
+    {
         by_type
             .entry(memory.memory_type.as_str())
             .or_default()
             .push(memory);
+    }
+    if by_type.is_empty() {
+        return;
     }
 
     let display_order = [
@@ -18,25 +35,37 @@ pub(in crate::context) fn render_memory_index(output: &mut String, memories: &[M
         "bugfix",
         "architecture",
         "discovery",
-        "preference",
         "session_activity",
     ];
 
     output.push_str("## Index\n");
+    let mut total_chars = 0usize;
     for memory_type in &display_order {
         if let Some(memories_for_type) = by_type.get(memory_type) {
+            if total_chars >= limits.memory_index_char_limit {
+                break;
+            }
             push_memory_index_line(
                 output,
                 type_label(memory_type),
                 memory_type,
                 memories_for_type,
+                limits.memory_index_char_limit,
+                &mut total_chars,
             );
         }
     }
 
     for (memory_type, memories_for_type) in &by_type {
-        if !display_order.contains(memory_type) {
-            push_memory_index_line(output, memory_type, memory_type, memories_for_type);
+        if !display_order.contains(memory_type) && total_chars < limits.memory_index_char_limit {
+            push_memory_index_line(
+                output,
+                memory_type,
+                memory_type,
+                memories_for_type,
+                limits.memory_index_char_limit,
+                &mut total_chars,
+            );
         }
     }
     output.push('\n');
@@ -47,21 +76,35 @@ fn push_memory_index_line(
     label: &str,
     memory_type: &str,
     memories: &[&Memory],
+    max_chars: usize,
+    total_chars: &mut usize,
 ) {
     let section_label = if label == memory_type {
         memory_type.to_string()
     } else {
         label.to_string()
     };
-    output.push_str(&format!("**{}** ({}): ", section_label, memories.len()));
-    let items: Vec<String> = memories
-        .iter()
-        .take(10)
-        .map(|memory| {
-            let date = format_epoch_short(memory.updated_at_epoch);
-            format!("#{} {} ({})", memory.id, memory.title, date)
-        })
-        .collect();
-    output.push_str(&items.join(" | "));
+    let prefix = format!("**{}** ({}): ", section_label, memories.len());
+    if *total_chars + prefix.len() > max_chars && *total_chars > 0 {
+        return;
+    }
+    output.push_str(&prefix);
+    *total_chars += prefix.len();
+
+    let mut first = true;
+    for memory in memories.iter().take(10) {
+        let date = format_epoch_short(memory.updated_at_epoch);
+        let item = format!("#{} {} ({})", memory.id, memory.title, date);
+        let separator = if first { "" } else { " | " };
+        let next_len = separator.len() + item.len();
+        if *total_chars + next_len > max_chars && !first {
+            break;
+        }
+        output.push_str(separator);
+        output.push_str(&item);
+        *total_chars += next_len;
+        first = false;
+    }
     output.push('\n');
+    *total_chars += 1;
 }

--- a/src/context/sections/sessions.rs
+++ b/src/context/sections/sessions.rs
@@ -1,11 +1,32 @@
 use super::super::format::{format_epoch_short, format_epoch_time};
 use super::super::types::SessionSummaryBrief;
 
+#[cfg(test)]
 pub(in crate::context) fn render_recent_sessions(
     output: &mut String,
     summaries: &[SessionSummaryBrief],
 ) {
-    output.push_str("## Sessions\n");
+    render_recent_sessions_with_limit(output, summaries, usize::MAX);
+}
+
+pub(in crate::context) fn render_recent_sessions_with_limit(
+    output: &mut String,
+    summaries: &[SessionSummaryBrief],
+    char_limit: usize,
+) {
+    if char_limit == 0 {
+        return;
+    }
+    let header = "## Sessions\n";
+    let header_chars = header.chars().count();
+    let trailer_chars = 1;
+    if header_chars + trailer_chars >= char_limit {
+        return;
+    }
+
+    let mut section = String::from(header);
+    let mut total_chars = header_chars + trailer_chars;
+    let mut rendered = 0usize;
     for summary in summaries {
         let date = format_epoch_short(summary.created_at_epoch);
         let time = format_epoch_time(summary.created_at_epoch);
@@ -15,12 +36,23 @@ pub(in crate::context) fn render_recent_sessions(
             .and_then(|completed| completed.lines().find(|line| !line.trim().is_empty()))
             .map(format_completed_line)
             .unwrap_or_default();
-        output.push_str(&format!(
+        let line = format!(
             "- **{}** {} {}{}\n",
             date, time, summary.request, completed_part
-        ));
+        );
+        let line_chars = line.chars().count();
+        if total_chars + line_chars > char_limit {
+            break;
+        }
+        section.push_str(&line);
+        total_chars += line_chars;
+        rendered += 1;
     }
-    output.push('\n');
+    if rendered == 0 {
+        return;
+    }
+    section.push('\n');
+    output.push_str(&section);
 }
 
 fn format_completed_line(line: &str) -> String {

--- a/src/context/sections/workstreams.rs
+++ b/src/context/sections/workstreams.rs
@@ -17,12 +17,13 @@ pub(in crate::context) fn render_workstreams_with_limits(
 
     let header = "## WorkStreams\n";
     let header_chars = header.chars().count();
-    if header_chars >= char_limit {
+    let trailer_chars = 1;
+    if header_chars + trailer_chars >= char_limit {
         return;
     }
 
     let mut section = String::from(header);
-    let mut total_chars = header_chars;
+    let mut total_chars = header_chars + trailer_chars;
     let mut rendered = 0usize;
 
     for workstream in workstreams.iter().take(item_limit) {

--- a/src/context/sections/workstreams.rs
+++ b/src/context/sections/workstreams.rs
@@ -1,21 +1,61 @@
 use crate::workstream::WorkStream;
 
+#[cfg(test)]
 pub(in crate::context) fn render_workstreams(output: &mut String, workstreams: &[WorkStream]) {
-    output.push_str("## WorkStreams\n");
-    for workstream in workstreams {
-        let next = workstream.next_action.as_deref().unwrap_or("");
-        let next_part = if next.is_empty() {
-            String::new()
-        } else {
-            format!(" -> {}", next)
-        };
-        output.push_str(&format!(
-            "- #{} [{}] {}{}\n",
-            workstream.id,
-            workstream.status.as_str(),
-            workstream.title,
-            next_part
-        ));
+    render_workstreams_with_limits(output, workstreams, usize::MAX, usize::MAX);
+}
+
+pub(in crate::context) fn render_workstreams_with_limits(
+    output: &mut String,
+    workstreams: &[WorkStream],
+    item_limit: usize,
+    char_limit: usize,
+) {
+    if item_limit == 0 || char_limit == 0 {
+        return;
     }
-    output.push('\n');
+
+    let header = "## WorkStreams\n";
+    let header_chars = header.chars().count();
+    if header_chars >= char_limit {
+        return;
+    }
+
+    let mut section = String::from(header);
+    let mut total_chars = header_chars;
+    let mut rendered = 0usize;
+
+    for workstream in workstreams.iter().take(item_limit) {
+        let line = format_workstream_line(workstream);
+        let line_chars = line.chars().count();
+        if total_chars + line_chars > char_limit {
+            break;
+        }
+        section.push_str(&line);
+        total_chars += line_chars;
+        rendered += 1;
+    }
+
+    if rendered == 0 {
+        return;
+    }
+
+    section.push('\n');
+    output.push_str(&section);
+}
+
+fn format_workstream_line(workstream: &WorkStream) -> String {
+    let next = workstream.next_action.as_deref().unwrap_or("");
+    let next_part = if next.is_empty() {
+        String::new()
+    } else {
+        format!(" -> {}", next)
+    };
+    format!(
+        "- #{} [{}] {}{}\n",
+        workstream.id,
+        workstream.status.as_str(),
+        workstream.title,
+        next_part
+    )
 }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -83,6 +83,25 @@ fn render_memory_index_respects_item_limit() {
 }
 
 #[test]
+fn render_memory_index_truncates_first_item_to_char_limit() {
+    let mut output = String::new();
+    let limits = ContextLimits {
+        memory_index_char_limit: 48,
+        ..ContextLimits::default()
+    };
+    let long_title = "Decision title that is far too long for the index budget";
+    let memories = vec![sample_memory(1, "decision", long_title)];
+
+    let rendered = render_memory_index_with_limits(&mut output, &memories, &limits);
+    let body = output.strip_prefix("## Index\n").unwrap().trim_end();
+
+    assert_eq!(rendered, 1);
+    assert!(body.chars().count() <= limits.memory_index_char_limit);
+    assert!(output.contains("..."));
+    assert!(!output.contains(long_title));
+}
+
+#[test]
 fn render_workstreams_includes_next_action_when_present() {
     let mut output = String::new();
     let workstreams = vec![WorkStream {
@@ -362,7 +381,7 @@ fn load_context_data_keeps_current_branch_memories_before_limit() {
 
     let loaded = load_context_data(&conn, project, Some("fix/context-selection"));
 
-    assert_eq!(loaded.memories.len(), 50);
+    assert!(loaded.memories.len() > ContextLimits::default().memory_index_limit);
     assert!(loaded
         .memories
         .iter()
@@ -561,13 +580,14 @@ fn context_limits_new_memory_index_env_wins_over_legacy_alias() {
 }
 
 #[test]
-fn load_context_data_respects_memory_index_limit_policy() {
+fn load_context_data_keeps_core_candidates_when_index_limit_is_small() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);
     let project = "/tmp/vibeguard";
     let now = chrono::Utc::now().timestamp();
     let limits = ContextLimits {
-        memory_index_limit: 3,
+        memory_index_limit: 1,
+        core_item_limit: 4,
         ..ContextLimits::default()
     };
     let policy = ContextPolicy::from_limits(limits);
@@ -587,7 +607,8 @@ fn load_context_data_respects_memory_index_limit_policy() {
 
     let loaded = super::query::load_context_data_with_policy(&conn, project, None, &policy);
 
-    assert_eq!(loaded.memories.len(), 3);
+    assert!(loaded.memories.len() > limits.memory_index_limit);
+    assert!(loaded.memories.len() >= limits.core_item_limit);
 }
 
 #[test]

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -7,8 +7,9 @@ use super::policy::{ContextLimits, ContextPolicy};
 use super::query::{load_context_data, query_recent_summaries};
 use super::render::enforce_total_char_limit;
 use super::sections::{
-    render_core_memory, render_memory_index, render_memory_index_with_limits,
-    render_recent_sessions, render_workstreams, render_workstreams_with_limits,
+    render_core_memory, render_core_memory_with_limits, render_memory_index,
+    render_memory_index_with_limits, render_recent_sessions, render_recent_sessions_with_limit,
+    render_workstreams, render_workstreams_with_limits,
 };
 use super::types::SessionSummaryBrief;
 
@@ -27,6 +28,29 @@ fn render_recent_sessions_truncates_completed_line() {
     assert!(output.contains("=> "));
     assert!(output.contains("..."));
     assert!(!output.contains("ignored"));
+}
+
+#[test]
+fn render_recent_sessions_respects_char_limit() {
+    let mut output = String::new();
+    let summaries = vec![
+        SessionSummaryBrief {
+            request: "Short followup".to_string(),
+            completed: Some("done".to_string()),
+            created_at_epoch: 1_710_000_000,
+        },
+        SessionSummaryBrief {
+            request: "Second session should not fit".to_string(),
+            completed: Some("done".to_string()),
+            created_at_epoch: 1_710_000_100,
+        },
+    ];
+
+    render_recent_sessions_with_limit(&mut output, &summaries, 70);
+
+    assert!(output.contains("Short followup"));
+    assert!(!output.contains("Second session should not fit"));
+    assert!(output.chars().count() <= 70);
 }
 
 #[test]
@@ -169,6 +193,25 @@ fn render_core_memory_prioritizes_higher_score_memories() {
     let high_pos = output.find("**#2 Higher score**").unwrap();
     let low_pos = output.find("**#1 Lower score**").unwrap();
     assert!(high_pos < low_pos);
+}
+
+#[test]
+fn render_core_memory_truncates_first_item_to_char_limit() {
+    let mut output = String::new();
+    let limits = ContextLimits {
+        core_char_limit: 120,
+        ..ContextLimits::default()
+    };
+    let mut long_memory = sample_memory(1, "decision", "Compact title");
+    long_memory.text = "x".repeat(500);
+    let memories = vec![long_memory];
+
+    render_core_memory_with_limits(&mut output, &memories, &limits);
+
+    let body = output.strip_prefix("## Core\n").unwrap().trim_end();
+    assert!(output.chars().count() <= limits.core_char_limit);
+    assert!(body.chars().count() <= limits.core_char_limit);
+    assert!(output.contains("..."));
 }
 
 #[test]

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -3,9 +3,11 @@ use crate::memory::Memory;
 use crate::workstream::{WorkStream, WorkStreamStatus};
 use rusqlite::{params, Connection};
 
+use super::policy::{ContextLimits, ContextPolicy};
 use super::query::{load_context_data, query_recent_summaries};
 use super::sections::{
-    render_core_memory, render_memory_index, render_recent_sessions, render_workstreams,
+    render_core_memory, render_memory_index, render_memory_index_with_limits,
+    render_recent_sessions, render_workstreams,
 };
 use super::types::SessionSummaryBrief;
 
@@ -42,6 +44,41 @@ fn render_memory_index_prioritizes_known_types() {
     let custom_pos = output.find("**custom**").unwrap();
     assert!(decision_pos < bugfix_pos);
     assert!(bugfix_pos < custom_pos);
+}
+
+#[test]
+fn render_memory_index_excludes_preferences() {
+    let mut output = String::new();
+    let memories = vec![
+        sample_memory(1, "preference", "Preference title"),
+        sample_memory(2, "decision", "Decision title"),
+    ];
+
+    render_memory_index(&mut output, &memories);
+
+    assert!(output.contains("Decision title"));
+    assert!(!output.contains("Preference title"));
+    assert!(!output.contains("**Preferences**"));
+}
+
+#[test]
+fn render_memory_index_respects_item_limit() {
+    let mut output = String::new();
+    let limits = ContextLimits {
+        memory_index_limit: 2,
+        ..ContextLimits::default()
+    };
+    let memories = vec![
+        sample_memory(1, "decision", "Decision one"),
+        sample_memory(2, "decision", "Decision two"),
+        sample_memory(3, "decision", "Decision three"),
+    ];
+
+    render_memory_index_with_limits(&mut output, &memories, &limits);
+
+    assert!(output.contains("Decision one"));
+    assert!(output.contains("Decision two"));
+    assert!(!output.contains("Decision three"));
 }
 
 #[test]
@@ -341,6 +378,117 @@ fn load_context_data_limits_memory_self_diagnostics_before_index_rendering() {
         .memories
         .iter()
         .any(|memory| memory.title == "Fix guard path source selection"));
+}
+
+#[test]
+fn load_context_data_excludes_preferences_from_main_memory_pool() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/computer";
+    let now = chrono::Utc::now().timestamp();
+
+    for idx in 0..60 {
+        insert_memory(
+            &conn,
+            idx + 1,
+            project,
+            Some(&format!("preference-topic-{idx}")),
+            "preference",
+            &format!("Preference {idx}"),
+            "User prefers evidence-backed coordination",
+            now - idx,
+        );
+    }
+    insert_memory(
+        &conn,
+        100,
+        project,
+        Some("context-budget-decision"),
+        "decision",
+        "Use host-aware context compiler",
+        "Split preferences from the main memory index",
+        now - 100,
+    );
+    insert_memory(
+        &conn,
+        101,
+        project,
+        Some("context-budget-discovery"),
+        "discovery",
+        "Preference flood starves core memories",
+        "The main index was dominated by preferences",
+        now - 101,
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+
+    assert!(!loaded
+        .memories
+        .iter()
+        .any(|memory| memory.memory_type == "preference"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Use host-aware context compiler"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Preference flood starves core memories"));
+}
+
+#[test]
+fn context_limits_env_override_and_legacy_alias_are_respected() {
+    let mut vars = std::collections::HashMap::new();
+    vars.insert("REMEM_CONTEXT_OBSERVATIONS", "7".to_string());
+    vars.insert("REMEM_CONTEXT_CORE_ITEM_LIMIT", "3".to_string());
+    vars.insert("REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT", "900".to_string());
+
+    let limits = ContextLimits::from_env_reader(|key| vars.get(key).cloned());
+
+    assert_eq!(limits.memory_index_limit, 7);
+    assert_eq!(limits.core_item_limit, 3);
+    assert_eq!(limits.preference_char_limit, 900);
+}
+
+#[test]
+fn context_limits_new_memory_index_env_wins_over_legacy_alias() {
+    let mut vars = std::collections::HashMap::new();
+    vars.insert("REMEM_CONTEXT_OBSERVATIONS", "7".to_string());
+    vars.insert("REMEM_CONTEXT_MEMORY_INDEX_LIMIT", "11".to_string());
+
+    let limits = ContextLimits::from_env_reader(|key| vars.get(key).cloned());
+
+    assert_eq!(limits.memory_index_limit, 11);
+}
+
+#[test]
+fn load_context_data_respects_memory_index_limit_policy() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/vibeguard";
+    let now = chrono::Utc::now().timestamp();
+    let limits = ContextLimits {
+        memory_index_limit: 3,
+        ..ContextLimits::default()
+    };
+    let policy = ContextPolicy::from_limits(limits);
+
+    for idx in 0..8 {
+        insert_memory(
+            &conn,
+            idx + 1,
+            project,
+            Some(&format!("decision-topic-{idx}")),
+            "decision",
+            &format!("Decision {idx}"),
+            "Decision body",
+            now - idx,
+        );
+    }
+
+    let loaded = super::query::load_context_data_with_policy(&conn, project, None, &policy);
+
+    assert_eq!(loaded.memories.len(), 3);
 }
 
 #[test]

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -5,9 +5,10 @@ use rusqlite::{params, Connection};
 
 use super::policy::{ContextLimits, ContextPolicy};
 use super::query::{load_context_data, query_recent_summaries};
+use super::render::enforce_total_char_limit;
 use super::sections::{
     render_core_memory, render_memory_index, render_memory_index_with_limits,
-    render_recent_sessions, render_workstreams,
+    render_recent_sessions, render_workstreams, render_workstreams_with_limits,
 };
 use super::types::SessionSummaryBrief;
 
@@ -101,6 +102,38 @@ fn render_workstreams_includes_next_action_when_present() {
     render_workstreams(&mut output, &workstreams);
 
     assert!(output.contains("#7 [active] Refactor context -> split renderers"));
+}
+
+#[test]
+fn render_workstreams_respects_item_and_char_limits() {
+    let mut output = String::new();
+    let workstreams = vec![
+        sample_workstream(1, "First stream", Some("ship the first fix")),
+        sample_workstream(2, "Second stream", Some("ship the second fix")),
+        sample_workstream(3, "Third stream", Some("ship the third fix")),
+    ];
+
+    render_workstreams_with_limits(&mut output, &workstreams, 2, 200);
+
+    assert!(output.contains("#1 [active] First stream"));
+    assert!(output.contains("#2 [active] Second stream"));
+    assert!(!output.contains("#3 [active] Third stream"));
+    assert!(output.chars().count() <= 200);
+}
+
+#[test]
+fn render_workstreams_stops_at_char_limit() {
+    let mut output = String::new();
+    let workstreams = vec![
+        sample_workstream(1, "First", Some("fix")),
+        sample_workstream(2, "Second", Some("fix")),
+    ];
+
+    render_workstreams_with_limits(&mut output, &workstreams, 10, 48);
+
+    assert!(output.contains("#1 [active] First"));
+    assert!(!output.contains("#2 [active] Second"));
+    assert!(output.chars().count() <= 48);
 }
 
 #[test]
@@ -437,6 +470,72 @@ fn load_context_data_excludes_preferences_from_main_memory_pool() {
 }
 
 #[test]
+fn load_context_data_excludes_preferences_before_candidate_limit() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/computer";
+    let now = chrono::Utc::now().timestamp();
+
+    for idx in 0..130 {
+        insert_memory(
+            &conn,
+            idx + 1,
+            project,
+            Some(&format!("preference-topic-{idx}")),
+            "preference",
+            &format!("Preference {idx}"),
+            "User prefers evidence-backed coordination",
+            now - idx,
+        );
+    }
+    insert_memory(
+        &conn,
+        200,
+        project,
+        Some("context-budget-decision"),
+        "decision",
+        "Use host-aware context compiler",
+        "Split preferences from the main memory index",
+        now - 1_000,
+    );
+    insert_memory(
+        &conn,
+        201,
+        project,
+        Some("context-budget-bugfix"),
+        "bugfix",
+        "Keep core memories visible",
+        "Filter preferences before applying the candidate cap",
+        now - 1_001,
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+
+    assert!(loaded
+        .memories
+        .iter()
+        .all(|memory| memory.memory_type != "preference"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Use host-aware context compiler"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Keep core memories visible"));
+}
+
+#[test]
+fn enforce_total_char_limit_truncates_rendered_output() {
+    let mut output = format!("{}{}", "# [/tmp/demo] context\n", "x".repeat(500));
+
+    enforce_total_char_limit(&mut output, 120);
+
+    assert!(output.chars().count() <= 120);
+    assert!(output.contains("REMEM_CONTEXT_TOTAL_CHAR_LIMIT"));
+}
+
+#[test]
 fn context_limits_env_override_and_legacy_alias_are_respected() {
     let mut vars = std::collections::HashMap::new();
     vars.insert("REMEM_CONTEXT_OBSERVATIONS", "7".to_string());
@@ -707,6 +806,22 @@ fn sample_memory_with_epoch(
         status: "active".to_string(),
         branch: None,
         scope: "project".to_string(),
+    }
+}
+
+fn sample_workstream(id: i64, title: &str, next_action: Option<&str>) -> WorkStream {
+    WorkStream {
+        id,
+        project: "demo/project".to_string(),
+        title: title.to_string(),
+        description: None,
+        status: WorkStreamStatus::Active,
+        progress: None,
+        next_action: next_action.map(str::to_string),
+        blockers: None,
+        created_at_epoch: 0,
+        updated_at_epoch: id,
+        completed_at_epoch: None,
     }
 }
 

--- a/src/context/types.rs
+++ b/src/context/types.rs
@@ -1,6 +1,18 @@
 use crate::memory::Memory;
 use crate::workstream::WorkStream;
 
+use super::host::HostKind;
+
+#[derive(Debug, Clone)]
+pub(super) struct ContextRequest {
+    pub cwd: String,
+    pub project: String,
+    pub session_id: Option<String>,
+    pub current_branch: Option<String>,
+    pub host: HostKind,
+    pub use_colors: bool,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct SessionSummaryBrief {
     pub request: String,

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -53,10 +53,24 @@ impl HookStrategy {
             Self::Codex => "codex-cli",
         }
     }
+
+    fn context_host(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude-code",
+            Self::Codex => "codex-cli",
+        }
+    }
 }
 
 fn hook_command(bin: &str, strategy: HookStrategy, subcommand: &str) -> String {
-    if subcommand == "summarize" {
+    if subcommand == "context" {
+        format!(
+            "REMEM_CONTEXT_HOST={} {} {}",
+            strategy.context_host(),
+            bin,
+            subcommand
+        )
+    } else if subcommand == "summarize" {
         match strategy.flush_executor() {
             Some(flush_executor) => format!(
                 "REMEM_SUMMARY_EXECUTOR={} REMEM_FLUSH_EXECUTOR={} {} {}",

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -7,7 +7,7 @@ fn build_hooks_contains_expected_claude_commands() {
     let hooks = build_hooks("/tmp/remem", HookStrategy::ClaudeCode);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
-        "/tmp/remem context"
+        "REMEM_CONTEXT_HOST=claude-code /tmp/remem context"
     );
     assert_eq!(
         hooks["UserPromptSubmit"][0]["hooks"][0]["command"],
@@ -28,7 +28,7 @@ fn build_hooks_contains_expected_codex_commands() {
     let hooks = build_hooks("/tmp/remem", HookStrategy::Codex);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
-        "/tmp/remem context"
+        "REMEM_CONTEXT_HOST=codex-cli /tmp/remem context"
     );
     assert!(hooks.get("UserPromptSubmit").is_none());
     assert_eq!(hooks["PostToolUse"][0]["matcher"], "Bash");

--- a/src/memory/store/read.rs
+++ b/src/memory/store/read.rs
@@ -8,6 +8,46 @@ pub fn get_recent_memories(conn: &Connection, project: &str, limit: i64) -> Resu
     list_memories(conn, project, None, limit, 0, false, None)
 }
 
+pub fn get_recent_memories_excluding_types(
+    conn: &Connection,
+    project: &str,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<Memory>> {
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    idx = push_project_filter_required("project", project, idx, &mut conditions, &mut params);
+    conditions.push("status = 'active'".to_string());
+
+    if !excluded_types.is_empty() {
+        let placeholders: Vec<String> = excluded_types
+            .iter()
+            .map(|memory_type| {
+                let placeholder = format!("?{idx}");
+                params.push(Box::new((*memory_type).to_string()));
+                idx += 1;
+                placeholder
+            })
+            .collect();
+        conditions.push(format!("memory_type NOT IN ({})", placeholders.join(", ")));
+    }
+
+    params.push(Box::new(limit));
+    let sql = format!(
+        "SELECT {} FROM memories \
+         WHERE {} \
+         ORDER BY updated_at_epoch DESC LIMIT ?{}",
+        MEMORY_COLS,
+        conditions.join(" AND "),
+        idx,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), map_memory_row)?;
+    crate::db_query::collect_rows(rows)
+}
+
 pub fn get_memories_by_type(
     conn: &Connection,
     project: &str,

--- a/src/preference.rs
+++ b/src/preference.rs
@@ -6,4 +6,4 @@ mod tests;
 
 pub use command::{add_preference, list_preferences, remove_preference};
 pub use query::query_global_preferences;
-pub use render::{dedup_with_claude_md, render_preferences};
+pub use render::{dedup_with_claude_md, render_preferences, render_preferences_with_limits};

--- a/src/preference/query.rs
+++ b/src/preference/query.rs
@@ -1,17 +1,37 @@
 use anyhow::Result;
 use rusqlite::{params, Connection};
+use std::collections::HashSet;
 
 use crate::memory::{self, Memory};
 
 pub fn query_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<Memory>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut results = query_explicit_global_preferences(conn, limit)?;
+    if results.len() >= limit {
+        return Ok(results);
+    }
+
+    let mut seen_keys: HashSet<String> = results.iter().map(global_preference_key).collect();
+    let derived = query_derived_global_preferences(conn, limit - results.len())?;
+    for memory in derived {
+        if seen_keys.insert(global_preference_key(&memory)) {
+            results.push(memory);
+        }
+        if results.len() >= limit {
+            break;
+        }
+    }
+    Ok(results)
+}
+
+fn query_explicit_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<Memory>> {
     let sql = format!(
         "SELECT {} FROM memories \
          WHERE memory_type = 'preference' AND status = 'active' \
-         AND (scope = 'global' OR (topic_key IS NOT NULL AND topic_key IN ( \
-             SELECT topic_key FROM memories \
-             WHERE memory_type = 'preference' AND status = 'active' AND topic_key IS NOT NULL \
-             GROUP BY topic_key HAVING COUNT(DISTINCT project) >= 3 \
-         ))) \
+         AND scope = 'global' \
          GROUP BY COALESCE(topic_key, id) \
          ORDER BY MAX(updated_at_epoch) DESC LIMIT ?1",
         memory::MEMORY_COLS,
@@ -19,4 +39,29 @@ pub fn query_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<M
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params![limit as i64], memory::map_memory_row_pub)?;
     crate::db_query::collect_rows(rows)
+}
+
+fn query_derived_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<Memory>> {
+    let sql = format!(
+        "SELECT {} FROM memories \
+         WHERE memory_type = 'preference' AND status = 'active' \
+         AND topic_key IS NOT NULL AND topic_key IN ( \
+             SELECT topic_key FROM memories \
+             WHERE memory_type = 'preference' AND status = 'active' AND topic_key IS NOT NULL \
+             GROUP BY topic_key HAVING COUNT(DISTINCT project) >= 3 \
+         ) \
+         GROUP BY COALESCE(topic_key, id) \
+         ORDER BY MAX(updated_at_epoch) DESC LIMIT ?1",
+        memory::MEMORY_COLS,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![limit as i64], memory::map_memory_row_pub)?;
+    crate::db_query::collect_rows(rows)
+}
+
+fn global_preference_key(memory: &Memory) -> String {
+    memory
+        .topic_key
+        .clone()
+        .unwrap_or_else(|| format!("id:{}", memory.id))
 }

--- a/src/preference/render.rs
+++ b/src/preference/render.rs
@@ -31,8 +31,21 @@ pub fn render_preferences(
     project: &str,
     cwd: &str,
 ) -> Result<()> {
-    let project_prefs = memory::get_memories_by_type(conn, project, "preference", 20)?;
-    let global_prefs = query_global_preferences(conn, 10).unwrap_or_default();
+    render_preferences_with_limits(output, conn, project, cwd, 20, 10, 1500).map(|_| ())
+}
+
+pub fn render_preferences_with_limits(
+    output: &mut String,
+    conn: &Connection,
+    project: &str,
+    cwd: &str,
+    project_limit: usize,
+    global_limit: usize,
+    char_limit: usize,
+) -> Result<usize> {
+    let project_prefs =
+        memory::get_memories_by_type(conn, project, "preference", project_limit as i64)?;
+    let global_prefs = query_global_preferences(conn, global_limit).unwrap_or_default();
 
     let mut all_prefs = project_prefs;
     let project_topics: std::collections::HashSet<String> = all_prefs
@@ -48,36 +61,35 @@ pub fn render_preferences(
     }
 
     if all_prefs.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
 
     let keep_indices = dedup_with_claude_md(&all_prefs, cwd);
     if keep_indices.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
 
     output.push_str("## Your Preferences (always apply these)\n");
     let mut total_chars = 0;
-    const MAX_CHARS: usize = 1500;
+    let mut rendered = 0usize;
 
     for &idx in &keep_indices {
         let pref = &all_prefs[idx];
         let text = pref.text.trim();
-        let line = if text.len() > 120 {
-            format!(
-                "- {}\n",
-                &text[..text.chars().take(120).map(|ch| ch.len_utf8()).sum()]
-            )
+        let preview: String = text.chars().take(120).collect();
+        let line = if preview.len() < text.len() {
+            format!("- {}\n", preview)
         } else {
             format!("- {}\n", text)
         };
-        if total_chars + line.len() > MAX_CHARS && total_chars > 0 {
+        if total_chars + line.len() > char_limit && total_chars > 0 {
             break;
         }
         output.push_str(&line);
         total_chars += line.len();
+        rendered += 1;
     }
     output.push('\n');
 
-    Ok(())
+    Ok(rendered)
 }


### PR DESCRIPTION
## What changed

- Add a host-aware context compiler shell for `remem context`:
  - `HostKind` / `ContextHostProfile` for Claude Code, Codex CLI, and unknown hosts.
  - `ContextPolicy` / `SectionPolicy` / env-backed `ContextLimits`.
  - `remem context --host` and `REMEM_CONTEXT_HOST` support.
- Split preferences from the main context memory pool:
  - preferences still render in `Your Preferences`;
  - preferences no longer enter `Core` or `Index` by default.
- Re-scope the old flat `CONTEXT_MEMORY_LIMIT=50` behavior:
  - new primary env: `REMEM_CONTEXT_MEMORY_INDEX_LIMIT`;
  - old `REMEM_CONTEXT_OBSERVATIONS` remains a deprecated alias.
- Install hooks now pass explicit host identity:
  - `REMEM_CONTEXT_HOST=claude-code` for Claude Code;
  - `REMEM_CONTEXT_HOST=codex-cli` for Codex.
- Add context design documentation:
  - `docs/context-budget-design-2026-04-29.md`;
  - `docs/spec-context-compiler.md`.
- Optimize global preference lookup by returning explicit global preferences first and only running the derived cross-project topic aggregation when needed.

## Why

The current SessionStart context used one flat memory pool, which let preference memories dominate the main index. A real `computer` project smoke showed the old shape as `Preferences (46) + Decisions (2) + Discoveries (2)`, even though preferences already had their own dedicated section.

The new shape treats SessionStart as a compact context map: preferences/profile are always-on, core/index are non-preference project memory, and details remain available through `search` / `get_observations`.

## Validation

- `cargo fmt --check`
- `cargo test context:: --lib` → 26 passed
- `cargo test install:: --lib` → 14 passed
- `cargo test preference:: --lib` → 5 passed
- `target/debug/remem context --cwd /Users/lifcc/Desktop/code/AI/tools/computer --host codex-cli | tail -n 2`
  - latest smoke: `6 indexed memories loaded. 6 core memories. 7 preferences. 4 sessions.`
  - confirms the main index is no longer dominated by `Preferences`.
