### PR TITLE
fix: isolate SessionStart preference scope

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,10 +137,10 @@ Stop hook fires
 New session starts
        │
        ▼
-  Load preferences (project + global)
+  Load preferences (project + explicit global opt-in)
        │
        ├─ Project preferences from memories table
-       ├─ Global preferences (topic_key in 3+ projects)
+       ├─ Global preferences only when the global limit is explicitly enabled
        ├─ Dedup against CLAUDE.md (skip already present)
        │
        ▼
@@ -264,16 +264,17 @@ Memories have a `scope` field: `project` (default) or `global`.
 
 | Scope | Visibility | Auto-assigned to |
 |-------|-----------|------------------|
-| `project` | Only in the originating project | decision, bugfix, discovery, architecture |
-| `global` | All projects | preference |
+| `project` | Only in the originating project | decision, bugfix, discovery, architecture, preference |
+| `global` | All projects | Explicit opt-in only |
 
 **How it works automatically:**
-- When a session summary is promoted to memories, `preference` type automatically gets `scope=global`
-- When Claude calls `save_memory(type="preference")`, scope defaults to `global`
-- Other types (decision, bugfix, etc.) stay `project`-scoped
-- Context injection query: `WHERE (project = ? OR scope = 'global')`
+- When a session summary is promoted to memories, `preference` type defaults to `scope=project`
+- When Claude calls `save_memory(type="preference")`, scope defaults to `project`
+- All memory types stay project-scoped unless the caller explicitly requests `scope=global`
+- General memory retrieval still uses the overlay query `WHERE (project = ? OR scope = 'global')`
+- SessionStart preference rendering uses project preferences by default; global preference injection is disabled unless `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` is set above `0`
 
-**No manual action needed.** Preferences learned in project A automatically appear in project B's context.
+Global preferences require deliberate action. Preferences learned in project A do not automatically appear in project B's SessionStart context.
 
 The `save_memory` MCP tool accepts an optional `scope` parameter for explicit control. The CLI supports `remem preferences add --global "text"` for manual global preferences.
 
@@ -312,7 +313,7 @@ Project key = `last two path segments + canonical absolute path hash`, balancing
 | `REMEM_CONTEXT_SESSION_COUNT` | `5` | Session summaries shown |
 | `REMEM_CONTEXT_SELF_DIAGNOSTIC_LIMIT` | `2` | Self-diagnostic memory cap |
 | `REMEM_CONTEXT_PREFERENCE_PROJECT_LIMIT` | `20` | Project preference query limit |
-| `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` | `10` | Global preference query limit |
+| `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` | `0` | Global preference query limit; disabled by default |
 | `REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT` | `1500` | Preference section character budget |
 | `REMEM_CLAUDE_PATH` | `claude` | Claude CLI path |
 | `REMEM_CODEX_PATH` | `codex` | Codex CLI path |
@@ -393,4 +394,4 @@ memories_fts (title, content)                                    -- FTS5 trigram
 - **Branch-aware memories**: Memories tagged with git branch, current branch prioritized in context
 - **Auto-promotion**: Session summaries automatically distilled into typed memories (decision/bugfix/preference/discovery)
 - **Preference-first context**: Preferences rendered before core memories, always visible at session start
-- **Global scope for preferences**: Preferences auto-scoped as `global`, visible across all projects without manual action. Other memory types stay `project`-scoped. Inspired by Augment's User Rules vs Workspace Rules separation
+- **Explicit global scope for preferences**: Preferences stay `project`-scoped by default. Cross-project preferences require explicit `scope=global` and SessionStart global preference injection is disabled by default. Inspired by Augment's User Rules vs Workspace Rules separation

--- a/docs/context-budget-design-2026-04-29.md
+++ b/docs/context-budget-design-2026-04-29.md
@@ -83,7 +83,7 @@ struct ContextLimits {
     session_limit: usize,               // default 5
     self_diagnostic_limit: usize,       // default 2
     preference_project_limit: usize,    // default 20
-    preference_global_limit: usize,     // default 10
+    preference_global_limit: usize,     // default 0
     preference_char_limit: usize,       // default 1500
 }
 ```
@@ -110,7 +110,7 @@ struct ContextLimits {
 | `REMEM_CONTEXT_SESSION_COUNT` | `5` | session summary 上限 |
 | `REMEM_CONTEXT_SELF_DIAGNOSTIC_LIMIT` | `2` | self-diagnostic 记忆上限 |
 | `REMEM_CONTEXT_PREFERENCE_PROJECT_LIMIT` | `20` | 项目偏好查询上限 |
-| `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` | `10` | 全局偏好查询上限 |
+| `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` | `0` | 全局偏好查询上限；默认关闭 |
 | `REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT` | `1500` | preference section 字符预算 |
 
 兼容策略：

--- a/docs/spec-context-compiler.md
+++ b/docs/spec-context-compiler.md
@@ -282,7 +282,7 @@ New env names:
 | `REMEM_CONTEXT_CORE_CHAR_LIMIT` | `3000` | core memory char cap |
 | `REMEM_CONTEXT_SESSION_COUNT` | `5` | recent session summary cap |
 | `REMEM_CONTEXT_PREFERENCE_PROJECT_LIMIT` | `20` | project preference query cap |
-| `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` | `10` | global preference query cap |
+| `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` | `0` | global preference query cap; disabled by default |
 | `REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT` | `1500` | rendered preference char cap |
 | `REMEM_CONTEXT_SELF_DIAGNOSTIC_LIMIT` | `2` | self-diagnostic memory cap |
 

--- a/src/context/policy.rs
+++ b/src/context/policy.rs
@@ -44,7 +44,7 @@ impl Default for ContextLimits {
             session_limit: 5,
             self_diagnostic_limit: 2,
             preference_project_limit: 20,
-            preference_global_limit: 10,
+            preference_global_limit: 0,
             preference_char_limit: 1_500,
         }
     }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -72,7 +72,7 @@ pub(super) struct SaveMemoryParams {
     )]
     pub local_path: Option<String>,
     #[schemars(
-        description = "Memory scope: 'project' (default, only this project) or 'global' (visible in all projects). Use 'global' for user preferences and cross-project knowledge."
+        description = "Memory scope: 'project' (default, only this project) or 'global' (visible in all projects). Use 'global' only for explicitly cross-project preferences or knowledge."
     )]
     pub scope: Option<String>,
 }

--- a/src/memory_promote/promote.rs
+++ b/src/memory_promote/promote.rs
@@ -68,7 +68,7 @@ pub fn promote_summary_to_memories(
                 "preference",
                 None,
                 None,
-                "global",
+                "project",
                 None,
             )?;
             count += 1;

--- a/src/memory_promote/tests/promote.rs
+++ b/src/memory_promote/tests/promote.rs
@@ -60,6 +60,29 @@ fn test_promote_multi_learned() {
 }
 
 #[test]
+fn test_promote_preference_defaults_to_project_scope() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    let count = promote_summary_to_memories(
+        &conn,
+        "session-1",
+        "test/proj",
+        Some("Capture local preference"),
+        None,
+        None,
+        Some("Always run project-specific smoke tests"),
+    )
+    .unwrap();
+    assert_eq!(count, 1);
+
+    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
+    assert_eq!(memories.len(), 1);
+    assert_eq!(memories[0].memory_type, "preference");
+    assert_eq!(memories[0].scope, "project");
+}
+
+#[test]
 fn test_promote_content_format() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);

--- a/src/memory_service/save.rs
+++ b/src/memory_service/save.rs
@@ -18,14 +18,7 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         .as_ref()
         .and_then(|files| serde_json::to_string(files).ok());
 
-    let scope = req
-        .scope
-        .as_deref()
-        .unwrap_or(if memory_type == "preference" {
-            "global"
-        } else {
-            "project"
-        });
+    let scope = req.scope.as_deref().unwrap_or("project");
     let mut local_copy = prepare_local_copy(project, title, req)?;
     write_local_copy(&mut local_copy)?;
 

--- a/src/memory_service/tests.rs
+++ b/src/memory_service/tests.rs
@@ -55,6 +55,30 @@ fn resolve_tilde_path_is_rejected() {
 }
 
 #[test]
+fn save_memory_preference_defaults_to_project_scope() {
+    let _dir = ScopedTestDataDir::new("preference-default-project-scope");
+    let conn = db::open_db().expect("db should open");
+    let req = SaveMemoryRequest {
+        text: "Prefer project-specific workflow notes".to_string(),
+        title: Some("Preference".to_string()),
+        project: Some("proj".to_string()),
+        memory_type: Some("preference".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+
+    let saved = save_memory(&conn, &req).expect("preference save should succeed");
+    let scope: String = conn
+        .query_row(
+            "SELECT scope FROM memories WHERE id = ?1",
+            [saved.id],
+            |row| row.get(0),
+        )
+        .expect("scope query should succeed");
+    assert_eq!(scope, "project");
+}
+
+#[test]
 fn save_memory_outside_local_path_does_not_persist_memory() {
     let _dir = ScopedTestDataDir::new("save-outside-path-no-db-write");
     let conn = db::open_db().expect("db should open");

--- a/src/preference.rs
+++ b/src/preference.rs
@@ -5,5 +5,5 @@ mod render;
 mod tests;
 
 pub use command::{add_preference, list_preferences, remove_preference};
-pub use query::query_global_preferences;
+pub use query::{query_global_preferences, query_project_preferences};
 pub use render::{dedup_with_claude_md, render_preferences, render_preferences_with_limits};

--- a/src/preference/command.rs
+++ b/src/preference/command.rs
@@ -3,10 +3,10 @@ use rusqlite::{params, Connection};
 
 use crate::memory;
 
-use super::query_global_preferences;
+use super::{query_global_preferences, query_project_preferences};
 
 pub fn list_preferences(conn: &Connection, project: &str) -> Result<()> {
-    let project_prefs = memory::get_memories_by_type(conn, project, "preference", 50)?;
+    let project_prefs = query_project_preferences(conn, project, 50)?;
     let global_prefs = query_global_preferences(conn, 10).unwrap_or_default();
 
     if project_prefs.is_empty() && global_prefs.is_empty() {

--- a/src/preference/command.rs
+++ b/src/preference/command.rs
@@ -23,7 +23,7 @@ pub fn list_preferences(conn: &Connection, project: &str) -> Result<()> {
     }
 
     if !global_prefs.is_empty() {
-        println!("\nGlobal preferences (3+ projects):");
+        println!("\nGlobal preferences:");
         for pref in &global_prefs {
             let text_preview: String = pref.text.chars().take(80).collect();
             println!("  [{}] {} (from: {})", pref.id, text_preview, pref.project);

--- a/src/preference/query.rs
+++ b/src/preference/query.rs
@@ -4,6 +4,28 @@ use std::collections::HashSet;
 
 use crate::memory::{self, Memory};
 
+pub fn query_project_preferences(
+    conn: &Connection,
+    project: &str,
+    limit: usize,
+) -> Result<Vec<Memory>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let sql = format!(
+        "SELECT {} FROM memories \
+         WHERE memory_type = 'preference' AND status = 'active' \
+         AND project = ?1 AND (scope IS NULL OR scope = 'project') \
+         GROUP BY COALESCE(topic_key, id) \
+         ORDER BY MAX(updated_at_epoch) DESC LIMIT ?2",
+        memory::MEMORY_COLS,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![project, limit as i64], memory::map_memory_row_pub)?;
+    crate::db_query::collect_rows(rows)
+}
+
 pub fn query_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<Memory>> {
     if limit == 0 {
         return Ok(Vec::new());

--- a/src/preference/query.rs
+++ b/src/preference/query.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use rusqlite::{params, Connection};
-use std::collections::HashSet;
 
 use crate::memory::{self, Memory};
 
@@ -31,25 +30,6 @@ pub fn query_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<M
         return Ok(Vec::new());
     }
 
-    let mut results = query_explicit_global_preferences(conn, limit)?;
-    if results.len() >= limit {
-        return Ok(results);
-    }
-
-    let mut seen_keys: HashSet<String> = results.iter().map(global_preference_key).collect();
-    let derived = query_derived_global_preferences(conn, limit - results.len())?;
-    for memory in derived {
-        if seen_keys.insert(global_preference_key(&memory)) {
-            results.push(memory);
-        }
-        if results.len() >= limit {
-            break;
-        }
-    }
-    Ok(results)
-}
-
-fn query_explicit_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<Memory>> {
     let sql = format!(
         "SELECT {} FROM memories \
          WHERE memory_type = 'preference' AND status = 'active' \
@@ -61,29 +41,4 @@ fn query_explicit_global_preferences(conn: &Connection, limit: usize) -> Result<
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params![limit as i64], memory::map_memory_row_pub)?;
     crate::db_query::collect_rows(rows)
-}
-
-fn query_derived_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<Memory>> {
-    let sql = format!(
-        "SELECT {} FROM memories \
-         WHERE memory_type = 'preference' AND status = 'active' \
-         AND topic_key IS NOT NULL AND topic_key IN ( \
-             SELECT topic_key FROM memories \
-             WHERE memory_type = 'preference' AND status = 'active' AND topic_key IS NOT NULL \
-             GROUP BY topic_key HAVING COUNT(DISTINCT project) >= 3 \
-         ) \
-         GROUP BY COALESCE(topic_key, id) \
-         ORDER BY MAX(updated_at_epoch) DESC LIMIT ?1",
-        memory::MEMORY_COLS,
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(params![limit as i64], memory::map_memory_row_pub)?;
-    crate::db_query::collect_rows(rows)
-}
-
-fn global_preference_key(memory: &Memory) -> String {
-    memory
-        .topic_key
-        .clone()
-        .unwrap_or_else(|| format!("id:{}", memory.id))
 }

--- a/src/preference/render.rs
+++ b/src/preference/render.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
-use crate::memory::{self, Memory};
+use crate::memory::Memory;
 
-use super::query_global_preferences;
+use super::{query_global_preferences, query_project_preferences};
 
 pub fn dedup_with_claude_md(prefs: &[Memory], cwd: &str) -> Vec<usize> {
     let claude_md_path = std::path::Path::new(cwd).join("CLAUDE.md");
@@ -31,7 +31,7 @@ pub fn render_preferences(
     project: &str,
     cwd: &str,
 ) -> Result<()> {
-    render_preferences_with_limits(output, conn, project, cwd, 20, 10, 1500).map(|_| ())
+    render_preferences_with_limits(output, conn, project, cwd, 20, 0, 1500).map(|_| ())
 }
 
 pub fn render_preferences_with_limits(
@@ -43,8 +43,7 @@ pub fn render_preferences_with_limits(
     global_limit: usize,
     char_limit: usize,
 ) -> Result<usize> {
-    let project_prefs =
-        memory::get_memories_by_type(conn, project, "preference", project_limit as i64)?;
+    let project_prefs = query_project_preferences(conn, project, project_limit)?;
     let global_prefs = query_global_preferences(conn, global_limit).unwrap_or_default();
 
     let mut all_prefs = project_prefs;

--- a/src/preference/tests.rs
+++ b/src/preference/tests.rs
@@ -4,8 +4,8 @@ use rusqlite::Connection;
 use crate::memory::{self, Memory};
 
 use super::{
-    add_preference, dedup_with_claude_md, query_global_preferences, remove_preference,
-    render_preferences,
+    add_preference, dedup_with_claude_md, query_global_preferences, query_project_preferences,
+    remove_preference, render_preferences, render_preferences_with_limits,
 };
 
 fn setup_test_db() -> Connection {
@@ -82,6 +82,106 @@ fn test_render_preferences_with_data() -> Result<()> {
     render_preferences(&mut output, &conn, "test/proj", "/nonexistent")?;
     assert!(output.contains("## Your Preferences"));
     assert!(output.contains("Use Chinese comments"));
+    Ok(())
+}
+
+#[test]
+fn test_project_preferences_exclude_global_overlay() -> Result<()> {
+    let conn = setup_test_db();
+    memory::insert_memory(
+        &conn,
+        None,
+        "test/proj",
+        Some("local-pref"),
+        "Preference: Local workflow",
+        "Use the local project workflow",
+        "preference",
+        None,
+    )?;
+    memory::insert_memory_full(
+        &conn,
+        None,
+        "other/proj",
+        Some("global-pref"),
+        "Preference: AtlasCloud markdown",
+        "Verify AtlasCloud markdown rendering",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+
+    let prefs = query_project_preferences(&conn, "test/proj", 20)?;
+    assert_eq!(prefs.len(), 1);
+    assert!(prefs[0].text.contains("local project workflow"));
+    assert!(!prefs[0].text.contains("AtlasCloud"));
+    Ok(())
+}
+
+#[test]
+fn test_render_preferences_global_limit_zero_does_not_leak_global() -> Result<()> {
+    let conn = setup_test_db();
+    memory::insert_memory_full(
+        &conn,
+        None,
+        "infra/aip",
+        Some("atlas-pref"),
+        "Preference: AtlasCloud markdown",
+        "Verify AtlasCloud markdown rendering",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+
+    let mut output = String::new();
+    let rendered = render_preferences_with_limits(
+        &mut output,
+        &conn,
+        "work/life/x",
+        "/nonexistent",
+        20,
+        0,
+        1500,
+    )?;
+
+    assert_eq!(rendered, 0);
+    assert!(!output.contains("AtlasCloud"));
+    Ok(())
+}
+
+#[test]
+fn test_render_preferences_global_limit_explicitly_opted_in() -> Result<()> {
+    let conn = setup_test_db();
+    memory::insert_memory_full(
+        &conn,
+        None,
+        "infra/aip",
+        Some("atlas-pref"),
+        "Preference: AtlasCloud markdown",
+        "Verify AtlasCloud markdown rendering",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+
+    let mut output = String::new();
+    let rendered = render_preferences_with_limits(
+        &mut output,
+        &conn,
+        "work/life/x",
+        "/nonexistent",
+        20,
+        1,
+        1500,
+    )?;
+
+    assert_eq!(rendered, 1);
+    assert!(output.contains("AtlasCloud"));
     Ok(())
 }
 

--- a/src/preference/tests.rs
+++ b/src/preference/tests.rs
@@ -186,7 +186,7 @@ fn test_render_preferences_global_limit_explicitly_opted_in() -> Result<()> {
 }
 
 #[test]
-fn test_global_preferences_threshold() -> Result<()> {
+fn test_global_preferences_require_explicit_global_scope() -> Result<()> {
     let conn = setup_test_db();
     for project in &["proj-a", "proj-b", "proj-c"] {
         memory::insert_memory(
@@ -200,24 +200,30 @@ fn test_global_preferences_threshold() -> Result<()> {
             None,
         )?;
     }
-    memory::insert_memory(
+
+    let global = query_global_preferences(&conn, 10)?;
+    assert!(
+        global.is_empty(),
+        "Repeated project-scoped topic_key values must not become global preferences"
+    );
+
+    memory::insert_memory_full(
         &conn,
         None,
         "proj-a",
-        Some("local-pref"),
-        "Preference: Use tabs",
-        "Use tabs for indentation",
+        Some("explicit-global"),
+        "Preference: Explicit global",
+        "Use explicit global preferences only",
         "preference",
+        None,
+        None,
+        "global",
         None,
     )?;
 
     let global = query_global_preferences(&conn, 10)?;
-    assert_eq!(
-        global.len(),
-        1,
-        "Only preferences in 3+ projects should be returned"
-    );
-    assert!(global[0].text.contains("terse"));
+    assert_eq!(global.len(), 1);
+    assert!(global[0].text.contains("explicit global"));
     Ok(())
 }
 

--- a/tests/bench_fixtures.rs
+++ b/tests/bench_fixtures.rs
@@ -417,8 +417,8 @@ pub fn search_eval_memories() -> Vec<MemorySeed> {
             "300 second cooldown between summary generations for same project",
         ),
         (
-            "Preference auto-promotion",
-            "Preferences from session summaries auto-promoted to global scope",
+            "Preference project-scope default",
+            "Preferences from session summaries stay project-scoped unless explicitly global",
         ),
         (
             "Docker build optimization",
@@ -484,15 +484,15 @@ pub fn search_eval_memories() -> Vec<MemorySeed> {
 
 pub fn summary_xml_with_all_fields() -> String {
     "<summary>\n\
-     <request>Add global memory scope for cross-project preference sharing</request>\n\
-     <completed>Implemented scope field on Memory struct, updated insert/query paths, \
-     added auto-promotion of preferences to global scope</completed>\n\
-     <decisions>Use 'global' scope string instead of boolean flag for extensibility. \
-     Preferences are auto-promoted to global scope during summary processing.</decisions>\n\
+     <request>Isolate SessionStart preferences to the active project</request>\n\
+     <completed>Implemented project-only preference query paths and disabled default \
+     global preference injection for SessionStart</completed>\n\
+     <decisions>Use 'project' as the default scope for promoted preferences. \
+     Require explicit scope=global for cross-project preference sharing.</decisions>\n\
      <learned>FTS5 trigram tokenizer handles Chinese characters well but requires \
      LIKE fallback for tokens under 3 characters</learned>\n\
-     <next_steps>Add scope filter to MCP search tool. Write migration for existing \
-     preferences to global scope.</next_steps>\n\
+     <next_steps>Keep global preference injection opt-in and verify SessionStart output \
+     from an unrelated project before release.</next_steps>\n\
      <preferences>Always use English for code comments and commit messages. \
      Prefer cargo check before cargo test for faster feedback.</preferences>\n\
      </summary>"

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -626,11 +626,11 @@ fn bench_summary_parse_full() -> Result<()> {
     assert!(
         p.request
             .as_ref()
-            .is_some_and(|r| r.contains("global memory scope")),
+            .is_some_and(|r| r.contains("SessionStart preferences")),
         "request field should be extracted"
     );
     assert!(
-        p.decisions.as_ref().is_some_and(|d| d.contains("global")),
+        p.decisions.as_ref().is_some_and(|d| d.contains("project")),
         "decisions field should be extracted"
     );
     assert!(
@@ -746,12 +746,19 @@ fn bench_summary_promote_creates_memories() -> Result<()> {
         "Preferences should be promoted to memories"
     );
 
-    // Verify preference is auto-scoped as global
-    let global_prefs: Vec<_> = preferences.iter().filter(|m| m.scope == "global").collect();
+    // Verify promoted preferences follow the current project-scope default.
+    let project_prefs: Vec<_> = preferences
+        .iter()
+        .filter(|m| m.scope == "project")
+        .collect();
     eprintln!(
-        "[Promote] global preferences: {}/{}",
-        global_prefs.len(),
+        "[Promote] project preferences: {}/{}",
+        project_prefs.len(),
         preferences.len()
+    );
+    assert!(
+        !project_prefs.is_empty(),
+        "Promoted preferences should default to project scope"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- make SessionStart project preferences use a project-only query instead of the project/global overlay
- default SessionStart global preference rendering to opt-in only
- default newly saved/promoted preferences to project scope unless global is explicit
- add regression tests for global preference leakage and default preference scope

## Validation
- cargo check
- cargo test
- git diff --check
- REMEM_CONTEXT_HOST=codex-cli /Users/lifcc/.local/bin/remem context --cwd /Users/lifcc/Desktop/code/work/life/x | rg -n "AtlasCloud|markdown 在 AtlasCloud|base vs LoRA" || true

## Notes
- Existing database rows are not migrated in this PR. This is intentionally code-only: existing global preferences remain searchable, but default SessionStart injection no longer pulls them into unrelated projects.