### PR TITLE
fix: detect schema-version downgrade before running migrations

### DIFF
--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -1,13 +1,26 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use rusqlite::Connection;
 
-use super::state::{applied_versions, ensure_migration_table, mark_applied};
+use super::state::{applied_versions, ensure_migration_table, mark_applied, max_applied_version};
 use super::transition::transition_from_old_system;
 use super::types::{MIGRATIONS, OLD_BASELINE_VERSION};
 
 pub(crate) fn run_migrations(conn: &Connection) -> Result<()> {
     ensure_migration_table(conn)?;
     transition_from_old_system(conn)?;
+
+    let binary_latest = MIGRATIONS
+        .iter()
+        .map(|m| m.version)
+        .max()
+        .unwrap_or(0);
+    let db_latest = max_applied_version(conn)?;
+    if db_latest > binary_latest {
+        return Err(anyhow!(
+            "database schema is at v{db_latest} but this binary only knows up to v{binary_latest}; \
+             please upgrade remem to a version that supports schema v{db_latest} before running again"
+        ));
+    }
 
     let applied = applied_versions(conn)?;
     for migration in MIGRATIONS {

--- a/src/migrate/state.rs
+++ b/src/migrate/state.rs
@@ -29,6 +29,15 @@ pub(super) fn applied_versions(conn: &Connection) -> Result<Vec<i64>> {
     Ok(versions)
 }
 
+pub(super) fn max_applied_version(conn: &Connection) -> Result<i64> {
+    let version: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM _schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(version)
+}
+
 pub(super) fn mark_applied(conn: &Connection, version: i64, name: &str) -> Result<()> {
     let now = chrono::Utc::now().timestamp();
     conn.execute(

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -269,6 +269,34 @@ fn dry_run_skips_schema_migrations_regardless_of_sql_quoting() -> Result<()> {
 }
 
 #[test]
+fn run_migrations_rejects_db_newer_than_binary() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    run_migrations(&conn)?;
+
+    let binary_latest: i64 = MIGRATIONS.iter().map(|m| m.version).max().unwrap_or(0);
+    let future_version = binary_latest + 1;
+    conn.execute(
+        "INSERT INTO _schema_migrations (version, name, applied_at_epoch) VALUES (?1, ?2, ?3)",
+        rusqlite::params![future_version, "future", 1_700_000_000_i64],
+    )?;
+
+    let error = run_migrations(&conn).expect_err("newer DB schema must abort startup");
+    let message = error.to_string();
+    assert!(
+        message.contains(&format!("v{}", future_version))
+            && message.contains(&format!("v{}", binary_latest)),
+        "error must name both DB schema and binary versions: {}",
+        message
+    );
+    assert!(
+        message.to_lowercase().contains("upgrade"),
+        "error must point users at upgrading remem: {}",
+        message
+    );
+    Ok(())
+}
+
+#[test]
 fn applied_versions_propagates_row_error() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     // TEXT column so we can insert a non-numeric value that fails i64 deserialization.


### PR DESCRIPTION
## Summary
- Add a startup guard in `migrate::run_migrations` that aborts when `MAX(version)` in `_schema_migrations` exceeds the highest migration the running binary knows about.
- Surfaces a clear `database schema is at vX but this binary only knows up to vY; please upgrade remem ...` error instead of letting an older binary silently operate against a newer schema.
- Migrations remain forward-only; only the guard was added.

## Why
Closes #69 — without this check, a user with `cargo install`'d v0.3.12 plus an older binary still on PATH would have the older binary open the newer DB, skip unknown migrations, and emit confusing per-query "no such column" errors (or worse, write rows against a schema it does not understand).

## Test plan
- [x] `cargo check` (clean)
- [x] `cargo test --lib migrate::` — 18/18 pass, including new `run_migrations_rejects_db_newer_than_binary`
- [x] `cargo test --lib` — 293/293 pass, no regressions

Signed-off-by: majiayu000 <1835304752@qq.com>