### PR TITLE
feat: v2 memory system — Milestone A foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"] }
+rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl", "backup"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/SPEC-memory-system-v2-no-compat-2026-05-08.md
+++ b/SPEC-memory-system-v2-no-compat-2026-05-08.md
@@ -1,0 +1,1070 @@
+---
+spec: memory-system-v2-no-compat
+status: proposed
+date: 2026-05-08
+owner: remem
+compatibility: breaking
+supersedes:
+  - SPEC-observation-drain-scheduler-2026-05-05.md
+  - SPEC-raw-archive-vs-curated-memory-2026-04-22.md
+---
+
+# remem Memory System v2 Spec（不考虑向后兼容）
+
+## 0. Executive Summary
+
+remem v2 的核心判断：
+
+> 自动捕获是正确方向；错误的是把 raw event queue 当成 memory system。
+
+v2 不再把 `pending_observations` 视为长期记忆入口，而是拆成五层：
+
+1. **Capture Log**：快速、AI-free、append-only，保证发生过的事可追溯。
+2. **Extraction Tasks**：可靠 worker/scheduler 队列，负责把 raw events 转成可用中间产物。
+3. **Derived Knowledge**：session summaries、observations、memory candidates、rule candidates。
+4. **Curated Memory**：真正进入长期上下文的高信号 memory，有 provenance、confidence、staleness 和 review 状态。
+5. **Context Compiler**：按预算把 rules、recent work、curated memory、raw fallback 和 code index 组合进 agent context。
+
+这是一版破坏性重构：
+
+- 不保留旧 `pending_observations` / `jobs` 的运行时兼容。
+- 不支持 `host = unknown` 的兼容 claim。
+- 不保证旧 MCP response shape 完全兼容。
+- 不在新 worker 中读取旧队列表。
+- 旧 DB 只允许通过显式 backup/export/import 进入 v2，不做隐式迁移。
+
+## 1. Problem Statement
+
+当前设计的问题不是单个 batch 太小，而是 memory boundary 错了。
+
+### 1.1 Raw event 与 memory 混淆
+
+工具事件、Bash 输出、Stop hook payload、chat transcript 都是 raw evidence。它们可以用于提炼 memory，但本身不是 durable memory。
+
+旧设计的隐含假设是：
+
+```text
+raw event -> pending_observations -> observation -> memory/search context
+```
+
+这个模型会导致：
+
+- 低价值事件和高价值知识争抢同一条队列。
+- 工具噪音越多，memory 质量越差。
+- 队列积压时，真正重要的 summary/memory 也被拖住。
+- 没有明确的 promotion 标准，容易过度记忆或漏记。
+
+### 1.2 Consumer 语义太弱
+
+旧 worker 的实际语义接近：
+
+```text
+Stop hook enqueues work
+worker --once handles a small batch
+future Stop hook maybe wakes it again
+```
+
+这不是可靠队列系统。正确语义应该是：
+
+```text
+capture is append-only
+scheduler continuously discovers ready work
+worker advances identities under explicit budgets
+leases recover automatically
+status/doctor show real queue health
+```
+
+### 1.3 Identity 不完整
+
+所有 capture、task、memory 都必须有明确 identity：
+
+```text
+host + workspace + project + session_id + turn_id/event_id
+```
+
+只靠 `session_id` 会混淆 Claude Code / Codex / Cursor-like adapters，也会混淆同名 session 在不同 workspace/project 下的语义。
+
+### 1.4 缺少 backpressure
+
+没有队列上限、事件大小上限、AI budget、priority isolation 和 drop/compact policy 时，任何高频 Bash 或长工具输出都会制造无界 backlog。
+
+### 1.5 缺少 review/governance
+
+Cursor/Augment 的公开设计都把“长期记住什么”作为可见、可控的层：
+
+- Cursor memories 是自动生成的 rules，background-generated memory 保存前需要用户批准。
+- Augment Memory Review 允许 approve/edit/discard。
+
+remem 不能依赖 Codex 主动调用 `save_memory`，但也不能把每个 raw event 自动升级为长期 memory。v2 需要自动捕获 + 自动提候选 + 可审查/可纠错的 durable memory。
+
+## 2. Goals
+
+- 自动捕获仍然是主路径，不依赖 agent 自觉调用 `save_memory`。
+- Hook 快速、AI-free，不能因为 LLM 或 worker 慢阻塞用户。
+- Raw evidence 与 curated memory 明确分层。
+- Worker/scheduler 能长期稳定 drain，不依赖未来 Stop hook。
+- 所有队列处理都有 leases、retry、backoff、idempotency 和 progress metrics。
+- 长期 memory 有类型、证据、置信度、staleness、scope 和 review 状态。
+- Context 注入受预算约束，不把 raw archive 直接塞进 prompt。
+- 支持 Codex 和 Claude Code，但通过 host identity 隔离。
+- 支持破坏性 schema reset，换取更简单、更正确的数据模型。
+
+## 3. Non-Goals
+
+- 不做旧 DB 原地兼容迁移。
+- 不让 v2 worker 读取旧 `pending_observations` / `jobs`。
+- 不保留 `unknown` host runtime path。
+- 不把所有 tool output 永久记忆化。
+- 不在 capture hook 调用 AI。
+- 不新增微服务；仍保持 Rust single-binary。
+- 不把 codebase indexing 伪装成 memory。代码、docs、git/PR 历史应走 index/search substrate。
+- 不让 review 成为唯一保存路径。review 是纠偏和治理层，自动候选/自动高置信 promotion 仍然需要存在。
+
+## 4. Breaking Compatibility Policy
+
+### 4.1 Schema policy
+
+v2 使用新的 schema family。启动时如果检测到旧 schema：
+
+```text
+remem detects legacy schema
+-> refuse to start writable commands
+-> print explicit reset/import instructions
+```
+
+允许的路径：
+
+```bash
+remem admin backup --output ~/.remem/backups/remem-v1-YYYYMMDD.sqlite
+remem admin reset-v2 --confirm-destructive
+remem import legacy --source ~/.remem/backups/remem-v1-YYYYMMDD.sqlite --best-effort
+```
+
+`import legacy` 是离线导入工具，不是 runtime compatibility。导入失败不能影响 v2 worker/capture 运行。
+
+### 4.2 Host policy
+
+v2 不允许 `host = unknown`。
+
+Hook 不能识别 host 时：
+
+- 不写 task。
+- 写一条 structured error log。
+- `doctor` 报错，提示重新 `remem install --target ...`。
+
+合法 host 起步为：
+
+```text
+codex-cli
+claude-code
+```
+
+未来可扩展：
+
+```text
+cursor
+augment
+manual
+```
+
+### 4.3 Hook install policy
+
+v2 install 重新生成 hook config，不尝试 merge 旧 remem hook blocks。
+
+安全规则：
+
+- 保留非 remem hooks。
+- 删除旧 remem-managed blocks。
+- 重新写入 v2 blocks。
+- 写入前备份原配置。
+
+## 5. System Architecture
+
+```text
+Host hook
+  -> capture_event / capture_message
+  -> captured_events + event_blobs
+  -> task coalescer
+  -> extraction_tasks
+
+Worker daemon
+  -> scheduler tick
+  -> claim task by identity + lease
+  -> extract summaries / observations / candidates
+  -> persist derived knowledge
+  -> update task cursor/progress
+  -> enqueue follow-up if budget exhausted
+
+Promotion engine
+  -> memory_candidates
+  -> auto-promote high-confidence low-risk
+  -> review queue for high-impact or ambiguous candidates
+  -> curated memories + memory_events
+
+Context compiler
+  -> rules
+  -> active workstream/session summary
+  -> relevant curated memories
+  -> raw fallback only when explicit or curated insufficient
+  -> code/docs index through dedicated retrieval
+```
+
+## 6. Core Data Model
+
+Names below are logical table names. Implementation may split modules, but semantics must remain.
+
+### 6.1 `hosts`
+
+```sql
+CREATE TABLE hosts (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,          -- codex-cli, claude-code
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at_epoch INTEGER NOT NULL
+);
+```
+
+No `unknown` host.
+
+### 6.2 `workspaces`
+
+```sql
+CREATE TABLE workspaces (
+    id INTEGER PRIMARY KEY,
+    root_path TEXT NOT NULL UNIQUE,
+    git_remote TEXT,
+    git_branch TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+```
+
+`root_path` is the stable workspace boundary used by install/config detection.
+
+### 6.3 `projects`
+
+```sql
+CREATE TABLE projects (
+    id INTEGER PRIMARY KEY,
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_path TEXT NOT NULL,
+    project_key TEXT NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    UNIQUE(workspace_id, project_path)
+);
+```
+
+`project_key` is a normalized identity used in MCP responses and context filtering.
+
+### 6.4 `sessions`
+
+```sql
+CREATE TABLE sessions (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_id TEXT NOT NULL,
+    started_at_epoch INTEGER,
+    last_seen_at_epoch INTEGER NOT NULL,
+    status TEXT NOT NULL,               -- active, stopped, abandoned
+    UNIQUE(host_id, project_id, session_id)
+);
+```
+
+### 6.5 `captured_events`
+
+Append-only event ledger.
+
+```sql
+CREATE TABLE captured_events (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+    session_id TEXT NOT NULL,
+    turn_id TEXT,
+    event_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,           -- user_message, assistant_message, tool_call, tool_result, file_edit, session_stop
+    role TEXT,                          -- user, assistant, tool, system
+    tool_name TEXT,
+    content_text TEXT,
+    content_blob_id INTEGER,
+    content_hash TEXT NOT NULL,
+    token_estimate INTEGER NOT NULL DEFAULT 0,
+    retention_class TEXT NOT NULL,      -- raw_keep, raw_compact, raw_drop_candidate
+    created_at_epoch INTEGER NOT NULL,
+    inserted_at_epoch INTEGER NOT NULL,
+    UNIQUE(host_id, session_id, event_id)
+);
+```
+
+Rules:
+
+- Small content goes into `content_text`.
+- Large content goes into `event_blobs`.
+- Very large low-value tool output is compacted before storage.
+- Nothing in this table is automatically treated as durable memory.
+
+### 6.6 `event_blobs`
+
+```sql
+CREATE TABLE event_blobs (
+    id INTEGER PRIMARY KEY,
+    content_hash TEXT NOT NULL UNIQUE,
+    content_encoding TEXT NOT NULL,     -- plain, gzip
+    content_bytes BLOB NOT NULL,
+    original_bytes INTEGER NOT NULL,
+    stored_bytes INTEGER NOT NULL,
+    created_at_epoch INTEGER NOT NULL
+);
+```
+
+Hard limits:
+
+- Single event raw text max before compaction: 256 KiB.
+- Single stored blob max after compression: 512 KiB.
+- Larger content is stored as a digest + prefix/suffix summary, not full raw text.
+
+### 6.7 `extraction_tasks`
+
+Unified reliable queue.
+
+```sql
+CREATE TABLE extraction_tasks (
+    id INTEGER PRIMARY KEY,
+    task_kind TEXT NOT NULL,            -- session_rollup, observation_extract, memory_candidate, rule_candidate, index_update
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER,
+    priority INTEGER NOT NULL,
+    status TEXT NOT NULL,               -- pending, processing, delayed, done, failed
+    idempotency_key TEXT NOT NULL UNIQUE,
+    cursor_event_id INTEGER,
+    high_watermark_event_id INTEGER,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_retry_epoch INTEGER,
+    lease_owner TEXT,
+    lease_expires_epoch INTEGER,
+    last_error TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+```
+
+Task coalescing:
+
+- Multiple hook events for the same identity update `high_watermark_event_id`.
+- They do not create unbounded duplicate jobs.
+- A task's progress is measured by event ids advanced, not by number of observations produced.
+
+### 6.8 `session_summaries`
+
+```sql
+CREATE TABLE session_summaries (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+    summary_text TEXT NOT NULL,
+    covered_from_event_id INTEGER NOT NULL,
+    covered_to_event_id INTEGER NOT NULL,
+    model TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    UNIQUE(session_row_id, covered_from_event_id, covered_to_event_id)
+);
+```
+
+### 6.9 `observations`
+
+Observations are extracted facts, not necessarily long-term memories.
+
+```sql
+CREATE TABLE observations (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+    observation_type TEXT NOT NULL,      -- action, discovery, error, decision_hint, preference_hint
+    text TEXT NOT NULL,
+    evidence_event_ids TEXT NOT NULL,   -- JSON array of captured_events ids
+    confidence REAL NOT NULL,
+    created_at_epoch INTEGER NOT NULL
+);
+```
+
+### 6.10 `memory_candidates`
+
+```sql
+CREATE TABLE memory_candidates (
+    id INTEGER PRIMARY KEY,
+    project_id INTEGER,
+    scope TEXT NOT NULL,                -- global, workspace, project
+    memory_type TEXT NOT NULL,          -- decision, discovery, bugfix, architecture, preference
+    topic_key TEXT NOT NULL,
+    text TEXT NOT NULL,
+    evidence_event_ids TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    risk_class TEXT NOT NULL,           -- low, medium, high
+    review_status TEXT NOT NULL,        -- auto_promoted, pending_review, approved, edited, discarded
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+```
+
+### 6.11 `memories`
+
+```sql
+CREATE TABLE memories (
+    id INTEGER PRIMARY KEY,
+    project_id INTEGER,
+    scope TEXT NOT NULL,
+    memory_type TEXT NOT NULL,
+    topic_key TEXT NOT NULL,
+    text TEXT NOT NULL,
+    evidence_event_ids TEXT NOT NULL,
+    source_candidate_id INTEGER,
+    confidence REAL NOT NULL,
+    status TEXT NOT NULL,               -- active, stale, superseded, rejected
+    stale_after_epoch INTEGER,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    UNIQUE(scope, COALESCE(project_id, 0), topic_key)
+);
+```
+
+FTS/vector/multihop indexes attach to `memories`, not raw event tables.
+
+### 6.12 `rule_candidates`
+
+Stable operating rules should become AGENTS/rules candidates, not hidden memories.
+
+```sql
+CREATE TABLE rule_candidates (
+    id INTEGER PRIMARY KEY,
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER,
+    rule_path TEXT,
+    rule_text TEXT NOT NULL,
+    evidence_event_ids TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    review_status TEXT NOT NULL,        -- pending_review, approved, discarded, exported
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+```
+
+remem may propose rule edits, but must not silently edit `AGENTS.md`, `CLAUDE.md`, or hook configs.
+
+### 6.13 `worker_heartbeats`
+
+```sql
+CREATE TABLE worker_heartbeats (
+    owner TEXT PRIMARY KEY,
+    pid INTEGER,
+    mode TEXT NOT NULL,                 -- daemon, once
+    started_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+```
+
+## 7. Capture Path
+
+### 7.1 Hook contract
+
+Hook responsibilities:
+
+1. Detect `host`.
+2. Resolve workspace/project/session identity.
+3. Normalize event payload.
+4. Insert `captured_events`.
+5. Coalesce/update `extraction_tasks`.
+6. Return quickly.
+
+Hooks must not:
+
+- Call AI.
+- Drain tasks.
+- Run broad filesystem scans.
+- Mutate rules/memories directly.
+- Silently drop events when identity is invalid.
+
+### 7.2 Event normalization
+
+Every adapter maps native events into canonical event types:
+
+```text
+user_message
+assistant_message
+tool_call
+tool_result
+file_edit
+session_stop
+```
+
+Codex initial support:
+
+- `PostToolUse(Bash)` -> `tool_result`
+- `Stop` -> `session_stop`
+- transcript messages when path is available -> `user_message` / `assistant_message`
+
+Claude Code initial support:
+
+- `UserPromptSubmit` -> `user_message`
+- `PostToolUse(Write/Edit/NotebookEdit/Bash/Task)` -> `tool_result` or `file_edit`
+- `Stop` -> `session_stop`
+
+### 7.3 Capture filtering
+
+Filtering is allowed only at the retention layer, not by pretending the event never happened.
+
+Examples:
+
+- Short successful `pwd`, `ls`, `git status` outputs: keep compact metadata, not full output.
+- Huge build logs: keep command, exit code, digest, first/last N lines, error spans.
+- Secrets: redact known token patterns before storage.
+
+## 8. Task Scheduling and Worker Semantics
+
+### 8.1 Task kinds
+
+```text
+session_rollup
+observation_extract
+memory_candidate
+rule_candidate
+index_update
+```
+
+Priority order:
+
+1. `session_rollup`: keeps recent context useful.
+2. `memory_candidate`: promotes durable high-value facts.
+3. `observation_extract`: lower-level facts for search/timeline.
+4. `rule_candidate`: stable rule suggestions.
+5. `index_update`: non-urgent local index maintenance.
+
+### 8.2 Progress invariant
+
+The most important invariant:
+
+> Worker progress is counted by claimed/advanced event ranges, not by generated memory/observation count.
+
+This avoids the liveness bug where a batch produces zero observations and the worker falsely treats the queue as drained.
+
+### 8.3 Lease and retry
+
+All task claims are lease-based:
+
+```text
+pending -> processing with lease_owner + lease_expires_epoch
+processing -> done only after derived writes commit
+processing -> delayed on transient failure
+processing -> failed on permanent failure after max attempts
+expired processing -> pending by scheduler recovery
+```
+
+Retry policy:
+
+- AI rate limit: exponential backoff with jitter.
+- Parse failure: retry once with repair prompt, then failed.
+- Empty extraction: mark event range advanced, not failed.
+- Invalid identity: failed and visible in doctor.
+
+### 8.4 Worker modes
+
+```bash
+remem worker --once
+remem worker --daemon
+```
+
+`--once`:
+
+- Recover expired leases.
+- Process ready tasks until budget exhausted or queue empty.
+- Exit.
+
+`--daemon`:
+
+- Heartbeat.
+- Recover leases.
+- Schedule stale work.
+- Process tasks.
+- Sleep with backoff when idle.
+
+Stop hook behavior:
+
+- Always enqueue/coalesce tasks.
+- If daemon heartbeat is healthy, return.
+- If daemon is absent/unhealthy, spawn `worker --once`.
+
+## 9. Backpressure and Budgeting
+
+### 9.1 Capture budgets
+
+Hard defaults:
+
+```text
+max_event_text_before_compact = 256 KiB
+max_blob_after_compress = 512 KiB
+max_events_per_session_per_hour = 2000
+max_low_value_tool_events_per_session_per_hour = 300
+```
+
+When over budget:
+
+- Chat messages remain highest priority.
+- File edits and failed commands remain high priority.
+- Repetitive successful Bash output is compacted.
+- Low-value duplicates are recorded as aggregate counters.
+
+### 9.2 AI budgets
+
+Initial safe defaults:
+
+```text
+max_concurrent_ai_tasks_per_host = 1
+max_ai_seconds_per_worker_once = 240
+max_ai_tasks_per_daemon_tick = 4
+max_events_per_extraction_batch = 30
+```
+
+These are operator-visible and should appear in `remem status --verbose`.
+
+### 9.3 Queue budgets
+
+`extraction_tasks` should not grow linearly with events. Coalescing by identity and kind is required.
+
+Bad:
+
+```text
+one tool result -> one observation job
+```
+
+Good:
+
+```text
+many events in same session -> one task with moving high_watermark
+```
+
+## 10. Promotion and Review Policy
+
+### 10.1 Candidate creation
+
+Memory candidates are created from observations/session summaries when the model detects:
+
+- Long-term user preference.
+- Project architecture decision.
+- Debugging root cause + fix.
+- Important discovery with future implications.
+- Stable workflow/process rule.
+
+### 10.2 Auto-promotion
+
+Auto-promote only when all are true:
+
+- `confidence >= 0.82`
+- `risk_class = low`
+- Memory type is `discovery`, `bugfix`, or low-risk `preference`
+- Evidence includes at least one user/assistant message or explicit command result.
+- Topic key does not conflict with an active memory.
+
+Require review when:
+
+- Memory changes security, auth, payments, keys, deployment, or data deletion behavior.
+- It proposes editing rules files.
+- It conflicts with an existing active memory.
+- It is global scope.
+- It is inferred only from tool output without user/assistant confirmation.
+
+### 10.3 Review UX
+
+CLI:
+
+```bash
+remem review list
+remem review show <candidate_id>
+remem review approve <candidate_id>
+remem review edit <candidate_id> --text ...
+remem review discard <candidate_id>
+```
+
+MCP:
+
+```text
+list_memory_candidates
+approve_memory_candidate
+discard_memory_candidate
+```
+
+Review is not required for the system to function, but pending candidates must be visible.
+
+## 11. Retrieval and Context Compilation
+
+### 11.1 Retrieval substrates
+
+Use the right substrate for the right question:
+
+| Need | Source |
+| --- | --- |
+| Stable instructions | AGENTS.md / CLAUDE.md / rules |
+| User/project long-term memory | `memories` |
+| Recent work continuity | `session_summaries` |
+| Debug timeline | `observations` + captured event provenance |
+| Literal old phrase | raw `captured_events` / raw messages FTS |
+| Codebase knowledge | code/docs/git index, not memory DB |
+
+### 11.2 Default context compiler order
+
+1. Active rules and project instructions.
+2. Current workstream and latest session summary.
+3. Relevant active memories.
+4. Recent observations for the same project/session.
+5. Raw fallback only when explicitly requested or curated results are insufficient.
+
+### 11.3 Raw fallback
+
+Raw fallback must be labeled:
+
+```text
+This came from raw archive, not curated memory.
+```
+
+This prevents raw noise from being treated as stable truth.
+
+## 12. CLI and MCP Surface
+
+### 12.1 CLI commands
+
+```bash
+remem status
+remem doctor
+remem worker --once
+remem worker --daemon
+remem review list
+remem review approve <id>
+remem review discard <id>
+remem admin backup
+remem admin reset-v2 --confirm-destructive
+remem import legacy --source <db>
+```
+
+### 12.2 MCP tools
+
+Keep core tools:
+
+```text
+search
+search_raw
+get_observations
+save_memory
+```
+
+Add review tools:
+
+```text
+list_memory_candidates
+approve_memory_candidate
+discard_memory_candidate
+```
+
+`save_memory` remains a manual supplement. It must not be the primary memory path.
+
+## 13. Doctor and Status
+
+`remem status` must show:
+
+```text
+Capture:
+  Events today
+  Compacted events
+  Dropped low-value aggregates
+
+Tasks:
+  Pending / processing / delayed / failed
+  Oldest pending age
+  Top identities by ready work
+
+Worker:
+  Daemon health
+  Last heartbeat
+  Lease recovery count
+
+Knowledge:
+  Session summaries
+  Observations
+  Memory candidates pending review
+  Active memories
+
+Budgets:
+  AI tasks used
+  Queue pressure
+  Capture compaction rate
+```
+
+`remem doctor` fails when:
+
+- Host identity cannot be detected.
+- Hooks are missing for selected target.
+- DB schema is legacy and writable commands are attempted.
+- Daemon is configured but not healthy.
+- Processing leases are expired beyond threshold.
+- Failed task count exceeds threshold.
+- Capture compaction/drop rate exceeds threshold for sustained periods.
+
+## 14. Security and Data Integrity
+
+- Use parameterized SQL for every query.
+- Never execute shell commands from DB content.
+- Never store secrets unredacted when pattern match detects them.
+- Do not print secrets in logs, doctor, or status.
+- Do not silently edit high-context files (`AGENTS.md`, `CLAUDE.md`, hooks).
+- Every memory must retain evidence ids.
+- Every destructive admin command must create a backup unless explicitly disabled with a second confirmation flag.
+
+## 15. Implementation Plan
+
+### Phase 0: Freeze and replace design target
+
+Deliverables:
+
+- Land this SPEC.
+- Mark older drain spec as superseded in docs/README or SPEC index.
+- Stop expanding old `pending_observations` compatibility work.
+
+Validation:
+
+```bash
+cargo check
+```
+
+### Phase 1: New schema and typed identity
+
+Files likely touched:
+
+- `src/db.rs`
+- `src/db_models.rs`
+- `src/migrate/*`
+- new `src/identity.rs`
+- new migrations for v2 schema family
+
+Deliverables:
+
+- New tables from this SPEC.
+- No `unknown` host.
+- Writable command refuses legacy schema.
+- Backup/reset admin commands.
+
+Validation:
+
+```bash
+cargo test migration -- --nocapture
+cargo test identity -- --nocapture
+cargo check
+```
+
+### Phase 2: Capture ledger
+
+Files likely touched:
+
+- `src/observe/*`
+- `src/summarize/summary_job/hook.rs`
+- adapter modules
+- new `src/capture/*`
+
+Deliverables:
+
+- Hooks write `captured_events`.
+- Large payload compaction.
+- Task coalescing by identity.
+- No AI in hook path.
+
+Validation:
+
+```bash
+cargo test capture -- --nocapture
+cargo test observe -- --nocapture
+cargo check
+```
+
+### Phase 3: Extraction task queue and worker
+
+Files likely touched:
+
+- replace or rewrite `src/db_job/*`
+- replace or rewrite `src/db_pending/*`
+- `src/worker.rs`
+- new `src/extraction/*`
+
+Deliverables:
+
+- Lease-based task queue.
+- Worker progress by event range.
+- Daemon heartbeat.
+- Stop fallback based on heartbeat.
+- Retry/backoff.
+
+Validation:
+
+```bash
+cargo test extraction_task_claims_are_lease_scoped -- --nocapture
+cargo test worker_advances_empty_extraction_ranges -- --nocapture
+cargo test daemon_heartbeat_controls_stop_fallback -- --nocapture
+cargo check
+```
+
+### Phase 4: Derived knowledge and promotion
+
+Files likely touched:
+
+- `src/summarize/*`
+- `src/memory_service/*`
+- new `src/promotion/*`
+- MCP handlers
+
+Deliverables:
+
+- Session summaries from event ranges.
+- Observations with evidence ids.
+- Memory candidates.
+- Auto-promotion policy.
+- Review commands and MCP tools.
+
+Validation:
+
+```bash
+cargo test memory_candidate -- --nocapture
+cargo test auto_promotion_policy -- --nocapture
+cargo test review -- --nocapture
+cargo check
+```
+
+### Phase 5: Retrieval and context compiler
+
+Files likely touched:
+
+- `src/search/*`
+- `src/context/*`
+- MCP server handlers
+
+Deliverables:
+
+- Curated-first search.
+- Raw fallback labeled as raw.
+- Context compiler budget tiers.
+- Provenance returned with memory hits.
+
+Validation:
+
+```bash
+cargo test search_curated_first -- --nocapture
+cargo test raw_fallback_is_labeled -- --nocapture
+cargo test context_budget -- --nocapture
+cargo check
+```
+
+### Phase 6: Install, doctor, and operational rollout
+
+Files likely touched:
+
+- `src/install/*`
+- `src/doctor/*`
+- `src/cli/actions/query/status.rs`
+- README docs
+
+Deliverables:
+
+- v2 hook install.
+- Optional daemon install.
+- Status/doctor for all core metrics.
+- Clear legacy-schema refusal message.
+
+Validation:
+
+```bash
+cargo test install -- --nocapture
+cargo test doctor -- --nocapture
+cargo test status -- --nocapture
+cargo check
+cargo test
+```
+
+## 16. Acceptance Criteria
+
+Functional:
+
+- Hook path remains AI-free and fast.
+- Every accepted event lands in `captured_events` or an explicit aggregate/drop record.
+- High-frequency Bash sessions do not create unbounded task rows.
+- Worker daemon drains tasks without future Stop hooks.
+- Expired leases recover automatically.
+- Empty extraction output still advances task progress.
+- Curated memories include evidence ids and confidence.
+- Raw archive is searchable but clearly labeled as raw.
+
+Quality:
+
+- Long-term context contains decisions, preferences, bug fixes, architecture facts, and important discoveries.
+- Low-value raw tool noise does not become durable memory.
+- Conflicting memories are not silently overwritten.
+- Stable operating rules become reviewable rule candidates.
+
+Performance:
+
+- AI concurrency is capped.
+- Queue growth is coalesced by identity.
+- Large payloads are compacted.
+- Status exposes queue pressure before backlog becomes invisible.
+
+Compatibility:
+
+- No runtime compatibility with old queue/schema.
+- Legacy DB is refused unless reset/import is explicitly requested.
+- Codex and Claude Code are isolated by host identity.
+
+Verification:
+
+```bash
+cargo check
+cargo test
+cargo build --release
+```
+
+Manual E2E:
+
+1. Install v2 hooks for Codex.
+2. Run a long Bash-heavy Codex session.
+3. Confirm `captured_events` grows but `extraction_tasks` stays coalesced.
+4. Confirm daemon drains tasks without another Stop hook.
+5. Confirm one high-value decision becomes a memory candidate or active memory.
+6. Confirm low-value Bash noise is not promoted.
+7. Confirm `search_raw` can find literal raw content with raw label.
+8. Confirm `search` returns curated memory first.
+
+## 17. Open Decisions
+
+Recommended defaults:
+
+- Auto-promote threshold: `confidence >= 0.82`.
+- AI concurrency: `1` per host.
+- Extraction batch size: `30` events.
+- Worker once budget: `240s`.
+- Daemon install: opt-in first, default only after manual validation.
+- Legacy import: best-effort offline only.
+
+Open questions before implementation:
+
+1. Should `captured_events.content_text` store assistant full text by default or compact it like tool output?
+2. Should vector search attach to observations as well as memories?
+3. Should global-scope memories always require review?
+4. Should `rule_candidates` export patches or only plain text suggestions?
+5. Should old raw transcripts be replayed into v2 during optional import?
+
+## 18. Decision
+
+Proceed with v2 as a breaking architecture change.
+
+The old design can be patched, but patching it preserves the wrong abstraction: a raw pending queue pretending to be a memory system. v2 keeps remem's correct product bet, automatic capture, while moving durable memory quality into the right layers: staged evidence, reliable extraction, governed promotion, and budgeted context compilation.

--- a/SPEC-memory-system-v2.1-revisions-2026-05-08.md
+++ b/SPEC-memory-system-v2.1-revisions-2026-05-08.md
@@ -1,0 +1,235 @@
+---
+spec: memory-system-v2.1-revisions
+status: proposed
+date: 2026-05-08
+owner: remem
+revises: SPEC-memory-system-v2-no-compat-2026-05-08.md
+sources:
+  - Claude Code v2.1.121 hooks reference (2026-04-28)
+  - openai/codex rust-v0.129.0 hooks schema (2026-05-07)
+  - remem 0.3.12 src/ audit (5/5 SPEC 落地状态)
+---
+
+# v2.1 修订:基于 host 能力调研的 SPEC 补丁
+
+## 0. 背景
+
+v2 SPEC 方向(分层、队列正确性、review)已审过接受。三方调研发现 11 条具体差距:
+
+1. Claude Code 2.1.121 的 hook payload 不含 `turn_id` / `host` / `workspace`;`transcript_path` 在 Stop 时有 race
+2. Codex Rust v0.129.0 的 hook 没有 `SubagentStop` / `host` 标识 / `event_id` / 内置后台 spawn 路径
+3. 5/5 SPEC 的 Phase 1/2/3 已落地 80%+,几乎全部可平移到 v2 schema(SPEC §15 没承认这点)
+4. §17 三条 open decisions 直接阻塞 Phase 1 schema
+
+本文件作为 v2 SPEC 的修订补丁,**不重写原文,只逐条标注修改点**。后续 PR 在描述里 reference 本文件的条目编号(M1-M5 / S1-S4 / N1-N2)作为 review checklist。SPEC 主文件保持不变,v2 ship 后再合并修订形成 v3。
+
+---
+
+## 1. Must-fix(开工前必须 patch)
+
+### M1. §1.3 / §6 显式区分六元组中"原生 vs 合成"字段
+
+**修订**: 在 §1.3 末尾追加:
+
+> 六元组必须显式标注字段来源;host 一律由 install 注入,部分字段由 host payload 提供,其余由 remem 在 capture hook 入口合成:
+>
+> | 字段 | 来源 | 合成规则 |
+> |---|---|---|
+> | host | install 时写入 hook 命令行 `--host` 参数 | claude-code / codex-cli |
+> | workspace | 运行时从 cwd + `git rev-parse --show-toplevel` 解析,fallback 到 cwd | 必填 |
+> | project | workspace + (子目录 / 显式 `--project` 标签) | 必填 |
+> | session_id | host payload | 两边都提供 |
+> | turn_id | codex-cli turn-scoped payload;claude-code 由 remem 自增计数器(SQLite + 文件锁)合成 | 必填 |
+> | event_id | `(turn_id, hook_event_name, tool_use_id?)` 复合 | remem 合成 |
+
+**为什么**: Claude Code payload 不暴露 turn_id;Codex turn-scoped hook 暴露 turn_id 但不暴露 event_id;两者都不暴露 host。SPEC 默认六元组都来自 host 会导致 Phase 1 schema 写到 captured_events 索引时回头改。
+
+### M2. §4.2 host 语义改成"install 注入,运行时验证"
+
+**原文**: "Hook 不能识别 host 时不写 task,写一条 structured error log"
+
+**改为**:
+
+> v2 不允许 `host = unknown`。host 由 install 流程在 hook 配置中**硬编码到命令行参数**,不依赖运行时识别。
+>
+> - claude-code: hook command 形如 `remem observe --host claude-code`
+> - codex-cli: hook command 形如 `remem observe --host codex-cli`,或通过 wrapper 脚本注入 `REMEM_HOST=codex-cli`
+>
+> 运行时若读不到 `--host`,视为 install 损坏:拒绝写入 captured_events,doctor 报错并提示重新 `remem install --target ...`。
+
+**为什么**: Codex 不导出 `CODEX_VERSION`,Claude Code 的 `$CLAUDECODE=1` 未官方文档化,运行时识别 host 不可靠。把识别问题前移到 install 时是唯一确定性方案。
+
+### M3. §4.3 / §15 Phase 6 install 必须为两个 host 写两份配置
+
+**修订**: §4.3 与 §15 Phase 6 deliverables 追加:
+
+> install 流程为每个目标 host 生成独立配置:
+>
+> | host | 配置文件 | 启用要求 |
+> |---|---|---|
+> | claude-code | `~/.claude/settings.json` 的 `hooks` 字段 | 无 |
+> | codex-cli | `~/.codex/config.toml` 的 `[[hooks.PostToolUse]]` 表(优先)或 `~/.codex/hooks.json` | **必须 `[features] codex_hooks = true`**,install 自动设置 |
+>
+> 两份配置共用同一 remem 二进制,通过 `--host` 参数区分。
+
+**为什么**: Codex hook 在没启用 features flag 时不触发。官方文档确认 inline TOML hooks 需要 `[features] codex_hooks = true`;`features.hooks` 不写入 SPEC,除非后续源码/PR 证明确认为受支持 alias。
+
+### M4. §15 Phase 1 / 3 加 5/5 已落地代码复用清单
+
+**修订**: §15 Phase 1 deliverables 后追加:
+
+> 5/5 SPEC 已落地代码可作为实现模板平移,但不能机械照搬。v2 只复用 budget / lease / heartbeat / host isolation 的结构;progress metric 必须改成"event range 或 claimed rows advanced",不能沿用"生成 observation 数"。
+>
+> | 5/5 工作 | 源文件 | 平移到 v2 |
+> |---|---|---|
+> | drain budget 常量 | `src/observe_flush/constants.rs:7-11` | 改名 `EXTRACTION_DRAIN_*` |
+> | drain loop + ObservationDrainOutcome | `src/observe_flush/batch.rs:26-38` | 挪进 `src/extraction/worker_loop.rs`,但 `0 observations` 不能等于 drained |
+> | release_expired_pending_claims | `src/db_pending/claim.rs:87-101` | 改名 `recover_expired_extraction_leases`,SQL 改表名 |
+> | host-aware claim 三元组 | `src/db_pending/claim.rs:7-15` | 三元组改 `host_id` FK,逻辑保持 |
+> | host-aware enqueue dedupe | `src/db_job/enqueue.rs:6-25` | dedupe 改用 `idempotency_key UNIQUE` |
+> | worker_heartbeats 表 | `src/migrations/v004_worker_heartbeat.sql` | 加 `mode TEXT` 列对齐 §6.13 |
+> | db_worker.rs 整文件 | `src/db_worker.rs:14-52` | 直接保留 |
+> | record_worker_heartbeat | `src/worker.rs:113-118 / 173 / 273` + 测试 :610 | 直接保留 |
+> | stuck-job stats fix | `src/db_query/stats.rs:115` | 直接保留 |
+>
+> 必须**删除**(v2 不允许 unknown host):
+> - `src/db_pending/claim.rs:27, 54` 的 `host = ?3 OR host = 'unknown'` 兼容分支
+>
+> 必须**修正**(v2 liveness invariant):
+> - `src/observe_flush/batch.rs:33-35, 150-152` 现有逻辑把 `flush_pending_once() == 0` 当作 drained;v2 中 task 进度只能由 claimed event range 是否推进决定。空提取输出应标记该 range advanced,然后继续 drain 或检查 remaining ready work。
+
+### M5. §17 D1/D2/D4 关闭
+
+参见本文件 §4。Phase 1 schema 在三条决策关闭前不得开工。
+
+---
+
+## 2. Should-fix(实现 Phase 内可解决)
+
+### S1. §7.2 transcript 读取语义
+
+**插入**:
+
+> transcript 读取在两个 host 上语义不同,capture hook 必须分支处理:
+>
+> - **claude-code**: Stop hook 触发时 `transcript_path` 末尾消息可能未落盘。capture 入口应:
+>   1. 优先从 payload 读 `last_assistant_message`(若提供)
+>   2. 降级:读已 flush 部分,把"截断"标进 `captured_events.retention_class`,在下次 SessionStart 补全
+>   3. 不允许 hook 内 sleep+retry(违反 §7.1 hook 必须快速返回)
+>
+> - **codex-cli**: `~/.codex/sessions/rollout-*.jsonl` 由 RolloutRecorder 每条 flush,Stop 前已写入完整内容,直接读即可,无 race。
+
+### S2. §8.4 Stop fallback 实现约束
+
+**插入**:
+
+> Stop hook 在 daemon 不健康时 spawn `worker --once`,**子进程必须 detach**:
+>
+> - macOS: `launchctl kickstart -k gui/$UID/com.remem.worker.once`(预先 `launchctl bootstrap gui/$UID <plist>` 安装一次性 LaunchAgent label)
+> - Linux: `systemd-run --user --scope --collect remem worker --once`
+> - 通用 fallback: `setsid remem worker --once </dev/null >>~/.remem/worker.log 2>&1 &`,立即 return
+>
+> 父 hook 不允许调用 `wait`。Codex 的 `kill_on_drop=true` 会让父进程退出时连带 kill 子进程,因此必须真正 detach。
+
+### S3. §6.4 sessions 表 subagent 语义注释
+
+**插入到 §6.4 schema 后**:
+
+> **subagent 语义**:
+> - host=claude-code: 一次用户交互可能产生多个 session_id(主 agent 与 SubagentStop 触发的子 agent 各自独立)。promotion 引擎需要把同一 `user_message` 触发的多 session_id 视为一个证据单元
+> - host=codex-cli: 没有 SubagentStop hook,一个 session_id = 一次完整交互
+>
+> 后续 phase 的 evidence_event_ids 关联逻辑必须考虑这个差异。
+
+### S4. §4.1 legacy schema 容许 read-only 命令
+
+**原文**: "v2 detects legacy schema -> refuse to start writable commands"
+
+**改为**:
+
+> read-only 命令(`status`, `doctor`, `search`, `show`, `pending list-failed`)在 legacy schema 下仍可用,只锁写命令(`worker`, `summarize`, `observe`, `dream`, `save_memory`)。doctor 输出固定文案:
+>
+> ```
+> Legacy schema detected (version v002).
+> Run `remem admin backup` then `remem admin reset-v2 --confirm-destructive` to upgrade.
+> Read-only commands remain available.
+> ```
+
+---
+
+## 3. Nice-to-have
+
+### N1. §10 promotion 阈值 calibration
+
+ship Phase 4 前用现有 1777 条 memory(README 内部 eval 数据集)跑一次 calibration,验证 `confidence >= 0.82` 的 precision/recall。若 precision < 0.9 或 recall < 0.5,调整阈值或加更多 review 触发条件。
+
+### N2. §11.2 context compiler 与 Claude additionalContext 耦合
+
+claude-code 的 SessionStart hook 可通过返回 `additionalContext` 字段直接注入文本。Phase 5 context compiler 应优先走这个路径,而非自己拼 prompt。codex-cli 当前没有等价机制,fallback 到 MCP 主动 search。
+
+---
+
+## 4. §17 Open Decisions 推荐答案(解锁 Phase 1)
+
+### D1. captured_events.content_text 是否压缩 assistant full text
+
+**推荐**: **压缩**。
+
+策略:
+- ≤ 16 KiB: 存 `content_text`
+- 16 KiB - 256 KiB: 存 `event_blobs`(plain),`content_text` 留 prefix/suffix 各 1 KiB + digest
+- > 256 KiB: prefix/suffix 各 2 KiB + digest,full body 存 `event_blobs`(gzip)
+
+依据(中置信): assistant 消息体积分布与 tool_result 类似,不压缩会让 captured_events 行膨胀,影响 FTS 性能。压缩对 promotion 影响小(promotion 看 evidence_event_ids,需要时再 join `event_blobs`)。
+
+### D2. vector index 是否 attach 到 observations
+
+**推荐**: **否**。
+
+依据:
+- observations 是中间产物,生命周期由 promotion 决定,会被 stale/superseded
+- vector 索引维护成本高(re-embedding 在每次 stale 时被迫触发)
+- §11.1 retrieval substrate 表已经把 "Debug timeline" 放在 observations + captured event provenance 两层,不需要额外 vector
+- 只让 vector attach 到 `memories`(stable,生命周期长)
+
+### D4. rule_candidates 输出 patch 还是 plain text
+
+**推荐**: **plain text 优先,patch 作为可选附件**。
+
+schema 微调(§6.12):
+```sql
+ALTER TABLE rule_candidates ADD COLUMN proposed_diff TEXT;  -- 可空,unified diff
+```
+
+依据:
+- 多数 rule 改动是新增段落或行内措辞,不是结构性 patch
+- patch 模式要求 candidate 与 AGENTS.md/CLAUDE.md 当前版本绑定,review 期间原文档可能已被人手改,apply 失败率高
+- plain text + 路径提示足够 review;若 approve,在 approve 阶段生成 patch
+
+### D3 / D5(不阻塞 Phase 1,推迟到 Phase 4 / import 工具)
+
+- D3 global memory 是否强制 review: 推荐**是**,但延后到 Phase 4 实现时再写死规则
+- D5 legacy import 是否重放 raw transcripts: 推荐**否**(默认),提供 `--replay-transcripts` 显式开关
+
+---
+
+## 5. Milestone 拆分(确认版)
+
+| Milestone | 含 v2 Phase | MVP 验收 | 用户可见 | 回滚 |
+|---|---|---|---|---|
+| **A** 基础设施 | Phase 0 + 1 + 6 子集 | 12 表 CREATE 通过;`admin backup/reset-v2/import` 可用;`~/.remem/v2.sqlite` 写入;legacy schema read-only 容许 | `remem status` 多一行 schema 版本 | 删 `~/.remem/v2.sqlite`,旧 DB 不动 |
+| **B** 捕获+队列+提炼 | Phase 2 + 3 + 4 | Codex Bash session → captured_events 增长 + extraction_tasks 收敛 + ≥1 memory_candidate | `remem review list/approve/discard` | 停 v2 worker,恢复 install 前 hook/config backup;旧 DB/runtime 不由 v2 binary 兼容 |
+| **C** 检索+上下文+Daemon | Phase 5 + 6 余下 | curated-first search;daemon 24h heartbeat 不丢 | MCP `search` 含 `raw_hits` 标签;`install --worker-daemon` | 卸载 LaunchAgent,恢复 Stop fallback 或恢复 install 前 hook/config backup |
+
+A 开工前必须关闭 §17 D1/D2/D4(本文件 §4 已给答案)。B/C 之间用户可任意停留。
+
+---
+
+## 6. 来源锚点
+
+- Claude Code hooks: <https://code.claude.com/docs/en/hooks> (v2.1.121, 2026-04-28)
+- Codex hook engine 源码: <https://github.com/openai/codex> `codex-rs/hooks/` (rust-v0.129.0, 2026-05-07)
+- Codex hook 配置: <https://developers.openai.com/codex/config-reference>, PR #18893 / #18888
+- remem 5/5 落地证据: file:line 引用见 M4 表格
+- v2 SPEC: `SPEC-memory-system-v2-no-compat-2026-05-08.md`
+- 5/5 SPEC: `SPEC-observation-drain-scheduler-2026-05-05.md`(supersede 关系不变,但 v2.1 承认 80%+ 代码复用)

--- a/SPEC-observation-drain-scheduler-2026-05-05.md
+++ b/SPEC-observation-drain-scheduler-2026-05-05.md
@@ -1,0 +1,776 @@
+# Observation Drain, Host Isolation, and Worker Scheduler Spec
+
+Date: 2026-05-05
+
+## Summary
+
+`remem` currently captures tool events faster than it consumes pending observations. The
+immediate production symptom is a large `pending_observations` backlog even though the
+`jobs` queue is empty and workers complete successfully.
+
+The long-term design is a layered fix:
+
+1. Make each observation job drain multiple pending batches within a strict budget.
+2. Add `host` to pending and job identity so Claude Code and Codex events never mix.
+3. Add a worker scheduler/daemon mode that continuously drains stale work, while keeping
+   Stop hooks as a fallback wake-up path.
+
+This keeps hooks fast, preserves session context, avoids oversized AI calls, and makes
+queue recovery independent of whether a future Stop hook fires.
+
+## Current State
+
+### Observed runtime state
+
+- `cargo check`, `cargo test`, `cargo build --release`, and CLI startup pass.
+- Codex hooks and MCP are registered.
+- Claude Code hooks/MCP may be absent on a given machine; that does not affect Codex.
+- `pending_observations` can grow into hundreds of rows while `jobs` has no failed or
+  pending work.
+- The largest backlog observed was a single Codex session under
+  `/Users/lifcc/Desktop/code/AI/tool/harness`, all `Bash` events.
+
+### Relevant code path
+
+- `observe` inserts events and pending observations:
+  - `src/observe/hook.rs`
+- Stop hook enqueues one observation job, one summary job, and one compress job:
+  - `src/summarize/summary_job/hook.rs`
+- `worker` handles an observation job by calling `observe_flush::flush_pending` once:
+  - `src/worker.rs`
+- `flush_pending` claims at most `FLUSH_BATCH_SIZE` rows:
+  - `src/observe_flush/batch.rs`
+  - `src/observe_flush/constants.rs`
+- `claim_pending` filters by `session_id` only:
+  - `src/db_pending/claim.rs`
+- Job dedupe prevents a new pending/processing job with the same
+  `job_type + project + session_id`:
+  - `src/db_job/enqueue.rs`
+
+## Problem Statement
+
+The current observation job means "flush one batch". In practice it needs to mean
+"advance this session's pending observation queue until it is empty or this worker has
+spent its allowed budget".
+
+The current model has four structural issues:
+
+1. One observation job processes at most 15 rows.
+2. Follow-up work is not automatically scheduled when rows remain.
+3. Pending rows can remain `processing` after a worker timeout because only job leases
+   are globally recovered.
+4. Queue identity does not include host, even though Claude Code and Codex have different
+   capture semantics.
+
+## Goals
+
+- Keep `observe` hooks fast and AI-free.
+- Preserve per-session memory quality.
+- Prevent Claude Code and Codex events from being consumed in the same batch.
+- Bound AI work per worker invocation.
+- Make backlog drain eventually complete without manual database intervention.
+- Improve `status` and `doctor` so queue health reflects real state.
+- Keep the existing Rust single-binary architecture.
+- Introduce daemon/scheduler support only after the bounded drain behavior is stable.
+
+## Non-Goals
+
+- Do not call AI from `observe`.
+- Do not increase `FLUSH_BATCH_SIZE` enough to hide the bug.
+- Do not drain by project alone.
+- Do not introduce a separate service or microservice.
+- Do not remove Stop hook scheduling.
+- Do not require Claude Code to be installed for Codex to work.
+
+## Design Principles
+
+1. Capture is fast, asynchronous, and loss-resistant.
+2. Consumption is budgeted, retryable, and observable.
+3. Exact consumption identity is `host + project + session_id`.
+4. Time windows are scheduler boundaries, not semantic ownership.
+5. Summary generation must not be starved by observation backlog.
+6. Daemon mode improves reliability but Stop hooks remain the compatibility fallback.
+
+## Phase 1: Bounded Observation Drain
+
+### New semantics
+
+An observation job drains ready pending rows for one session under a budget:
+
+```text
+process observation job:
+    recover expired pending leases
+
+    while drain budget remains:
+        claim up to FLUSH_BATCH_SIZE ready rows for this session
+        if no rows:
+            return Drained
+
+        flush claimed rows
+        delete successful rows
+        retry transient failures
+        fail permanent non-observation rows
+
+    if ready rows remain:
+        return NeedsFollowUp
+
+    return Drained
+```
+
+### Budget constants
+
+Add constants in `src/observe_flush/constants.rs`:
+
+```rust
+pub(crate) const FLUSH_DRAIN_MAX_BATCHES: usize = 4;
+pub(crate) const FLUSH_DRAIN_MAX_SECS: u64 = 240;
+pub(crate) const OBSERVATION_FOLLOW_UP_PRIORITY: i64 = 150;
+```
+
+Rationale:
+
+- Keep each AI request small with `FLUSH_BATCH_SIZE = 15`.
+- Let one job make real progress.
+- Keep summary priority `100` able to run before follow-up observation priority `150`.
+- Leave room under the current worker timeout.
+
+`FLUSH_DRAIN_MAX_SECS` must remain lower than `JOB_TIMEOUT_SECS` in `src/worker.rs`.
+
+### Follow-up scheduling
+
+The follow-up job must be enqueued only after the current job is marked `done`.
+
+Reason: `enqueue_job` dedupes `pending` and `processing` jobs. If the current job is still
+`processing`, a follow-up enqueue will return the current job id instead of creating new
+work.
+
+Worker flow:
+
+```text
+let outcome = process_job(job)
+
+if outcome succeeds:
+    mark_job_done(job)
+    if outcome.needs_follow_up:
+        enqueue observation job with OBSERVATION_FOLLOW_UP_PRIORITY
+```
+
+### Drain outcome
+
+Add an internal outcome type:
+
+```rust
+pub(crate) enum ObservationDrainOutcome {
+    Drained,
+    NeedsFollowUp,
+}
+```
+
+`worker::process_job` should return a richer outcome than `Result<()>` so the caller can
+schedule follow-up after `mark_job_done`.
+
+### Remaining-row query
+
+Add query helpers in `src/db_pending/query.rs`:
+
+- `count_ready_pending_for_session(conn, session_id) -> Result<i64>`
+- later phase: `count_ready_pending_for_identity(conn, host, project, session_id) -> Result<i64>`
+- `oldest_ready_pending_epoch(...) -> Result<Option<i64>>`
+
+The Phase 1 query may keep session-only behavior to minimize schema churn, but Phase 2
+must replace it with the exact identity.
+
+### Expired pending lease recovery
+
+Add `release_expired_pending_claims(conn) -> Result<usize>` in
+`src/db_pending/claim.rs`.
+
+It should reset expired `processing` pending rows:
+
+```sql
+UPDATE pending_observations
+SET status = 'pending',
+    lease_owner = NULL,
+    lease_expires_epoch = NULL,
+    updated_at_epoch = ?1
+WHERE status = 'processing'
+  AND lease_expires_epoch IS NOT NULL
+  AND lease_expires_epoch < ?1
+```
+
+Call it before claiming pending rows and from worker startup next to
+`requeue_stuck_jobs`.
+
+### Failure behavior
+
+Transient AI errors:
+
+- Reset pending rows to `status='pending'`.
+- Set `next_retry_epoch`.
+- Store `last_error`.
+- Let follow-up or scheduler pick them up later.
+
+Permanent parse/no-observation behavior:
+
+- Keep current behavior for empty action-batch output: mark rows `failed`.
+- Keep current Task skip/fail semantics.
+- Do not silently delete rows when no observation is produced unless the existing code has
+  an explicit skip rule for that class.
+
+### Tests
+
+Add or update tests:
+
+- `worker_drains_multiple_observation_batches`
+- `worker_reenqueues_follow_up_after_mark_done`
+- `follow_up_priority_allows_summary_to_run_first`
+- `expired_pending_processing_rows_are_released`
+- `observation_job_does_not_enqueue_follow_up_when_empty`
+- `observation_job_retries_transient_ai_failure`
+
+## Phase 2: Host Isolation and Exact Consumption Identity
+
+### Schema additions
+
+Add migration `v003_host_identity.sql`:
+
+```sql
+ALTER TABLE pending_observations
+ADD COLUMN host TEXT NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE jobs
+ADD COLUMN host TEXT NOT NULL DEFAULT 'unknown';
+
+CREATE INDEX IF NOT EXISTS idx_pending_identity_claim
+ON pending_observations(host, project, session_id, status, next_retry_epoch, lease_expires_epoch, id);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_identity_state
+ON jobs(host, project, session_id, job_type, state, created_at_epoch DESC);
+```
+
+Update `src/migrate/types.rs` to include version 3.
+
+### Host source
+
+Use adapter identity as host:
+
+- Claude Code: `claude-code`
+- Codex CLI: `codex-cli`
+
+`observe` already knows the adapter returned by `detect_adapter`. Pass
+`adapter.name()` into `enqueue_pending`.
+
+Stop hook payloads do not currently persist host. Add host to observation job payload and
+job row:
+
+```json
+{
+  "host": "codex-cli",
+  "session_id": "...",
+  "project": "..."
+}
+```
+
+For Stop hook host detection:
+
+- Prefer `REMEM_CONTEXT_HOST` or a new explicit `REMEM_HOOK_HOST`.
+- Fall back to executor hint:
+  - `REMEM_SUMMARY_EXECUTOR=codex-cli` means `codex-cli`.
+  - `REMEM_SUMMARY_EXECUTOR=claude-cli` means `claude-code`.
+- If neither is present, use `unknown` and keep compatibility.
+
+### Enqueue APIs
+
+Change APIs:
+
+```rust
+enqueue_pending(conn, host, session_id, project, ...)
+enqueue_job(conn, host, job_type, project, session_id, payload_json, priority)
+```
+
+Update dedupe:
+
+```sql
+WHERE host = ?1
+  AND job_type = ?2
+  AND project = ?3
+  AND COALESCE(session_id, '') = COALESCE(?4, '')
+  AND state IN ('pending', 'processing')
+```
+
+### Claim APIs
+
+Replace session-only claim with exact identity:
+
+```rust
+claim_pending(conn, host, project, session_id, limit, lease_owner, lease_secs)
+```
+
+SQL:
+
+```sql
+WHERE host = ?host
+  AND project = ?project
+  AND session_id = ?session_id
+  AND status = 'pending'
+  AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?now)
+  AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?now)
+```
+
+### Compatibility for existing rows
+
+Existing rows get `host='unknown'`.
+
+Compatibility options:
+
+1. Drain existing `unknown` rows before enabling host-strict claim.
+2. During migration window, allow exact host claims to also claim `unknown` rows only when
+   `project + session_id` matches.
+
+Recommended:
+
+- Implement compatibility option 2.
+- Add a `doctor` warning when `unknown` host rows remain.
+- Remove compatibility only in a future major migration.
+
+### Tests
+
+Add tests:
+
+- `claim_pending_respects_host_project_session_identity`
+- `same_session_different_project_not_claimed`
+- `same_session_different_host_not_claimed`
+- `legacy_unknown_host_rows_can_be_claimed_by_matching_identity`
+- `job_dedupe_includes_host`
+- `stale_pending_sessions_group_by_host_project_session`
+
+## Phase 3: Scheduler and Daemon
+
+### Desired mode
+
+Use the existing single binary:
+
+```bash
+remem worker
+```
+
+Long-running worker mode should:
+
+- Process ready jobs.
+- Requeue expired job leases.
+- Release expired pending leases.
+- Scan stale pending rows and enqueue observation jobs.
+- Emit heartbeat.
+- Sleep when idle.
+
+Stop hook remains:
+
+- Enqueue observation/summary/compress jobs.
+- Spawn `worker --once` only when no healthy daemon heartbeat exists.
+
+### Scheduler tick
+
+Every idle tick:
+
+1. Recover expired job leases.
+2. Recover expired pending leases.
+3. Find stale pending identities older than a threshold.
+4. Enqueue observation jobs for those identities.
+
+Add helper:
+
+```rust
+get_stale_pending_identities(conn, age_secs, limit)
+    -> Vec<PendingIdentity { host, project, session_id, ready_count, oldest_epoch }>
+```
+
+Use `host + project + session_id`, not project-only.
+
+### Daemon heartbeat
+
+Add a lightweight heartbeat table:
+
+```sql
+CREATE TABLE IF NOT EXISTS worker_heartbeats (
+    owner TEXT PRIMARY KEY,
+    pid INTEGER,
+    started_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+```
+
+Alternative: write a heartbeat file under `~/.remem/worker-heartbeat.json`.
+
+Preferred for this project: database table, because `doctor` and `status` already open the
+database.
+
+### Stop fallback
+
+Stop hook should check daemon health:
+
+- If heartbeat age is healthy, enqueue jobs and return.
+- If no healthy heartbeat, spawn `worker --once` as today.
+
+This preserves current behavior when daemon is not installed.
+
+### Installation path
+
+Do not enable daemon by default until manual mode is proven.
+
+Rollout:
+
+1. Manual:
+   - `remem worker`
+   - `remem doctor`
+2. Opt-in install:
+   - `remem install --worker-daemon`
+3. Stable default:
+   - enable daemon for selected target if user opts in or if install policy changes later.
+
+macOS daemon should use `launchd` under `~/Library/LaunchAgents`.
+Linux should use user `systemd` when available.
+
+### Executor hints
+
+Daemon processes do not naturally inherit hook env variables. Therefore, jobs must carry
+host/executor hints.
+
+Add to job payload or columns:
+
+- `host`
+- `summary_executor`
+- `flush_executor`
+
+Minimum:
+
+- `host` column in Phase 2.
+- Resolve executor from host at execution time.
+
+Future:
+
+- explicit `executor` column if users configure non-default execution.
+
+### Tests
+
+Add tests:
+
+- `scheduler_enqueues_stale_pending_identity`
+- `scheduler_does_not_enqueue_duplicate_processing_job`
+- `healthy_daemon_skips_stop_spawn`
+- `missing_daemon_uses_stop_fallback_spawn`
+- `worker_heartbeat_updates_in_loop`
+
+## Status and Doctor Improvements
+
+Current stats should be expanded and corrected.
+
+### Bug fix
+
+`query_system_stats` checks stuck jobs with `state = 'running'`, but the real state is
+`processing`.
+
+Fix:
+
+```sql
+SELECT COUNT(*) FROM jobs
+WHERE state = 'processing'
+  AND lease_expires_epoch < strftime('%s', 'now')
+```
+
+### New metrics
+
+Expose:
+
+- pending ready count
+- pending delayed count
+- pending processing count
+- pending failed count
+- expired pending processing count
+- oldest ready pending age
+- top backlog identities
+- jobs pending count
+- jobs processing count
+- jobs failed count
+- expired processing jobs
+- daemon heartbeat age
+
+### CLI output
+
+`remem status` should show:
+
+```text
+Pending observations:
+  Ready:        734
+  Delayed:        0
+  Processing:     0
+  Failed:         0
+  Oldest ready:   25h
+
+Top backlog identities:
+  734  codex-cli  /path/project  session-id
+
+Jobs:
+  Pending:        0
+  Processing:     0
+  Failed:         0
+  Stuck:          0
+
+Worker:
+  Daemon:         healthy, last heartbeat 3s ago
+```
+
+`remem doctor` should warn when:
+
+- ready pending count exceeds threshold
+- oldest ready pending exceeds threshold
+- processing pending lease expired
+- daemon expected but not healthy
+- unknown host rows remain after migration
+
+## Claude Code Impact
+
+Claude Code captures a broader event set:
+
+- `Write`
+- `Edit`
+- `NotebookEdit`
+- `Bash`
+- `Task`
+
+It also has `UserPromptSubmit` in install configuration, unlike Codex.
+
+Expected impact:
+
+- Positive: Claude pending rows drain more reliably.
+- Positive: stale recovery handles missed Stop hooks.
+- Positive: host isolation prevents Codex Bash streams from mixing with Claude file/task
+  events.
+- Neutral: native memory sync remains in `observe`; this spec does not move it.
+- Risk: daemon environments may not have Claude CLI credentials or PATH.
+
+Mitigation:
+
+- Keep Stop fallback.
+- Store host/executor hints.
+- Prefer absolute binary paths in install output.
+- Let `doctor` report daemon executor availability.
+
+## Codex Impact
+
+Codex capture is currently Bash-focused:
+
+- `PostToolUse(Bash)`
+- short observe timeout
+- no native file-edit capture through this hook path
+- Stop hook sets Codex executor env for summary and flush
+
+Expected impact:
+
+- Strongly positive: high-volume Bash sessions no longer accumulate unbounded pending rows.
+- Stop hook remains fast because AI stays in worker.
+- Follow-up priority prevents observation backlog from starving summary jobs.
+- Daemon scheduler prevents long sessions from depending on a future Stop hook.
+
+Risk:
+
+- Daemon launched outside Codex may not know to use Codex executor.
+
+Mitigation:
+
+- Persist host in jobs.
+- Resolve flush executor from host.
+- Keep Stop fallback until daemon executor behavior is verified.
+
+## Data Integrity and Idempotency
+
+- Pending rows are deleted only after observations are persisted.
+- Delete remains lease-owner scoped.
+- Follow-up jobs are enqueued after current job completion to avoid dedupe self-collision.
+- Transient failures retry pending rows with backoff.
+- Permanent failures remain inspectable through existing pending admin commands.
+- Host migration must not orphan old `unknown` rows.
+
+## Security Considerations
+
+- Do not execute shell commands from database fields.
+- Use parameterized SQL for all claim, retry, and scheduler queries.
+- Do not store secrets in job payloads.
+- Do not broaden daemon environment with user shell startup scripts.
+- Use absolute paths for installed binaries.
+- `doctor` may report missing executor credentials but must not print secret values.
+
+## Implementation Plan
+
+### Step 1: Queue correctness patch
+
+Files:
+
+- `src/observe_flush/constants.rs`
+- `src/observe_flush/batch.rs`
+- `src/db_pending/claim.rs`
+- `src/db_pending/query.rs`
+- `src/worker.rs`
+- `src/db_query/stats.rs`
+- `src/doctor/database.rs`
+- `src/cli/actions/query/status.rs`
+
+Deliverables:
+
+- bounded drain
+- follow-up scheduling after `mark_job_done`
+- expired pending lease recovery
+- stuck jobs stats bug fix
+- basic queue metrics
+
+Validation:
+
+```bash
+cargo test worker_drains_multiple_observation_batches -- --nocapture
+cargo test expired_pending_processing_rows_are_released -- --nocapture
+cargo test check_pending_queue_reports_shared_counts -- --nocapture
+cargo check
+cargo test
+```
+
+### Step 2: Host identity migration
+
+Files:
+
+- `src/migrations/v003_host_identity.sql`
+- `src/migrate/types.rs`
+- `src/db_pending/types.rs`
+- `src/db_pending/queue.rs`
+- `src/db_pending/claim.rs`
+- `src/db_pending/query.rs`
+- `src/db_job/enqueue.rs`
+- `src/db_models.rs`
+- `src/observe/hook.rs`
+- `src/summarize/summary_job/hook.rs`
+- `src/worker.rs`
+
+Deliverables:
+
+- host column on pending and jobs
+- host-aware enqueue/dedupe/claim
+- legacy unknown-host compatibility
+- host-aware job payload
+
+Validation:
+
+```bash
+cargo test claim_pending_respects_host_project_session_identity -- --nocapture
+cargo test same_session_different_host_not_claimed -- --nocapture
+cargo test job_dedupe_includes_host -- --nocapture
+cargo test full_migration_on_empty_db -- --nocapture
+cargo test real_queries_work_on_upgraded_db -- --nocapture
+cargo check
+cargo test
+```
+
+### Step 3: Scheduler mode
+
+Files:
+
+- `src/worker.rs`
+- `src/db_pending/query.rs`
+- `src/db_job/enqueue.rs`
+- `src/doctor/database.rs`
+- `src/cli/actions/query/status.rs`
+- optional new module: `src/worker/scheduler.rs`
+
+Deliverables:
+
+- stale pending identity scanner
+- daemon heartbeat
+- Stop fallback only when daemon unhealthy
+- status/doctor daemon reporting
+
+Validation:
+
+```bash
+cargo test scheduler_enqueues_stale_pending_identity -- --nocapture
+cargo test healthy_daemon_skips_stop_spawn -- --nocapture
+cargo check
+cargo test
+```
+
+### Step 4: Optional managed daemon install
+
+Files:
+
+- `src/install`
+- `README.md`
+- `README.zh-CN.md`
+
+Deliverables:
+
+- opt-in daemon install
+- uninstall cleanup
+- doctor instructions
+
+Validation:
+
+```bash
+cargo test install -- --nocapture
+cargo check
+cargo test
+```
+
+## Rollout Plan
+
+1. Land Step 1 and verify it drains the current backlog with manual `remem worker`.
+2. Run `remem doctor` and confirm pending ready count decreases.
+3. Land Step 2 and verify legacy `unknown` rows are still claimable.
+4. Run mixed Codex and Claude fixture tests.
+5. Land Step 3 behind existing worker command behavior.
+6. Manually run daemon mode before adding managed install.
+7. Add opt-in install only after manual daemon behavior is stable.
+
+## Acceptance Criteria
+
+Functional:
+
+- A single observation job can process more than one batch.
+- Large pending backlog eventually drains without manual SQL.
+- Summary jobs are not starved by observation follow-ups.
+- Expired pending processing rows recover automatically.
+- Host-specific claim prevents Claude/Codex mixing.
+- Existing `unknown` rows remain drainable.
+
+Observability:
+
+- `status` reports ready/delayed/processing/failed pending rows.
+- `doctor` reports accurate stuck jobs using `processing`.
+- Top backlog identities are visible.
+- Daemon health is visible once daemon mode is added.
+
+Compatibility:
+
+- Codex hooks remain fast.
+- Claude Code hooks remain compatible.
+- Stop hook fallback remains available.
+- Existing databases migrate without data loss.
+
+Validation:
+
+- `cargo check` passes.
+- `cargo test` passes.
+- Targeted queue, migration, worker, and install tests pass.
+
+## Open Questions
+
+1. Should `FLUSH_DRAIN_MAX_BATCHES` default to 4 or 8?
+2. Should `FLUSH_DRAIN_MAX_SECS` be 180, 240, or tied to `JOB_TIMEOUT_SECS`?
+3. Should daemon heartbeat live in SQLite or a JSON file?
+4. Should executor hints be columns or only job payload fields?
+5. Should old `unknown` host rows be migrated heuristically from hook logs, or only handled
+   through compatibility claim?
+
+Recommended defaults:
+
+- `FLUSH_DRAIN_MAX_BATCHES = 4`
+- `FLUSH_DRAIN_MAX_SECS = 240`
+- heartbeat in SQLite
+- `host` as a column; executor hint can start in payload
+- keep `unknown` compatibility instead of heuristic rewrite
+

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -1,5 +1,6 @@
 mod admin;
 mod eval;
+mod import;
 mod maintenance;
 mod pending;
 mod preferences;
@@ -7,6 +8,7 @@ mod query;
 mod shared;
 
 pub(super) use admin::run_admin;
+pub(super) use import::run_import;
 pub(super) use eval::{run_eval, run_eval_local};
 pub(super) use maintenance::{run_cleanup, run_dream, run_encrypt};
 pub(super) use pending::run_pending;

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -1,3 +1,4 @@
+mod admin;
 mod eval;
 mod maintenance;
 mod pending;
@@ -5,6 +6,7 @@ mod preferences;
 mod query;
 mod shared;
 
+pub(super) use admin::run_admin;
 pub(super) use eval::{run_eval, run_eval_local};
 pub(super) use maintenance::{run_cleanup, run_dream, run_encrypt};
 pub(super) use pending::run_pending;

--- a/src/cli/actions/admin.rs
+++ b/src/cli/actions/admin.rs
@@ -1,0 +1,132 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Local};
+use rusqlite::{Connection, DatabaseName};
+use std::path::{Path, PathBuf};
+
+use crate::cli::types::AdminAction;
+
+pub(in crate::cli) fn run_admin(action: AdminAction) -> Result<()> {
+    match action {
+        AdminAction::Backup { output } => run_backup(output),
+    }
+}
+
+fn run_backup(output: Option<PathBuf>) -> Result<()> {
+    let src_path = crate::db::db_path();
+    if !src_path.exists() {
+        anyhow::bail!(
+            "v1 database not found at {}. Nothing to back up.",
+            src_path.display()
+        );
+    }
+    let dst_path = output.unwrap_or_else(|| default_backup_path(Local::now()));
+    backup_db(&src_path, &dst_path)?;
+    println!("Backed up v1 database to: {}", dst_path.display());
+    Ok(())
+}
+
+/// `<data_dir>/backups/remem-v1-YYYYMMDD-HHMMSS.sqlite` for the given moment.
+/// Pure path construction — no IO — so tests can pin the timestamp.
+pub fn default_backup_path(now: DateTime<Local>) -> PathBuf {
+    let timestamp = now.format("%Y%m%d-%H%M%S").to_string();
+    crate::db::data_dir()
+        .join("backups")
+        .join(format!("remem-v1-{timestamp}.sqlite"))
+}
+
+/// Copy the SQLite file at `src_path` to `dst_path` via the SQLite Online
+/// Backup API. Byte-for-byte (so an encrypted source produces an encrypted
+/// backup readable with the same key) and consistent across WAL.
+pub fn backup_db(src_path: &Path, dst_path: &Path) -> Result<()> {
+    if !src_path.exists() {
+        anyhow::bail!("source database not found at {}", src_path.display());
+    }
+    if let Some(parent) = dst_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create backup dir {}", parent.display()))?;
+    }
+    let src = Connection::open(src_path)
+        .with_context(|| format!("open source db {}", src_path.display()))?;
+    src.backup(DatabaseName::Main, dst_path, None)
+        .with_context(|| format!("write backup to {}", dst_path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_path() -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let pid = std::process::id();
+        std::env::temp_dir().join(format!("remem-admin-test-{pid}-{nonce}.sqlite"))
+    }
+
+    fn cleanup_paths(paths: &[&Path]) {
+        for p in paths {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn default_backup_path_uses_timestamp() {
+        let dt = Local.with_ymd_and_hms(2026, 5, 8, 14, 30, 45).unwrap();
+        let path = default_backup_path(dt);
+        let s = path.to_string_lossy();
+        assert!(s.contains("backups"), "got {s}");
+        assert!(s.contains("remem-v1-20260508-143045.sqlite"), "got {s}");
+    }
+
+    #[test]
+    fn backup_copies_rows_to_target() {
+        let src = unique_temp_path();
+        let dst = unique_temp_path();
+        {
+            let conn = Connection::open(&src).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); \
+                 INSERT INTO t(id, v) VALUES (42, 'hello');",
+            )
+            .unwrap();
+        }
+        backup_db(&src, &dst).expect("backup");
+        let restored = Connection::open(&dst).unwrap();
+        let v: String = restored
+            .query_row("SELECT v FROM t WHERE id = 42", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(v, "hello");
+        cleanup_paths(&[&src, &dst]);
+    }
+
+    #[test]
+    fn backup_returns_error_when_source_missing() {
+        let src = unique_temp_path();
+        let dst = unique_temp_path();
+        let err = backup_db(&src, &dst).unwrap_err().to_string();
+        assert!(err.contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn backup_creates_parent_directory() {
+        let src = unique_temp_path();
+        let dst = std::env::temp_dir()
+            .join(format!("remem-admin-nested-{}", std::process::id()))
+            .join("nested")
+            .join("backup.sqlite");
+        {
+            let conn = Connection::open(&src).unwrap();
+            conn.execute_batch("CREATE TABLE t(id INTEGER);").unwrap();
+        }
+        backup_db(&src, &dst).expect("backup with new dirs");
+        assert!(dst.exists());
+        cleanup_paths(&[&src, &dst]);
+        if let Some(parent) = dst.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
+    }
+}

--- a/src/cli/actions/admin.rs
+++ b/src/cli/actions/admin.rs
@@ -74,20 +74,15 @@ pub fn backup_db(src_path: &Path, dst_path: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use chrono::TimeZone;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
 
     fn unique_temp_path() -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let pid = std::process::id();
-        std::env::temp_dir().join(format!("remem-admin-test-{pid}-{nonce}.sqlite"))
+        unique_temp_db_path("admin")
     }
 
     fn cleanup_paths(paths: &[&Path]) {
         for p in paths {
-            let _ = std::fs::remove_file(p);
+            cleanup_temp_db_files(p);
         }
     }
 

--- a/src/cli/actions/admin.rs
+++ b/src/cli/actions/admin.rs
@@ -8,7 +8,25 @@ use crate::cli::types::AdminAction;
 pub(in crate::cli) fn run_admin(action: AdminAction) -> Result<()> {
     match action {
         AdminAction::Backup { output } => run_backup(output),
+        AdminAction::ResetV2 {
+            confirm_destructive,
+        } => run_reset_v2(confirm_destructive),
     }
+}
+
+fn run_reset_v2(confirm_destructive: bool) -> Result<()> {
+    if !confirm_destructive {
+        anyhow::bail!(
+            "reset-v2 destroys the v2 database at {}.\n\
+             Re-run with --confirm-destructive to proceed.",
+            crate::v2_db::default_v2_db_path().display()
+        );
+    }
+    let path = crate::v2_db::default_v2_db_path();
+    crate::v2_db::reset_v2_db_at(&path)
+        .with_context(|| format!("reset v2 db at {}", path.display()))?;
+    println!("Reset v2 database at: {}", path.display());
+    Ok(())
 }
 
 fn run_backup(output: Option<PathBuf>) -> Result<()> {
@@ -109,6 +127,15 @@ mod tests {
         let dst = unique_temp_path();
         let err = backup_db(&src, &dst).unwrap_err().to_string();
         assert!(err.contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn reset_v2_without_confirmation_returns_error() {
+        let action = AdminAction::ResetV2 {
+            confirm_destructive: false,
+        };
+        let err = run_admin(action).unwrap_err().to_string();
+        assert!(err.contains("--confirm-destructive"), "got: {err}");
     }
 
     #[test]

--- a/src/cli/actions/import.rs
+++ b/src/cli/actions/import.rs
@@ -1,0 +1,32 @@
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+use crate::cli::types::ImportAction;
+
+pub(in crate::cli) fn run_import(action: ImportAction) -> Result<()> {
+    match action {
+        ImportAction::Legacy {
+            source,
+            best_effort,
+        } => run_import_legacy(source, best_effort),
+    }
+}
+
+fn run_import_legacy(source: PathBuf, best_effort: bool) -> Result<()> {
+    if !best_effort {
+        anyhow::bail!(
+            "import legacy currently only supports --best-effort mode (per SPEC §17 D5)."
+        );
+    }
+    let v2_conn = crate::v2_db::open_v2_db().context("open v2 database for import target")?;
+    let stats = crate::v2_import::import_legacy_memories(&source, &v2_conn)
+        .with_context(|| format!("import from {}", source.display()))?;
+    println!(
+        "Imported {} memories ({} skipped). Created {} workspaces, {} projects.",
+        stats.memories_imported,
+        stats.memories_skipped,
+        stats.workspaces_created,
+        stats.projects_created,
+    );
+    Ok(())
+}

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -30,8 +30,45 @@ pub(in crate::cli) fn run_status() -> Result<()> {
     println!("  Observations:  {:>6}", stats.active_observations);
     println!("  Sessions:      {:>6}", stats.session_summaries);
     println!("  Raw messages:  {:>6}", stats.raw_messages);
-    println!("  Pending:       {:>6}", stats.pending_observations);
-    println!("  Pending failed:{:>6}", stats.failed_pending_observations);
+    println!();
+    println!("Pending observations:");
+    println!("  Ready:        {:>6}", stats.ready_pending_observations);
+    println!("  Delayed:      {:>6}", stats.delayed_pending_observations);
+    println!(
+        "  Processing:   {:>6}",
+        stats.processing_pending_observations
+    );
+    println!(
+        "  Expired:      {:>6}",
+        stats.expired_processing_pending_observations
+    );
+    println!("  Failed:       {:>6}", stats.failed_pending_observations);
+    if let Some(epoch) = stats.oldest_ready_pending_epoch {
+        let age_secs = chrono::Utc::now().timestamp().saturating_sub(epoch);
+        println!("  Oldest ready: {:>6}s", age_secs);
+    }
+    println!();
+    println!("Jobs:");
+    println!("  Pending:      {:>6}", stats.pending_jobs);
+    println!("  Processing:   {:>6}", stats.processing_jobs);
+    println!("  Failed:       {:>6}", stats.failed_jobs);
+    println!("  Stuck:        {:>6}", stats.stuck_jobs);
+    println!();
+    println!("Worker daemon:");
+    let daemon_health = if stats.worker_daemon_healthy {
+        "healthy"
+    } else if stats.worker_heartbeat_age_secs.is_some() {
+        "stale"
+    } else {
+        "missing"
+    };
+    println!("  Health:       {:>7}", daemon_health);
+    if let Some(age_secs) = stats.worker_heartbeat_age_secs {
+        println!("  Last beat:    {:>6}s", age_secs);
+    }
+    if let Some(owner) = &stats.worker_heartbeat_owner {
+        println!("  Owner:        {}", owner);
+    }
     println!();
     println!("Today:");
     println!("  New memories:      {:>4}", daily_stats.memories);

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -82,5 +82,10 @@ pub(in crate::cli) fn run_status() -> Result<()> {
         }
     }
 
+    println!();
+    for line in crate::v2_status::format_v2_summary() {
+        println!("{}", line);
+    }
+
     Ok(())
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -4,7 +4,7 @@ use crate::{api, claude_memory, context, db, doctor, install, mcp, observe, summ
 
 use super::actions::{
     run_admin, run_backfill_entities, run_cleanup, run_dream, run_encrypt, run_eval,
-    run_eval_local, run_pending, run_preferences, run_search, run_show, run_status,
+    run_eval_local, run_import, run_pending, run_preferences, run_search, run_show, run_status,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands};
@@ -71,6 +71,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             run_dream(project.as_deref(), dry_run).await?;
         }
         Commands::Admin { action } => run_admin(action)?,
+        Commands::Import { action } => run_import(action)?,
     }
 
     Ok(())

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -3,8 +3,8 @@ use anyhow::Result;
 use crate::{api, claude_memory, context, db, doctor, install, mcp, observe, summarize, worker};
 
 use super::actions::{
-    run_backfill_entities, run_cleanup, run_dream, run_encrypt, run_eval, run_eval_local,
-    run_pending, run_preferences, run_search, run_show, run_status,
+    run_admin, run_backfill_entities, run_cleanup, run_dream, run_encrypt, run_eval,
+    run_eval_local, run_pending, run_preferences, run_search, run_show, run_status,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands};
@@ -70,6 +70,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         Commands::Dream { project, dry_run } => {
             run_dream(project.as_deref(), dry_run).await?;
         }
+        Commands::Admin { action } => run_admin(action)?,
     }
 
     Ok(())

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -102,6 +102,11 @@ pub(super) enum Commands {
         #[command(subcommand)]
         action: AdminAction,
     },
+    /// v2 import commands (legacy v1 -> v2 best-effort).
+    Import {
+        #[command(subcommand)]
+        action: ImportAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -132,6 +137,22 @@ pub(in crate::cli) enum AdminAction {
     ResetV2 {
         #[arg(long)]
         confirm_destructive: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum ImportAction {
+    /// Import v1 memories from a backup sqlite file. Per SPEC §17 D5,
+    /// transcripts are not replayed; only the v1 `memories` table is
+    /// migrated, with synthesized v2 provenance defaults.
+    Legacy {
+        /// v1 db path (typically a backup produced by `remem admin backup`).
+        #[arg(long)]
+        source: PathBuf,
+        /// Acknowledge that import is best-effort and skips constraint
+        /// violations rather than failing.
+        #[arg(long)]
+        best_effort: bool,
     },
 }
 

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 pub(super) use crate::install::InstallTarget;
 
@@ -96,6 +97,11 @@ pub(super) enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// v2 admin commands (backup/reset/import). See SPEC §4.1.
+    Admin {
+        #[command(subcommand)]
+        action: AdminAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -110,6 +116,16 @@ pub(in crate::cli) enum PreferenceAction {
     },
     Remove {
         id: i64,
+    },
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum AdminAction {
+    /// Back up the v1 database to a timestamped file.
+    Backup {
+        /// Output path. Defaults to <data_dir>/backups/remem-v1-<ts>.sqlite.
+        #[arg(long)]
+        output: Option<PathBuf>,
     },
 }
 

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -127,6 +127,12 @@ pub(in crate::cli) enum AdminAction {
         #[arg(long)]
         output: Option<PathBuf>,
     },
+    /// Drop and re-initialize the v2 database (~/.remem/v2.sqlite).
+    /// Requires --confirm-destructive to actually run.
+    ResetV2 {
+        #[arg(long)]
+        confirm_destructive: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -10,6 +10,7 @@ pub use crate::db_models::*;
 pub use crate::db_pending::*;
 pub use crate::db_query::*;
 pub use crate::db_usage::*;
+pub use crate::db_worker::*;
 
 pub use core::*;
 pub use crypto::*;

--- a/src/db/test_support.rs
+++ b/src/db/test_support.rs
@@ -60,3 +60,26 @@ impl Drop for ScopedTestDataDir {
         let _ = std::fs::remove_dir_all(&self.path);
     }
 }
+
+/// Generate a unique temp file path for a test sqlite db. Used by v2_db /
+/// admin / v2_import test modules; nonce is `pid + nanos` so concurrent
+/// `cargo test` runs do not collide. Caller owns cleanup (pair with
+/// `cleanup_temp_db_files` for `-wal` / `-shm` sidecars).
+pub fn unique_temp_db_path(label: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "remem-{label}-{}-{}.sqlite",
+        std::process::id(),
+        nonce
+    ))
+}
+
+/// Remove a sqlite test file along with its `-wal` / `-shm` sidecars.
+pub fn cleanup_temp_db_files(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+    let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+}

--- a/src/db_job/claim.rs
+++ b/src/db_job/claim.rs
@@ -48,7 +48,7 @@ pub fn claim_next_job(
 
 fn load_claimed_job(conn: &Connection, job_id: i64) -> Result<Job> {
     let row = conn.query_row(
-        "SELECT id, job_type, project, session_id, payload_json, attempt_count, max_attempts
+        "SELECT id, host, job_type, project, session_id, payload_json, attempt_count, max_attempts
          FROM jobs WHERE id = ?1",
         params![job_id],
         |row| {
@@ -56,21 +56,23 @@ fn load_claimed_job(conn: &Connection, job_id: i64) -> Result<Job> {
                 row.get::<_, i64>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
-                row.get::<_, Option<String>>(3)?,
-                row.get::<_, String>(4)?,
-                row.get::<_, i64>(5)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(5)?,
                 row.get::<_, i64>(6)?,
+                row.get::<_, i64>(7)?,
             ))
         },
     )?;
 
     Ok(Job {
         id: row.0,
-        job_type: JobType::from_db(&row.1)?,
-        project: row.2,
-        session_id: row.3,
-        payload_json: row.4,
-        attempt_count: row.5,
-        max_attempts: row.6,
+        host: row.1,
+        job_type: JobType::from_db(&row.2)?,
+        project: row.3,
+        session_id: row.4,
+        payload_json: row.5,
+        attempt_count: row.6,
+        max_attempts: row.7,
     })
 }

--- a/src/db_job/enqueue.rs
+++ b/src/db_job/enqueue.rs
@@ -5,6 +5,7 @@ use crate::db_job::JobType;
 
 pub fn enqueue_job(
     conn: &Connection,
+    host: &str,
     job_type: JobType,
     project: &str,
     session_id: Option<&str>,
@@ -14,13 +15,14 @@ pub fn enqueue_job(
     let existing: Option<i64> = conn
         .query_row(
             "SELECT id FROM jobs
-             WHERE job_type = ?1
-               AND project = ?2
-               AND COALESCE(session_id, '') = COALESCE(?3, '')
+             WHERE host = ?1
+               AND job_type = ?2
+               AND project = ?3
+               AND COALESCE(session_id, '') = COALESCE(?4, '')
                AND state IN ('pending', 'processing')
              ORDER BY id DESC
              LIMIT 1",
-            params![job_type.as_str(), project, session_id],
+            params![host, job_type.as_str(), project, session_id],
             |row| row.get(0),
         )
         .optional()?;
@@ -31,11 +33,12 @@ pub fn enqueue_job(
     let now = chrono::Utc::now().timestamp();
     conn.execute(
         "INSERT INTO jobs
-         (job_type, project, session_id, payload_json, state, priority,
+         (host, job_type, project, session_id, payload_json, state, priority,
           attempt_count, max_attempts, lease_owner, lease_expires_epoch,
           next_retry_epoch, last_error, created_at_epoch, updated_at_epoch)
-         VALUES (?1, ?2, ?3, ?4, 'pending', ?5, 0, 6, NULL, NULL, ?6, NULL, ?6, ?6)",
+         VALUES (?1, ?2, ?3, ?4, ?5, 'pending', ?6, 0, 6, NULL, NULL, ?7, NULL, ?7, ?7)",
         params![
+            host,
             job_type.as_str(),
             project,
             session_id,

--- a/src/db_job/tests.rs
+++ b/src/db_job/tests.rs
@@ -5,18 +5,36 @@ use crate::migrate::MIGRATIONS;
 
 fn setup_conn() -> Connection {
     let conn = Connection::open_in_memory().expect("in-memory db should open");
-    conn.execute_batch(MIGRATIONS[0].sql)
-        .expect("baseline schema should load");
+    for migration in MIGRATIONS {
+        conn.execute_batch(migration.sql)
+            .expect("schema migration should load");
+    }
     conn
 }
 
 #[test]
 fn enqueue_job_dedups_inflight_job() {
     let conn = setup_conn();
-    let first = enqueue_job(&conn, JobType::Summary, "alpha", Some("s1"), "{}", 100)
-        .expect("first enqueue should succeed");
-    let second = enqueue_job(&conn, JobType::Summary, "alpha", Some("s1"), "{}", 100)
-        .expect("second enqueue should dedup");
+    let first = enqueue_job(
+        &conn,
+        "codex-cli",
+        JobType::Summary,
+        "alpha",
+        Some("s1"),
+        "{}",
+        100,
+    )
+    .expect("first enqueue should succeed");
+    let second = enqueue_job(
+        &conn,
+        "codex-cli",
+        JobType::Summary,
+        "alpha",
+        Some("s1"),
+        "{}",
+        100,
+    )
+    .expect("second enqueue should dedup");
 
     assert_eq!(first, second);
     let count: i64 = conn
@@ -26,12 +44,70 @@ fn enqueue_job_dedups_inflight_job() {
 }
 
 #[test]
+fn enqueue_job_dedupe_includes_host() {
+    let conn = setup_conn();
+    let codex = enqueue_job(
+        &conn,
+        "codex-cli",
+        JobType::Summary,
+        "alpha",
+        Some("s1"),
+        "{}",
+        100,
+    )
+    .expect("codex enqueue should succeed");
+    let claude = enqueue_job(
+        &conn,
+        "claude-code",
+        JobType::Summary,
+        "alpha",
+        Some("s1"),
+        "{}",
+        100,
+    )
+    .expect("claude enqueue should succeed");
+    let codex_again = enqueue_job(
+        &conn,
+        "codex-cli",
+        JobType::Summary,
+        "alpha",
+        Some("s1"),
+        "{}",
+        100,
+    )
+    .expect("codex duplicate should dedup");
+
+    assert_ne!(codex, claude);
+    assert_eq!(codex, codex_again);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM jobs", [], |row| row.get(0))
+        .expect("job count should load");
+    assert_eq!(count, 2);
+}
+
+#[test]
 fn claim_next_job_picks_highest_priority_ready_job() {
     let mut conn = setup_conn();
-    let low = enqueue_job(&conn, JobType::Summary, "alpha", Some("s1"), "{}", 200)
-        .expect("low priority enqueue should succeed");
-    let high = enqueue_job(&conn, JobType::Observation, "alpha", Some("s2"), "{}", 50)
-        .expect("high priority enqueue should succeed");
+    let low = enqueue_job(
+        &conn,
+        "codex-cli",
+        JobType::Summary,
+        "alpha",
+        Some("s1"),
+        "{}",
+        200,
+    )
+    .expect("low priority enqueue should succeed");
+    let high = enqueue_job(
+        &conn,
+        "codex-cli",
+        JobType::Observation,
+        "alpha",
+        Some("s2"),
+        "{}",
+        50,
+    )
+    .expect("high priority enqueue should succeed");
     conn.execute(
         "UPDATE jobs SET next_retry_epoch = ?2 WHERE id = ?1",
         params![low, chrono::Utc::now().timestamp() + 3600],
@@ -57,8 +133,16 @@ fn claim_next_job_picks_highest_priority_ready_job() {
 #[test]
 fn mark_job_failed_or_retry_requeues_before_max_attempts() {
     let mut conn = setup_conn();
-    let job_id = enqueue_job(&conn, JobType::Summary, "alpha", Some("s1"), "{}", 100)
-        .expect("job enqueue should succeed");
+    let job_id = enqueue_job(
+        &conn,
+        "codex-cli",
+        JobType::Summary,
+        "alpha",
+        Some("s1"),
+        "{}",
+        100,
+    )
+    .expect("job enqueue should succeed");
     let claimed = claim_next_job(&mut conn, "worker-a", 60)
         .expect("claim should succeed")
         .expect("job should be claimed");
@@ -92,8 +176,16 @@ fn mark_job_failed_or_retry_requeues_before_max_attempts() {
 #[test]
 fn mark_job_failed_or_retry_marks_failed_when_exhausted() {
     let mut conn = setup_conn();
-    let job_id = enqueue_job(&conn, JobType::Summary, "alpha", Some("s1"), "{}", 100)
-        .expect("job enqueue should succeed");
+    let job_id = enqueue_job(
+        &conn,
+        "codex-cli",
+        JobType::Summary,
+        "alpha",
+        Some("s1"),
+        "{}",
+        100,
+    )
+    .expect("job enqueue should succeed");
     conn.execute(
         "UPDATE jobs SET attempt_count = 5, max_attempts = 6 WHERE id = ?1",
         params![job_id],

--- a/src/db_models.rs
+++ b/src/db_models.rs
@@ -85,6 +85,7 @@ impl JobType {
 #[derive(Debug, Clone)]
 pub struct Job {
     pub id: i64,
+    pub host: String,
     pub job_type: JobType,
     pub project: String,
     pub session_id: Option<String>,

--- a/src/db_pending.rs
+++ b/src/db_pending.rs
@@ -7,9 +7,12 @@ mod tests;
 mod types;
 
 pub use claim::{
-    claim_pending, delete_pending_claimed, fail_pending_claimed, release_pending_claims,
-    retry_pending_claimed,
+    claim_pending, delete_pending_claimed, fail_pending_claimed, release_expired_pending_claims,
+    release_pending_claims, retry_pending_claimed,
 };
-pub use query::{count_pending, get_stale_pending_sessions};
+pub use query::{
+    count_pending, count_pending_for_identity, get_stale_pending_identities,
+    get_stale_pending_sessions, PendingIdentity,
+};
 pub use queue::enqueue_pending;
 pub use types::PendingObservation;

--- a/src/db_pending/claim.rs
+++ b/src/db_pending/claim.rs
@@ -6,6 +6,8 @@ use crate::db_pending::types::PendingObservation;
 
 pub fn claim_pending(
     conn: &Connection,
+    host: &str,
+    project: &str,
     session_id: &str,
     limit: usize,
     lease_owner: &str,
@@ -19,31 +21,45 @@ pub fn claim_pending(
              lease_expires_epoch = ?2,
              status = 'processing',
              attempt_count = COALESCE(attempt_count, 0) + 1,
-             updated_at_epoch = ?4
+             updated_at_epoch = ?6
          WHERE id IN (
              SELECT id FROM pending_observations
-             WHERE session_id = ?3
+             WHERE (host = ?3 OR host = 'unknown')
+               AND project = ?4
+               AND session_id = ?5
                AND status = 'pending'
-               AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?4)
-               AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?4)
+               AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?6)
+               AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?6)
              ORDER BY id ASC
-             LIMIT ?5
+             LIMIT ?7
          )
            AND status = 'pending'
-           AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?4)
-           AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?4)",
-        params![lease_owner, lease_expires, session_id, now, limit as i64],
+           AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?6)
+           AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?6)",
+        params![
+            lease_owner,
+            lease_expires,
+            host,
+            project,
+            session_id,
+            now,
+            limit as i64
+        ],
     )?;
 
     let mut stmt = conn.prepare(
-        "SELECT id, session_id, project, tool_name, tool_input, tool_response, cwd, created_at_epoch, \
+        "SELECT id, host, session_id, project, tool_name, tool_input, tool_response, cwd, created_at_epoch, \
                 updated_at_epoch, status, attempt_count, next_retry_epoch, last_error
          FROM pending_observations
-         WHERE session_id = ?1 AND lease_owner = ?2 AND status = 'processing'
+         WHERE (host = ?1 OR host = 'unknown')
+           AND project = ?2
+           AND session_id = ?3
+           AND lease_owner = ?4
+           AND status = 'processing'
          ORDER BY id ASC",
     )?;
     let rows = stmt.query_map(
-        params![session_id, lease_owner],
+        params![host, project, session_id, lease_owner],
         PendingObservation::from_row,
     )?;
     let mut result = Vec::new();
@@ -64,6 +80,22 @@ pub fn release_pending_claims(conn: &Connection, lease_owner: &str) -> Result<us
              updated_at_epoch = ?2
          WHERE lease_owner = ?1 AND status = 'processing'",
         params![lease_owner, now],
+    )?;
+    Ok(count)
+}
+
+pub fn release_expired_pending_claims(conn: &Connection) -> Result<usize> {
+    let now = chrono::Utc::now().timestamp();
+    let count = conn.execute(
+        "UPDATE pending_observations
+         SET lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             status = 'pending',
+             updated_at_epoch = ?1
+         WHERE status = 'processing'
+           AND lease_expires_epoch IS NOT NULL
+           AND lease_expires_epoch < ?1",
+        params![now],
     )?;
     Ok(count)
 }

--- a/src/db_pending/query.rs
+++ b/src/db_pending/query.rs
@@ -1,6 +1,15 @@
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingIdentity {
+    pub host: String,
+    pub project: String,
+    pub session_id: String,
+    pub ready_count: i64,
+    pub oldest_epoch: i64,
+}
+
 pub fn get_stale_pending_sessions(
     conn: &Connection,
     project: &str,
@@ -24,15 +33,60 @@ pub fn get_stale_pending_sessions(
     Ok(result)
 }
 
+pub fn get_stale_pending_identities(
+    conn: &Connection,
+    age_secs: i64,
+    limit: i64,
+) -> Result<Vec<PendingIdentity>> {
+    let cutoff = chrono::Utc::now().timestamp() - age_secs;
+    let now = chrono::Utc::now().timestamp();
+    let mut stmt = conn.prepare(
+        "SELECT host, project, session_id, COUNT(*) AS ready_count, MIN(created_at_epoch) AS oldest_epoch
+         FROM pending_observations
+         WHERE status = 'pending'
+           AND created_at_epoch < ?1
+           AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?2)
+           AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?2)
+         GROUP BY host, project, session_id
+         ORDER BY oldest_epoch ASC, ready_count DESC
+         LIMIT ?3",
+    )?;
+    let rows = stmt.query_map(params![cutoff, now, limit.max(1)], |row| {
+        Ok(PendingIdentity {
+            host: row.get(0)?,
+            project: row.get(1)?,
+            session_id: row.get(2)?,
+            ready_count: row.get(3)?,
+            oldest_epoch: row.get(4)?,
+        })
+    })?;
+    let mut result = Vec::new();
+    for row in rows {
+        result.push(row?);
+    }
+    Ok(result)
+}
+
 pub fn count_pending(conn: &Connection, session_id: &str) -> Result<i64> {
+    count_pending_for_identity(conn, "unknown", "", session_id)
+}
+
+pub fn count_pending_for_identity(
+    conn: &Connection,
+    host: &str,
+    project: &str,
+    session_id: &str,
+) -> Result<i64> {
     let now = chrono::Utc::now().timestamp();
     let count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM pending_observations
-         WHERE session_id = ?1
+         WHERE (host = ?1 OR host = 'unknown')
+           AND (?2 = '' OR project = ?2)
+           AND session_id = ?3
            AND status = 'pending'
-           AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?2)
-           AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?2)",
-        params![session_id, now],
+           AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?4)
+           AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?4)",
+        params![host, project, session_id, now],
         |row| row.get(0),
     )?;
     Ok(count)

--- a/src/db_pending/queue.rs
+++ b/src/db_pending/queue.rs
@@ -3,6 +3,7 @@ use rusqlite::{params, Connection};
 
 pub fn enqueue_pending(
     conn: &Connection,
+    host: &str,
     session_id: &str,
     project: &str,
     tool_name: &str,
@@ -13,10 +14,19 @@ pub fn enqueue_pending(
     let epoch = chrono::Utc::now().timestamp();
     conn.execute(
         "INSERT INTO pending_observations \
-         (session_id, project, tool_name, tool_input, tool_response, cwd, created_at_epoch, updated_at_epoch, \
+         (host, session_id, project, tool_name, tool_input, tool_response, cwd, created_at_epoch, updated_at_epoch, \
           status, attempt_count, next_retry_epoch, last_error, lease_owner, lease_expires_epoch) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, 'pending', 0, NULL, NULL, NULL, NULL)",
-        params![session_id, project, tool_name, tool_input, tool_response, cwd, epoch],
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8, 'pending', 0, NULL, NULL, NULL, NULL)",
+        params![
+            host,
+            session_id,
+            project,
+            tool_name,
+            tool_input,
+            tool_response,
+            cwd,
+            epoch
+        ],
     )?;
     Ok(conn.last_insert_rowid())
 }

--- a/src/db_pending/tests.rs
+++ b/src/db_pending/tests.rs
@@ -1,24 +1,47 @@
 use rusqlite::{params, Connection};
 
-use super::{claim_pending, delete_pending_claimed, enqueue_pending, retry_pending_claimed};
+use super::{
+    claim_pending, delete_pending_claimed, enqueue_pending, release_expired_pending_claims,
+    retry_pending_claimed,
+};
 use crate::migrate::MIGRATIONS;
 
 fn setup_conn() -> Connection {
     let conn = Connection::open_in_memory().expect("in-memory db should open");
-    conn.execute_batch(MIGRATIONS[0].sql)
-        .expect("baseline schema should load");
+    for migration in MIGRATIONS {
+        conn.execute_batch(migration.sql)
+            .expect("schema migration should load");
+    }
     conn
 }
 
 #[test]
 fn claim_pending_only_returns_requested_session_rows() {
     let conn = setup_conn();
-    let expected_id = enqueue_pending(&conn, "session-a", "proj", "tool", None, None, None)
-        .expect("first pending row should be queued");
-    enqueue_pending(&conn, "session-b", "proj", "tool", None, None, None)
-        .expect("second pending row should be queued");
+    let expected_id = enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-a",
+        "proj",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("first pending row should be queued");
+    enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-b",
+        "proj",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("second pending row should be queued");
 
-    let claimed = claim_pending(&conn, "session-a", 5, "worker-a", 60)
+    let claimed = claim_pending(&conn, "codex-cli", "proj", "session-a", 5, "worker-a", 60)
         .expect("session-specific claim should succeed");
 
     assert_eq!(claimed.len(), 1);
@@ -28,11 +51,117 @@ fn claim_pending_only_returns_requested_session_rows() {
 }
 
 #[test]
+fn claim_pending_respects_host_project_session_identity() {
+    let conn = setup_conn();
+    let expected_id = enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-a",
+        "proj-a",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("target row should be queued");
+    enqueue_pending(
+        &conn,
+        "claude-code",
+        "session-a",
+        "proj-a",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("different host row should be queued");
+    enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-a",
+        "proj-b",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("different project row should be queued");
+
+    let claimed = claim_pending(
+        &conn,
+        "codex-cli",
+        "proj-a",
+        "session-a",
+        10,
+        "worker-a",
+        60,
+    )
+    .expect("identity claim should succeed");
+
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].id, expected_id);
+    assert_eq!(claimed[0].host, "codex-cli");
+    assert_eq!(claimed[0].project, "proj-a");
+    assert_eq!(claimed[0].session_id, "session-a");
+}
+
+#[test]
+fn claim_pending_allows_legacy_unknown_host_for_matching_identity() {
+    let conn = setup_conn();
+    let legacy_id = enqueue_pending(
+        &conn,
+        "unknown",
+        "session-a",
+        "proj-a",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("legacy row should be queued");
+    enqueue_pending(
+        &conn,
+        "unknown",
+        "session-a",
+        "proj-b",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("different legacy project row should be queued");
+
+    let claimed = claim_pending(
+        &conn,
+        "codex-cli",
+        "proj-a",
+        "session-a",
+        10,
+        "worker-a",
+        60,
+    )
+    .expect("legacy-compatible claim should succeed");
+
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].id, legacy_id);
+    assert_eq!(claimed[0].host, "unknown");
+}
+
+#[test]
 fn retry_pending_claimed_resets_status_and_sets_next_retry() {
     let conn = setup_conn();
-    let pending_id = enqueue_pending(&conn, "session-a", "proj", "tool", None, None, None)
-        .expect("pending row should be queued");
-    let claimed = claim_pending(&conn, "session-a", 1, "worker-a", 60)
+    let pending_id = enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-a",
+        "proj",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("pending row should be queued");
+    let claimed = claim_pending(&conn, "codex-cli", "proj", "session-a", 1, "worker-a", 60)
         .expect("pending row should be claimed");
     let lower_bound = chrono::Utc::now().timestamp() + 120;
 
@@ -68,15 +197,44 @@ fn retry_pending_claimed_resets_status_and_sets_next_retry() {
 #[test]
 fn delete_pending_claimed_only_deletes_processing_rows_for_owner() {
     let conn = setup_conn();
-    let owned_id = enqueue_pending(&conn, "session-a", "proj", "tool", None, None, None)
-        .expect("owned row should be queued");
-    let pending_id = enqueue_pending(&conn, "session-a", "proj", "tool", None, None, None)
-        .expect("unclaimed row should be queued");
-    let other_owner_id = enqueue_pending(&conn, "session-b", "proj", "tool", None, None, None)
-        .expect("other owner row should be queued");
+    let owned_id = enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-a",
+        "proj",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("owned row should be queued");
+    let pending_id = enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-a",
+        "proj",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("unclaimed row should be queued");
+    let other_owner_id = enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-b",
+        "proj",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("other owner row should be queued");
 
-    claim_pending(&conn, "session-a", 1, "worker-a", 60).expect("worker a should claim its row");
-    claim_pending(&conn, "session-b", 1, "worker-b", 60).expect("worker b should claim its row");
+    claim_pending(&conn, "codex-cli", "proj", "session-a", 1, "worker-a", 60)
+        .expect("worker a should claim its row");
+    claim_pending(&conn, "codex-cli", "proj", "session-b", 1, "worker-b", 60)
+        .expect("worker b should claim its row");
 
     let deleted =
         delete_pending_claimed(&conn, "worker-a", &[owned_id, pending_id, other_owner_id])
@@ -91,4 +249,91 @@ fn delete_pending_claimed_only_deletes_processing_rows_for_owner() {
         .collect::<rusqlite::Result<Vec<_>>>()
         .expect("row collection should succeed");
     assert_eq!(remaining_ids, vec![pending_id, other_owner_id]);
+}
+
+#[test]
+fn release_expired_pending_claims_resets_only_expired_processing_rows() {
+    let conn = setup_conn();
+    let expired_id = enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-a",
+        "proj",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("expired row should be queued");
+    let fresh_id = enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-b",
+        "proj",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("fresh row should be queued");
+    let pending_id = enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-c",
+        "proj",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("pending row should be queued");
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "UPDATE pending_observations
+         SET status = 'processing', lease_owner = 'old-worker', lease_expires_epoch = ?2
+         WHERE id = ?1",
+        params![expired_id, now - 1],
+    )
+    .expect("expired row should update");
+    conn.execute(
+        "UPDATE pending_observations
+         SET status = 'processing', lease_owner = 'fresh-worker', lease_expires_epoch = ?2
+         WHERE id = ?1",
+        params![fresh_id, now + 60],
+    )
+    .expect("fresh row should update");
+
+    let released = release_expired_pending_claims(&conn).expect("release should succeed");
+
+    assert_eq!(released, 1);
+    let rows = conn
+        .prepare(
+            "SELECT id, status, lease_owner
+             FROM pending_observations
+             ORDER BY id ASC",
+        )
+        .expect("select should prepare")
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })
+        .expect("rows should load")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("rows should collect");
+
+    assert_eq!(
+        rows,
+        vec![
+            (expired_id, "pending".to_string(), None),
+            (
+                fresh_id,
+                "processing".to_string(),
+                Some("fresh-worker".to_string())
+            ),
+            (pending_id, "pending".to_string(), None),
+        ]
+    );
 }

--- a/src/db_pending/types.rs
+++ b/src/db_pending/types.rs
@@ -4,6 +4,7 @@ use rusqlite::Row;
 #[allow(dead_code)]
 pub struct PendingObservation {
     pub id: i64,
+    pub host: String,
     pub session_id: String,
     pub project: String,
     pub tool_name: String,
@@ -22,18 +23,19 @@ impl PendingObservation {
     pub(super) fn from_row(row: &Row<'_>) -> rusqlite::Result<Self> {
         Ok(Self {
             id: row.get(0)?,
-            session_id: row.get(1)?,
-            project: row.get(2)?,
-            tool_name: row.get(3)?,
-            tool_input: row.get(4)?,
-            tool_response: row.get(5)?,
-            cwd: row.get(6)?,
-            created_at_epoch: row.get(7)?,
-            updated_at_epoch: row.get(8)?,
-            status: row.get(9)?,
-            attempt_count: row.get(10)?,
-            next_retry_epoch: row.get(11)?,
-            last_error: row.get(12)?,
+            host: row.get(1)?,
+            session_id: row.get(2)?,
+            project: row.get(3)?,
+            tool_name: row.get(4)?,
+            tool_input: row.get(5)?,
+            tool_response: row.get(6)?,
+            cwd: row.get(7)?,
+            created_at_epoch: row.get(8)?,
+            updated_at_epoch: row.get(9)?,
+            status: row.get(10)?,
+            attempt_count: row.get(11)?,
+            next_retry_epoch: row.get(12)?,
+            last_error: row.get(13)?,
         })
     }
 }

--- a/src/db_query/stats.rs
+++ b/src/db_query/stats.rs
@@ -10,8 +10,19 @@ pub struct SystemStats {
     pub session_summaries: i64,
     pub raw_messages: i64,
     pub pending_observations: i64,
+    pub ready_pending_observations: i64,
+    pub delayed_pending_observations: i64,
+    pub processing_pending_observations: i64,
+    pub expired_processing_pending_observations: i64,
     pub failed_pending_observations: i64,
+    pub oldest_ready_pending_epoch: Option<i64>,
+    pub pending_jobs: i64,
+    pub processing_jobs: i64,
+    pub failed_jobs: i64,
     pub stuck_jobs: i64,
+    pub worker_daemon_healthy: bool,
+    pub worker_heartbeat_owner: Option<String>,
+    pub worker_heartbeat_age_secs: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,6 +38,14 @@ pub struct ProjectCount {
 }
 
 pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
+    let now = chrono::Utc::now().timestamp();
+    let worker_heartbeat = crate::db_worker::latest_worker_heartbeat(conn)?;
+    let worker_heartbeat_age_secs = worker_heartbeat
+        .as_ref()
+        .map(|heartbeat| now.saturating_sub(heartbeat.updated_at_epoch));
+    let worker_daemon_healthy = worker_heartbeat_age_secs
+        .map(|age| age <= crate::db_worker::WORKER_HEARTBEAT_HEALTH_SECS)
+        .unwrap_or(false);
     Ok(SystemStats {
         active_memories: conn.query_row(
             "SELECT COUNT(*) FROM memories WHERE status = 'active'",
@@ -47,17 +66,68 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
             [],
             |row| row.get(0),
         )?,
+        ready_pending_observations: conn.query_row(
+            "SELECT COUNT(*) FROM pending_observations
+             WHERE status = 'pending'
+               AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?1)
+               AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?1)",
+            params![now],
+            |row| row.get(0),
+        )?,
+        delayed_pending_observations: conn.query_row(
+            "SELECT COUNT(*) FROM pending_observations
+             WHERE status = 'pending'
+               AND next_retry_epoch IS NOT NULL
+               AND next_retry_epoch > ?1",
+            params![now],
+            |row| row.get(0),
+        )?,
+        processing_pending_observations: conn.query_row(
+            "SELECT COUNT(*) FROM pending_observations WHERE status = 'processing'",
+            [],
+            |row| row.get(0),
+        )?,
+        expired_processing_pending_observations: conn.query_row(
+            "SELECT COUNT(*) FROM pending_observations
+             WHERE status = 'processing'
+               AND lease_expires_epoch IS NOT NULL
+               AND lease_expires_epoch < ?1",
+            params![now],
+            |row| row.get(0),
+        )?,
         failed_pending_observations: conn.query_row(
             "SELECT COUNT(*) FROM pending_observations WHERE status = 'failed'",
             [],
             |row| row.get(0),
         )?,
+        oldest_ready_pending_epoch: conn.query_row(
+            "SELECT MIN(created_at_epoch) FROM pending_observations
+             WHERE status = 'pending'
+               AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?1)
+               AND (lease_owner IS NULL OR lease_expires_epoch IS NULL OR lease_expires_epoch < ?1)",
+            params![now],
+            |row| row.get(0),
+        )?,
+        pending_jobs: conn.query_row("SELECT COUNT(*) FROM jobs WHERE state = 'pending'", [], |row| {
+            row.get(0)
+        })?,
+        processing_jobs: conn.query_row(
+            "SELECT COUNT(*) FROM jobs WHERE state = 'processing'",
+            [],
+            |row| row.get(0),
+        )?,
+        failed_jobs: conn.query_row("SELECT COUNT(*) FROM jobs WHERE state = 'failed'", [], |row| {
+            row.get(0)
+        })?,
         stuck_jobs: conn.query_row(
-            "SELECT COUNT(*) FROM jobs WHERE state = 'running' \
+            "SELECT COUNT(*) FROM jobs WHERE state = 'processing' \
              AND lease_expires_epoch < strftime('%s', 'now')",
             [],
             |row| row.get(0),
         )?,
+        worker_daemon_healthy,
+        worker_heartbeat_owner: worker_heartbeat.map(|heartbeat| heartbeat.owner),
+        worker_heartbeat_age_secs,
     })
 }
 

--- a/src/db_query/stats/tests.rs
+++ b/src/db_query/stats/tests.rs
@@ -25,12 +25,22 @@ fn setup_stats_schema(conn: &Connection) {
         );
         CREATE TABLE pending_observations (
             id INTEGER PRIMARY KEY,
-            status TEXT NOT NULL
+            status TEXT NOT NULL,
+            created_at_epoch INTEGER NOT NULL DEFAULT 0,
+            next_retry_epoch INTEGER,
+            lease_owner TEXT,
+            lease_expires_epoch INTEGER
         );
         CREATE TABLE jobs (
             id INTEGER PRIMARY KEY,
             state TEXT NOT NULL,
             lease_expires_epoch INTEGER
+        );
+        CREATE TABLE worker_heartbeats (
+            owner TEXT PRIMARY KEY,
+            pid INTEGER,
+            started_at_epoch INTEGER NOT NULL,
+            updated_at_epoch INTEGER NOT NULL
         );",
     )
     .expect("schema should be created");
@@ -69,20 +79,52 @@ fn query_system_stats_and_related_views_share_one_definition() {
     conn.execute("INSERT INTO session_summaries (id) VALUES (1)", [])
         .expect("summary insert should succeed");
     conn.execute(
-        "INSERT INTO pending_observations (status) VALUES ('pending')",
+        "INSERT INTO pending_observations (status, created_at_epoch) VALUES ('pending', 100)",
         [],
     )
     .expect("pending insert should succeed");
     conn.execute(
-        "INSERT INTO pending_observations (status) VALUES ('failed')",
+        "INSERT INTO pending_observations (status, created_at_epoch) VALUES ('pending', 120)",
+        [],
+    )
+    .expect("second pending insert should succeed");
+    conn.execute(
+        "UPDATE pending_observations SET next_retry_epoch = strftime('%s', 'now') + 3600 WHERE id = 2",
+        [],
+    )
+    .expect("delayed pending update should succeed");
+    conn.execute(
+        "INSERT INTO pending_observations (status, created_at_epoch, lease_owner, lease_expires_epoch)
+         VALUES ('processing', 130, 'worker-a', strftime('%s', 'now') - 1)",
+        [],
+    )
+    .expect("processing pending insert should succeed");
+    conn.execute(
+        "INSERT INTO pending_observations (status, created_at_epoch) VALUES ('failed', 140)",
         [],
     )
     .expect("failed pending insert should succeed");
     conn.execute(
-        "INSERT INTO jobs (state, lease_expires_epoch) VALUES ('running', 0)",
+        "INSERT INTO jobs (state, lease_expires_epoch) VALUES ('pending', NULL)",
+        [],
+    )
+    .expect("pending job insert should succeed");
+    conn.execute(
+        "INSERT INTO jobs (state, lease_expires_epoch) VALUES ('processing', 0)",
         [],
     )
     .expect("stuck job insert should succeed");
+    conn.execute(
+        "INSERT INTO jobs (state, lease_expires_epoch) VALUES ('failed', NULL)",
+        [],
+    )
+    .expect("failed job insert should succeed");
+    conn.execute(
+        "INSERT INTO worker_heartbeats (owner, pid, started_at_epoch, updated_at_epoch)
+         VALUES ('worker-a', 123, strftime('%s', 'now') - 10, strftime('%s', 'now') - 10)",
+        [],
+    )
+    .expect("heartbeat insert should succeed");
 
     let system = query_system_stats(&conn).expect("system stats should load");
     assert_eq!(
@@ -92,10 +134,25 @@ fn query_system_stats_and_related_views_share_one_definition() {
             active_observations: 1,
             session_summaries: 1,
             raw_messages: 0,
-            pending_observations: 1,
+            pending_observations: 2,
+            ready_pending_observations: 1,
+            delayed_pending_observations: 1,
+            processing_pending_observations: 1,
+            expired_processing_pending_observations: 1,
             failed_pending_observations: 1,
+            oldest_ready_pending_epoch: Some(100),
+            pending_jobs: 1,
+            processing_jobs: 1,
+            failed_jobs: 1,
             stuck_jobs: 1,
+            worker_daemon_healthy: true,
+            worker_heartbeat_owner: Some("worker-a".to_string()),
+            worker_heartbeat_age_secs: system.worker_heartbeat_age_secs,
         }
+    );
+    assert!(
+        system.worker_heartbeat_age_secs.unwrap_or_default() <= 20,
+        "heartbeat age should be recent"
     );
 
     let daily = query_daily_activity_stats(&conn, 180).expect("daily stats should load");

--- a/src/db_worker.rs
+++ b/src/db_worker.rs
@@ -1,0 +1,126 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+
+pub const WORKER_HEARTBEAT_HEALTH_SECS: i64 = 480;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerHeartbeat {
+    pub owner: String,
+    pub pid: Option<i64>,
+    pub started_at_epoch: i64,
+    pub updated_at_epoch: i64,
+}
+
+pub fn upsert_worker_heartbeat(
+    conn: &Connection,
+    owner: &str,
+    pid: i64,
+    started_at_epoch: i64,
+    updated_at_epoch: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO worker_heartbeats (owner, pid, started_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(owner) DO UPDATE SET
+             pid = excluded.pid,
+             updated_at_epoch = excluded.updated_at_epoch",
+        params![owner, pid, started_at_epoch, updated_at_epoch],
+    )?;
+    Ok(())
+}
+
+pub fn latest_worker_heartbeat(conn: &Connection) -> Result<Option<WorkerHeartbeat>> {
+    conn.query_row(
+        "SELECT owner, pid, started_at_epoch, updated_at_epoch
+         FROM worker_heartbeats
+         ORDER BY updated_at_epoch DESC, owner ASC
+         LIMIT 1",
+        [],
+        |row| {
+            Ok(WorkerHeartbeat {
+                owner: row.get(0)?,
+                pid: row.get(1)?,
+                started_at_epoch: row.get(2)?,
+                updated_at_epoch: row.get(3)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub fn healthy_worker_heartbeat(
+    conn: &Connection,
+    max_age_secs: i64,
+) -> Result<Option<WorkerHeartbeat>> {
+    let now = chrono::Utc::now().timestamp();
+    conn.query_row(
+        "SELECT owner, pid, started_at_epoch, updated_at_epoch
+         FROM worker_heartbeats
+         WHERE updated_at_epoch >= ?1
+         ORDER BY updated_at_epoch DESC, owner ASC
+         LIMIT 1",
+        params![now.saturating_sub(max_age_secs)],
+        |row| {
+            Ok(WorkerHeartbeat {
+                owner: row.get(0)?,
+                pid: row.get(1)?,
+                started_at_epoch: row.get(2)?,
+                updated_at_epoch: row.get(3)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::{
+        healthy_worker_heartbeat, latest_worker_heartbeat, upsert_worker_heartbeat,
+        WORKER_HEARTBEAT_HEALTH_SECS,
+    };
+
+    fn setup(conn: &Connection) {
+        conn.execute_batch(include_str!("migrations/v004_worker_heartbeat.sql"))
+            .expect("heartbeat migration should run");
+    }
+
+    #[test]
+    fn heartbeat_upsert_tracks_latest_healthy_worker() {
+        let conn = Connection::open_in_memory().expect("db should open");
+        setup(&conn);
+        let now = chrono::Utc::now().timestamp();
+
+        upsert_worker_heartbeat(&conn, "worker-old", 10, now - 900, now - 900)
+            .expect("old heartbeat should insert");
+        upsert_worker_heartbeat(&conn, "worker-new", 11, now - 10, now - 10)
+            .expect("new heartbeat should insert");
+
+        let latest = latest_worker_heartbeat(&conn)
+            .expect("latest should load")
+            .expect("heartbeat should exist");
+        assert_eq!(latest.owner, "worker-new");
+
+        let healthy = healthy_worker_heartbeat(&conn, WORKER_HEARTBEAT_HEALTH_SECS)
+            .expect("healthy heartbeat should load")
+            .expect("healthy heartbeat should exist");
+        assert_eq!(healthy.owner, "worker-new");
+    }
+
+    #[test]
+    fn stale_heartbeat_is_not_healthy() {
+        let conn = Connection::open_in_memory().expect("db should open");
+        setup(&conn);
+        let now = chrono::Utc::now().timestamp();
+
+        upsert_worker_heartbeat(&conn, "worker-old", 10, now - 900, now - 900)
+            .expect("old heartbeat should insert");
+
+        let healthy = healthy_worker_heartbeat(&conn, WORKER_HEARTBEAT_HEALTH_SECS)
+            .expect("healthy heartbeat query should run");
+        assert!(healthy.is_none());
+    }
+}

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -62,43 +62,92 @@ pub(super) fn check_pending_queue() -> Check {
             };
         }
     };
-    let pending = stats.pending_observations;
-    let failed_pending = stats.failed_pending_observations;
-    let stuck_jobs = stats.stuck_jobs;
+    let detail = format!(
+        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} jobs pending, {} processing, {} failed, {} stuck",
+        stats.ready_pending_observations,
+        stats.delayed_pending_observations,
+        stats.processing_pending_observations,
+        stats.expired_processing_pending_observations,
+        stats.failed_pending_observations,
+        stats.pending_jobs,
+        stats.processing_jobs,
+        stats.failed_jobs,
+        stats.stuck_jobs,
+    );
 
-    if stuck_jobs > 0 {
+    if stats.expired_processing_pending_observations > 0 || stats.stuck_jobs > 0 {
         Check {
             name: "Pending queue",
             status: Status::Warn,
-            detail: format!(
-                "{} pending, {} failed, {} stuck jobs (will auto-recover)",
-                pending, failed_pending, stuck_jobs
-            ),
+            detail: format!("{} (will auto-recover)", detail),
         }
-    } else if failed_pending > 0 {
+    } else if stats.failed_pending_observations > 0 || stats.failed_jobs > 0 {
         Check {
             name: "Pending queue",
             status: Status::Warn,
-            detail: format!(
-                "{} pending, {} failed (inspect parsing/AI failures)",
-                pending, failed_pending
-            ),
+            detail: format!("{} (inspect failures)", detail),
         }
-    } else if pending > 100 {
+    } else if stats.ready_pending_observations > 100 {
         Check {
             name: "Pending queue",
             status: Status::Warn,
-            detail: format!(
-                "{} pending, {} failed (backlog building up)",
-                pending, failed_pending
-            ),
+            detail: format!("{} (backlog building up)", detail),
         }
     } else {
         Check {
             name: "Pending queue",
             status: Status::Ok,
-            detail: format!("{} pending, {} failed", pending, failed_pending),
+            detail,
         }
+    }
+}
+
+pub(super) fn check_worker_daemon() -> Check {
+    let conn = match db::open_db() {
+        Ok(conn) => conn,
+        Err(_) => {
+            return Check {
+                name: "Worker daemon",
+                status: Status::Warn,
+                detail: "cannot open database".to_string(),
+            };
+        }
+    };
+
+    let stats = match db::query_system_stats(&conn) {
+        Ok(stats) => stats,
+        Err(err) => {
+            return Check {
+                name: "Worker daemon",
+                status: Status::Warn,
+                detail: format!("cannot load heartbeat stats: {}", err),
+            };
+        }
+    };
+
+    match (
+        stats.worker_daemon_healthy,
+        stats.worker_heartbeat_owner,
+        stats.worker_heartbeat_age_secs,
+    ) {
+        (true, Some(owner), Some(age_secs)) => Check {
+            name: "Worker daemon",
+            status: Status::Ok,
+            detail: format!("healthy, last heartbeat {}s ago ({})", age_secs, owner),
+        },
+        (false, Some(owner), Some(age_secs)) => Check {
+            name: "Worker daemon",
+            status: Status::Warn,
+            detail: format!(
+                "stale, last heartbeat {}s ago ({}) — Stop hooks will use worker --once",
+                age_secs, owner
+            ),
+        },
+        _ => Check {
+            name: "Worker daemon",
+            status: Status::Ok,
+            detail: "not running; Stop hooks will use worker --once".to_string(),
+        },
     }
 }
 

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use super::database::{check_database, check_disk_space, check_pending_queue};
+use super::database::{check_database, check_disk_space, check_pending_queue, check_worker_daemon};
 use super::environment::{check_binary, check_hooks, check_mcp};
 use super::schema::check_schema_migration;
 use super::types::Status;
@@ -13,6 +13,7 @@ pub fn run_doctor() -> Result<()> {
     let mut checks = vec![check_binary(), check_schema_migration(), check_database()];
     checks.extend(check_hooks());
     checks.extend(check_mcp());
+    checks.push(check_worker_daemon());
     checks.push(check_pending_queue());
     checks.push(check_disk_space());
 

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -3,7 +3,7 @@ use rusqlite::params;
 use crate::db::test_support::ScopedTestDataDir;
 use crate::{db, memory};
 
-use super::database::{check_database, check_pending_queue};
+use super::database::{check_database, check_pending_queue, check_worker_daemon};
 
 #[test]
 fn check_database_reports_shared_active_memory_count() {
@@ -51,10 +51,28 @@ fn check_database_reports_shared_active_memory_count() {
 fn check_pending_queue_reports_shared_counts() {
     let _test_dir = ScopedTestDataDir::new("doctor-pending");
     let conn = db::open_db().expect("db should open");
-    db::enqueue_pending(&conn, "session-1", "proj-a", "tool", None, None, None)
-        .expect("pending row insert should succeed");
-    let failed_id = db::enqueue_pending(&conn, "session-2", "proj-a", "tool", None, None, None)
-        .expect("failed row insert should succeed");
+    db::enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-1",
+        "proj-a",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("pending row insert should succeed");
+    let failed_id = db::enqueue_pending(
+        &conn,
+        "codex-cli",
+        "session-2",
+        "proj-a",
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("failed row insert should succeed");
     conn.execute(
         "UPDATE pending_observations SET status = 'failed' WHERE id = ?1",
         params![failed_id],
@@ -63,6 +81,7 @@ fn check_pending_queue_reports_shared_counts() {
 
     let job_id = db::enqueue_job(
         &conn,
+        "codex-cli",
         db::JobType::Observation,
         "proj-a",
         Some("session-3"),
@@ -71,7 +90,7 @@ fn check_pending_queue_reports_shared_counts() {
     )
     .expect("job insert should succeed");
     conn.execute(
-        "UPDATE jobs SET state = 'running', lease_expires_epoch = ?2 WHERE id = ?1",
+        "UPDATE jobs SET state = 'processing', lease_expires_epoch = ?2 WHERE id = ?1",
         params![job_id, chrono::Utc::now().timestamp() - 1],
     )
     .expect("job update should succeed");
@@ -84,8 +103,43 @@ fn check_pending_queue_reports_shared_counts() {
     assert_eq!(
         check.detail,
         format!(
-            "{} pending, {} failed, {} stuck jobs (will auto-recover)",
-            stats.pending_observations, stats.failed_pending_observations, stats.stuck_jobs
+            "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} jobs pending, {} processing, {} failed, {} stuck (will auto-recover)",
+            stats.ready_pending_observations,
+            stats.delayed_pending_observations,
+            stats.processing_pending_observations,
+            stats.expired_processing_pending_observations,
+            stats.failed_pending_observations,
+            stats.pending_jobs,
+            stats.processing_jobs,
+            stats.failed_jobs,
+            stats.stuck_jobs,
         )
+    );
+}
+
+#[test]
+fn check_worker_daemon_reports_healthy_heartbeat() {
+    let _test_dir = ScopedTestDataDir::new("doctor-worker-healthy");
+    let conn = db::open_db().expect("db should open");
+    let now = chrono::Utc::now().timestamp();
+    db::upsert_worker_heartbeat(&conn, "worker-daemon", 123, now - 5, now - 5)
+        .expect("heartbeat should insert");
+    drop(conn);
+
+    let check = check_worker_daemon();
+    assert_eq!(check.icon(), "ok");
+    assert!(check.detail.contains("healthy"));
+    assert!(check.detail.contains("worker-daemon"));
+}
+
+#[test]
+fn check_worker_daemon_reports_missing_as_fallback_ok() {
+    let _test_dir = ScopedTestDataDir::new("doctor-worker-missing");
+
+    let check = check_worker_daemon();
+    assert_eq!(check.icon(), "ok");
+    assert_eq!(
+        check.detail,
+        "not running; Stop hooks will use worker --once"
     );
 }

--- a/src/git_util.rs
+++ b/src/git_util.rs
@@ -1,0 +1,62 @@
+//! Minimal git CLI helpers used by v2 capture identity. The pure parser is
+//! split from the side-effecting subprocess spawn so the parser stays
+//! unit-testable; the spawn itself is documented but not unit-tested (it
+//! would require tempdir + git init in the test environment, which adds an
+//! external dependency for a single helper).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Parse the output of `git rev-parse --show-toplevel`. Returns `None` for
+/// empty or whitespace-only input so callers can fall back cleanly.
+pub fn parse_toplevel_output(stdout: &str) -> Option<PathBuf> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+/// Spawn `git rev-parse --show-toplevel` in `cwd`. Returns `None` when git
+/// is unavailable, the directory is outside any git worktree, or the output
+/// is empty. Single subprocess, no network.
+pub fn resolve_toplevel(cwd: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_toplevel_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_returns_path_for_normal_output() {
+        assert_eq!(
+            parse_toplevel_output("/Users/foo/project\n"),
+            Some(PathBuf::from("/Users/foo/project"))
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_empty_or_whitespace() {
+        assert_eq!(parse_toplevel_output(""), None);
+        assert_eq!(parse_toplevel_output("\n"), None);
+        assert_eq!(parse_toplevel_output("   \t\n  "), None);
+    }
+
+    #[test]
+    fn parse_strips_trailing_whitespace() {
+        assert_eq!(
+            parse_toplevel_output("/path/with-spaces  \n\t"),
+            Some(PathBuf::from("/path/with-spaces"))
+        );
+    }
+}

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -9,7 +9,9 @@
 use anyhow::{anyhow, Result};
 use std::path::{Path, PathBuf};
 
-/// Install-time host. Distinct from the v1 `context::host::InstallHost` (which
+use crate::git_util::resolve_toplevel;
+
+/// Install-time host. Distinct from the v1 `context::host::HostKind` (which
 /// allows `Unknown` for legacy detection): v2.1 M2 forbids `unknown`, and the
 /// value is always sourced from the install-baked `--host` argument.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -31,7 +33,7 @@ impl InstallHost {
 
     /// Parse from the `--host` CLI argument. v2.1 M2: any other value is an
     /// install error and must be refused at the boundary. `unknown` is
-    /// explicitly rejected here, in contrast to `context::host::InstallHost`.
+    /// explicitly rejected here, in contrast to `context::host::HostKind`.
     pub fn parse(s: &str) -> Result<Self> {
         match s {
             "claude-code" => Ok(InstallHost::ClaudeCode),
@@ -58,6 +60,14 @@ impl WorkspaceKey {
     pub fn from_cwd_and_toplevel(cwd: &Path, git_toplevel: Option<&Path>) -> Self {
         let root_path = git_toplevel.unwrap_or(cwd).to_path_buf();
         Self { root_path }
+    }
+
+    /// Convenience wrapper that resolves the git toplevel for `cwd` via the
+    /// `git` binary, falling back to `cwd` when the directory is outside any
+    /// git worktree or git is unavailable. Spawns one subprocess.
+    pub fn from_cwd(cwd: &Path) -> Self {
+        let toplevel = resolve_toplevel(cwd);
+        Self::from_cwd_and_toplevel(cwd, toplevel.as_deref())
     }
 }
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,0 +1,199 @@
+//! Typed identity for v2 capture / extraction / memory rows.
+//!
+//! Per SPEC-memory-system-v2.1-revisions §1 M1, the v2 six-tuple
+//! `(host, workspace, project, session_id, turn_id, event_id)` is a mix of
+//! host-supplied and remem-synthesized fields. This module owns the synthesis
+//! rules and the typed wrappers; nothing else should construct these values
+//! from raw strings.
+
+use anyhow::{anyhow, Result};
+use std::path::{Path, PathBuf};
+
+/// Install-time host. Distinct from the v1 `context::host::InstallHost` (which
+/// allows `Unknown` for legacy detection): v2.1 M2 forbids `unknown`, and the
+/// value is always sourced from the install-baked `--host` argument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InstallHost {
+    ClaudeCode,
+    CodexCli,
+}
+
+impl InstallHost {
+    /// String written into `hosts.name` and matched by capture / extraction
+    /// queries. Kept separate from any context/env representations so that a
+    /// rename in one layer does not silently widen identity.
+    pub fn as_db_value(self) -> &'static str {
+        match self {
+            InstallHost::ClaudeCode => "claude-code",
+            InstallHost::CodexCli => "codex-cli",
+        }
+    }
+
+    /// Parse from the `--host` CLI argument. v2.1 M2: any other value is an
+    /// install error and must be refused at the boundary. `unknown` is
+    /// explicitly rejected here, in contrast to `context::host::InstallHost`.
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "claude-code" => Ok(InstallHost::ClaudeCode),
+            "codex-cli" => Ok(InstallHost::CodexCli),
+            other => Err(anyhow!(
+                "invalid host '{other}'; v2 requires --host claude-code or --host codex-cli"
+            )),
+        }
+    }
+}
+
+/// Workspace identity. v2.1 M1: synthesized from cwd + `git rev-parse
+/// --show-toplevel`, falling back to cwd when the directory is not a git
+/// worktree.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WorkspaceKey {
+    pub root_path: PathBuf,
+}
+
+impl WorkspaceKey {
+    /// Resolve the workspace root for a capture event. Pure: callers pass in
+    /// the cwd and the resolved git toplevel (if any). The caller is
+    /// responsible for invoking git; this keeps the function unit-testable.
+    pub fn from_cwd_and_toplevel(cwd: &Path, git_toplevel: Option<&Path>) -> Self {
+        let root_path = git_toplevel.unwrap_or(cwd).to_path_buf();
+        Self { root_path }
+    }
+}
+
+/// Project identity within a workspace. Defaults to the workspace root, but
+/// may be narrowed via an explicit `--project` label or sub-directory.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProjectKey {
+    pub workspace: WorkspaceKey,
+    pub project_path: PathBuf,
+    pub project_key: String,
+}
+
+impl ProjectKey {
+    pub fn from_workspace(workspace: WorkspaceKey, project_label: Option<&str>) -> Self {
+        let project_path = workspace.root_path.clone();
+        let project_key = project_label
+            .map(str::to_owned)
+            .unwrap_or_else(|| project_path.to_string_lossy().into_owned());
+        Self {
+            workspace,
+            project_path,
+            project_key,
+        }
+    }
+}
+
+/// Session id, supplied by the host payload (Claude Code & Codex both expose
+/// it). Wrapped to avoid mixing it with `event_id` and `turn_id` strings.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionId(pub String);
+
+/// Turn id. Codex provides it on every turn-scoped hook; Claude Code does not,
+/// so remem synthesizes a per-(host, session) monotonic counter (handled in a
+/// later Milestone A step against the `sessions` table).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TurnId(pub String);
+
+/// Event id. Always remem-synthesized: neither Claude Code nor Codex exposes
+/// a stable per-event id. The composition rule keeps it deterministic so that
+/// duplicate hook invocations coalesce on `UNIQUE(host_id, session_id, event_id)`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EventId(pub String);
+
+impl EventId {
+    /// `event_id = "<turn>:<event_name>" + optional ":<tool_use_id>"`.
+    /// `turn` falls back to the literal `no-turn` when the host does not
+    /// expose a turn id (Claude Code outside a single user turn).
+    pub fn synthesize(turn: Option<&TurnId>, event_name: &str, tool_use_id: Option<&str>) -> Self {
+        let turn_part = turn.map(|t| t.0.as_str()).unwrap_or("no-turn");
+        let id = match tool_use_id {
+            Some(t) => format!("{turn_part}:{event_name}:{t}"),
+            None => format!("{turn_part}:{event_name}"),
+        };
+        EventId(id)
+    }
+}
+
+/// Full six-tuple captured at hook entry. The capture path passes this
+/// straight into `captured_events` after resolving foreign keys for host /
+/// workspace / project / session.
+#[derive(Debug, Clone)]
+pub struct CaptureIdentity {
+    pub host: InstallHost,
+    pub workspace: WorkspaceKey,
+    pub project: ProjectKey,
+    pub session_id: SessionId,
+    pub turn_id: Option<TurnId>,
+    pub event_id: EventId,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_host_round_trip() {
+        assert_eq!(InstallHost::parse("claude-code").unwrap(), InstallHost::ClaudeCode);
+        assert_eq!(InstallHost::parse("codex-cli").unwrap(), InstallHost::CodexCli);
+        assert_eq!(InstallHost::ClaudeCode.as_db_value(), "claude-code");
+        assert_eq!(InstallHost::CodexCli.as_db_value(), "codex-cli");
+    }
+
+    #[test]
+    fn install_host_rejects_unknown() {
+        let err = InstallHost::parse("unknown").unwrap_err().to_string();
+        assert!(err.contains("invalid host"));
+        assert!(InstallHost::parse("").is_err());
+    }
+
+    #[test]
+    fn workspace_prefers_git_toplevel_over_cwd() {
+        let cwd = Path::new("/repo/sub/dir");
+        let toplevel = Path::new("/repo");
+        let ws = WorkspaceKey::from_cwd_and_toplevel(cwd, Some(toplevel));
+        assert_eq!(ws.root_path, PathBuf::from("/repo"));
+    }
+
+    #[test]
+    fn workspace_falls_back_to_cwd_when_not_in_git() {
+        let cwd = Path::new("/tmp/scratch");
+        let ws = WorkspaceKey::from_cwd_and_toplevel(cwd, None);
+        assert_eq!(ws.root_path, PathBuf::from("/tmp/scratch"));
+    }
+
+    #[test]
+    fn project_defaults_to_workspace_root_path_string() {
+        let ws = WorkspaceKey::from_cwd_and_toplevel(Path::new("/repo"), None);
+        let project = ProjectKey::from_workspace(ws.clone(), None);
+        assert_eq!(project.project_path, PathBuf::from("/repo"));
+        assert_eq!(project.project_key, "/repo");
+    }
+
+    #[test]
+    fn project_uses_explicit_label_when_provided() {
+        let ws = WorkspaceKey::from_cwd_and_toplevel(Path::new("/repo"), None);
+        let project = ProjectKey::from_workspace(ws, Some("my-project"));
+        assert_eq!(project.project_key, "my-project");
+    }
+
+    #[test]
+    fn event_id_includes_tool_use_id_when_present() {
+        let turn = TurnId("t1".into());
+        let id = EventId::synthesize(Some(&turn), "PostToolUse", Some("tu_42"));
+        assert_eq!(id.0, "t1:PostToolUse:tu_42");
+    }
+
+    #[test]
+    fn event_id_omits_tool_use_id_for_turn_level_events() {
+        let turn = TurnId("t1".into());
+        let id = EventId::synthesize(Some(&turn), "UserPromptSubmit", None);
+        assert_eq!(id.0, "t1:UserPromptSubmit");
+    }
+
+    #[test]
+    fn event_id_uses_no_turn_marker_when_host_lacks_turn() {
+        let id = EventId::synthesize(None, "SessionStart", None);
+        assert_eq!(id.0, "no-turn:SessionStart");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod dream;
 pub mod entity;
 pub mod eval_local;
 pub mod eval_metrics;
+pub mod git_util;
 pub mod identity;
 pub mod install;
 pub mod log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod search_multihop;
 pub mod summarize;
 pub mod temporal;
 pub mod timeline;
+pub mod v2_db;
 pub mod v2_gate;
 pub mod vector;
 pub mod worker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod db_models;
 pub mod db_pending;
 pub mod db_query;
 pub mod db_usage;
+pub mod db_worker;
 pub mod dedup;
 pub mod doctor;
 pub mod dream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod temporal;
 pub mod timeline;
 pub mod v2_db;
 pub mod v2_gate;
+pub mod v2_import;
 pub mod vector;
 pub mod worker;
 pub mod workstream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod timeline;
 pub mod v2_db;
 pub mod v2_gate;
 pub mod v2_import;
+pub mod v2_status;
 pub mod vector;
 pub mod worker;
 pub mod workstream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod search_multihop;
 pub mod summarize;
 pub mod temporal;
 pub mod timeline;
+pub mod v2_gate;
 pub mod vector;
 pub mod worker;
 pub mod workstream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod dream;
 pub mod entity;
 pub mod eval_local;
 pub mod eval_metrics;
+pub mod identity;
 pub mod install;
 pub mod log;
 pub mod mcp;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -7,8 +7,11 @@ mod tests;
 mod tests_convergence;
 mod transition;
 mod types;
+mod v2;
 
 pub(crate) use dry_run::dry_run_pending;
 pub(crate) use run::run_migrations;
+#[allow(unused_imports)]
+pub(crate) use v2::run_v2_migrations;
 #[cfg(test)]
 pub(crate) use types::MIGRATIONS;

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -6,10 +6,11 @@ use super::transition::backfill_to_baseline;
 use super::types::{DryRunResult, Migration, MIGRATIONS, OLD_BASELINE_VERSION};
 
 pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
-    let current_version: i64 = real_conn
+    let raw_current_version: i64 = real_conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap_or(0);
-    let applied = infer_applied_versions(real_conn, current_version)?;
+    let applied = infer_applied_versions(real_conn, raw_current_version)?;
+    let current_version = logical_current_version(raw_current_version, &applied);
 
     let test_conn = Connection::open_in_memory()?;
     if let Err(error) = clone_schema(real_conn, &test_conn) {
@@ -19,7 +20,7 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
             error: Some(format!("schema clone: {}", error)),
         });
     }
-    if current_version >= OLD_BASELINE_VERSION || has_migration_table(real_conn) {
+    if raw_current_version >= OLD_BASELINE_VERSION || has_migration_table(real_conn) {
         if let Err(error) = backfill_to_baseline(&test_conn) {
             return Ok(DryRunResult {
                 current_version,
@@ -85,6 +86,13 @@ fn infer_applied_versions(conn: &Connection, current_version: i64) -> Result<Vec
         return Ok(vec![1]);
     }
     Ok(Vec::new())
+}
+
+fn logical_current_version(raw_current_version: i64, applied: &[i64]) -> i64 {
+    let Some(latest_applied) = applied.iter().max() else {
+        return raw_current_version;
+    };
+    raw_current_version.max(OLD_BASELINE_VERSION - 1 + latest_applied)
 }
 
 fn clone_schema(src: &Connection, dst: &Connection) -> Result<()> {

--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -35,7 +35,10 @@ pub(crate) fn run_migrations(conn: &Connection) -> Result<()> {
         .last()
         .map(|migration| migration.version)
         .unwrap_or(0);
-    let user_version = OLD_BASELINE_VERSION - 1 + latest;
+    let current_user_version: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .unwrap_or(0);
+    let user_version = current_user_version.max(OLD_BASELINE_VERSION - 1 + latest);
     conn.execute_batch(&format!("PRAGMA user_version = {}", user_version))?;
     Ok(())
 }

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -62,10 +62,35 @@ fn full_migration_on_empty_db() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2]);
+    assert_eq!(applied, vec![1, 2, 3, 4]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 14);
+    assert_eq!(user_version, 16);
+
+    let has_worker_heartbeats: bool = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='worker_heartbeats'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+    assert!(
+        has_worker_heartbeats,
+        "worker_heartbeats table should exist after migration"
+    );
+    Ok(())
+}
+
+#[test]
+fn run_migrations_does_not_downgrade_newer_user_version() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    run_migrations(&conn)?;
+    conn.execute_batch("PRAGMA user_version = 99;")?;
+
+    run_migrations(&conn)?;
+
+    let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    assert_eq!(user_version, 99);
     Ok(())
 }
 
@@ -78,7 +103,7 @@ fn transition_from_old_system_skips_baseline() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2]);
+    assert_eq!(applied, vec![1, 2, 3, 4]);
     Ok(())
 }
 
@@ -103,10 +128,10 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
 
     // Should have auto-upgraded and marked baseline + raw_messages as applied
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2]);
+    assert_eq!(applied, vec![1, 2, 3, 4]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 14);
+    assert_eq!(user_version, 16);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -139,13 +164,27 @@ fn dry_run_pending_reports_no_pending_for_current_schema() -> Result<()> {
 }
 
 #[test]
+fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    run_migrations(&conn)?;
+    conn.execute_batch("PRAGMA user_version = 14;")?;
+
+    let result = dry_run_pending(&conn)?;
+
+    assert_eq!(result.current_version, 16);
+    assert_eq!(result.pending_count, 0);
+    assert!(result.error.is_none());
+    Ok(())
+}
+
+#[test]
 fn dry_run_pending_reports_pending_for_new_db() -> Result<()> {
     let conn = Connection::open_in_memory()?;
 
     let result = dry_run_pending(&conn)?;
 
     assert_eq!(result.current_version, 0);
-    assert_eq!(result.pending_count, 2);
+    assert_eq!(result.pending_count, 4);
     assert!(result.error.is_none());
     Ok(())
 }
@@ -204,7 +243,7 @@ fn dry_run_pending_reports_backfill_error_for_broken_schema() -> Result<()> {
     let result = dry_run_pending(&conn)?;
     // After broken baseline backfill fails, dry_run reports the still-unapplied
     // migrations (v2 raw_messages is not yet in _schema_migrations).
-    assert_eq!(result.pending_count, 1);
+    assert_eq!(result.pending_count, 3);
     let error = result
         .error
         .expect("broken schema should surface in dry-run");

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -15,6 +15,16 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "raw_messages",
         sql: include_str!("../migrations/v002_raw_messages.sql"),
     },
+    Migration {
+        version: 3,
+        name: "host_identity",
+        sql: include_str!("../migrations/v003_host_identity.sql"),
+    },
+    Migration {
+        version: 4,
+        name: "worker_heartbeat",
+        sql: include_str!("../migrations/v004_worker_heartbeat.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrate/v2.rs
+++ b/src/migrate/v2.rs
@@ -1,0 +1,149 @@
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+
+const V2_BASELINE_SQL: &str = include_str!("../migrations/v2_001_baseline.sql");
+const V2_SCHEMA_VERSION: i64 = 1;
+
+/// Apply the v2 baseline migration to a fresh `~/.remem/v2.sqlite` connection.
+/// Independent from v1 migrations: the v2 DB file never sees v001-v004.
+pub(crate) fn run_v2_migrations(conn: &Connection) -> Result<()> {
+    let current: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .unwrap_or(0);
+    if current >= V2_SCHEMA_VERSION {
+        return Ok(());
+    }
+    conn.execute_batch(V2_BASELINE_SQL)
+        .context("v2_001_baseline migration failed")?;
+    conn.execute_batch(&format!("PRAGMA user_version = {}", V2_SCHEMA_VERSION))?;
+    crate::log::info("migrate", "applied v2_001_baseline");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_in_memory() -> Connection {
+        Connection::open_in_memory().expect("open in-memory sqlite")
+    }
+
+    fn table_exists(conn: &Connection, name: &str) -> bool {
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                [name],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+        count == 1
+    }
+
+    fn index_exists(conn: &Connection, name: &str) -> bool {
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?1",
+                [name],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+        count == 1
+    }
+
+    #[test]
+    fn v2_baseline_creates_all_tables() {
+        let conn = open_in_memory();
+        run_v2_migrations(&conn).expect("v2 migration");
+        for table in [
+            "hosts",
+            "workspaces",
+            "projects",
+            "sessions",
+            "captured_events",
+            "event_blobs",
+            "extraction_tasks",
+            "session_summaries",
+            "observations",
+            "memory_candidates",
+            "memories",
+            "rule_candidates",
+            "worker_heartbeats",
+        ] {
+            assert!(table_exists(&conn, table), "table {} missing", table);
+        }
+    }
+
+    #[test]
+    fn v2_baseline_creates_memories_fts() {
+        let conn = open_in_memory();
+        run_v2_migrations(&conn).expect("v2 migration");
+        // FTS5 virtual tables show up as 'table' rows in sqlite_master.
+        assert!(table_exists(&conn, "memories_fts"));
+    }
+
+    #[test]
+    fn v2_baseline_creates_critical_indexes() {
+        let conn = open_in_memory();
+        run_v2_migrations(&conn).expect("v2 migration");
+        for idx in [
+            "idx_sessions_host_project_seen",
+            "idx_captured_events_session_event",
+            "idx_extraction_tasks_claim",
+            "idx_extraction_tasks_lease",
+            "idx_memories_topic_unique",
+        ] {
+            assert!(index_exists(&conn, idx), "index {} missing", idx);
+        }
+    }
+
+    #[test]
+    fn v2_baseline_seeds_two_hosts() {
+        let conn = open_in_memory();
+        run_v2_migrations(&conn).expect("v2 migration");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM hosts", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
+        let names: Vec<String> = conn
+            .prepare("SELECT name FROM hosts ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(names, vec!["claude-code", "codex-cli"]);
+    }
+
+    #[test]
+    fn v2_baseline_is_idempotent() {
+        let conn = open_in_memory();
+        run_v2_migrations(&conn).expect("first run");
+        run_v2_migrations(&conn).expect("second run");
+        let host_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM hosts", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(host_count, 2, "seed must not duplicate on re-run");
+    }
+
+    #[test]
+    fn v2_baseline_rejects_unique_topic_collision() {
+        let conn = open_in_memory();
+        run_v2_migrations(&conn).expect("v2 migration");
+        // Insert two memories with same (scope, project_id=NULL, topic_key).
+        // The expression-based unique index must reject the second one.
+        conn.execute(
+            "INSERT INTO memories(project_id, scope, memory_type, topic_key, text,
+             evidence_event_ids, confidence, status, created_at_epoch, updated_at_epoch)
+             VALUES (NULL, 'global', 'preference', 'k1', 't1', '[]', 0.9, 'active', 0, 0)",
+            [],
+        )
+        .unwrap();
+        let dup = conn.execute(
+            "INSERT INTO memories(project_id, scope, memory_type, topic_key, text,
+             evidence_event_ids, confidence, status, created_at_epoch, updated_at_epoch)
+             VALUES (NULL, 'global', 'preference', 'k1', 't2', '[]', 0.9, 'active', 0, 0)",
+            [],
+        );
+        assert!(dup.is_err(), "expected UNIQUE violation on duplicate topic_key");
+    }
+}

--- a/src/migrations/v003_host_identity.sql
+++ b/src/migrations/v003_host_identity.sql
@@ -1,0 +1,11 @@
+ALTER TABLE pending_observations
+ADD COLUMN host TEXT NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE jobs
+ADD COLUMN host TEXT NOT NULL DEFAULT 'unknown';
+
+CREATE INDEX IF NOT EXISTS idx_pending_identity_claim
+ON pending_observations(host, project, session_id, status, next_retry_epoch, lease_expires_epoch, id);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_identity_state
+ON jobs(host, project, session_id, job_type, state, created_at_epoch DESC);

--- a/src/migrations/v004_worker_heartbeat.sql
+++ b/src/migrations/v004_worker_heartbeat.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS worker_heartbeats (
+    owner TEXT PRIMARY KEY,
+    pid INTEGER,
+    started_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_worker_heartbeats_updated
+ON worker_heartbeats(updated_at_epoch DESC);

--- a/src/migrations/v2_001_baseline.sql
+++ b/src/migrations/v2_001_baseline.sql
@@ -1,0 +1,256 @@
+-- v2_001_baseline: full v2 memory-system schema for a fresh ~/.remem/v2.sqlite
+-- file. v1 (~/.remem/remem.db) is untouched. Per SPEC-memory-system-v2-no-compat
+-- §6 + SPEC-memory-system-v2.1-revisions §4 (D1/D2/D4).
+
+PRAGMA foreign_keys = ON;
+
+-- === Identity tables (§6.1-6.4) ===
+
+CREATE TABLE IF NOT EXISTS hosts (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,                  -- claude-code | codex-cli
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workspaces (
+    id INTEGER PRIMARY KEY,
+    root_path TEXT NOT NULL UNIQUE,
+    git_remote TEXT,
+    git_branch TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS projects (
+    id INTEGER PRIMARY KEY,
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_path TEXT NOT NULL,
+    project_key TEXT NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    UNIQUE(workspace_id, project_path)
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_id TEXT NOT NULL,
+    started_at_epoch INTEGER,
+    last_seen_at_epoch INTEGER NOT NULL,
+    status TEXT NOT NULL,                       -- active | stopped | abandoned
+    UNIQUE(host_id, project_id, session_id)
+);
+
+-- === Capture layer (§6.5-6.6) ===
+
+CREATE TABLE IF NOT EXISTS event_blobs (
+    id INTEGER PRIMARY KEY,
+    content_hash TEXT NOT NULL UNIQUE,
+    content_encoding TEXT NOT NULL,             -- plain | gzip
+    content_bytes BLOB NOT NULL,
+    original_bytes INTEGER NOT NULL,
+    stored_bytes INTEGER NOT NULL,
+    created_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS captured_events (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+    session_id TEXT NOT NULL,
+    turn_id TEXT,
+    event_id TEXT NOT NULL,                     -- v2.1 M1: remem-synthesized
+    event_type TEXT NOT NULL,                   -- user_message|assistant_message|tool_call|tool_result|file_edit|session_stop
+    role TEXT,
+    tool_name TEXT,
+    content_text TEXT,                          -- D1: <=16 KiB direct, else prefix/suffix + digest
+    content_blob_id INTEGER REFERENCES event_blobs(id),
+    content_hash TEXT NOT NULL,
+    token_estimate INTEGER NOT NULL DEFAULT 0,
+    retention_class TEXT NOT NULL,              -- raw_keep | raw_compact | raw_drop_candidate | truncated
+    created_at_epoch INTEGER NOT NULL,
+    inserted_at_epoch INTEGER NOT NULL,
+    UNIQUE(host_id, session_id, event_id)
+);
+
+-- === Extraction queue (§6.7) ===
+
+CREATE TABLE IF NOT EXISTS extraction_tasks (
+    id INTEGER PRIMARY KEY,
+    task_kind TEXT NOT NULL,                    -- session_rollup|observation_extract|memory_candidate|rule_candidate|index_update
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER REFERENCES sessions(id),
+    priority INTEGER NOT NULL,
+    status TEXT NOT NULL,                       -- pending|processing|delayed|done|failed
+    idempotency_key TEXT NOT NULL UNIQUE,
+    cursor_event_id INTEGER,
+    high_watermark_event_id INTEGER,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_retry_epoch INTEGER,
+    lease_owner TEXT,
+    lease_expires_epoch INTEGER,
+    last_error TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+-- === Derived knowledge (§6.8-6.9) ===
+
+CREATE TABLE IF NOT EXISTS session_summaries (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+    summary_text TEXT NOT NULL,
+    covered_from_event_id INTEGER NOT NULL,
+    covered_to_event_id INTEGER NOT NULL,
+    model TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    UNIQUE(session_row_id, covered_from_event_id, covered_to_event_id)
+);
+
+CREATE TABLE IF NOT EXISTS observations (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+    observation_type TEXT NOT NULL,             -- action|discovery|error|decision_hint|preference_hint
+    text TEXT NOT NULL,
+    evidence_event_ids TEXT NOT NULL,           -- JSON array of captured_events ids
+    confidence REAL NOT NULL,
+    created_at_epoch INTEGER NOT NULL
+);
+
+-- === Curated memory (§6.10-6.12) ===
+
+CREATE TABLE IF NOT EXISTS memory_candidates (
+    id INTEGER PRIMARY KEY,
+    project_id INTEGER REFERENCES projects(id),
+    scope TEXT NOT NULL,                        -- global|workspace|project
+    memory_type TEXT NOT NULL,                  -- decision|discovery|bugfix|architecture|preference
+    topic_key TEXT NOT NULL,
+    text TEXT NOT NULL,
+    evidence_event_ids TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    risk_class TEXT NOT NULL,                   -- low|medium|high
+    review_status TEXT NOT NULL,                -- auto_promoted|pending_review|approved|edited|discarded
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS memories (
+    id INTEGER PRIMARY KEY,
+    project_id INTEGER REFERENCES projects(id),
+    scope TEXT NOT NULL,
+    memory_type TEXT NOT NULL,
+    topic_key TEXT NOT NULL,
+    text TEXT NOT NULL,
+    evidence_event_ids TEXT NOT NULL,
+    source_candidate_id INTEGER REFERENCES memory_candidates(id),
+    confidence REAL NOT NULL,
+    status TEXT NOT NULL,                       -- active|stale|superseded|rejected
+    stale_after_epoch INTEGER,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS rule_candidates (
+    id INTEGER PRIMARY KEY,
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER REFERENCES projects(id),
+    rule_path TEXT,
+    rule_text TEXT NOT NULL,
+    proposed_diff TEXT,                         -- D4: optional unified diff, plain text is primary
+    evidence_event_ids TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    review_status TEXT NOT NULL,                -- pending_review|approved|discarded|exported
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+-- === Operational (§6.13 with v2.1 M4 mode column) ===
+
+CREATE TABLE IF NOT EXISTS worker_heartbeats (
+    owner TEXT PRIMARY KEY,
+    pid INTEGER,
+    mode TEXT NOT NULL,                         -- daemon | once
+    started_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+-- === Indexes ===
+
+CREATE INDEX IF NOT EXISTS idx_sessions_host_project_seen
+    ON sessions(host_id, project_id, last_seen_at_epoch DESC);
+
+CREATE INDEX IF NOT EXISTS idx_captured_events_session_event
+    ON captured_events(session_row_id, event_id);
+CREATE INDEX IF NOT EXISTS idx_captured_events_project_created
+    ON captured_events(project_id, created_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_captured_events_event_type
+    ON captured_events(event_type, retention_class);
+
+CREATE INDEX IF NOT EXISTS idx_extraction_tasks_claim
+    ON extraction_tasks(host_id, project_id, status, priority, next_retry_epoch, id);
+CREATE INDEX IF NOT EXISTS idx_extraction_tasks_lease
+    ON extraction_tasks(status, lease_expires_epoch);
+CREATE INDEX IF NOT EXISTS idx_extraction_tasks_kind
+    ON extraction_tasks(task_kind, status, created_at_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_observations_session
+    ON observations(session_row_id, created_at_epoch);
+CREATE INDEX IF NOT EXISTS idx_observations_project_type
+    ON observations(project_id, observation_type);
+
+CREATE INDEX IF NOT EXISTS idx_memory_candidates_review
+    ON memory_candidates(review_status, created_at_epoch);
+CREATE INDEX IF NOT EXISTS idx_memory_candidates_project
+    ON memory_candidates(project_id, scope, memory_type);
+
+CREATE INDEX IF NOT EXISTS idx_memories_project_status
+    ON memories(project_id, scope, status, updated_at_epoch DESC);
+-- §6.11 UNIQUE(scope, COALESCE(project_id, 0), topic_key) needs an expression
+-- index, since SQLite UNIQUE table constraints reject expressions.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_topic_unique
+    ON memories(scope, COALESCE(project_id, 0), topic_key);
+
+CREATE INDEX IF NOT EXISTS idx_rule_candidates_review
+    ON rule_candidates(workspace_id, review_status);
+
+CREATE INDEX IF NOT EXISTS idx_session_summaries_session
+    ON session_summaries(session_row_id, covered_from_event_id);
+
+-- === FTS (D2: vector attaches to memories only; FTS still useful) ===
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+    text,
+    content='memories',
+    content_rowid='id',
+    tokenize='trigram'
+);
+
+CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, text) VALUES (new.id, new.text);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, text) VALUES ('delete', old.id, old.text);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, text) VALUES ('delete', old.id, old.text);
+    INSERT INTO memories_fts(rowid, text) VALUES (new.id, new.text);
+END;
+
+-- === Seed hosts (only the two that v2 supports per §4.2 + v2.1 M2) ===
+
+INSERT OR IGNORE INTO hosts(name, enabled, created_at_epoch) VALUES
+    ('claude-code', 1, strftime('%s', 'now')),
+    ('codex-cli', 1, strftime('%s', 'now'));

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -58,6 +58,7 @@ pub async fn observe() -> Result<()> {
     let tool_response_str = event.tool_response.as_ref().map(|value| value.to_string());
     db::enqueue_pending(
         &conn,
+        adapter.name(),
         &event.session_id,
         &event.project,
         &event.tool_name,

--- a/src/observe_flush.rs
+++ b/src/observe_flush.rs
@@ -7,3 +7,5 @@ mod runtime;
 mod task;
 
 pub use batch::flush_pending;
+pub use batch::ObservationDrainOutcome;
+pub(crate) use constants::OBSERVATION_FOLLOW_UP_PRIORITY;

--- a/src/observe_flush/action/helpers.rs
+++ b/src/observe_flush/action/helpers.rs
@@ -8,6 +8,7 @@ pub(crate) fn clone_pending_batch(
         .iter()
         .map(|pending| db::PendingObservation {
             id: pending.id,
+            host: pending.host.clone(),
             session_id: pending.session_id.clone(),
             project: pending.project.clone(),
             tool_name: pending.tool_name.clone(),

--- a/src/observe_flush/batch.rs
+++ b/src/observe_flush/batch.rs
@@ -3,12 +3,49 @@ use anyhow::Result;
 use crate::db;
 
 use super::action::flush_action_batches;
-use super::constants::{FLUSH_BATCH_SIZE, PENDING_LEASE_SECS};
+use super::constants::{
+    FLUSH_BATCH_SIZE, FLUSH_DRAIN_MAX_BATCHES, FLUSH_DRAIN_MAX_SECS, PENDING_LEASE_SECS,
+};
 use super::runtime::pending_retry_backoff_secs;
 use super::task::flush_single_task;
 
-pub async fn flush_pending(session_id: &str, project: &str) -> Result<usize> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObservationDrainOutcome {
+    Drained,
+    NeedsFollowUp,
+}
+
+pub async fn flush_pending(
+    host: &str,
+    session_id: &str,
+    project: &str,
+) -> Result<ObservationDrainOutcome> {
+    let started = std::time::Instant::now();
+    let mut batches = 0usize;
+
+    loop {
+        if batches >= FLUSH_DRAIN_MAX_BATCHES
+            || started.elapsed() >= std::time::Duration::from_secs(FLUSH_DRAIN_MAX_SECS)
+        {
+            return follow_up_if_needed(host, project, session_id);
+        }
+
+        match flush_pending_once(host, session_id, project).await? {
+            0 => return Ok(ObservationDrainOutcome::Drained),
+            _ => batches += 1,
+        }
+    }
+}
+
+async fn flush_pending_once(host: &str, session_id: &str, project: &str) -> Result<usize> {
     let mut conn = db::open_db()?;
+    let recovered = db::release_expired_pending_claims(&conn)?;
+    if recovered > 0 {
+        crate::log::warn(
+            "flush",
+            &format!("released {} expired pending claim(s)", recovered),
+        );
+    }
     let lease_owner = format!(
         "flush-{}-{}-{}",
         std::process::id(),
@@ -17,6 +54,8 @@ pub async fn flush_pending(session_id: &str, project: &str) -> Result<usize> {
     );
     let pending = db::claim_pending(
         &conn,
+        host,
+        project,
         session_id,
         FLUSH_BATCH_SIZE,
         &lease_owner,
@@ -121,4 +160,17 @@ pub async fn flush_pending(session_id: &str, project: &str) -> Result<usize> {
     ));
 
     Ok(total_observations)
+}
+
+fn follow_up_if_needed(
+    host: &str,
+    project: &str,
+    session_id: &str,
+) -> Result<ObservationDrainOutcome> {
+    let conn = db::open_db()?;
+    if db::count_pending_for_identity(&conn, host, project, session_id)? > 0 {
+        Ok(ObservationDrainOutcome::NeedsFollowUp)
+    } else {
+        Ok(ObservationDrainOutcome::Drained)
+    }
 }

--- a/src/observe_flush/constants.rs
+++ b/src/observe_flush/constants.rs
@@ -3,6 +3,12 @@ pub(crate) const TASK_OBSERVATION_PROMPT: &str = include_str!("../../prompts/tas
 
 /// Max events per flush batch (prevents oversized AI input)
 pub(crate) const FLUSH_BATCH_SIZE: usize = 15;
+/// Max flush batches processed by one observation job before scheduling follow-up work.
+pub(crate) const FLUSH_DRAIN_MAX_BATCHES: usize = 4;
+/// Max wall-clock seconds spent draining pending observations in one observation job.
+pub(crate) const FLUSH_DRAIN_MAX_SECS: u64 = 240;
+/// Follow-up observation jobs must not starve summary jobs.
+pub(crate) const OBSERVATION_FOLLOW_UP_PRIORITY: i64 = 150;
 /// On AI timeout, split large batches recursively to improve success rate.
 pub(crate) const FLUSH_RETRY_MIN_BATCH_SIZE: usize = 1;
 /// Pending lease duration for a single flush worker.

--- a/src/observe_flush/task.rs
+++ b/src/observe_flush/task.rs
@@ -151,6 +151,7 @@ mod tests {
     fn make_pending(long_response: String) -> PendingObservation {
         PendingObservation {
             id: 1,
+            host: "codex-cli".to_string(),
             session_id: "sess-test".to_string(),
             project: "test-proj".to_string(),
             tool_name: "Bash".to_string(),

--- a/src/pending_admin/tests.rs
+++ b/src/pending_admin/tests.rs
@@ -5,8 +5,10 @@ use crate::{db, migrate::MIGRATIONS};
 
 fn setup_conn() -> Connection {
     let conn = Connection::open_in_memory().expect("in-memory db should open");
-    conn.execute_batch(MIGRATIONS[0].sql)
-        .expect("baseline schema should load");
+    for migration in MIGRATIONS {
+        conn.execute_batch(migration.sql)
+            .expect("schema migration should load");
+    }
     conn
 }
 
@@ -17,8 +19,17 @@ fn insert_failed_row(
     updated_at_epoch: i64,
     last_error: &str,
 ) -> i64 {
-    let id = db::enqueue_pending(conn, session_id, project, "tool", None, None, None)
-        .expect("pending row should enqueue");
+    let id = db::enqueue_pending(
+        conn,
+        "codex-cli",
+        session_id,
+        project,
+        "tool",
+        None,
+        None,
+        None,
+    )
+    .expect("pending row should enqueue");
     conn.execute(
         "UPDATE pending_observations
          SET status = 'failed',

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -25,25 +25,36 @@ pub async fn summarize() -> Result<()> {
     };
     let cwd = hook.cwd.as_deref().unwrap_or(".");
     let project = db::project_from_cwd(cwd);
+    let host = resolve_hook_host();
     let conn = db::open_db()?;
 
-    enqueue_summary_jobs(&conn, session_id, &project, &input)?;
-    spawn_worker_once()?;
+    enqueue_summary_jobs(&conn, &host, session_id, &project, &input)?;
+    if should_spawn_worker_once(&conn)? {
+        spawn_worker_once()?;
+    } else {
+        crate::log::info(
+            "summarize",
+            "worker daemon heartbeat healthy; skip worker --once",
+        );
+    }
     Ok(())
 }
 
 fn enqueue_summary_jobs(
     conn: &rusqlite::Connection,
+    host: &str,
     session_id: &str,
     project: &str,
     input: &str,
 ) -> Result<()> {
     let obs_payload = serde_json::json!({
+        "host": host,
         "session_id": session_id,
         "project": project,
     });
     db::enqueue_job(
         conn,
+        host,
         db::JobType::Observation,
         project,
         Some(session_id),
@@ -52,13 +63,14 @@ fn enqueue_summary_jobs(
     )?;
     db::enqueue_job(
         conn,
+        host,
         db::JobType::Summary,
         project,
         Some(session_id),
         input,
         100,
     )?;
-    db::enqueue_job(conn, db::JobType::Compress, project, None, "{}", 200)?;
+    db::enqueue_job(conn, host, db::JobType::Compress, project, None, "{}", 200)?;
     crate::log::info(
         "summarize",
         &format!(
@@ -67,6 +79,31 @@ fn enqueue_summary_jobs(
         ),
     );
     Ok(())
+}
+
+fn resolve_hook_host() -> String {
+    if let Ok(host) = std::env::var("REMEM_HOOK_HOST") {
+        if !host.trim().is_empty() {
+            return host;
+        }
+    }
+    if let Ok(host) = std::env::var("REMEM_CONTEXT_HOST") {
+        if !host.trim().is_empty() {
+            return host;
+        }
+    }
+    if let Ok(executor) = std::env::var("REMEM_SUMMARY_EXECUTOR") {
+        match executor.as_str() {
+            "codex-cli" => return "codex-cli".to_string(),
+            "claude-cli" => return "claude-code".to_string(),
+            _ => {}
+        }
+    }
+    "unknown".to_string()
+}
+
+fn should_spawn_worker_once(conn: &rusqlite::Connection) -> Result<bool> {
+    Ok(db::healthy_worker_heartbeat(conn, db::WORKER_HEARTBEAT_HEALTH_SECS)?.is_none())
 }
 
 fn spawn_worker_once() -> Result<()> {
@@ -102,7 +139,9 @@ mod tests {
     use std::ffi::OsStr;
     use std::sync::Mutex;
 
-    use super::configure_worker_executor_env;
+    use crate::db::{self, test_support::ScopedTestDataDir};
+
+    use super::{configure_worker_executor_env, should_spawn_worker_once};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -173,6 +212,45 @@ mod tests {
                 assert_eq!(command_env(&command, "REMEM_SUMMARY_EXECUTOR"), None);
                 assert_eq!(command_env(&command, "REMEM_EXECUTOR"), None);
             },
+        );
+    }
+
+    #[test]
+    fn missing_daemon_uses_stop_fallback_spawn() {
+        let _test_dir = ScopedTestDataDir::new("summary-missing-daemon");
+        let conn = db::open_db().expect("db should open");
+
+        assert!(
+            should_spawn_worker_once(&conn).expect("daemon check should run"),
+            "missing heartbeat should keep worker --once fallback"
+        );
+    }
+
+    #[test]
+    fn healthy_daemon_skips_stop_spawn() {
+        let _test_dir = ScopedTestDataDir::new("summary-healthy-daemon");
+        let conn = db::open_db().expect("db should open");
+        let now = chrono::Utc::now().timestamp();
+        db::upsert_worker_heartbeat(&conn, "worker-daemon", 123, now - 5, now - 5)
+            .expect("heartbeat should insert");
+
+        assert!(
+            !should_spawn_worker_once(&conn).expect("daemon check should run"),
+            "healthy heartbeat should skip worker --once fallback"
+        );
+    }
+
+    #[test]
+    fn stale_daemon_uses_stop_fallback_spawn() {
+        let _test_dir = ScopedTestDataDir::new("summary-stale-daemon");
+        let conn = db::open_db().expect("db should open");
+        let now = chrono::Utc::now().timestamp();
+        db::upsert_worker_heartbeat(&conn, "worker-daemon", 123, now - 900, now - 900)
+            .expect("heartbeat should insert");
+
+        assert!(
+            should_spawn_worker_once(&conn).expect("daemon check should run"),
+            "stale heartbeat should keep worker --once fallback"
         );
     }
 }

--- a/src/v2_db.rs
+++ b/src/v2_db.rs
@@ -51,21 +51,10 @@ pub fn reset_v2_db_at(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use crate::db::test_support::{cleanup_temp_db_files as cleanup, unique_temp_db_path};
 
     fn unique_temp_path() -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let pid = std::process::id();
-        std::env::temp_dir().join(format!("remem-v2-test-{pid}-{nonce}.sqlite"))
-    }
-
-    fn cleanup(path: &Path) {
-        let _ = std::fs::remove_file(path);
-        let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
-        let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+        unique_temp_db_path("v2-db")
     }
 
     #[test]

--- a/src/v2_db.rs
+++ b/src/v2_db.rs
@@ -37,6 +37,17 @@ pub fn open_v2_db() -> Result<Connection> {
     open_v2_db_at(&default_v2_db_path())
 }
 
+/// Drop the v2 database file at `path` (along with WAL/SHM sidecars), then
+/// re-create it via `open_v2_db_at`. Caller is responsible for confirming the
+/// destructive intent (CLI gate is in `admin::run_reset_v2`).
+pub fn reset_v2_db_at(path: &Path) -> Result<()> {
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+    let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    let _ = open_v2_db_at(path)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,6 +103,30 @@ mod tests {
         let path = unique_temp_path();
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         let _c = open_v2_db_at(&path).expect("open should not fail when dir exists");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn reset_drops_existing_v2_data_and_reseeds() {
+        let path = unique_temp_path();
+        {
+            let conn = open_v2_db_at(&path).unwrap();
+            conn.execute(
+                "INSERT INTO hosts(name, enabled, created_at_epoch) VALUES ('extra', 1, 0)",
+                [],
+            )
+            .unwrap();
+            let count: i64 = conn
+                .query_row("SELECT COUNT(*) FROM hosts", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(count, 3, "seeded 2 + extra 1");
+        }
+        reset_v2_db_at(&path).expect("reset");
+        let conn = open_v2_db_at(&path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM hosts", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "after reset only the 2 seed rows remain");
         cleanup(&path);
     }
 }

--- a/src/v2_db.rs
+++ b/src/v2_db.rs
@@ -1,0 +1,97 @@
+//! Open and migrate the v2 database file (`~/.remem/v2.sqlite`). Independent
+//! from src/db/core which manages the v1 file (`remem.db`); both live in the
+//! same data directory so admin commands can locate them together.
+
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+
+use crate::migrate::run_v2_migrations;
+
+const V2_DB_FILENAME: &str = "v2.sqlite";
+
+/// Default path. Reuses `crate::db::data_dir()` so v1 and v2 sit side-by-side
+/// (`~/.remem/remem.db` and `~/.remem/v2.sqlite`).
+pub fn default_v2_db_path() -> PathBuf {
+    crate::db::data_dir().join(V2_DB_FILENAME)
+}
+
+/// Open (creating if missing) the v2 database at `path`, run the v2 baseline
+/// migration, and apply standard pragmas. Idempotent on re-open.
+pub fn open_v2_db_at(path: &Path) -> Result<Connection> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create v2 db parent {}", parent.display()))?;
+    }
+    let conn = Connection::open(path)
+        .with_context(|| format!("open v2 db at {}", path.display()))?;
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
+    )?;
+    run_v2_migrations(&conn)?;
+    Ok(conn)
+}
+
+/// Open the default v2 database (`~/.remem/v2.sqlite`).
+pub fn open_v2_db() -> Result<Connection> {
+    open_v2_db_at(&default_v2_db_path())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_path() -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let pid = std::process::id();
+        std::env::temp_dir().join(format!("remem-v2-test-{pid}-{nonce}.sqlite"))
+    }
+
+    fn cleanup(path: &Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+        let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    }
+
+    #[test]
+    fn open_creates_file_and_applies_v2_baseline() {
+        let path = unique_temp_path();
+        let conn = open_v2_db_at(&path).expect("open v2 db");
+        assert!(path.exists(), "db file should exist at {}", path.display());
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='hosts'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn reopen_is_idempotent() {
+        let path = unique_temp_path();
+        {
+            let _c = open_v2_db_at(&path).expect("first open");
+        }
+        let c = open_v2_db_at(&path).expect("second open");
+        let host_count: i64 = c
+            .query_row("SELECT COUNT(*) FROM hosts", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(host_count, 2, "seed must not duplicate on re-open");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn open_succeeds_after_dir_already_exists() {
+        let path = unique_temp_path();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let _c = open_v2_db_at(&path).expect("open should not fail when dir exists");
+        cleanup(&path);
+    }
+}

--- a/src/v2_gate.rs
+++ b/src/v2_gate.rs
@@ -1,0 +1,163 @@
+//! v2 / v1 schema detection gate.
+//!
+//! v2 lives in `~/.remem/v2.sqlite`, but the same `remem` binary still opens
+//! the legacy `~/.remem/remem.db` for read-only commands. Per
+//! SPEC-memory-system-v2.1-revisions §2 S4, write commands must refuse a
+//! legacy v1 connection with a fixed user-facing message; read-only commands
+//! remain available. This module is the single source of truth for
+//! distinguishing the two database states. Wiring into the CLI router lands
+//! in Milestone A.4.
+
+use anyhow::{anyhow, Context, Result};
+use rusqlite::Connection;
+
+const V2_MARKER_TABLE: &str = "hosts";
+const V1_MARKER_TABLE: &str = "sdk_sessions";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DbKind {
+    Empty,
+    V1Legacy { user_version: i64 },
+    V2 { user_version: i64 },
+}
+
+fn table_exists(conn: &Connection, name: &str) -> Result<bool> {
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+            [name],
+            |row| row.get(0),
+        )
+        .with_context(|| format!("probe sqlite_master for table {name}"))?;
+    Ok(count == 1)
+}
+
+pub fn detect_db_kind(conn: &Connection) -> Result<DbKind> {
+    let user_version: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .unwrap_or(0);
+    let has_v2 = table_exists(conn, V2_MARKER_TABLE)?;
+    let has_v1 = table_exists(conn, V1_MARKER_TABLE)?;
+    match (has_v2, has_v1) {
+        (true, false) => Ok(DbKind::V2 { user_version }),
+        (false, true) => Ok(DbKind::V1Legacy { user_version }),
+        (false, false) => Ok(DbKind::Empty),
+        (true, true) => Err(anyhow!(
+            "DB has both v1 (sdk_sessions) and v2 (hosts) tables; \
+             refusing to operate on a mixed-schema database"
+        )),
+    }
+}
+
+/// Gate for write-side commands. Empty / V2 pass; V1Legacy returns the fixed
+/// user-facing message from v2.1 §2 S4 so every refusal site emits the same
+/// guidance.
+pub fn refuse_v1_for_writes(conn: &Connection) -> Result<()> {
+    match detect_db_kind(conn)? {
+        DbKind::V2 { .. } | DbKind::Empty => Ok(()),
+        DbKind::V1Legacy { user_version } => Err(anyhow!(legacy_refusal_message(user_version))),
+    }
+}
+
+pub fn legacy_refusal_message(user_version: i64) -> String {
+    format!(
+        "Legacy v1 schema detected (user_version={user_version}).\n\
+         Run `remem admin backup` then `remem admin reset-v2 --confirm-destructive` to upgrade.\n\
+         Read-only commands remain available."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_in_memory() -> Connection {
+        Connection::open_in_memory().expect("open in-memory sqlite")
+    }
+
+    fn install_v1_marker(conn: &Connection, user_version: i64) {
+        conn.execute_batch(&format!(
+            "CREATE TABLE sdk_sessions(id INTEGER PRIMARY KEY); \
+             PRAGMA user_version = {user_version};"
+        ))
+        .expect("install v1 marker");
+    }
+
+    fn install_v2_marker(conn: &Connection, user_version: i64) {
+        conn.execute_batch(&format!(
+            "CREATE TABLE hosts(id INTEGER PRIMARY KEY); \
+             PRAGMA user_version = {user_version};"
+        ))
+        .expect("install v2 marker");
+    }
+
+    #[test]
+    fn empty_db_is_classified_as_empty() {
+        let conn = open_in_memory();
+        assert_eq!(detect_db_kind(&conn).unwrap(), DbKind::Empty);
+    }
+
+    #[test]
+    fn v1_baseline_is_classified_as_v1_legacy() {
+        let conn = open_in_memory();
+        install_v1_marker(&conn, 13);
+        assert_eq!(
+            detect_db_kind(&conn).unwrap(),
+            DbKind::V1Legacy { user_version: 13 }
+        );
+    }
+
+    #[test]
+    fn v2_baseline_is_classified_as_v2() {
+        let conn = open_in_memory();
+        install_v2_marker(&conn, 1);
+        assert_eq!(
+            detect_db_kind(&conn).unwrap(),
+            DbKind::V2 { user_version: 1 }
+        );
+    }
+
+    #[test]
+    fn mixed_v1_and_v2_tables_returns_error() {
+        let conn = open_in_memory();
+        install_v1_marker(&conn, 13);
+        // install_v2_marker would reset user_version; here we only need the table.
+        conn.execute_batch("CREATE TABLE hosts(id INTEGER PRIMARY KEY);")
+            .unwrap();
+        let err = detect_db_kind(&conn).unwrap_err().to_string();
+        assert!(err.contains("mixed-schema"), "got: {err}");
+    }
+
+    #[test]
+    fn refuse_passes_on_v2() {
+        let conn = open_in_memory();
+        install_v2_marker(&conn, 1);
+        refuse_v1_for_writes(&conn).expect("v2 must pass");
+    }
+
+    #[test]
+    fn refuse_passes_on_empty() {
+        let conn = open_in_memory();
+        refuse_v1_for_writes(&conn).expect("empty must pass; caller will init");
+    }
+
+    #[test]
+    fn refuse_blocks_v1_with_fixed_message() {
+        let conn = open_in_memory();
+        install_v1_marker(&conn, 4);
+        let err = refuse_v1_for_writes(&conn).unwrap_err().to_string();
+        assert!(err.contains("Legacy v1 schema detected"), "got: {err}");
+        assert!(err.contains("user_version=4"), "got: {err}");
+        assert!(err.contains("remem admin backup"), "got: {err}");
+        assert!(err.contains("remem admin reset-v2"), "got: {err}");
+        assert!(err.contains("Read-only commands remain available"), "got: {err}");
+    }
+
+    #[test]
+    fn legacy_refusal_message_is_deterministic() {
+        let m1 = legacy_refusal_message(4);
+        let m2 = legacy_refusal_message(4);
+        assert_eq!(m1, m2);
+        assert!(m1.contains("user_version=4"));
+    }
+}

--- a/src/v2_import.rs
+++ b/src/v2_import.rs
@@ -138,26 +138,12 @@ fn find_or_create_project(conn: &Connection, project_path: &str) -> Result<(i64,
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::test_support::{cleanup_temp_db_files as cleanup, unique_temp_db_path};
     use crate::v2_db::open_v2_db_at;
     use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn unique_temp_path(label: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        std::env::temp_dir().join(format!(
-            "remem-import-{label}-{}-{}.sqlite",
-            std::process::id(),
-            nonce
-        ))
-    }
-
-    fn cleanup(path: &Path) {
-        let _ = std::fs::remove_file(path);
-        let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
-        let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+        unique_temp_db_path(&format!("import-{label}"))
     }
 
     fn create_v1_db(path: &Path) -> Connection {

--- a/src/v2_import.rs
+++ b/src/v2_import.rs
@@ -1,0 +1,322 @@
+//! v1 -> v2 best-effort data migration. Per
+//! SPEC-memory-system-v2.1-revisions §4 D5, transcripts are NOT replayed by
+//! default. Only the v1 `memories` table is migrated; observations /
+//! pending_observations / events / raw messages are intentionally left out
+//! because they have no clean v2 mapping at the granularity of
+//! `evidence_event_ids` (the v2 provenance contract).
+
+use anyhow::{anyhow, Context, Result};
+use rusqlite::{Connection, OpenFlags};
+use std::path::Path;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ImportStats {
+    pub memories_imported: usize,
+    pub memories_skipped: usize,
+    pub workspaces_created: usize,
+    pub projects_created: usize,
+}
+
+/// Read v1 memories from `v1_path` and INSERT them into the v2 DB connected
+/// as `v2_conn`. Best-effort: rows that violate v2 constraints (e.g. the
+/// unique `(scope, project_id, topic_key)` index) are counted as skipped,
+/// not propagated as an error. Confidence defaults to 0.7 because v1 had no
+/// calibration; `evidence_event_ids` is `'[]'` since v1 did not preserve
+/// event-level provenance.
+pub fn import_legacy_memories(v1_path: &Path, v2_conn: &Connection) -> Result<ImportStats> {
+    if !v1_path.exists() {
+        return Err(anyhow!("source v1 db not found at {}", v1_path.display()));
+    }
+    let v1 = Connection::open_with_flags(v1_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("open v1 source {}", v1_path.display()))?;
+
+    let mut stmt = v1.prepare(
+        "SELECT id, project, topic_key, title, content, memory_type, scope, status,
+                created_at_epoch, updated_at_epoch
+         FROM memories",
+    )?;
+    let mut rows = stmt.query([])?;
+
+    let mut stats = ImportStats::default();
+    while let Some(row) = rows.next()? {
+        let v1_id: i64 = row.get(0)?;
+        let project: String = row.get(1)?;
+        let topic_key: Option<String> = row.get(2).ok();
+        let title: String = row.get(3)?;
+        let content: String = row.get(4)?;
+        let memory_type: String = row.get(5)?;
+        let scope: String = row
+            .get::<_, Option<String>>(6)?
+            .unwrap_or_else(|| "project".to_string());
+        let status: String = row
+            .get::<_, Option<String>>(7)?
+            .unwrap_or_else(|| "active".to_string());
+        let created_at: i64 = row.get(8)?;
+        let updated_at: i64 = row.get(9)?;
+
+        let project_id = if scope == "global" {
+            None
+        } else {
+            let (id, ws_inserted, p_inserted) = find_or_create_project(v2_conn, &project)?;
+            if ws_inserted {
+                stats.workspaces_created += 1;
+            }
+            if p_inserted {
+                stats.projects_created += 1;
+            }
+            Some(id)
+        };
+
+        let topic_key = topic_key.unwrap_or_else(|| format!("legacy-{v1_id}"));
+        let text = match (title.is_empty(), content.is_empty()) {
+            (true, true) => continue,
+            (true, _) => content,
+            (_, true) => title,
+            _ => format!("{title}\n\n{content}"),
+        };
+
+        let result = v2_conn.execute(
+            "INSERT INTO memories(project_id, scope, memory_type, topic_key, text,
+                evidence_event_ids, confidence, status, created_at_epoch, updated_at_epoch)
+             VALUES (?1, ?2, ?3, ?4, ?5, '[]', 0.7, ?6, ?7, ?8)",
+            rusqlite::params![
+                project_id, scope, memory_type, topic_key, text, status, created_at, updated_at
+            ],
+        );
+        match result {
+            Ok(_) => stats.memories_imported += 1,
+            Err(e) => {
+                crate::log::warn(
+                    "import",
+                    &format!("skipped v1 memory id={v1_id}: {e}"),
+                );
+                stats.memories_skipped += 1;
+            }
+        }
+    }
+    Ok(stats)
+}
+
+/// Returns `(project_id, workspace_inserted, project_inserted)`. Looks up
+/// the joined `workspaces`/`projects` row first; on miss, creates the
+/// workspace (if needed) and the project.
+fn find_or_create_project(conn: &Connection, project_path: &str) -> Result<(i64, bool, bool)> {
+    if let Ok(id) = conn.query_row(
+        "SELECT p.id FROM projects p
+         JOIN workspaces w ON w.id = p.workspace_id
+         WHERE w.root_path = ?1 AND p.project_path = ?1",
+        [project_path],
+        |row| row.get::<_, i64>(0),
+    ) {
+        return Ok((id, false, false));
+    }
+    let now = chrono::Utc::now().timestamp();
+    let (ws_id, ws_inserted) = match conn.query_row(
+        "SELECT id FROM workspaces WHERE root_path = ?1",
+        [project_path],
+        |row| row.get::<_, i64>(0),
+    ) {
+        Ok(id) => (id, false),
+        Err(_) => {
+            conn.execute(
+                "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
+                 VALUES (?1, ?2, ?2)",
+                rusqlite::params![project_path, now],
+            )?;
+            (conn.last_insert_rowid(), true)
+        }
+    };
+    conn.execute(
+        "INSERT INTO projects(workspace_id, project_path, project_key,
+            created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?4)",
+        rusqlite::params![ws_id, project_path, project_path, now],
+    )?;
+    Ok((conn.last_insert_rowid(), ws_inserted, true))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v2_db::open_v2_db_at;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "remem-import-{label}-{}-{}.sqlite",
+            std::process::id(),
+            nonce
+        ))
+    }
+
+    fn cleanup(path: &Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+        let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    }
+
+    fn create_v1_db(path: &Path) -> Connection {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE memories (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT,
+                project TEXT NOT NULL,
+                topic_key TEXT,
+                title TEXT NOT NULL,
+                content TEXT NOT NULL,
+                memory_type TEXT NOT NULL,
+                files TEXT,
+                created_at_epoch INTEGER NOT NULL,
+                updated_at_epoch INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                branch TEXT,
+                scope TEXT DEFAULT 'project'
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn missing_source_returns_error() {
+        let v1 = unique_temp_path("missing");
+        let v2 = unique_temp_path("v2-empty");
+        let v2_conn = open_v2_db_at(&v2).unwrap();
+        let err = import_legacy_memories(&v1, &v2_conn).unwrap_err().to_string();
+        assert!(err.contains("not found"), "got: {err}");
+        cleanup(&v2);
+    }
+
+    #[test]
+    fn project_scope_creates_workspace_and_project() {
+        let v1_path = unique_temp_path("v1-proj");
+        let v2_path = unique_temp_path("v2-proj");
+        {
+            let v1 = create_v1_db(&v1_path);
+            v1.execute(
+                "INSERT INTO memories(project, topic_key, title, content, memory_type,
+                  status, scope, created_at_epoch, updated_at_epoch)
+                 VALUES ('/repo/foo', 'topic1', 'title', 'content', 'discovery',
+                  'active', 'project', 100, 200)",
+                [],
+            )
+            .unwrap();
+        }
+        let v2_conn = open_v2_db_at(&v2_path).unwrap();
+        let stats = import_legacy_memories(&v1_path, &v2_conn).unwrap();
+        assert_eq!(stats.memories_imported, 1);
+        assert_eq!(stats.workspaces_created, 1);
+        assert_eq!(stats.projects_created, 1);
+        let mem_count: i64 = v2_conn
+            .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(mem_count, 1);
+        cleanup(&v1_path);
+        cleanup(&v2_path);
+    }
+
+    #[test]
+    fn global_scope_has_null_project_id() {
+        let v1_path = unique_temp_path("v1-glob");
+        let v2_path = unique_temp_path("v2-glob");
+        {
+            let v1 = create_v1_db(&v1_path);
+            v1.execute(
+                "INSERT INTO memories(project, topic_key, title, content, memory_type,
+                  status, scope, created_at_epoch, updated_at_epoch)
+                 VALUES ('/anywhere', 'g1', 'gtitle', 'gcontent', 'preference',
+                  'active', 'global', 100, 200)",
+                [],
+            )
+            .unwrap();
+        }
+        let v2_conn = open_v2_db_at(&v2_path).unwrap();
+        let stats = import_legacy_memories(&v1_path, &v2_conn).unwrap();
+        assert_eq!(stats.memories_imported, 1);
+        assert_eq!(stats.workspaces_created, 0, "global scope skips workspace");
+        let project_id: Option<i64> = v2_conn
+            .query_row("SELECT project_id FROM memories", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(project_id, None);
+        cleanup(&v1_path);
+        cleanup(&v2_path);
+    }
+
+    #[test]
+    fn same_project_reuses_workspace() {
+        let v1_path = unique_temp_path("v1-reuse");
+        let v2_path = unique_temp_path("v2-reuse");
+        {
+            let v1 = create_v1_db(&v1_path);
+            v1.execute(
+                "INSERT INTO memories(project, topic_key, title, content, memory_type,
+                  status, scope, created_at_epoch, updated_at_epoch)
+                 VALUES ('/repo/a', 't1', 'title1', 'c1', 'discovery', 'active', 'project', 100, 200),
+                        ('/repo/a', 't2', 'title2', 'c2', 'bugfix', 'active', 'project', 300, 400)",
+                [],
+            )
+            .unwrap();
+        }
+        let v2_conn = open_v2_db_at(&v2_path).unwrap();
+        let stats = import_legacy_memories(&v1_path, &v2_conn).unwrap();
+        assert_eq!(stats.memories_imported, 2);
+        assert_eq!(stats.workspaces_created, 1);
+        assert_eq!(stats.projects_created, 1);
+        cleanup(&v1_path);
+        cleanup(&v2_path);
+    }
+
+    #[test]
+    fn duplicate_topic_key_is_skipped_not_failed() {
+        let v1_path = unique_temp_path("v1-dup");
+        let v2_path = unique_temp_path("v2-dup");
+        {
+            let v1 = create_v1_db(&v1_path);
+            v1.execute(
+                "INSERT INTO memories(project, topic_key, title, content, memory_type,
+                  status, scope, created_at_epoch, updated_at_epoch)
+                 VALUES ('/repo/x', 'same-topic', 'title1', 'c1', 'discovery', 'active', 'project', 100, 200),
+                        ('/repo/x', 'same-topic', 'title2', 'c2', 'bugfix', 'active', 'project', 300, 400)",
+                [],
+            )
+            .unwrap();
+        }
+        let v2_conn = open_v2_db_at(&v2_path).unwrap();
+        let stats = import_legacy_memories(&v1_path, &v2_conn).unwrap();
+        assert_eq!(stats.memories_imported, 1);
+        assert_eq!(stats.memories_skipped, 1, "second row violates UNIQUE topic");
+        cleanup(&v1_path);
+        cleanup(&v2_path);
+    }
+
+    #[test]
+    fn null_topic_key_is_synthesized() {
+        let v1_path = unique_temp_path("v1-nullkey");
+        let v2_path = unique_temp_path("v2-nullkey");
+        {
+            let v1 = create_v1_db(&v1_path);
+            v1.execute(
+                "INSERT INTO memories(project, title, content, memory_type, status, scope,
+                  created_at_epoch, updated_at_epoch)
+                 VALUES ('/repo/n', 'title', 'content', 'discovery', 'active', 'project', 100, 200)",
+                [],
+            )
+            .unwrap();
+        }
+        let v2_conn = open_v2_db_at(&v2_path).unwrap();
+        let stats = import_legacy_memories(&v1_path, &v2_conn).unwrap();
+        assert_eq!(stats.memories_imported, 1);
+        let topic: String = v2_conn
+            .query_row("SELECT topic_key FROM memories", [], |r| r.get(0))
+            .unwrap();
+        assert!(topic.starts_with("legacy-"), "got: {topic}");
+        cleanup(&v1_path);
+        cleanup(&v2_path);
+    }
+}

--- a/src/v2_status.rs
+++ b/src/v2_status.rs
@@ -1,0 +1,84 @@
+//! Render v2 schema status lines for `remem status` (and later `remem doctor`).
+//! Pure formatting, no DB connection required — only checks for the presence
+//! of the v2 file at `crate::v2_db::default_v2_db_path()`.
+
+use std::path::Path;
+
+use crate::v2_db::default_v2_db_path;
+
+/// Render the v2 status block at the default path (`~/.remem/v2.sqlite`).
+pub fn format_v2_summary() -> Vec<String> {
+    format_v2_summary_at(&default_v2_db_path())
+}
+
+/// Render the v2 status block for an arbitrary path (testable entry).
+pub fn format_v2_summary_at(path: &Path) -> Vec<String> {
+    let mut lines = vec!["v2 schema:".to_string()];
+    if path.exists() {
+        let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        lines.push(format!("  Location: {}", path.display()));
+        lines.push("  Status:   initialized".to_string());
+        lines.push(format!("  Size:     {:.1} MB", size as f64 / 1_048_576.0));
+    } else {
+        lines.push(format!(
+            "  Location: {} (would be created here)",
+            path.display()
+        ));
+        lines.push("  Status:   not initialized".to_string());
+        lines.push(
+            "  Hint:     run `remem admin reset-v2 --confirm-destructive` to create"
+                .to_string(),
+        );
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_marker_path(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "remem-v2-status-{label}-{}-{}.tmp",
+            std::process::id(),
+            nonce
+        ))
+    }
+
+    #[test]
+    fn summary_indicates_initialized_when_path_exists() {
+        let path = unique_marker_path("exists");
+        std::fs::write(&path, b"placeholder").unwrap();
+        let lines = format_v2_summary_at(&path);
+        let body = lines.join("\n");
+        assert!(body.contains("v2 schema:"), "got: {body}");
+        assert!(body.contains("Status:   initialized"), "got: {body}");
+        assert!(body.contains("Size:"), "got: {body}");
+        assert!(!body.contains("not initialized"), "got: {body}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn summary_indicates_not_initialized_when_path_missing() {
+        let path = unique_marker_path("missing");
+        // Ensure absent (best-effort cleanup; nonce already makes it unique).
+        let _ = std::fs::remove_file(&path);
+        let lines = format_v2_summary_at(&path);
+        let body = lines.join("\n");
+        assert!(body.contains("not initialized"), "got: {body}");
+        assert!(body.contains("remem admin reset-v2"), "got: {body}");
+    }
+
+    #[test]
+    fn summary_first_line_is_section_header() {
+        let path = unique_marker_path("hdr");
+        let lines = format_v2_summary_at(&path);
+        assert_eq!(lines[0], "v2 schema:");
+    }
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,16 +1,78 @@
 use anyhow::Result;
 use serde::Deserialize;
+use std::ffi::OsString;
 use tokio::time::{sleep, Duration};
 
 use crate::{db, observe_flush, summarize};
 
 const JOB_LEASE_SECS: i64 = 600;
 const JOB_TIMEOUT_SECS: u64 = 420;
+const STALE_PENDING_AGE_SECS: i64 = 60;
+const STALE_PENDING_SCAN_LIMIT: i64 = 8;
 
 #[derive(Debug, Deserialize)]
 struct ObservationPayload {
+    host: Option<String>,
     session_id: String,
     project: String,
+}
+
+#[derive(Debug, Clone)]
+enum JobOutcome {
+    Done,
+    ObservationNeedsFollowUp {
+        host: String,
+        session_id: String,
+        project: String,
+        payload_json: String,
+    },
+}
+
+struct ScopedExecutorEnv {
+    previous: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl ScopedExecutorEnv {
+    fn for_job(job: &db::Job) -> Self {
+        let Some(executor) = executor_for_host(&job.host) else {
+            return Self {
+                previous: Vec::new(),
+            };
+        };
+        let keys: &[&'static str] = match job.job_type {
+            db::JobType::Observation => &["REMEM_FLUSH_EXECUTOR"],
+            db::JobType::Summary => &["REMEM_SUMMARY_EXECUTOR"],
+            db::JobType::Compress | db::JobType::Dream => &[],
+        };
+        let previous = keys
+            .iter()
+            .map(|key| {
+                let old = std::env::var_os(key);
+                unsafe { std::env::set_var(key, executor) };
+                (*key, old)
+            })
+            .collect();
+        Self { previous }
+    }
+}
+
+impl Drop for ScopedExecutorEnv {
+    fn drop(&mut self) {
+        for (key, old) in self.previous.iter().rev() {
+            match old {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+    }
+}
+
+fn executor_for_host(host: &str) -> Option<&'static str> {
+    match host {
+        "codex-cli" => Some("codex-cli"),
+        "claude-code" => Some("claude-cli"),
+        _ => None,
+    }
 }
 
 fn retry_backoff_secs(attempt: i64) -> i64 {
@@ -24,20 +86,80 @@ fn retry_backoff_secs(attempt: i64) -> i64 {
     }
 }
 
-async fn process_job(job: &db::Job) -> Result<()> {
+fn enqueue_stale_observation_jobs(conn: &rusqlite::Connection) -> Result<usize> {
+    let identities =
+        db::get_stale_pending_identities(conn, STALE_PENDING_AGE_SECS, STALE_PENDING_SCAN_LIMIT)?;
+    let mut queued = 0usize;
+    for identity in identities {
+        let payload = serde_json::json!({
+            "host": identity.host.as_str(),
+            "session_id": identity.session_id.as_str(),
+            "project": identity.project.as_str(),
+        });
+        db::enqueue_job(
+            conn,
+            &identity.host,
+            db::JobType::Observation,
+            &identity.project,
+            Some(&identity.session_id),
+            &payload.to_string(),
+            observe_flush::OBSERVATION_FOLLOW_UP_PRIORITY,
+        )?;
+        queued += 1;
+    }
+    Ok(queued)
+}
+
+fn record_worker_heartbeat(
+    conn: &rusqlite::Connection,
+    lease_owner: &str,
+    started_at_epoch: i64,
+) -> Result<()> {
+    db::upsert_worker_heartbeat(
+        conn,
+        lease_owner,
+        i64::from(std::process::id()),
+        started_at_epoch,
+        chrono::Utc::now().timestamp(),
+    )
+}
+
+async fn process_job(job: &db::Job) -> Result<JobOutcome> {
     match job.job_type {
         db::JobType::Observation => {
             let payload: ObservationPayload = serde_json::from_str(&job.payload_json)?;
-            let _ = observe_flush::flush_pending(&payload.session_id, &payload.project).await?;
-            Ok(())
+            let host = payload.host.unwrap_or_else(|| job.host.clone());
+            let outcome =
+                observe_flush::flush_pending(&host, &payload.session_id, &payload.project).await?;
+            match outcome {
+                observe_flush::ObservationDrainOutcome::Drained => Ok(JobOutcome::Done),
+                observe_flush::ObservationDrainOutcome::NeedsFollowUp => {
+                    Ok(JobOutcome::ObservationNeedsFollowUp {
+                        host,
+                        session_id: payload.session_id,
+                        project: payload.project,
+                        payload_json: job.payload_json.clone(),
+                    })
+                }
+            }
         }
-        db::JobType::Summary => summarize::process_summary_job_input(&job.payload_json).await,
-        db::JobType::Compress => summarize::process_compress_job(&job.project).await,
-        db::JobType::Dream => crate::dream::process_dream_job(&job.project).await,
+        db::JobType::Summary => {
+            summarize::process_summary_job_input(&job.payload_json).await?;
+            Ok(JobOutcome::Done)
+        }
+        db::JobType::Compress => {
+            summarize::process_compress_job(&job.project).await?;
+            Ok(JobOutcome::Done)
+        }
+        db::JobType::Dream => {
+            crate::dream::process_dream_job(&job.project).await?;
+            Ok(JobOutcome::Done)
+        }
     }
 }
 
 pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
+    let started_at_epoch = chrono::Utc::now().timestamp();
     let lease_owner = format!(
         "worker-{}-{}",
         std::process::id(),
@@ -47,9 +169,26 @@ pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
 
     loop {
         let mut conn = db::open_db()?;
+        if !once {
+            record_worker_heartbeat(&conn, &lease_owner, started_at_epoch)?;
+        }
         let recovered = db::requeue_stuck_jobs(&conn)?;
         if recovered > 0 {
             crate::log::warn("worker", &format!("requeued {} stuck job(s)", recovered));
+        }
+        let recovered_pending = db::release_expired_pending_claims(&conn)?;
+        if recovered_pending > 0 {
+            crate::log::warn(
+                "worker",
+                &format!("released {} expired pending claim(s)", recovered_pending),
+            );
+        }
+        let queued_stale = enqueue_stale_observation_jobs(&conn)?;
+        if queued_stale > 0 {
+            crate::log::info(
+                "worker",
+                &format!("queued {} stale observation job(s)", queued_stale),
+            );
         }
 
         let Some(job) = db::claim_next_job(&mut conn, &lease_owner, JOB_LEASE_SECS)? else {
@@ -72,13 +211,36 @@ pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
             ),
         );
 
+        let scoped_executor = ScopedExecutorEnv::for_job(&job);
         let timed =
             tokio::time::timeout(Duration::from_secs(JOB_TIMEOUT_SECS), process_job(&job)).await;
+        drop(scoped_executor);
         let conn = db::open_db()?;
         match timed {
-            Ok(Ok(())) => {
+            Ok(Ok(outcome)) => {
                 db::mark_job_done(&conn, job.id, &lease_owner)?;
                 crate::log::info("worker", &format!("done id={}", job.id));
+                if let JobOutcome::ObservationNeedsFollowUp {
+                    host,
+                    session_id,
+                    project,
+                    payload_json,
+                } = outcome
+                {
+                    let follow_up_id = db::enqueue_job(
+                        &conn,
+                        &host,
+                        db::JobType::Observation,
+                        &project,
+                        Some(&session_id),
+                        &payload_json,
+                        observe_flush::OBSERVATION_FOLLOW_UP_PRIORITY,
+                    )?;
+                    crate::log::info(
+                        "worker",
+                        &format!("queued observation follow-up id={}", follow_up_id),
+                    );
+                }
             }
             Ok(Err(e)) => {
                 let msg = e.to_string();
@@ -106,6 +268,10 @@ pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
         }
     }
 
+    if !once {
+        let conn = db::open_db()?;
+        record_worker_heartbeat(&conn, &lease_owner, started_at_epoch)?;
+    }
     crate::log::info("worker", "stopped");
     Ok(())
 }
@@ -216,7 +382,7 @@ EOF
             .expect("stub codex path should be valid utf-8");
         let _env = ScopedEnv::set(&[
             ("REMEM_EXECUTOR", None),
-            ("REMEM_SUMMARY_EXECUTOR", Some("codex-cli")),
+            ("REMEM_SUMMARY_EXECUTOR", None),
             ("REMEM_FLUSH_EXECUTOR", None),
             ("REMEM_CODEX_PATH", Some(stub_codex_str)),
             ("REMEM_CLAUDE_PATH", Some("/definitely/missing/claude")),
@@ -227,6 +393,7 @@ EOF
         let conn = db::open_db()?;
         db::enqueue_pending(
             &conn,
+            "codex-cli",
             "sess-codex",
             "proj-codex",
             "Bash",
@@ -236,10 +403,11 @@ EOF
         )?;
         let job_id = db::enqueue_job(
             &conn,
+            "codex-cli",
             db::JobType::Observation,
             "proj-codex",
             Some("sess-codex"),
-            r#"{"session_id":"sess-codex","project":"proj-codex"}"#,
+            r#"{"host":"codex-cli","session_id":"sess-codex","project":"proj-codex"}"#,
             50,
         )?;
 
@@ -282,5 +450,181 @@ EOF
 
         let _ = std::fs::remove_file(&stub_codex);
         test_result
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn worker_drains_multiple_observation_batches() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-drain-multiple");
+        let stub_codex = std::env::temp_dir().join(format!(
+            "remem-test-codex-drain-{}-{}.sh",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        install_stub_codex(&stub_codex);
+        let stub_codex_str = stub_codex
+            .as_os_str()
+            .to_str()
+            .expect("stub codex path should be valid utf-8");
+        let _env = ScopedEnv::set(&[
+            ("REMEM_EXECUTOR", None),
+            ("REMEM_SUMMARY_EXECUTOR", None),
+            ("REMEM_FLUSH_EXECUTOR", None),
+            ("REMEM_CODEX_PATH", Some(stub_codex_str)),
+            ("REMEM_CLAUDE_PATH", Some("/definitely/missing/claude")),
+            ("ANTHROPIC_API_KEY", None),
+            ("ANTHROPIC_AUTH_TOKEN", None),
+        ]);
+
+        let conn = db::open_db()?;
+        for idx in 0..20 {
+            db::enqueue_pending(
+                &conn,
+                "codex-cli",
+                "sess-drain",
+                "proj-drain",
+                "Bash",
+                Some(&format!("echo codex {idx}")),
+                Some("codex output"),
+                None,
+            )?;
+        }
+        let job_id = db::enqueue_job(
+            &conn,
+            "codex-cli",
+            db::JobType::Observation,
+            "proj-drain",
+            Some("sess-drain"),
+            r#"{"host":"codex-cli","session_id":"sess-drain","project":"proj-drain"}"#,
+            50,
+        )?;
+
+        let test_result = async {
+            run(true, 10).await?;
+
+            let conn = db::open_db()?;
+            let pending_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM pending_observations WHERE session_id = ?1",
+                params!["sess-drain"],
+                |row| row.get(0),
+            )?;
+            let observation_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM observations WHERE project = ?1",
+                params!["proj-drain"],
+                |row| row.get(0),
+            )?;
+            let flush_calls: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM ai_usage_events WHERE operation = 'flush'",
+                [],
+                |row| row.get(0),
+            )?;
+            let job_state: String = conn.query_row(
+                "SELECT state FROM jobs WHERE id = ?1",
+                params![job_id],
+                |row| row.get(0),
+            )?;
+
+            anyhow::ensure!(pending_count == 0, "expected all pending rows to drain");
+            anyhow::ensure!(observation_count > 0, "expected persisted observations");
+            anyhow::ensure!(flush_calls >= 2, "expected multiple flush batches");
+            anyhow::ensure!(job_state == "done", "expected job done, got {job_state}");
+
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+
+        let _ = std::fs::remove_file(&stub_codex);
+        test_result
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn worker_schedules_stale_pending_observation_job() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-stale-scheduler");
+        let stub_codex = std::env::temp_dir().join(format!(
+            "remem-test-codex-stale-{}-{}.sh",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        install_stub_codex(&stub_codex);
+        let stub_codex_str = stub_codex
+            .as_os_str()
+            .to_str()
+            .expect("stub codex path should be valid utf-8");
+        let _env = ScopedEnv::set(&[
+            ("REMEM_EXECUTOR", None),
+            ("REMEM_SUMMARY_EXECUTOR", None),
+            ("REMEM_FLUSH_EXECUTOR", None),
+            ("REMEM_CODEX_PATH", Some(stub_codex_str)),
+            ("REMEM_CLAUDE_PATH", Some("/definitely/missing/claude")),
+            ("ANTHROPIC_API_KEY", None),
+            ("ANTHROPIC_AUTH_TOKEN", None),
+        ]);
+
+        let conn = db::open_db()?;
+        let pending_id = db::enqueue_pending(
+            &conn,
+            "codex-cli",
+            "sess-stale",
+            "proj-stale",
+            "Bash",
+            Some("echo stale"),
+            Some("codex output"),
+            None,
+        )?;
+        conn.execute(
+            "UPDATE pending_observations
+             SET created_at_epoch = ?2, updated_at_epoch = ?2
+             WHERE id = ?1",
+            params![pending_id, chrono::Utc::now().timestamp() - 120],
+        )?;
+
+        let test_result = async {
+            run(true, 10).await?;
+
+            let conn = db::open_db()?;
+            let pending_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM pending_observations WHERE session_id = ?1",
+                params!["sess-stale"],
+                |row| row.get(0),
+            )?;
+            let done_jobs: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM jobs
+                 WHERE job_type = 'observation' AND state = 'done' AND session_id = ?1",
+                params!["sess-stale"],
+                |row| row.get(0),
+            )?;
+
+            anyhow::ensure!(pending_count == 0, "expected stale pending row to drain");
+            anyhow::ensure!(done_jobs == 1, "expected one scheduled observation job");
+
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+
+        let _ = std::fs::remove_file(&stub_codex);
+        test_result
+    }
+
+    #[tokio::test]
+    async fn worker_heartbeat_updates_in_loop() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-heartbeat-loop");
+
+        let timed =
+            tokio::time::timeout(std::time::Duration::from_millis(40), run(false, 10)).await;
+        anyhow::ensure!(timed.is_err(), "daemon worker should keep running");
+        let conn = db::open_db()?;
+        let heartbeat = db::latest_worker_heartbeat(&conn)?;
+        let heartbeat = heartbeat.expect("daemon worker should emit heartbeat");
+        anyhow::ensure!(
+            heartbeat.owner.starts_with("worker-"),
+            "unexpected heartbeat owner {}",
+            heartbeat.owner
+        );
+        anyhow::ensure!(
+            heartbeat.updated_at_epoch >= heartbeat.started_at_epoch,
+            "heartbeat should advance updated_at_epoch"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Lands the v2 memory system Milestone A on top of the 5/5 observation-drain
SPEC work. v2 lives entirely in a separate `~/.remem/v2.sqlite`; v1
(`remem.db`) is untouched. Both files share `data_dir()` so admin
commands locate them together.

11 commits split across:

- `feat(worker)`: 5/5 SPEC Phase 1-3 implementation (1 commit)
- `docs`: v2 / v2.1 SPEC baseline freeze + AGENTS.md (1 commit)
- `feat(v2)`: Milestone A subrounds A.1-A.6 + A.8 (8 commits)
- `refactor(test)`: extract `unique_temp_db_path` helper (1 commit)

### Highlights

- **13-table v2 schema** (hosts/workspaces/projects/sessions/captured_events/event_blobs/extraction_tasks/session_summaries/observations/memory_candidates/memories/rule_candidates/worker_heartbeats), seeded with the two install-permitted hosts (claude-code, codex-cli)
- **Typed identity** (`InstallHost` — strict, no Unknown; `WorkspaceKey::from_cwd` git toplevel resolver; `EventId` six-tuple synthesis rule per v2.1 M1)
- **Admin commands**: `remem admin backup` / `remem admin reset-v2 --confirm-destructive` / `remem import legacy --source <path> --best-effort`
- **Legacy gate**: write commands refuse on v1 schema with the fixed v2.1 §2 S4 message; read-only commands (status/doctor/search/show) remain available
- **Status**: `remem status` shows a v2 schema block (initialized / not initialized + hint)

### Reference docs (now committed)

- `SPEC-memory-system-v2-no-compat-2026-05-08.md` — main v2 SPEC (proposed, breaking)
- `SPEC-memory-system-v2.1-revisions-2026-05-08.md` — patch doc with M1-M5 must-fix, S1-S4 should-fix, N1-N2 nice-to-have, and §17 D1/D2/D4/D5 open decisions resolved
- `SPEC-observation-drain-scheduler-2026-05-05.md` — superseded by v2 but its Phase 1-3 implementation ships in this PR

### Open Decisions resolved (v2.1 §4)

- **D1** `captured_events.content_text`: ≤16 KiB direct; 16-256 KiB stores prefix/suffix + digest in `event_blobs`; >256 KiB gzip
- **D2** vector index attaches to `memories` only, not `observations`
- **D4** `rule_candidates.proposed_diff TEXT` (nullable) — plain text primary path
- **D5** legacy import does NOT replay transcripts by default

### Deferred (out of Milestone A scope)

- A.7 `install --host` injection — deferred to Milestone B (depends on observe/summarize accepting `--host`, which is the capture path)
- `remem doctor` v2 schema lines — status only this PR
- Encrypted v1 db handling in `import legacy` (current path is `OPEN_READ_ONLY`; sqlcipher-keyed v1 dbs not yet supported)
- v2.1 §3 N1 promotion threshold calibration — Milestone B Phase 4

## Test plan

- [x] `cargo test --lib` passes 352 tests (303 baseline + 49 across 5/5 + v2 work + cleanup; 0 failed)
- [ ] Manual: run `remem status` against v1-only environment — expect v2 section showing "not initialized"
- [ ] Manual: `remem admin reset-v2 --confirm-destructive` creates `~/.remem/v2.sqlite` with 13 tables
- [ ] Manual: `remem admin backup` writes a timestamped sqlite under `~/.remem/backups/`
- [ ] Manual: `remem import legacy --source <backup> --best-effort` migrates v1 memories into v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)