### PR TITLE
fix(admin): unlock encrypted v1 backup and import

### DIFF
--- a/src/cli/actions/admin.rs
+++ b/src/cli/actions/admin.rs
@@ -63,17 +63,53 @@ pub fn backup_db(src_path: &Path, dst_path: &Path) -> Result<()> {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create backup dir {}", parent.display()))?;
     }
-    let src = Connection::open(src_path)
+    let mut src = Connection::open(src_path)
         .with_context(|| format!("open source db {}", src_path.display()))?;
+    let has_cipher_key = crate::db::apply_cipher_key_if_available(&src)
+        .with_context(|| format!("unlock source db {}", src_path.display()))?;
+    if has_cipher_key {
+        if crate::db::can_read_schema(&src) {
+            backup_encrypted_db(&src, dst_path)?;
+            return Ok(());
+        }
+        drop(src);
+        src = Connection::open(src_path)
+            .with_context(|| format!("reopen unencrypted source db {}", src_path.display()))?;
+    }
     src.backup(DatabaseName::Main, dst_path, None)
         .with_context(|| format!("write backup to {}", dst_path.display()))?;
+    Ok(())
+}
+
+fn backup_encrypted_db(src: &Connection, dst_path: &Path) -> Result<()> {
+    if dst_path.exists() {
+        anyhow::bail!(
+            "backup destination already exists at {}",
+            dst_path.display()
+        );
+    }
+    let dst = dst_path.to_str().ok_or_else(|| {
+        anyhow::anyhow!(
+            "backup destination path is not valid UTF-8: {}",
+            dst_path.display()
+        )
+    })?;
+    if dst.contains('\0') {
+        anyhow::bail!(
+            "backup destination path contains a NUL byte: {}",
+            dst_path.display()
+        );
+    }
+    let dst_lit = dst.replace('\'', "''");
+    src.execute(&format!("VACUUM INTO '{dst_lit}'"), [])
+        .with_context(|| format!("write encrypted backup to {}", dst_path.display()))?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
+    use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path, ScopedTestDataDir};
     use chrono::TimeZone;
 
     fn unique_temp_path() -> PathBuf {
@@ -84,6 +120,17 @@ mod tests {
         for p in paths {
             cleanup_temp_db_files(p);
         }
+    }
+
+    fn create_encrypted_test_db(path: &Path, key: &str) {
+        let conn = Connection::open(path).expect("open encrypted test db");
+        conn.pragma_update(None, "key", key)
+            .expect("apply test key");
+        conn.execute_batch(
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); \
+             INSERT INTO t(id, v) VALUES (42, 'hello-encrypted');",
+        )
+        .expect("seed encrypted test db");
     }
 
     #[test]
@@ -114,6 +161,28 @@ mod tests {
             .unwrap();
         assert_eq!(v, "hello");
         cleanup_paths(&[&src, &dst]);
+    }
+
+    #[test]
+    fn backup_copies_encrypted_source_with_cipher_key() {
+        let test_dir = ScopedTestDataDir::new("admin-encrypted-backup");
+        std::fs::create_dir_all(&test_dir.path).unwrap();
+        let key = "backup-test-key";
+        std::fs::write(test_dir.path.join(".key"), key).unwrap();
+        let src = test_dir.db_path();
+        let dst = test_dir.path.join("backup.sqlite");
+        create_encrypted_test_db(&src, key);
+
+        backup_db(&src, &dst).expect("encrypted backup");
+
+        let restored = Connection::open(&dst).unwrap();
+        restored
+            .pragma_update(None, "key", key)
+            .expect("apply backup key");
+        let v: String = restored
+            .query_row("SELECT v FROM t WHERE id = 42", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(v, "hello-encrypted");
     }
 
     #[test]

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -67,9 +67,7 @@ pub fn open_db() -> Result<Connection> {
     let conn = Connection::open(&path)
         .with_context(|| format!("Failed to open database: {}", path.display()))?;
 
-    if let Some(key) = super::crypto::load_cipher_key() {
-        conn.pragma_update(None, "key", &key)?;
-    }
+    super::crypto::apply_cipher_key_if_available(&conn)?;
 
     conn.execute_batch(
         "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",

--- a/src/db/crypto.rs
+++ b/src/db/crypto.rs
@@ -20,6 +20,21 @@ pub(super) fn load_cipher_key() -> Option<String> {
     None
 }
 
+pub(crate) fn apply_cipher_key_if_available(conn: &Connection) -> Result<bool> {
+    if let Some(key) = load_cipher_key() {
+        conn.pragma_update(None, "key", &key)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+pub(crate) fn can_read_schema(conn: &Connection) -> bool {
+    conn.query_row("SELECT COUNT(*) FROM sqlite_master", [], |row| {
+        row.get::<_, i64>(0)
+    })
+    .is_ok()
+}
+
 pub fn generate_cipher_key() -> Result<String> {
     generate_cipher_key_with(getrandom::fill)
 }

--- a/src/v2_import.rs
+++ b/src/v2_import.rs
@@ -27,8 +27,15 @@ pub fn import_legacy_memories(v1_path: &Path, v2_conn: &Connection) -> Result<Im
     if !v1_path.exists() {
         return Err(anyhow!("source v1 db not found at {}", v1_path.display()));
     }
-    let v1 = Connection::open_with_flags(v1_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+    let mut v1 = Connection::open_with_flags(v1_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| format!("open v1 source {}", v1_path.display()))?;
+    let has_cipher_key = crate::db::apply_cipher_key_if_available(&v1)
+        .with_context(|| format!("unlock v1 source {}", v1_path.display()))?;
+    if has_cipher_key && !crate::db::can_read_schema(&v1) {
+        drop(v1);
+        v1 = Connection::open_with_flags(v1_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .with_context(|| format!("reopen unencrypted v1 source {}", v1_path.display()))?;
+    }
 
     let mut stmt = v1.prepare(
         "SELECT id, project, topic_key, title, content, memory_type, scope, status,
@@ -173,6 +180,30 @@ mod tests {
         conn
     }
 
+    fn create_encrypted_v1_db(path: &Path, key: &str) -> Connection {
+        let conn = Connection::open(path).unwrap();
+        conn.pragma_update(None, "key", key).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE memories (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT,
+                project TEXT NOT NULL,
+                topic_key TEXT,
+                title TEXT NOT NULL,
+                content TEXT NOT NULL,
+                memory_type TEXT NOT NULL,
+                files TEXT,
+                created_at_epoch INTEGER NOT NULL,
+                updated_at_epoch INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                branch TEXT,
+                scope TEXT DEFAULT 'project'
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
     #[test]
     fn missing_source_returns_error() {
         let v1 = unique_temp_path("missing");
@@ -211,6 +242,37 @@ mod tests {
         assert_eq!(mem_count, 1);
         cleanup(&v1_path);
         cleanup(&v2_path);
+    }
+
+    #[test]
+    fn imports_encrypted_v1_with_cipher_key() {
+        let test_dir = crate::db::test_support::ScopedTestDataDir::new("v2-import-encrypted");
+        std::fs::create_dir_all(&test_dir.path).unwrap();
+        let key = "import-test-key";
+        std::fs::write(test_dir.path.join(".key"), key).unwrap();
+        let v1_path = test_dir.path.join("legacy.sqlite");
+        let v2_path = test_dir.path.join("v2.sqlite");
+        {
+            let v1 = create_encrypted_v1_db(&v1_path, key);
+            v1.execute(
+                "INSERT INTO memories(project, topic_key, title, content, memory_type,
+                  status, scope, created_at_epoch, updated_at_epoch)
+                 VALUES ('/repo/encrypted', 'encrypted-topic', 'encrypted title',
+                  'encrypted content', 'discovery', 'active', 'project', 100, 200)",
+                [],
+            )
+            .unwrap();
+        }
+
+        let v2_conn = open_v2_db_at(&v2_path).unwrap();
+        let stats = import_legacy_memories(&v1_path, &v2_conn).unwrap();
+
+        assert_eq!(stats.memories_imported, 1);
+        let text: String = v2_conn
+            .query_row("SELECT text FROM memories", [], |r| r.get(0))
+            .unwrap();
+        assert!(text.contains("encrypted title"), "got: {text}");
+        assert!(text.contains("encrypted content"), "got: {text}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- share cipher-key application through db::apply_cipher_key_if_available
- let admin backup unlock encrypted v1 databases and use VACUUM INTO because rusqlite backup is unsupported for SQLCipher connections
- let v2 import unlock encrypted v1 source databases before reading memories
- add regression tests for encrypted admin backup and encrypted v1 import

Closes #99
Closes #101

## Test plan
- cargo fmt --check
- cargo test --lib cli::actions::admin
- cargo test --lib v2_import
- cargo test --lib db::crypto
- cargo check
- cargo test --lib