### PR TITLE
Add memory extraction capture queue and worker loop

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,0 +1,15 @@
+//! v2 capture-path entry point. Wraps the conversion from a host-supplied
+//! hook event into a `captured_events` row, resolving the foreign keys for
+//! host / workspace / project / session along the way. Hook adapters and
+//! the v2 capture command consume this; nothing else should INSERT into
+//! `captured_events` directly.
+//!
+//! See SPEC-memory-system-v2-no-compat §6.5 (captured_events) and §7
+//! (capture path) plus SPEC-memory-system-v2.1-revisions §4 D1 for the
+//! `content_text` storage policy.
+
+mod insert;
+mod types;
+
+pub use insert::{ensure_session, insert_captured_event};
+pub use types::NormalizedEvent;

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,12 +1,8 @@
-//! v2 capture-path entry point. Wraps the conversion from a host-supplied
+//! Capture-path entry point. Wraps the conversion from a host-supplied
 //! hook event into a `captured_events` row, resolving the foreign keys for
 //! host / workspace / project / session along the way. Hook adapters and
-//! the v2 capture command consume this; nothing else should INSERT into
+//! the capture command consume this; nothing else should INSERT into
 //! `captured_events` directly.
-//!
-//! See SPEC-memory-system-v2-no-compat §6.5 (captured_events) and §7
-//! (capture path) plus SPEC-memory-system-v2.1-revisions §4 D1 for the
-//! `content_text` storage policy.
 
 mod blob;
 mod insert;

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -8,6 +8,7 @@
 //! (capture path) plus SPEC-memory-system-v2.1-revisions §4 D1 for the
 //! `content_text` storage policy.
 
+mod blob;
 mod insert;
 mod types;
 

--- a/src/capture/blob.rs
+++ b/src/capture/blob.rs
@@ -1,7 +1,6 @@
-//! `event_blobs` writer for the v2 capture path. SPEC-memory-system-v2.1
-//! §4 D1 spills oversize content out of the inline `content_text` column
-//! and into this table; B.1.x stores plain bytes, B.1.y will add gzip for
-//! payloads above 256 KiB.
+//! `event_blobs` writer for the capture path. Oversize content is stored
+//! outside the inline `content_text` column while the event row keeps a
+//! compact preview.
 
 use anyhow::Result;
 use rusqlite::{params, Connection, OptionalExtension};
@@ -59,18 +58,18 @@ pub fn summarize_oversize(content: &str, prefix_bytes: usize, suffix_bytes: usiz
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::schema::open_at as open_schema_at;
     use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
-    use crate::v2_db::open_v2_db_at;
 
-    fn open_v2() -> (rusqlite::Connection, std::path::PathBuf) {
+    fn open_schema() -> (rusqlite::Connection, std::path::PathBuf) {
         let path = unique_temp_db_path("blob");
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
         (conn, path)
     }
 
     #[test]
     fn insert_blob_writes_row_with_plain_encoding() {
-        let (conn, path) = open_v2();
+        let (conn, path) = open_schema();
         let bytes = b"hello world";
         let id = insert_or_get_blob(&conn, "h1", bytes, 100).unwrap();
         assert!(id > 0);
@@ -83,13 +82,13 @@ mod tests {
             .unwrap();
         assert_eq!(encoding, "plain");
         assert_eq!(original, bytes.len() as i64);
-        assert_eq!(stored, original, "B.1.x stores plain — no compression");
+        assert_eq!(stored, original, "plain storage keeps byte counts aligned");
         cleanup_temp_db_files(&path);
     }
 
     #[test]
     fn duplicate_hash_dedupes_to_same_row() {
-        let (conn, path) = open_v2();
+        let (conn, path) = open_schema();
         let id1 = insert_or_get_blob(&conn, "dup", b"payload", 100).unwrap();
         let id2 = insert_or_get_blob(&conn, "dup", b"payload", 200).unwrap();
         assert_eq!(id1, id2);
@@ -106,7 +105,10 @@ mod tests {
         let summary = summarize_oversize(&content, 16, 16);
         assert!(summary.starts_with("AAAAAAAAAAAAAAAA"), "16-byte prefix");
         assert!(summary.ends_with("AAAAAAAAAAAAAAAA"), "16-byte suffix");
-        assert!(summary.contains("4000 bytes"), "size marker present: {summary}");
+        assert!(
+            summary.contains("4000 bytes"),
+            "size marker present: {summary}"
+        );
     }
 
     #[test]

--- a/src/capture/blob.rs
+++ b/src/capture/blob.rs
@@ -1,0 +1,134 @@
+//! `event_blobs` writer for the v2 capture path. SPEC-memory-system-v2.1
+//! §4 D1 spills oversize content out of the inline `content_text` column
+//! and into this table; B.1.x stores plain bytes, B.1.y will add gzip for
+//! payloads above 256 KiB.
+
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+
+/// Insert a plain-encoded blob row for `content_bytes`. If a row with the
+/// same `content_hash` already exists, return the existing id without
+/// re-inserting (dedupe across captured events that share content).
+pub fn insert_or_get_blob(
+    conn: &Connection,
+    content_hash: &str,
+    content_bytes: &[u8],
+    now: i64,
+) -> Result<i64> {
+    if let Some(id) = conn
+        .query_row(
+            "SELECT id FROM event_blobs WHERE content_hash = ?1",
+            [content_hash],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+    {
+        return Ok(id);
+    }
+    let original = content_bytes.len() as i64;
+    conn.execute(
+        "INSERT INTO event_blobs(content_hash, content_encoding, content_bytes,
+            original_bytes, stored_bytes, created_at_epoch)
+         VALUES (?1, 'plain', ?2, ?3, ?3, ?4)",
+        params![content_hash, content_bytes, original, now],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// Build the inline `content_text` summary for an oversize event:
+/// `<prefix>\n\n... [truncated; full content N bytes in event_blobs] ...\n\n<suffix>`.
+/// Both ends are truncated on UTF-8 boundaries so multi-byte characters are
+/// not split across the cut.
+pub fn summarize_oversize(content: &str, prefix_bytes: usize, suffix_bytes: usize) -> String {
+    let total_len = content.len();
+    let mut p_cut = prefix_bytes.min(total_len);
+    while p_cut > 0 && !content.is_char_boundary(p_cut) {
+        p_cut -= 1;
+    }
+    let mut s_start = total_len.saturating_sub(suffix_bytes);
+    while s_start < total_len && !content.is_char_boundary(s_start) {
+        s_start += 1;
+    }
+    let prefix = &content[..p_cut];
+    let suffix = &content[s_start..];
+    format!(
+        "{prefix}\n\n... [truncated; full content {total_len} bytes in event_blobs] ...\n\n{suffix}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
+    use crate::v2_db::open_v2_db_at;
+
+    fn open_v2() -> (rusqlite::Connection, std::path::PathBuf) {
+        let path = unique_temp_db_path("blob");
+        let conn = open_v2_db_at(&path).unwrap();
+        (conn, path)
+    }
+
+    #[test]
+    fn insert_blob_writes_row_with_plain_encoding() {
+        let (conn, path) = open_v2();
+        let bytes = b"hello world";
+        let id = insert_or_get_blob(&conn, "h1", bytes, 100).unwrap();
+        assert!(id > 0);
+        let (encoding, original, stored): (String, i64, i64) = conn
+            .query_row(
+                "SELECT content_encoding, original_bytes, stored_bytes FROM event_blobs WHERE id = ?1",
+                [id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(encoding, "plain");
+        assert_eq!(original, bytes.len() as i64);
+        assert_eq!(stored, original, "B.1.x stores plain — no compression");
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn duplicate_hash_dedupes_to_same_row() {
+        let (conn, path) = open_v2();
+        let id1 = insert_or_get_blob(&conn, "dup", b"payload", 100).unwrap();
+        let id2 = insert_or_get_blob(&conn, "dup", b"payload", 200).unwrap();
+        assert_eq!(id1, id2);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM event_blobs", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn summarize_keeps_prefix_and_suffix_on_byte_boundary() {
+        let content = "AAAA".repeat(1000); // 4000 bytes ASCII
+        let summary = summarize_oversize(&content, 16, 16);
+        assert!(summary.starts_with("AAAAAAAAAAAAAAAA"), "16-byte prefix");
+        assert!(summary.ends_with("AAAAAAAAAAAAAAAA"), "16-byte suffix");
+        assert!(summary.contains("4000 bytes"), "size marker present: {summary}");
+    }
+
+    #[test]
+    fn summarize_respects_utf8_boundaries() {
+        // 中 is 3 bytes; place one at the boundary so a naive cut would split it.
+        let mut s = "a".repeat(15);
+        s.push('中'); // bytes 15..18
+        s.push_str(&"b".repeat(2000));
+        let summary = summarize_oversize(&s, 16, 16);
+        // The prefix should not include a partial multi-byte char — the cut
+        // backs off to byte 15 (the boundary before '中').
+        assert!(summary.starts_with(&"a".repeat(15)));
+        assert!(!summary.starts_with(&format!("{}\u{0}", "a".repeat(15))));
+    }
+
+    #[test]
+    fn summarize_handles_overlapping_prefix_suffix() {
+        // Content shorter than prefix + suffix: both halves can overlap.
+        let s = "abcdef";
+        let summary = summarize_oversize(s, 4, 4);
+        assert!(summary.contains("6 bytes"));
+        // Allow either prefix == "abcd" + suffix == "cdef" or the whole string
+        // appearing twice; just verify it does not panic and contains the marker.
+    }
+}

--- a/src/capture/blob.rs
+++ b/src/capture/blob.rs
@@ -3,7 +3,7 @@
 //! compact preview.
 
 use anyhow::Result;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection};
 
 /// Insert a plain-encoded blob row for `content_bytes`. If a row with the
 /// same `content_hash` already exists, return the existing id without
@@ -14,24 +14,19 @@ pub fn insert_or_get_blob(
     content_bytes: &[u8],
     now: i64,
 ) -> Result<i64> {
-    if let Some(id) = conn
-        .query_row(
-            "SELECT id FROM event_blobs WHERE content_hash = ?1",
-            [content_hash],
-            |row| row.get::<_, i64>(0),
-        )
-        .optional()?
-    {
-        return Ok(id);
-    }
     let original = content_bytes.len() as i64;
     conn.execute(
-        "INSERT INTO event_blobs(content_hash, content_encoding, content_bytes,
+        "INSERT OR IGNORE INTO event_blobs(content_hash, content_encoding, content_bytes,
             original_bytes, stored_bytes, created_at_epoch)
          VALUES (?1, 'plain', ?2, ?3, ?3, ?4)",
         params![content_hash, content_bytes, original, now],
     )?;
-    Ok(conn.last_insert_rowid())
+    conn.query_row(
+        "SELECT id FROM event_blobs WHERE content_hash = ?1",
+        [content_hash],
+        |row| row.get::<_, i64>(0),
+    )
+    .map_err(Into::into)
 }
 
 /// Build the inline `content_text` summary for an oversize event:

--- a/src/capture/insert.rs
+++ b/src/capture/insert.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection};
 
 use super::types::NormalizedEvent;
 use crate::identity::{InstallHost, ProjectKey, SessionId, WorkspaceKey};
@@ -97,44 +97,34 @@ fn lookup_host_id(conn: &Connection, host: InstallHost) -> Result<i64> {
 
 fn ensure_workspace(conn: &Connection, ws: &WorkspaceKey, now: i64) -> Result<i64> {
     let path_str = ws.root_path.to_string_lossy();
-    if let Some(id) = conn
-        .query_row(
-            "SELECT id FROM workspaces WHERE root_path = ?1",
-            [path_str.as_ref()],
-            |row| row.get::<_, i64>(0),
-        )
-        .optional()?
-    {
-        return Ok(id);
-    }
     conn.execute(
-        "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
+        "INSERT OR IGNORE INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
          VALUES (?1, ?2, ?2)",
         params![path_str.as_ref(), now],
     )?;
-    Ok(conn.last_insert_rowid())
+    conn.query_row(
+        "SELECT id FROM workspaces WHERE root_path = ?1",
+        [path_str.as_ref()],
+        |row| row.get::<_, i64>(0),
+    )
+    .map_err(Into::into)
 }
 
 fn ensure_project(conn: &Connection, workspace_id: i64, p: &ProjectKey, now: i64) -> Result<i64> {
     let path_str = p.project_path.to_string_lossy();
-    if let Some(id) = conn
-        .query_row(
-            "SELECT id FROM projects
-             WHERE workspace_id = ?1 AND project_path = ?2",
-            params![workspace_id, path_str.as_ref()],
-            |row| row.get::<_, i64>(0),
-        )
-        .optional()?
-    {
-        return Ok(id);
-    }
     conn.execute(
-        "INSERT INTO projects(workspace_id, project_path, project_key,
+        "INSERT OR IGNORE INTO projects(workspace_id, project_path, project_key,
             created_at_epoch, updated_at_epoch)
          VALUES (?1, ?2, ?3, ?4, ?4)",
         params![workspace_id, path_str.as_ref(), p.project_key, now],
     )?;
-    Ok(conn.last_insert_rowid())
+    conn.query_row(
+        "SELECT id FROM projects
+         WHERE workspace_id = ?1 AND project_path = ?2",
+        params![workspace_id, path_str.as_ref()],
+        |row| row.get::<_, i64>(0),
+    )
+    .map_err(Into::into)
 }
 
 /// Find or create the session row and bump its `last_seen_at_epoch`.
@@ -146,28 +136,25 @@ pub fn ensure_session(
     session_id: &SessionId,
     now: i64,
 ) -> Result<i64> {
-    if let Some(id) = conn
-        .query_row(
-            "SELECT id FROM sessions
-             WHERE host_id = ?1 AND project_id = ?2 AND session_id = ?3",
-            params![host_id, project_id, session_id.0],
-            |row| row.get::<_, i64>(0),
-        )
-        .optional()?
-    {
-        conn.execute(
-            "UPDATE sessions SET last_seen_at_epoch = ?1 WHERE id = ?2",
-            params![now, id],
-        )?;
-        return Ok(id);
-    }
     conn.execute(
-        "INSERT INTO sessions(host_id, workspace_id, project_id, session_id,
+        "INSERT OR IGNORE INTO sessions(host_id, workspace_id, project_id, session_id,
             started_at_epoch, last_seen_at_epoch, status)
          VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'active')",
         params![host_id, workspace_id, project_id, session_id.0, now],
     )?;
-    Ok(conn.last_insert_rowid())
+    conn.execute(
+        "UPDATE sessions
+         SET last_seen_at_epoch = MAX(last_seen_at_epoch, ?1)
+         WHERE host_id = ?2 AND project_id = ?3 AND session_id = ?4",
+        params![now, host_id, project_id, session_id.0],
+    )?;
+    conn.query_row(
+        "SELECT id FROM sessions
+         WHERE host_id = ?1 AND project_id = ?2 AND session_id = ?3",
+        params![host_id, project_id, session_id.0],
+        |row| row.get::<_, i64>(0),
+    )
+    .map_err(Into::into)
 }
 
 enum StorageKind {
@@ -186,9 +173,8 @@ struct Storage {
 /// Apply the capture storage policy.
 /// - `None` content: empty hash, no inline text, no blob.
 /// - ≤16 KiB: inline as `content_text`, blob unused.
-/// - >16 KiB: spill the full text into `event_blobs`, keep a
-///   prefix+suffix+marker summary in `content_text`, flip retention to
-///   `raw_compact`.
+/// - Over 16 KiB: spill the full text into `event_blobs`; `content_text`
+///   keeps a compact prefix/suffix summary and retention becomes `raw_compact`.
 fn resolve_storage(conn: &Connection, content: Option<&str>, now: i64) -> Result<Storage> {
     match content {
         None => Ok(Storage {

--- a/src/capture/insert.rs
+++ b/src/capture/insert.rs
@@ -4,23 +4,24 @@ use rusqlite::{params, Connection, OptionalExtension};
 use super::types::NormalizedEvent;
 use crate::identity::{InstallHost, ProjectKey, SessionId, WorkspaceKey};
 
-/// Per SPEC-memory-system-v2.1-revisions §4 D1 — content_text up to 16 KiB
-/// stays inline; bigger payloads spill into `event_blobs` (full prefix /
-/// suffix + digest, gzip beyond 256 KiB). B.1 ships only the inline path
-/// and truncates oversize content with `retention_class = "truncated"`; the
-/// blob spill writer lands in B.1.x.
+/// `content_text` stays inline up to 16 KiB; bigger payloads spill into
+/// `event_blobs` while keeping a prefix/suffix summary in the event row.
 const MAX_CONTENT_TEXT_BYTES: usize = 16 * 1024;
 
 /// Insert one normalized event into `captured_events`, creating any missing
 /// hosts / workspaces / projects / sessions rows along the way. Oversize
-/// payloads spill into `event_blobs` per v2.1 §4 D1; `content_text` keeps
+/// payloads spill into `event_blobs`; `content_text` keeps
 /// a prefix + suffix summary so the row is still useful for FTS / preview.
 /// Idempotent on `(host_id, session_id, event_id)`.
 pub fn insert_captured_event(conn: &Connection, ev: &NormalizedEvent) -> Result<i64> {
     let host_id = lookup_host_id(conn, ev.identity.host)?;
     let workspace_id = ensure_workspace(conn, &ev.identity.workspace, ev.created_at_epoch)?;
-    let project_id =
-        ensure_project(conn, workspace_id, &ev.identity.project, ev.created_at_epoch)?;
+    let project_id = ensure_project(
+        conn,
+        workspace_id,
+        &ev.identity.project,
+        ev.created_at_epoch,
+    )?;
     let session_row_id = ensure_session(
         conn,
         host_id,
@@ -74,11 +75,7 @@ pub fn insert_captured_event(conn: &Connection, ev: &NormalizedEvent) -> Result<
     let id: i64 = conn.query_row(
         "SELECT id FROM captured_events
          WHERE host_id = ?1 AND session_id = ?2 AND event_id = ?3",
-        params![
-            host_id,
-            ev.identity.session_id.0,
-            ev.identity.event_id.0
-        ],
+        params![host_id, ev.identity.session_id.0, ev.identity.event_id.0],
         |row| row.get(0),
     )?;
     Ok(id)
@@ -92,7 +89,7 @@ fn lookup_host_id(conn: &Connection, host: InstallHost) -> Result<i64> {
     )
     .with_context(|| {
         format!(
-            "host '{}' not seeded in v2 schema; run admin reset-v2 to initialize",
+            "host '{}' is not seeded in the schema database; run admin reset-schema to initialize",
             host.as_db_value()
         )
     })
@@ -118,12 +115,7 @@ fn ensure_workspace(conn: &Connection, ws: &WorkspaceKey, now: i64) -> Result<i6
     Ok(conn.last_insert_rowid())
 }
 
-fn ensure_project(
-    conn: &Connection,
-    workspace_id: i64,
-    p: &ProjectKey,
-    now: i64,
-) -> Result<i64> {
+fn ensure_project(conn: &Connection, workspace_id: i64, p: &ProjectKey, now: i64) -> Result<i64> {
     let path_str = p.project_path.to_string_lossy();
     if let Some(id) = conn
         .query_row(
@@ -191,12 +183,12 @@ struct Storage {
     content_hash: String,
 }
 
-/// Apply the v2.1 §4 D1 storage policy.
+/// Apply the capture storage policy.
 /// - `None` content: empty hash, no inline text, no blob.
 /// - ≤16 KiB: inline as `content_text`, blob unused.
 /// - >16 KiB: spill the full text into `event_blobs`, keep a
 ///   prefix+suffix+marker summary in `content_text`, flip retention to
-///   `raw_compact`. (B.1.y will add gzip beyond 256 KiB.)
+///   `raw_compact`.
 fn resolve_storage(conn: &Connection, content: Option<&str>, now: i64) -> Result<Storage> {
     match content {
         None => Ok(Storage {
@@ -229,11 +221,11 @@ fn resolve_storage(conn: &Connection, content: Option<&str>, now: i64) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::schema::open_at as open_schema_at;
     use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
     use crate::identity::{
         CaptureIdentity, EventId, InstallHost, ProjectKey, SessionId, TurnId, WorkspaceKey,
     };
-    use crate::v2_db::open_v2_db_at;
     use std::path::Path;
 
     fn unique_temp_path() -> std::path::PathBuf {
@@ -272,7 +264,7 @@ mod tests {
     #[test]
     fn insert_creates_fk_chain_and_returns_id() {
         let path = unique_temp_path();
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
         let ev = make_event("a", "hello");
         let id = insert_captured_event(&conn, &ev).unwrap();
         assert!(id > 0);
@@ -299,7 +291,7 @@ mod tests {
     #[test]
     fn duplicate_event_id_is_idempotent() {
         let path = unique_temp_path();
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
         let ev = make_event("dup", "same");
         let id1 = insert_captured_event(&conn, &ev).unwrap();
         let id2 = insert_captured_event(&conn, &ev).unwrap();
@@ -314,15 +306,14 @@ mod tests {
     #[test]
     fn same_session_multiple_events_reuse_session_row() {
         let path = unique_temp_path();
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
 
         let ws = WorkspaceKey::from_cwd_and_toplevel(Path::new("/tmp/r"), None);
         let project = ProjectKey::from_workspace(ws.clone(), Some("r"));
         let sid = SessionId("shared-session".into());
         let turn = Some(TurnId("turn1".into()));
         for n in 0..3 {
-            let event_id =
-                EventId::synthesize(turn.as_ref(), "PostToolUse", Some(&n.to_string()));
+            let event_id = EventId::synthesize(turn.as_ref(), "PostToolUse", Some(&n.to_string()));
             let identity = CaptureIdentity {
                 host: InstallHost::CodexCli,
                 workspace: ws.clone(),
@@ -357,7 +348,7 @@ mod tests {
     #[test]
     fn oversize_content_spills_to_event_blobs_and_marks_raw_compact() {
         let path = unique_temp_path();
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
         let big = "x".repeat(MAX_CONTENT_TEXT_BYTES + 5_000);
         let ev = make_event("big", &big);
         insert_captured_event(&conn, &ev).unwrap();
@@ -376,7 +367,10 @@ mod tests {
             stored_text.contains(&format!("{} bytes", big.len())),
             "summary must include size marker"
         );
-        assert!(stored_text.len() < MAX_CONTENT_TEXT_BYTES, "summary stays small");
+        assert!(
+            stored_text.len() < MAX_CONTENT_TEXT_BYTES,
+            "summary stays small"
+        );
         assert_eq!(retention, "raw_compact");
 
         // event_blobs has the full payload, plain encoding.
@@ -396,7 +390,7 @@ mod tests {
     #[test]
     fn duplicate_oversize_content_dedupes_blob() {
         let path = unique_temp_path();
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
         let big = "y".repeat(MAX_CONTENT_TEXT_BYTES + 1);
         let ev_a = make_event("dup-a", &big);
         let ev_b = make_event("dup-b", &big);
@@ -416,7 +410,7 @@ mod tests {
     #[test]
     fn lookup_host_id_returns_seeded_rows() {
         let path = unique_temp_path();
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
         let claude = lookup_host_id(&conn, InstallHost::ClaudeCode).unwrap();
         let codex = lookup_host_id(&conn, InstallHost::CodexCli).unwrap();
         assert_ne!(claude, codex);

--- a/src/capture/insert.rs
+++ b/src/capture/insert.rs
@@ -1,0 +1,372 @@
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::types::NormalizedEvent;
+use crate::identity::{InstallHost, ProjectKey, SessionId, WorkspaceKey};
+
+/// Per SPEC-memory-system-v2.1-revisions §4 D1 — content_text up to 16 KiB
+/// stays inline; bigger payloads spill into `event_blobs` (full prefix /
+/// suffix + digest, gzip beyond 256 KiB). B.1 ships only the inline path
+/// and truncates oversize content with `retention_class = "truncated"`; the
+/// blob spill writer lands in B.1.x.
+const MAX_CONTENT_TEXT_BYTES: usize = 16 * 1024;
+
+/// Insert one normalized event into `captured_events`, creating any missing
+/// hosts / workspaces / projects / sessions rows along the way. Idempotent
+/// on `(host_id, session_id, event_id)`.
+pub fn insert_captured_event(conn: &Connection, ev: &NormalizedEvent) -> Result<i64> {
+    let host_id = lookup_host_id(conn, ev.identity.host)?;
+    let workspace_id = ensure_workspace(conn, &ev.identity.workspace, ev.created_at_epoch)?;
+    let project_id =
+        ensure_project(conn, workspace_id, &ev.identity.project, ev.created_at_epoch)?;
+    let session_row_id = ensure_session(
+        conn,
+        host_id,
+        workspace_id,
+        project_id,
+        &ev.identity.session_id,
+        ev.created_at_epoch,
+    )?;
+
+    let (content_text, retention_class) =
+        compact_for_storage(ev.content_text.as_deref(), &ev.retention_class);
+    let content_hash = compute_content_hash(content_text.as_deref());
+
+    conn.execute(
+        "INSERT INTO captured_events(
+            host_id, workspace_id, project_id, session_row_id, session_id,
+            turn_id, event_id, event_type, role, tool_name,
+            content_text, content_blob_id, content_hash,
+            token_estimate, retention_class,
+            created_at_epoch, inserted_at_epoch
+         ) VALUES (
+            ?1, ?2, ?3, ?4, ?5,
+            ?6, ?7, ?8, ?9, ?10,
+            ?11, NULL, ?12,
+            ?13, ?14,
+            ?15, ?15
+         )
+         ON CONFLICT(host_id, session_id, event_id) DO NOTHING",
+        params![
+            host_id,
+            workspace_id,
+            project_id,
+            session_row_id,
+            ev.identity.session_id.0,
+            ev.identity.turn_id.as_ref().map(|t| t.0.as_str()),
+            ev.identity.event_id.0,
+            ev.event_type,
+            ev.role,
+            ev.tool_name,
+            content_text,
+            content_hash,
+            ev.token_estimate,
+            retention_class,
+            ev.created_at_epoch,
+        ],
+    )?;
+
+    let id: i64 = conn.query_row(
+        "SELECT id FROM captured_events
+         WHERE host_id = ?1 AND session_id = ?2 AND event_id = ?3",
+        params![
+            host_id,
+            ev.identity.session_id.0,
+            ev.identity.event_id.0
+        ],
+        |row| row.get(0),
+    )?;
+    Ok(id)
+}
+
+fn lookup_host_id(conn: &Connection, host: InstallHost) -> Result<i64> {
+    conn.query_row(
+        "SELECT id FROM hosts WHERE name = ?1",
+        [host.as_db_value()],
+        |row| row.get(0),
+    )
+    .with_context(|| {
+        format!(
+            "host '{}' not seeded in v2 schema; run admin reset-v2 to initialize",
+            host.as_db_value()
+        )
+    })
+}
+
+fn ensure_workspace(conn: &Connection, ws: &WorkspaceKey, now: i64) -> Result<i64> {
+    let path_str = ws.root_path.to_string_lossy();
+    if let Some(id) = conn
+        .query_row(
+            "SELECT id FROM workspaces WHERE root_path = ?1",
+            [path_str.as_ref()],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+    {
+        return Ok(id);
+    }
+    conn.execute(
+        "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?2)",
+        params![path_str.as_ref(), now],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn ensure_project(
+    conn: &Connection,
+    workspace_id: i64,
+    p: &ProjectKey,
+    now: i64,
+) -> Result<i64> {
+    let path_str = p.project_path.to_string_lossy();
+    if let Some(id) = conn
+        .query_row(
+            "SELECT id FROM projects
+             WHERE workspace_id = ?1 AND project_path = ?2",
+            params![workspace_id, path_str.as_ref()],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+    {
+        return Ok(id);
+    }
+    conn.execute(
+        "INSERT INTO projects(workspace_id, project_path, project_key,
+            created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?4)",
+        params![workspace_id, path_str.as_ref(), p.project_key, now],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// Find or create the session row and bump its `last_seen_at_epoch`.
+pub fn ensure_session(
+    conn: &Connection,
+    host_id: i64,
+    workspace_id: i64,
+    project_id: i64,
+    session_id: &SessionId,
+    now: i64,
+) -> Result<i64> {
+    if let Some(id) = conn
+        .query_row(
+            "SELECT id FROM sessions
+             WHERE host_id = ?1 AND project_id = ?2 AND session_id = ?3",
+            params![host_id, project_id, session_id.0],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+    {
+        conn.execute(
+            "UPDATE sessions SET last_seen_at_epoch = ?1 WHERE id = ?2",
+            params![now, id],
+        )?;
+        return Ok(id);
+    }
+    conn.execute(
+        "INSERT INTO sessions(host_id, workspace_id, project_id, session_id,
+            started_at_epoch, last_seen_at_epoch, status)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'active')",
+        params![host_id, workspace_id, project_id, session_id.0, now],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// Apply the v2.1 §4 D1 storage policy. Returns `(content_text, retention)`.
+/// B.1 minimal version: ≤16 KiB → keep, >16 KiB → truncate to 16 KiB on a
+/// UTF-8 boundary + flip retention_class to "truncated". The 16-256 KiB and
+/// >256 KiB blob cases land in B.1.x once the event_blobs writer ships.
+fn compact_for_storage(
+    content: Option<&str>,
+    retention_class: &str,
+) -> (Option<String>, String) {
+    match content {
+        None => (None, retention_class.to_string()),
+        Some(text) if text.len() <= MAX_CONTENT_TEXT_BYTES => {
+            (Some(text.to_string()), retention_class.to_string())
+        }
+        Some(text) => {
+            let mut cut = MAX_CONTENT_TEXT_BYTES;
+            while cut > 0 && !text.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            (Some(text[..cut].to_string()), "truncated".to_string())
+        }
+    }
+}
+
+fn compute_content_hash(content: Option<&str>) -> String {
+    let bytes = content.unwrap_or("").as_bytes();
+    format!("{:016x}", crate::db::deterministic_hash(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
+    use crate::identity::{
+        CaptureIdentity, EventId, InstallHost, ProjectKey, SessionId, TurnId, WorkspaceKey,
+    };
+    use crate::v2_db::open_v2_db_at;
+    use std::path::Path;
+
+    fn unique_temp_path() -> std::path::PathBuf {
+        unique_temp_db_path("capture")
+    }
+
+    fn make_identity(label: &str) -> CaptureIdentity {
+        let workspace = WorkspaceKey::from_cwd_and_toplevel(Path::new("/tmp/repo-x"), None);
+        let project = ProjectKey::from_workspace(workspace.clone(), Some("repo-x"));
+        let session_id = SessionId(format!("session-{label}"));
+        let turn_id = Some(TurnId(format!("turn-{label}")));
+        let event_id = EventId::synthesize(turn_id.as_ref(), "PostToolUse", Some(label));
+        CaptureIdentity {
+            host: InstallHost::CodexCli,
+            workspace,
+            project,
+            session_id,
+            turn_id,
+            event_id,
+        }
+    }
+
+    fn make_event(label: &str, content: &str) -> NormalizedEvent {
+        NormalizedEvent {
+            identity: make_identity(label),
+            event_type: "tool_result".into(),
+            role: Some("tool".into()),
+            tool_name: Some("Bash".into()),
+            content_text: Some(content.into()),
+            token_estimate: 0,
+            retention_class: "raw_keep".into(),
+            created_at_epoch: 1_700_000_000,
+        }
+    }
+
+    #[test]
+    fn insert_creates_fk_chain_and_returns_id() {
+        let path = unique_temp_path();
+        let conn = open_v2_db_at(&path).unwrap();
+        let ev = make_event("a", "hello");
+        let id = insert_captured_event(&conn, &ev).unwrap();
+        assert!(id > 0);
+
+        let host_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM hosts", [], |r| r.get(0))
+            .unwrap();
+        assert!(host_count >= 2, "seeded hosts must exist");
+        let ws_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM workspaces", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(ws_count, 1);
+        let proj_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM projects", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(proj_count, 1);
+        let sess_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(sess_count, 1);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn duplicate_event_id_is_idempotent() {
+        let path = unique_temp_path();
+        let conn = open_v2_db_at(&path).unwrap();
+        let ev = make_event("dup", "same");
+        let id1 = insert_captured_event(&conn, &ev).unwrap();
+        let id2 = insert_captured_event(&conn, &ev).unwrap();
+        assert_eq!(id1, id2);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM captured_events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn same_session_multiple_events_reuse_session_row() {
+        let path = unique_temp_path();
+        let conn = open_v2_db_at(&path).unwrap();
+
+        let ws = WorkspaceKey::from_cwd_and_toplevel(Path::new("/tmp/r"), None);
+        let project = ProjectKey::from_workspace(ws.clone(), Some("r"));
+        let sid = SessionId("shared-session".into());
+        let turn = Some(TurnId("turn1".into()));
+        for n in 0..3 {
+            let event_id =
+                EventId::synthesize(turn.as_ref(), "PostToolUse", Some(&n.to_string()));
+            let identity = CaptureIdentity {
+                host: InstallHost::CodexCli,
+                workspace: ws.clone(),
+                project: project.clone(),
+                session_id: sid.clone(),
+                turn_id: turn.clone(),
+                event_id,
+            };
+            let ev = NormalizedEvent {
+                identity,
+                event_type: "tool_result".into(),
+                role: Some("tool".into()),
+                tool_name: Some("Bash".into()),
+                content_text: Some(format!("payload-{n}")),
+                token_estimate: 0,
+                retention_class: "raw_keep".into(),
+                created_at_epoch: 1_700_000_000 + n,
+            };
+            insert_captured_event(&conn, &ev).unwrap();
+        }
+        let sess_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(sess_count, 1);
+        let event_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM captured_events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(event_count, 3);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn oversize_content_is_truncated_and_marked() {
+        let path = unique_temp_path();
+        let conn = open_v2_db_at(&path).unwrap();
+        let big = "x".repeat(MAX_CONTENT_TEXT_BYTES + 100);
+        let ev = make_event("big", &big);
+        insert_captured_event(&conn, &ev).unwrap();
+        let (stored, retention): (String, String) = conn
+            .query_row(
+                "SELECT content_text, retention_class FROM captured_events",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(stored.len(), MAX_CONTENT_TEXT_BYTES);
+        assert_eq!(retention, "truncated");
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn truncate_respects_utf8_boundaries() {
+        let mut s = "a".repeat(MAX_CONTENT_TEXT_BYTES - 1);
+        s.push('中');
+        s.push_str(&"b".repeat(50));
+        let (out, retention) = compact_for_storage(Some(&s), "raw_keep");
+        let out = out.unwrap();
+        assert!(out.is_char_boundary(out.len()), "must end on a UTF-8 boundary");
+        assert!(out.len() <= MAX_CONTENT_TEXT_BYTES);
+        assert_eq!(retention, "truncated");
+    }
+
+    #[test]
+    fn lookup_host_id_returns_seeded_rows() {
+        let path = unique_temp_path();
+        let conn = open_v2_db_at(&path).unwrap();
+        let claude = lookup_host_id(&conn, InstallHost::ClaudeCode).unwrap();
+        let codex = lookup_host_id(&conn, InstallHost::CodexCli).unwrap();
+        assert_ne!(claude, codex);
+        cleanup_temp_db_files(&path);
+    }
+}

--- a/src/capture/insert.rs
+++ b/src/capture/insert.rs
@@ -12,8 +12,10 @@ use crate::identity::{InstallHost, ProjectKey, SessionId, WorkspaceKey};
 const MAX_CONTENT_TEXT_BYTES: usize = 16 * 1024;
 
 /// Insert one normalized event into `captured_events`, creating any missing
-/// hosts / workspaces / projects / sessions rows along the way. Idempotent
-/// on `(host_id, session_id, event_id)`.
+/// hosts / workspaces / projects / sessions rows along the way. Oversize
+/// payloads spill into `event_blobs` per v2.1 §4 D1; `content_text` keeps
+/// a prefix + suffix summary so the row is still useful for FTS / preview.
+/// Idempotent on `(host_id, session_id, event_id)`.
 pub fn insert_captured_event(conn: &Connection, ev: &NormalizedEvent) -> Result<i64> {
     let host_id = lookup_host_id(conn, ev.identity.host)?;
     let workspace_id = ensure_workspace(conn, &ev.identity.workspace, ev.created_at_epoch)?;
@@ -28,9 +30,11 @@ pub fn insert_captured_event(conn: &Connection, ev: &NormalizedEvent) -> Result<
         ev.created_at_epoch,
     )?;
 
-    let (content_text, retention_class) =
-        compact_for_storage(ev.content_text.as_deref(), &ev.retention_class);
-    let content_hash = compute_content_hash(content_text.as_deref());
+    let storage = resolve_storage(conn, ev.content_text.as_deref(), ev.created_at_epoch)?;
+    let retention_class = match storage.kind {
+        StorageKind::Empty | StorageKind::Inline => ev.retention_class.clone(),
+        StorageKind::Spilled => "raw_compact".to_string(),
+    };
 
     conn.execute(
         "INSERT INTO captured_events(
@@ -42,9 +46,9 @@ pub fn insert_captured_event(conn: &Connection, ev: &NormalizedEvent) -> Result<
          ) VALUES (
             ?1, ?2, ?3, ?4, ?5,
             ?6, ?7, ?8, ?9, ?10,
-            ?11, NULL, ?12,
-            ?13, ?14,
-            ?15, ?15
+            ?11, ?12, ?13,
+            ?14, ?15,
+            ?16, ?16
          )
          ON CONFLICT(host_id, session_id, event_id) DO NOTHING",
         params![
@@ -58,8 +62,9 @@ pub fn insert_captured_event(conn: &Connection, ev: &NormalizedEvent) -> Result<
             ev.event_type,
             ev.role,
             ev.tool_name,
-            content_text,
-            content_hash,
+            storage.content_text,
+            storage.content_blob_id,
+            storage.content_hash,
             ev.token_estimate,
             retention_class,
             ev.created_at_epoch,
@@ -173,32 +178,52 @@ pub fn ensure_session(
     Ok(conn.last_insert_rowid())
 }
 
-/// Apply the v2.1 §4 D1 storage policy. Returns `(content_text, retention)`.
-/// B.1 minimal version: ≤16 KiB → keep, >16 KiB → truncate to 16 KiB on a
-/// UTF-8 boundary + flip retention_class to "truncated". The 16-256 KiB and
-/// >256 KiB blob cases land in B.1.x once the event_blobs writer ships.
-fn compact_for_storage(
-    content: Option<&str>,
-    retention_class: &str,
-) -> (Option<String>, String) {
-    match content {
-        None => (None, retention_class.to_string()),
-        Some(text) if text.len() <= MAX_CONTENT_TEXT_BYTES => {
-            (Some(text.to_string()), retention_class.to_string())
-        }
-        Some(text) => {
-            let mut cut = MAX_CONTENT_TEXT_BYTES;
-            while cut > 0 && !text.is_char_boundary(cut) {
-                cut -= 1;
-            }
-            (Some(text[..cut].to_string()), "truncated".to_string())
-        }
-    }
+enum StorageKind {
+    Empty,
+    Inline,
+    Spilled,
 }
 
-fn compute_content_hash(content: Option<&str>) -> String {
-    let bytes = content.unwrap_or("").as_bytes();
-    format!("{:016x}", crate::db::deterministic_hash(bytes))
+struct Storage {
+    kind: StorageKind,
+    content_text: Option<String>,
+    content_blob_id: Option<i64>,
+    content_hash: String,
+}
+
+/// Apply the v2.1 §4 D1 storage policy.
+/// - `None` content: empty hash, no inline text, no blob.
+/// - ≤16 KiB: inline as `content_text`, blob unused.
+/// - >16 KiB: spill the full text into `event_blobs`, keep a
+///   prefix+suffix+marker summary in `content_text`, flip retention to
+///   `raw_compact`. (B.1.y will add gzip beyond 256 KiB.)
+fn resolve_storage(conn: &Connection, content: Option<&str>, now: i64) -> Result<Storage> {
+    match content {
+        None => Ok(Storage {
+            kind: StorageKind::Empty,
+            content_text: None,
+            content_blob_id: None,
+            content_hash: format!("{:016x}", crate::db::deterministic_hash(&[])),
+        }),
+        Some(text) if text.len() <= MAX_CONTENT_TEXT_BYTES => Ok(Storage {
+            kind: StorageKind::Inline,
+            content_text: Some(text.to_string()),
+            content_blob_id: None,
+            content_hash: format!("{:016x}", crate::db::deterministic_hash(text.as_bytes())),
+        }),
+        Some(text) => {
+            let bytes = text.as_bytes();
+            let hash = format!("{:016x}", crate::db::deterministic_hash(bytes));
+            let blob_id = super::blob::insert_or_get_blob(conn, &hash, bytes, now)?;
+            let summary = super::blob::summarize_oversize(text, 1024, 1024);
+            Ok(Storage {
+                kind: StorageKind::Spilled,
+                content_text: Some(summary),
+                content_blob_id: Some(blob_id),
+                content_hash: hash,
+            })
+        }
+    }
 }
 
 #[cfg(test)]
@@ -330,34 +355,62 @@ mod tests {
     }
 
     #[test]
-    fn oversize_content_is_truncated_and_marked() {
+    fn oversize_content_spills_to_event_blobs_and_marks_raw_compact() {
         let path = unique_temp_path();
         let conn = open_v2_db_at(&path).unwrap();
-        let big = "x".repeat(MAX_CONTENT_TEXT_BYTES + 100);
+        let big = "x".repeat(MAX_CONTENT_TEXT_BYTES + 5_000);
         let ev = make_event("big", &big);
         insert_captured_event(&conn, &ev).unwrap();
-        let (stored, retention): (String, String) = conn
+
+        let (stored_text, blob_id, retention): (String, Option<i64>, String) = conn
             .query_row(
-                "SELECT content_text, retention_class FROM captured_events",
+                "SELECT content_text, content_blob_id, retention_class FROM captured_events",
                 [],
-                |r| Ok((r.get(0)?, r.get(1)?)),
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
             )
             .unwrap();
-        assert_eq!(stored.len(), MAX_CONTENT_TEXT_BYTES);
-        assert_eq!(retention, "truncated");
+        let blob_id = blob_id.expect("blob id must be set for spilled content");
+
+        // content_text is the prefix/suffix summary, not the whole thing.
+        assert!(
+            stored_text.contains(&format!("{} bytes", big.len())),
+            "summary must include size marker"
+        );
+        assert!(stored_text.len() < MAX_CONTENT_TEXT_BYTES, "summary stays small");
+        assert_eq!(retention, "raw_compact");
+
+        // event_blobs has the full payload, plain encoding.
+        let (encoding, original, stored): (String, i64, i64) = conn
+            .query_row(
+                "SELECT content_encoding, original_bytes, stored_bytes FROM event_blobs WHERE id = ?1",
+                [blob_id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(encoding, "plain");
+        assert_eq!(original, big.len() as i64);
+        assert_eq!(stored, original);
         cleanup_temp_db_files(&path);
     }
 
     #[test]
-    fn truncate_respects_utf8_boundaries() {
-        let mut s = "a".repeat(MAX_CONTENT_TEXT_BYTES - 1);
-        s.push('中');
-        s.push_str(&"b".repeat(50));
-        let (out, retention) = compact_for_storage(Some(&s), "raw_keep");
-        let out = out.unwrap();
-        assert!(out.is_char_boundary(out.len()), "must end on a UTF-8 boundary");
-        assert!(out.len() <= MAX_CONTENT_TEXT_BYTES);
-        assert_eq!(retention, "truncated");
+    fn duplicate_oversize_content_dedupes_blob() {
+        let path = unique_temp_path();
+        let conn = open_v2_db_at(&path).unwrap();
+        let big = "y".repeat(MAX_CONTENT_TEXT_BYTES + 1);
+        let ev_a = make_event("dup-a", &big);
+        let ev_b = make_event("dup-b", &big);
+        insert_captured_event(&conn, &ev_a).unwrap();
+        insert_captured_event(&conn, &ev_b).unwrap();
+        let blob_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM event_blobs", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(blob_count, 1, "same content_hash must dedupe to 1 blob");
+        let event_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM captured_events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(event_count, 2, "two distinct events still recorded");
+        cleanup_temp_db_files(&path);
     }
 
     #[test]

--- a/src/capture/types.rs
+++ b/src/capture/types.rs
@@ -1,0 +1,25 @@
+use crate::identity::CaptureIdentity;
+
+/// Normalized hook event ready for `captured_events` insertion.
+///
+/// Adapters (Claude Code / Codex CLI) translate raw hook payloads into this
+/// shape; the capture entry point sees only `NormalizedEvent` so v2 storage
+/// stays host-agnostic.
+#[derive(Debug, Clone)]
+pub struct NormalizedEvent {
+    pub identity: CaptureIdentity,
+    /// One of: `user_message` | `assistant_message` | `tool_call` |
+    /// `tool_result` | `file_edit` | `session_stop` (v2 SPEC §7.2).
+    pub event_type: String,
+    /// `user` | `assistant` | `tool` | `system` (free-form for now).
+    pub role: Option<String>,
+    pub tool_name: Option<String>,
+    /// Adapter-supplied content. `insert_captured_event` may downgrade this
+    /// to a truncated form when it exceeds the 16 KiB direct-storage limit.
+    pub content_text: Option<String>,
+    pub token_estimate: i64,
+    /// Initial retention class assigned by the adapter; `insert` may flip it
+    /// to `"truncated"` when content overflows the direct-storage budget.
+    pub retention_class: String,
+    pub created_at_epoch: i64,
+}

--- a/src/capture/types.rs
+++ b/src/capture/types.rs
@@ -19,7 +19,7 @@ pub struct NormalizedEvent {
     pub content_text: Option<String>,
     pub token_estimate: i64,
     /// Initial retention class assigned by the adapter; `insert` may flip it
-    /// to `"truncated"` when content overflows the direct-storage budget.
+    /// to `"raw_compact"` when content overflows the direct-storage budget.
     pub retention_class: String,
     pub created_at_epoch: i64,
 }

--- a/src/capture/types.rs
+++ b/src/capture/types.rs
@@ -3,13 +3,13 @@ use crate::identity::CaptureIdentity;
 /// Normalized hook event ready for `captured_events` insertion.
 ///
 /// Adapters (Claude Code / Codex CLI) translate raw hook payloads into this
-/// shape; the capture entry point sees only `NormalizedEvent` so v2 storage
+/// shape; the capture entry point sees only `NormalizedEvent` so storage
 /// stays host-agnostic.
 #[derive(Debug, Clone)]
 pub struct NormalizedEvent {
     pub identity: CaptureIdentity,
     /// One of: `user_message` | `assistant_message` | `tool_call` |
-    /// `tool_result` | `file_edit` | `session_stop` (v2 SPEC §7.2).
+    /// `tool_result` | `file_edit` | `session_stop`.
     pub event_type: String,
     /// `user` | `assistant` | `tool` | `system` (free-form for now).
     pub role: Option<String>,

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
+use crate::{api, context, db, doctor, extraction, install, mcp, observe, summarize};
 
 use super::actions::{
     run_admin, run_backfill_entities, run_cleanup, run_dream, run_encrypt, run_eval,
@@ -41,7 +41,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             }
             summarize::summarize().await?;
         }
-        Commands::Worker { once } => worker::run(once, 2000).await?,
+        Commands::Worker { once } => extraction::worker::run(once, 2000).await?,
         Commands::Mcp => mcp::run_mcp_server().await?,
         Commands::Install { target, dry_run } => install::install(target, dry_run)?,
         Commands::Uninstall { target, dry_run } => install::uninstall(target, dry_run)?,

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::{api, context, db, doctor, extraction, install, mcp, observe, summarize};
+use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 
 use super::actions::{
     run_admin, run_backfill_entities, run_cleanup, run_dream, run_encrypt, run_eval,
@@ -41,7 +41,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             }
             summarize::summarize().await?;
         }
-        Commands::Worker { once } => extraction::worker::run(once, 2000).await?,
+        Commands::Worker { once } => worker::run(once, 2000).await?,
         Commands::Mcp => mcp::run_mcp_server().await?,
         Commands::Install { target, dry_run } => install::install(target, dry_run)?,
         Commands::Uninstall { target, dry_run } => install::uninstall(target, dry_run)?,

--- a/src/db/test_support.rs
+++ b/src/db/test_support.rs
@@ -65,17 +65,19 @@ impl Drop for ScopedTestDataDir {
 }
 
 /// Generate a unique temp file path for a test sqlite db. Used by schema,
-/// admin, and import test modules; nonce is `pid + nanos` so concurrent
-/// `cargo test` runs do not collide. Caller owns cleanup (pair with
+/// admin, import, and capture test modules. Combines `pid + nanos +
+/// process-local atomic counter` so quick successive calls under the cargo
+/// default thread pool cannot collide (pid+nanos alone occasionally aliases
+/// on macOS when two threads sample SystemTime within the same nanosecond
+/// resolution bucket). Caller owns cleanup (pair with
 /// `cleanup_temp_db_files` for `-wal` / `-shm` sidecars).
 pub fn unique_temp_db_path(label: &str) -> PathBuf {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
     let nonce = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
     std::env::temp_dir().join(format!(
         "remem-{label}-{}-{nonce}-{counter}.sqlite",
         std::process::id(),

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -1,0 +1,19 @@
+//! v2 extraction queue (`extraction_tasks`). Replaces the v1 split between
+//! `pending_observations` and `jobs` with a single coalesced queue keyed by
+//! `idempotency_key`. Lifts the lease / retry / scheduler shape from the
+//! 5/5 SPEC implementation but uses the v2.1 §1 M4 progress invariant:
+//! progress is event-range-based (`cursor_event_id` / `high_watermark_event_id`),
+//! not observation-count-based.
+
+pub mod claim;
+pub mod enqueue;
+pub mod query;
+pub mod types;
+
+pub use claim::{
+    claim_ready_tasks, mark_task_delayed, mark_task_done, mark_task_failed,
+    recover_expired_leases, ClaimedTask, DEFAULT_LEASE_SECS,
+};
+pub use enqueue::{enqueue_extraction_task, EnqueueRequest};
+pub use query::{count_ready_for_identity, oldest_ready_epoch};
+pub use types::{TaskKind, TaskStatus};

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -1,17 +1,15 @@
-//! v2 extraction queue (`extraction_tasks`). Replaces the v1 split between
-//! `pending_observations` and `jobs` with a single coalesced queue keyed by
-//! `idempotency_key`. Lifts the lease / retry / scheduler shape from the
-//! 5/5 SPEC implementation but uses the v2.1 §1 M4 progress invariant:
-//! progress is event-range-based (`cursor_event_id` / `high_watermark_event_id`),
-//! not observation-count-based.
+//! Extraction queue (`extraction_tasks`). The queue is coalesced by
+//! `idempotency_key`, has explicit leases/retries, and tracks progress by
+//! event range (`cursor_event_id` / `high_watermark_event_id`).
 
 pub mod claim;
 pub mod enqueue;
 pub mod query;
 pub mod types;
+pub mod worker;
 
 pub use claim::{
-    claim_ready_tasks, mark_task_delayed, mark_task_done, mark_task_failed,
+    claim_next_ready_task, claim_ready_tasks, mark_task_delayed, mark_task_done, mark_task_failed,
     recover_expired_leases, ClaimedTask, DEFAULT_LEASE_SECS,
 };
 pub use enqueue::{enqueue_extraction_task, EnqueueRequest};

--- a/src/extraction/claim.rs
+++ b/src/extraction/claim.rs
@@ -1,0 +1,354 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use super::types::TaskKind;
+
+/// Default lease duration. Short enough that crashed workers do not block
+/// progress for long; long enough that healthy workers do not get racy
+/// re-claims under normal AI batch latency.
+pub const DEFAULT_LEASE_SECS: i64 = 600;
+
+/// Minimal projection returned to the worker after a successful claim.
+pub struct ClaimedTask {
+    pub id: i64,
+    pub task_kind: TaskKind,
+    pub host_id: i64,
+    pub project_id: i64,
+    pub session_row_id: Option<i64>,
+    pub cursor_event_id: Option<i64>,
+    pub high_watermark_event_id: Option<i64>,
+    pub attempts: i64,
+}
+
+/// Claim up to `limit` ready tasks under `(host_id, project_id)`. Ready
+/// means status is `pending` or `delayed` and `next_retry_epoch` has
+/// passed; expired processing rows must be recovered first via
+/// `recover_expired_leases`. Sets the lease, bumps attempts, transitions
+/// to `processing`, and returns the projected rows.
+pub fn claim_ready_tasks(
+    conn: &Connection,
+    host_id: i64,
+    project_id: i64,
+    lease_owner: &str,
+    lease_secs: i64,
+    limit: usize,
+    now: i64,
+) -> Result<Vec<ClaimedTask>> {
+    let lease_expires = now + lease_secs;
+    let candidate_ids: Vec<i64> = conn
+        .prepare(
+            "SELECT id FROM extraction_tasks
+             WHERE host_id = ?1
+               AND project_id = ?2
+               AND status IN ('pending', 'delayed')
+               AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?3)
+               AND (lease_owner IS NULL OR lease_expires_epoch IS NULL
+                    OR lease_expires_epoch < ?3)
+             ORDER BY priority ASC, created_at_epoch ASC, id ASC
+             LIMIT ?4",
+        )?
+        .query_map(
+            params![host_id, project_id, now, limit as i64],
+            |row| row.get::<_, i64>(0),
+        )?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut claimed = Vec::with_capacity(candidate_ids.len());
+    for id in candidate_ids {
+        let updated = conn.execute(
+            "UPDATE extraction_tasks
+             SET status = 'processing',
+                 lease_owner = ?1,
+                 lease_expires_epoch = ?2,
+                 attempts = attempts + 1,
+                 next_retry_epoch = NULL,
+                 updated_at_epoch = ?3
+             WHERE id = ?4
+               AND status IN ('pending', 'delayed')",
+            params![lease_owner, lease_expires, now, id],
+        )?;
+        if updated == 0 {
+            // Lost race — another worker claimed in between SELECT and UPDATE.
+            continue;
+        }
+        let task = conn.query_row(
+            "SELECT id, task_kind, host_id, project_id, session_row_id,
+                    cursor_event_id, high_watermark_event_id, attempts
+             FROM extraction_tasks WHERE id = ?1",
+            [id],
+            |row| {
+                let kind_str: String = row.get(1)?;
+                let task_kind = TaskKind::parse(&kind_str).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        1,
+                        rusqlite::types::Type::Text,
+                        Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())),
+                    )
+                })?;
+                Ok(ClaimedTask {
+                    id: row.get(0)?,
+                    task_kind,
+                    host_id: row.get(2)?,
+                    project_id: row.get(3)?,
+                    session_row_id: row.get(4)?,
+                    cursor_event_id: row.get(5)?,
+                    high_watermark_event_id: row.get(6)?,
+                    attempts: row.get(7)?,
+                })
+            },
+        )?;
+        claimed.push(task);
+    }
+    Ok(claimed)
+}
+
+/// Reset processing rows whose lease has expired back to `pending` so
+/// future `claim_ready_tasks` calls can pick them up. Returns the number
+/// of rows recovered.
+pub fn recover_expired_leases(conn: &Connection, now: i64) -> Result<usize> {
+    let n = conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'pending',
+             lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             updated_at_epoch = ?1
+         WHERE status = 'processing'
+           AND lease_expires_epoch IS NOT NULL
+           AND lease_expires_epoch < ?1",
+        [now],
+    )?;
+    Ok(n)
+}
+
+/// Mark a task done. `new_cursor` is the event id range advanced by this
+/// run (per v2.1 §1 M4 progress invariant: progress is event-range-based,
+/// not observation-count-based). When `None`, leaves the cursor alone.
+pub fn mark_task_done(
+    conn: &Connection,
+    id: i64,
+    new_cursor: Option<i64>,
+    now: i64,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'done',
+             cursor_event_id = COALESCE(?1, cursor_event_id),
+             lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             last_error = NULL,
+             updated_at_epoch = ?2
+         WHERE id = ?3",
+        params![new_cursor, now, id],
+    )?;
+    Ok(())
+}
+
+/// Mark a task delayed (transient failure). Sets `next_retry_epoch`,
+/// records `last_error`, and clears the lease.
+pub fn mark_task_delayed(
+    conn: &Connection,
+    id: i64,
+    next_retry_epoch: i64,
+    last_error: &str,
+    now: i64,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'delayed',
+             lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             next_retry_epoch = ?1,
+             last_error = ?2,
+             updated_at_epoch = ?3
+         WHERE id = ?4",
+        params![next_retry_epoch, last_error, now, id],
+    )?;
+    Ok(())
+}
+
+/// Mark a task permanently failed. Lease is cleared.
+pub fn mark_task_failed(conn: &Connection, id: i64, last_error: &str, now: i64) -> Result<()> {
+    conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'failed',
+             lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             last_error = ?1,
+             updated_at_epoch = ?2
+         WHERE id = ?3",
+        params![last_error, now, id],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
+    use crate::extraction::enqueue::{enqueue_extraction_task, EnqueueRequest};
+    use crate::v2_db::open_v2_db_at;
+
+    fn fresh() -> (Connection, std::path::PathBuf, i64, i64, i64) {
+        let path = unique_temp_db_path("extr-claim");
+        let conn = open_v2_db_at(&path).unwrap();
+        conn.execute(
+            "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
+             VALUES ('/tmp/repo', 0, 0)",
+            [],
+        )
+        .unwrap();
+        let ws_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO projects(workspace_id, project_path, project_key,
+                created_at_epoch, updated_at_epoch)
+             VALUES (?1, '/tmp/repo', '/tmp/repo', 0, 0)",
+            [ws_id],
+        )
+        .unwrap();
+        let proj_id = conn.last_insert_rowid();
+        let host_id: i64 = conn
+            .query_row(
+                "SELECT id FROM hosts WHERE name = 'codex-cli'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        (conn, path, host_id, ws_id, proj_id)
+    }
+
+    fn enq(conn: &Connection, h: i64, w: i64, p: i64, key: &str, prio: i64, now: i64) -> i64 {
+        enqueue_extraction_task(
+            conn,
+            EnqueueRequest {
+                task_kind: TaskKind::SessionRollup,
+                host_id: h,
+                workspace_id: w,
+                project_id: p,
+                session_row_id: None,
+                priority: prio,
+                idempotency_key: key,
+                high_watermark_event_id: Some(1),
+                now,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn claim_returns_ready_in_priority_order() {
+        let (conn, path, h, w, p) = fresh();
+        enq(&conn, h, w, p, "low", 200, 100);
+        enq(&conn, h, w, p, "high", 50, 200);
+        enq(&conn, h, w, p, "mid", 100, 150);
+        let claimed = claim_ready_tasks(&conn, h, p, "owner", 600, 10, 1_000).unwrap();
+        let kinds: Vec<i64> = claimed.iter().map(|c| c.id).collect();
+        assert_eq!(kinds.len(), 3);
+        // Verify ordering by checking the priorities of the claimed rows.
+        let prios: Vec<i64> = kinds
+            .iter()
+            .map(|id| {
+                conn.query_row(
+                    "SELECT priority FROM extraction_tasks WHERE id = ?1",
+                    [id],
+                    |r| r.get(0),
+                )
+                .unwrap()
+            })
+            .collect();
+        assert_eq!(prios, vec![50, 100, 200]);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn claim_sets_lease_and_bumps_attempts() {
+        let (conn, path, h, w, p) = fresh();
+        enq(&conn, h, w, p, "k", 100, 100);
+        let claimed = claim_ready_tasks(&conn, h, p, "worker-1", 600, 10, 1_000).unwrap();
+        assert_eq!(claimed.len(), 1);
+        let (status, owner, expires, attempts): (String, String, i64, i64) = conn
+            .query_row(
+                "SELECT status, lease_owner, lease_expires_epoch, attempts FROM extraction_tasks",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "processing");
+        assert_eq!(owner, "worker-1");
+        assert_eq!(expires, 1_600);
+        assert_eq!(attempts, 1);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn claim_skips_rows_with_active_lease() {
+        let (conn, path, h, w, p) = fresh();
+        enq(&conn, h, w, p, "k", 100, 100);
+        let _ = claim_ready_tasks(&conn, h, p, "owner-a", 600, 10, 1_000).unwrap();
+        let second = claim_ready_tasks(&conn, h, p, "owner-b", 600, 10, 1_500).unwrap();
+        assert!(second.is_empty(), "lease still active, no claim");
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn claim_ignores_delayed_until_retry_epoch() {
+        let (conn, path, h, w, p) = fresh();
+        let id = enq(&conn, h, w, p, "k", 100, 100);
+        mark_task_delayed(&conn, id, 5_000, "transient", 1_000).unwrap();
+        let early = claim_ready_tasks(&conn, h, p, "owner", 600, 10, 4_000).unwrap();
+        assert!(early.is_empty(), "next_retry_epoch in the future");
+        let late = claim_ready_tasks(&conn, h, p, "owner", 600, 10, 6_000).unwrap();
+        assert_eq!(late.len(), 1);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn recover_expired_leases_resets_to_pending() {
+        let (conn, path, h, w, p) = fresh();
+        enq(&conn, h, w, p, "k", 100, 100);
+        let _ = claim_ready_tasks(&conn, h, p, "stale-worker", 60, 10, 1_000).unwrap();
+        // Time jumps past lease expiry.
+        let n = recover_expired_leases(&conn, 5_000).unwrap();
+        assert_eq!(n, 1);
+        let claimed = claim_ready_tasks(&conn, h, p, "fresh-worker", 600, 10, 6_000).unwrap();
+        assert_eq!(claimed.len(), 1);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn mark_task_done_clears_lease_and_advances_cursor() {
+        let (conn, path, h, w, p) = fresh();
+        enq(&conn, h, w, p, "k", 100, 100);
+        let claimed = claim_ready_tasks(&conn, h, p, "owner", 600, 10, 1_000).unwrap();
+        mark_task_done(&conn, claimed[0].id, Some(99), 2_000).unwrap();
+        let (status, owner, cursor): (String, Option<String>, Option<i64>) = conn
+            .query_row(
+                "SELECT status, lease_owner, cursor_event_id FROM extraction_tasks",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "done");
+        assert!(owner.is_none());
+        assert_eq!(cursor, Some(99));
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn mark_task_failed_clears_lease() {
+        let (conn, path, h, w, p) = fresh();
+        enq(&conn, h, w, p, "k", 100, 100);
+        let claimed = claim_ready_tasks(&conn, h, p, "owner", 600, 10, 1_000).unwrap();
+        mark_task_failed(&conn, claimed[0].id, "permanent", 2_000).unwrap();
+        let (status, err, owner): (String, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT status, last_error, lease_owner FROM extraction_tasks",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "failed");
+        assert_eq!(err.as_deref(), Some("permanent"));
+        assert!(owner.is_none());
+        cleanup_temp_db_files(&path);
+    }
+}

--- a/src/extraction/claim.rs
+++ b/src/extraction/claim.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use super::types::TaskKind;
 
@@ -18,6 +18,33 @@ pub struct ClaimedTask {
     pub cursor_event_id: Option<i64>,
     pub high_watermark_event_id: Option<i64>,
     pub attempts: i64,
+}
+
+/// Claim one ready task across all host/project identities.
+pub fn claim_next_ready_task(
+    conn: &Connection,
+    lease_owner: &str,
+    lease_secs: i64,
+    now: i64,
+) -> Result<Option<ClaimedTask>> {
+    let candidate_id: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM extraction_tasks
+             WHERE status IN ('pending', 'delayed')
+               AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?1)
+               AND (lease_owner IS NULL OR lease_expires_epoch IS NULL
+                    OR lease_expires_epoch < ?1)
+             ORDER BY priority ASC, created_at_epoch ASC, id ASC
+             LIMIT 1",
+            params![now],
+            |row| row.get(0),
+        )
+        .optional()?;
+
+    let Some(id) = candidate_id else {
+        return Ok(None);
+    };
+    claim_task_by_id(conn, id, lease_owner, now + lease_secs.max(1), now)
 }
 
 /// Claim up to `limit` ready tasks under `(host_id, project_id)`. Ready
@@ -47,59 +74,76 @@ pub fn claim_ready_tasks(
              ORDER BY priority ASC, created_at_epoch ASC, id ASC
              LIMIT ?4",
         )?
-        .query_map(
-            params![host_id, project_id, now, limit as i64],
-            |row| row.get::<_, i64>(0),
-        )?
+        .query_map(params![host_id, project_id, now, limit as i64], |row| {
+            row.get::<_, i64>(0)
+        })?
         .collect::<Result<Vec<_>, _>>()?;
 
     let mut claimed = Vec::with_capacity(candidate_ids.len());
     for id in candidate_ids {
-        let updated = conn.execute(
-            "UPDATE extraction_tasks
-             SET status = 'processing',
-                 lease_owner = ?1,
-                 lease_expires_epoch = ?2,
-                 attempts = attempts + 1,
-                 next_retry_epoch = NULL,
-                 updated_at_epoch = ?3
-             WHERE id = ?4
-               AND status IN ('pending', 'delayed')",
-            params![lease_owner, lease_expires, now, id],
-        )?;
-        if updated == 0 {
-            // Lost race — another worker claimed in between SELECT and UPDATE.
-            continue;
+        if let Some(task) = claim_task_by_id(conn, id, lease_owner, lease_expires, now)? {
+            claimed.push(task);
         }
-        let task = conn.query_row(
-            "SELECT id, task_kind, host_id, project_id, session_row_id,
-                    cursor_event_id, high_watermark_event_id, attempts
-             FROM extraction_tasks WHERE id = ?1",
-            [id],
-            |row| {
-                let kind_str: String = row.get(1)?;
-                let task_kind = TaskKind::parse(&kind_str).map_err(|e| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        1,
-                        rusqlite::types::Type::Text,
-                        Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())),
-                    )
-                })?;
-                Ok(ClaimedTask {
-                    id: row.get(0)?,
-                    task_kind,
-                    host_id: row.get(2)?,
-                    project_id: row.get(3)?,
-                    session_row_id: row.get(4)?,
-                    cursor_event_id: row.get(5)?,
-                    high_watermark_event_id: row.get(6)?,
-                    attempts: row.get(7)?,
-                })
-            },
-        )?;
-        claimed.push(task);
     }
     Ok(claimed)
+}
+
+fn claim_task_by_id(
+    conn: &Connection,
+    id: i64,
+    lease_owner: &str,
+    lease_expires: i64,
+    now: i64,
+) -> Result<Option<ClaimedTask>> {
+    let updated = conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'processing',
+             lease_owner = ?1,
+             lease_expires_epoch = ?2,
+             attempts = attempts + 1,
+             next_retry_epoch = NULL,
+             updated_at_epoch = ?3
+         WHERE id = ?4
+           AND status IN ('pending', 'delayed')",
+        params![lease_owner, lease_expires, now, id],
+    )?;
+    if updated == 0 {
+        return Ok(None);
+    }
+    load_claimed_task(conn, id).map(Some)
+}
+
+fn load_claimed_task(conn: &Connection, id: i64) -> Result<ClaimedTask> {
+    conn.query_row(
+        "SELECT id, task_kind, host_id, project_id, session_row_id,
+                cursor_event_id, high_watermark_event_id, attempts
+         FROM extraction_tasks WHERE id = ?1",
+        [id],
+        |row| {
+            let kind_str: String = row.get(1)?;
+            let task_kind = TaskKind::parse(&kind_str).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    1,
+                    rusqlite::types::Type::Text,
+                    Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        e.to_string(),
+                    )),
+                )
+            })?;
+            Ok(ClaimedTask {
+                id: row.get(0)?,
+                task_kind,
+                host_id: row.get(2)?,
+                project_id: row.get(3)?,
+                session_row_id: row.get(4)?,
+                cursor_event_id: row.get(5)?,
+                high_watermark_event_id: row.get(6)?,
+                attempts: row.get(7)?,
+            })
+        },
+    )
+    .map_err(Into::into)
 }
 
 /// Reset processing rows whose lease has expired back to `pending` so
@@ -121,14 +165,9 @@ pub fn recover_expired_leases(conn: &Connection, now: i64) -> Result<usize> {
 }
 
 /// Mark a task done. `new_cursor` is the event id range advanced by this
-/// run (per v2.1 §1 M4 progress invariant: progress is event-range-based,
+/// run. Progress is event-range-based,
 /// not observation-count-based). When `None`, leaves the cursor alone.
-pub fn mark_task_done(
-    conn: &Connection,
-    id: i64,
-    new_cursor: Option<i64>,
-    now: i64,
-) -> Result<()> {
+pub fn mark_task_done(conn: &Connection, id: i64, new_cursor: Option<i64>, now: i64) -> Result<()> {
     conn.execute(
         "UPDATE extraction_tasks
          SET status = 'done',
@@ -184,13 +223,13 @@ pub fn mark_task_failed(conn: &Connection, id: i64, last_error: &str, now: i64) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::schema::open_at as open_schema_at;
     use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
     use crate::extraction::enqueue::{enqueue_extraction_task, EnqueueRequest};
-    use crate::v2_db::open_v2_db_at;
 
     fn fresh() -> (Connection, std::path::PathBuf, i64, i64, i64) {
         let path = unique_temp_db_path("extr-claim");
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
         conn.execute(
             "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
              VALUES ('/tmp/repo', 0, 0)",
@@ -207,11 +246,9 @@ mod tests {
         .unwrap();
         let proj_id = conn.last_insert_rowid();
         let host_id: i64 = conn
-            .query_row(
-                "SELECT id FROM hosts WHERE name = 'codex-cli'",
-                [],
-                |r| r.get(0),
-            )
+            .query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         (conn, path, host_id, ws_id, proj_id)
     }

--- a/src/extraction/claim.rs
+++ b/src/extraction/claim.rs
@@ -104,7 +104,10 @@ fn claim_task_by_id(
              next_retry_epoch = NULL,
              updated_at_epoch = ?3
          WHERE id = ?4
-           AND status IN ('pending', 'delayed')",
+           AND status IN ('pending', 'delayed')
+           AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?3)
+           AND (lease_owner IS NULL OR lease_expires_epoch IS NULL
+                OR lease_expires_epoch < ?3)",
         params![lease_owner, lease_expires, now, id],
     )?;
     if updated == 0 {

--- a/src/extraction/enqueue.rs
+++ b/src/extraction/enqueue.rs
@@ -1,0 +1,218 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::types::TaskKind;
+
+/// Inputs for `enqueue_extraction_task`. `idempotency_key` carries the
+/// uniqueness contract — repeated enqueues with the same key coalesce
+/// onto the existing row instead of creating duplicates.
+pub struct EnqueueRequest<'a> {
+    pub task_kind: TaskKind,
+    pub host_id: i64,
+    pub workspace_id: i64,
+    pub project_id: i64,
+    pub session_row_id: Option<i64>,
+    pub priority: i64,
+    pub idempotency_key: &'a str,
+    pub high_watermark_event_id: Option<i64>,
+    pub now: i64,
+}
+
+/// Insert or coalesce an extraction task. Idempotent on `idempotency_key`:
+/// when a row already exists, only `high_watermark_event_id` is bumped (and
+/// only when the new value is strictly greater than the current). Returns
+/// the row id of the new or existing task.
+pub fn enqueue_extraction_task(conn: &Connection, req: EnqueueRequest) -> Result<i64> {
+    if let Some((id, current_hwm)) = conn
+        .query_row(
+            "SELECT id, high_watermark_event_id FROM extraction_tasks
+             WHERE idempotency_key = ?1",
+            [req.idempotency_key],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Option<i64>>(1)?)),
+        )
+        .optional()?
+    {
+        let bumped = match (current_hwm, req.high_watermark_event_id) {
+            (Some(curr), Some(new)) if new > curr => Some(new),
+            (None, Some(new)) => Some(new),
+            _ => None,
+        };
+        if let Some(new_hwm) = bumped {
+            conn.execute(
+                "UPDATE extraction_tasks
+                 SET high_watermark_event_id = ?1, updated_at_epoch = ?2
+                 WHERE id = ?3",
+                params![new_hwm, req.now, id],
+            )?;
+        }
+        return Ok(id);
+    }
+    conn.execute(
+        "INSERT INTO extraction_tasks(
+            task_kind, host_id, workspace_id, project_id, session_row_id,
+            priority, status, idempotency_key,
+            cursor_event_id, high_watermark_event_id,
+            attempts, next_retry_epoch, lease_owner, lease_expires_epoch,
+            last_error, created_at_epoch, updated_at_epoch
+         ) VALUES (
+            ?1, ?2, ?3, ?4, ?5,
+            ?6, 'pending', ?7,
+            NULL, ?8,
+            0, NULL, NULL, NULL,
+            NULL, ?9, ?9
+         )",
+        params![
+            req.task_kind.as_db_value(),
+            req.host_id,
+            req.workspace_id,
+            req.project_id,
+            req.session_row_id,
+            req.priority,
+            req.idempotency_key,
+            req.high_watermark_event_id,
+            req.now,
+        ],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
+    use crate::v2_db::open_v2_db_at;
+
+    fn fresh() -> (Connection, std::path::PathBuf) {
+        let path = unique_temp_db_path("extr-enq");
+        let conn = open_v2_db_at(&path).unwrap();
+        // Seed minimal FK rows.
+        conn.execute(
+            "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
+             VALUES ('/tmp/repo', 0, 0)",
+            [],
+        )
+        .unwrap();
+        let ws_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO projects(workspace_id, project_path, project_key,
+                created_at_epoch, updated_at_epoch)
+             VALUES (?1, '/tmp/repo', '/tmp/repo', 0, 0)",
+            [ws_id],
+        )
+        .unwrap();
+        (conn, path)
+    }
+
+    fn host_codex(conn: &Connection) -> i64 {
+        conn.query_row(
+            "SELECT id FROM hosts WHERE name = 'codex-cli'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    fn ids(conn: &Connection) -> (i64, i64, i64) {
+        let host_id = host_codex(conn);
+        let ws_id: i64 = conn
+            .query_row("SELECT id FROM workspaces LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        let proj_id: i64 = conn
+            .query_row("SELECT id FROM projects LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        (host_id, ws_id, proj_id)
+    }
+
+    #[test]
+    fn enqueue_inserts_pending_row() {
+        let (conn, path) = fresh();
+        let (h, w, p) = ids(&conn);
+        let id = enqueue_extraction_task(
+            &conn,
+            EnqueueRequest {
+                task_kind: TaskKind::SessionRollup,
+                host_id: h,
+                workspace_id: w,
+                project_id: p,
+                session_row_id: None,
+                priority: 100,
+                idempotency_key: "k1",
+                high_watermark_event_id: Some(42),
+                now: 1_000,
+            },
+        )
+        .unwrap();
+        let (status, hwm, attempts): (String, i64, i64) = conn
+            .query_row(
+                "SELECT status, high_watermark_event_id, attempts FROM extraction_tasks WHERE id = ?1",
+                [id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "pending");
+        assert_eq!(hwm, 42);
+        assert_eq!(attempts, 0);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn enqueue_dedupes_on_idempotency_key() {
+        let (conn, path) = fresh();
+        let (h, w, p) = ids(&conn);
+        let req = |hwm| EnqueueRequest {
+            task_kind: TaskKind::SessionRollup,
+            host_id: h,
+            workspace_id: w,
+            project_id: p,
+            session_row_id: None,
+            priority: 100,
+            idempotency_key: "shared",
+            high_watermark_event_id: Some(hwm),
+            now: 1_000,
+        };
+        let id1 = enqueue_extraction_task(&conn, req(10)).unwrap();
+        let id2 = enqueue_extraction_task(&conn, req(20)).unwrap();
+        assert_eq!(id1, id2);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM extraction_tasks", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        let hwm: i64 = conn
+            .query_row(
+                "SELECT high_watermark_event_id FROM extraction_tasks WHERE id = ?1",
+                [id1],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(hwm, 20, "second enqueue with larger hwm bumps the row");
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn enqueue_does_not_lower_existing_hwm() {
+        let (conn, path) = fresh();
+        let (h, w, p) = ids(&conn);
+        let req = |hwm| EnqueueRequest {
+            task_kind: TaskKind::SessionRollup,
+            host_id: h,
+            workspace_id: w,
+            project_id: p,
+            session_row_id: None,
+            priority: 100,
+            idempotency_key: "lower",
+            high_watermark_event_id: Some(hwm),
+            now: 1_000,
+        };
+        enqueue_extraction_task(&conn, req(50)).unwrap();
+        enqueue_extraction_task(&conn, req(30)).unwrap();
+        let hwm: i64 = conn
+            .query_row(
+                "SELECT high_watermark_event_id FROM extraction_tasks",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(hwm, 50, "smaller hwm must not regress");
+        cleanup_temp_db_files(&path);
+    }
+}

--- a/src/extraction/enqueue.rs
+++ b/src/extraction/enqueue.rs
@@ -79,12 +79,12 @@ pub fn enqueue_extraction_task(conn: &Connection, req: EnqueueRequest) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::schema::open_at as open_schema_at;
     use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
-    use crate::v2_db::open_v2_db_at;
 
     fn fresh() -> (Connection, std::path::PathBuf) {
         let path = unique_temp_db_path("extr-enq");
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
         // Seed minimal FK rows.
         conn.execute(
             "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
@@ -104,11 +104,9 @@ mod tests {
     }
 
     fn host_codex(conn: &Connection) -> i64 {
-        conn.query_row(
-            "SELECT id FROM hosts WHERE name = 'codex-cli'",
-            [],
-            |r| r.get(0),
-        )
+        conn.query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |r| {
+            r.get(0)
+        })
         .unwrap()
     }
 

--- a/src/extraction/enqueue.rs
+++ b/src/extraction/enqueue.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection};
 
 use super::types::TaskKind;
 
@@ -23,30 +23,6 @@ pub struct EnqueueRequest<'a> {
 /// only when the new value is strictly greater than the current). Returns
 /// the row id of the new or existing task.
 pub fn enqueue_extraction_task(conn: &Connection, req: EnqueueRequest) -> Result<i64> {
-    if let Some((id, current_hwm)) = conn
-        .query_row(
-            "SELECT id, high_watermark_event_id FROM extraction_tasks
-             WHERE idempotency_key = ?1",
-            [req.idempotency_key],
-            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Option<i64>>(1)?)),
-        )
-        .optional()?
-    {
-        let bumped = match (current_hwm, req.high_watermark_event_id) {
-            (Some(curr), Some(new)) if new > curr => Some(new),
-            (None, Some(new)) => Some(new),
-            _ => None,
-        };
-        if let Some(new_hwm) = bumped {
-            conn.execute(
-                "UPDATE extraction_tasks
-                 SET high_watermark_event_id = ?1, updated_at_epoch = ?2
-                 WHERE id = ?3",
-                params![new_hwm, req.now, id],
-            )?;
-        }
-        return Ok(id);
-    }
     conn.execute(
         "INSERT INTO extraction_tasks(
             task_kind, host_id, workspace_id, project_id, session_row_id,
@@ -54,13 +30,28 @@ pub fn enqueue_extraction_task(conn: &Connection, req: EnqueueRequest) -> Result
             cursor_event_id, high_watermark_event_id,
             attempts, next_retry_epoch, lease_owner, lease_expires_epoch,
             last_error, created_at_epoch, updated_at_epoch
-         ) VALUES (
+             ) VALUES (
             ?1, ?2, ?3, ?4, ?5,
             ?6, 'pending', ?7,
             NULL, ?8,
             0, NULL, NULL, NULL,
             NULL, ?9, ?9
-         )",
+         )
+         ON CONFLICT(idempotency_key) DO UPDATE SET
+             high_watermark_event_id = CASE
+                 WHEN excluded.high_watermark_event_id IS NOT NULL
+                  AND (extraction_tasks.high_watermark_event_id IS NULL
+                       OR excluded.high_watermark_event_id > extraction_tasks.high_watermark_event_id)
+                 THEN excluded.high_watermark_event_id
+                 ELSE extraction_tasks.high_watermark_event_id
+             END,
+             updated_at_epoch = CASE
+                 WHEN excluded.high_watermark_event_id IS NOT NULL
+                  AND (extraction_tasks.high_watermark_event_id IS NULL
+                       OR excluded.high_watermark_event_id > extraction_tasks.high_watermark_event_id)
+                 THEN excluded.updated_at_epoch
+                 ELSE extraction_tasks.updated_at_epoch
+             END",
         params![
             req.task_kind.as_db_value(),
             req.host_id,
@@ -73,7 +64,12 @@ pub fn enqueue_extraction_task(conn: &Connection, req: EnqueueRequest) -> Result
             req.now,
         ],
     )?;
-    Ok(conn.last_insert_rowid())
+    conn.query_row(
+        "SELECT id FROM extraction_tasks WHERE idempotency_key = ?1",
+        [req.idempotency_key],
+        |row| row.get::<_, i64>(0),
+    )
+    .map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/extraction/query.rs
+++ b/src/extraction/query.rs
@@ -47,15 +47,15 @@ pub fn oldest_ready_epoch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::schema::open_at as open_schema_at;
     use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
     use crate::extraction::claim::mark_task_delayed;
     use crate::extraction::enqueue::{enqueue_extraction_task, EnqueueRequest};
     use crate::extraction::types::TaskKind;
-    use crate::v2_db::open_v2_db_at;
 
     fn fresh() -> (Connection, std::path::PathBuf, i64, i64, i64) {
         let path = unique_temp_db_path("extr-q");
-        let conn = open_v2_db_at(&path).unwrap();
+        let conn = open_schema_at(&path).unwrap();
         conn.execute(
             "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
              VALUES ('/tmp/repo', 0, 0)",
@@ -72,11 +72,9 @@ mod tests {
         .unwrap();
         let proj_id = conn.last_insert_rowid();
         let host_id: i64 = conn
-            .query_row(
-                "SELECT id FROM hosts WHERE name = 'codex-cli'",
-                [],
-                |r| r.get(0),
-            )
+            .query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         (conn, path, host_id, ws_id, proj_id)
     }

--- a/src/extraction/query.rs
+++ b/src/extraction/query.rs
@@ -1,0 +1,141 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+
+/// Count tasks ready to be claimed under `(host_id, project_id)`. "Ready"
+/// matches the same predicate as `claim_ready_tasks`: status pending /
+/// delayed and `next_retry_epoch` past.
+pub fn count_ready_for_identity(
+    conn: &Connection,
+    host_id: i64,
+    project_id: i64,
+    now: i64,
+) -> Result<i64> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM extraction_tasks
+         WHERE host_id = ?1
+           AND project_id = ?2
+           AND status IN ('pending', 'delayed')
+           AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?3)",
+        params![host_id, project_id, now],
+        |row| row.get(0),
+    )?;
+    Ok(count)
+}
+
+/// Earliest `created_at_epoch` among ready tasks for this identity, or
+/// `None` when nothing is ready. Useful for status / doctor age signals.
+pub fn oldest_ready_epoch(
+    conn: &Connection,
+    host_id: i64,
+    project_id: i64,
+    now: i64,
+) -> Result<Option<i64>> {
+    let row = conn
+        .query_row(
+            "SELECT MIN(created_at_epoch) FROM extraction_tasks
+             WHERE host_id = ?1
+               AND project_id = ?2
+               AND status IN ('pending', 'delayed')
+               AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?3)",
+            params![host_id, project_id, now],
+            |r| r.get::<_, Option<i64>>(0),
+        )
+        .optional()?;
+    Ok(row.flatten())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
+    use crate::extraction::claim::mark_task_delayed;
+    use crate::extraction::enqueue::{enqueue_extraction_task, EnqueueRequest};
+    use crate::extraction::types::TaskKind;
+    use crate::v2_db::open_v2_db_at;
+
+    fn fresh() -> (Connection, std::path::PathBuf, i64, i64, i64) {
+        let path = unique_temp_db_path("extr-q");
+        let conn = open_v2_db_at(&path).unwrap();
+        conn.execute(
+            "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
+             VALUES ('/tmp/repo', 0, 0)",
+            [],
+        )
+        .unwrap();
+        let ws_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO projects(workspace_id, project_path, project_key,
+                created_at_epoch, updated_at_epoch)
+             VALUES (?1, '/tmp/repo', '/tmp/repo', 0, 0)",
+            [ws_id],
+        )
+        .unwrap();
+        let proj_id = conn.last_insert_rowid();
+        let host_id: i64 = conn
+            .query_row(
+                "SELECT id FROM hosts WHERE name = 'codex-cli'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        (conn, path, host_id, ws_id, proj_id)
+    }
+
+    fn enq(conn: &Connection, h: i64, w: i64, p: i64, key: &str, now: i64) -> i64 {
+        enqueue_extraction_task(
+            conn,
+            EnqueueRequest {
+                task_kind: TaskKind::SessionRollup,
+                host_id: h,
+                workspace_id: w,
+                project_id: p,
+                session_row_id: None,
+                priority: 100,
+                idempotency_key: key,
+                high_watermark_event_id: Some(1),
+                now,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn count_ready_returns_zero_for_empty_table() {
+        let (conn, path, h, _, p) = fresh();
+        assert_eq!(count_ready_for_identity(&conn, h, p, 1_000).unwrap(), 0);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn count_ready_includes_pending_and_due_delayed() {
+        let (conn, path, h, w, p) = fresh();
+        enq(&conn, h, w, p, "pending-1", 100);
+        enq(&conn, h, w, p, "pending-2", 200);
+        let id = enq(&conn, h, w, p, "delayed", 300);
+        mark_task_delayed(&conn, id, 5_000, "transient", 400).unwrap();
+
+        // Before retry epoch: only the 2 pending rows count.
+        assert_eq!(count_ready_for_identity(&conn, h, p, 4_000).unwrap(), 2);
+        // After retry epoch: delayed becomes ready.
+        assert_eq!(count_ready_for_identity(&conn, h, p, 6_000).unwrap(), 3);
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn oldest_ready_returns_earliest_created_at() {
+        let (conn, path, h, w, p) = fresh();
+        enq(&conn, h, w, p, "newer", 500);
+        enq(&conn, h, w, p, "oldest", 100);
+        enq(&conn, h, w, p, "middle", 300);
+        let oldest = oldest_ready_epoch(&conn, h, p, 1_000).unwrap();
+        assert_eq!(oldest, Some(100));
+        cleanup_temp_db_files(&path);
+    }
+
+    #[test]
+    fn oldest_ready_returns_none_when_empty() {
+        let (conn, path, h, _, p) = fresh();
+        assert_eq!(oldest_ready_epoch(&conn, h, p, 1_000).unwrap(), None);
+        cleanup_temp_db_files(&path);
+    }
+}

--- a/src/extraction/types.rs
+++ b/src/extraction/types.rs
@@ -1,0 +1,81 @@
+use anyhow::{anyhow, Result};
+
+/// v2 SPEC §8.1 task kinds. Priority order is encoded by the caller via the
+/// `priority` column (lower number = higher priority); this enum carries
+/// only the canonical name written into `extraction_tasks.task_kind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskKind {
+    SessionRollup,
+    ObservationExtract,
+    MemoryCandidate,
+    RuleCandidate,
+    IndexUpdate,
+}
+
+impl TaskKind {
+    pub fn as_db_value(self) -> &'static str {
+        match self {
+            TaskKind::SessionRollup => "session_rollup",
+            TaskKind::ObservationExtract => "observation_extract",
+            TaskKind::MemoryCandidate => "memory_candidate",
+            TaskKind::RuleCandidate => "rule_candidate",
+            TaskKind::IndexUpdate => "index_update",
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "session_rollup" => Ok(TaskKind::SessionRollup),
+            "observation_extract" => Ok(TaskKind::ObservationExtract),
+            "memory_candidate" => Ok(TaskKind::MemoryCandidate),
+            "rule_candidate" => Ok(TaskKind::RuleCandidate),
+            "index_update" => Ok(TaskKind::IndexUpdate),
+            other => Err(anyhow!("unknown extraction task_kind: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskStatus {
+    Pending,
+    Processing,
+    Delayed,
+    Done,
+    Failed,
+}
+
+impl TaskStatus {
+    pub fn as_db_value(self) -> &'static str {
+        match self {
+            TaskStatus::Pending => "pending",
+            TaskStatus::Processing => "processing",
+            TaskStatus::Delayed => "delayed",
+            TaskStatus::Done => "done",
+            TaskStatus::Failed => "failed",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_kind_round_trip() {
+        for k in [
+            TaskKind::SessionRollup,
+            TaskKind::ObservationExtract,
+            TaskKind::MemoryCandidate,
+            TaskKind::RuleCandidate,
+            TaskKind::IndexUpdate,
+        ] {
+            assert_eq!(TaskKind::parse(k.as_db_value()).unwrap(), k);
+        }
+    }
+
+    #[test]
+    fn task_kind_rejects_unknown() {
+        assert!(TaskKind::parse("nope").is_err());
+        assert!(TaskKind::parse("").is_err());
+    }
+}

--- a/src/extraction/types.rs
+++ b/src/extraction/types.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 
-/// v2 SPEC §8.1 task kinds. Priority order is encoded by the caller via the
+/// Extraction task kinds. Priority order is encoded by the caller via the
 /// `priority` column (lower number = higher priority); this enum carries
 /// only the canonical name written into `extraction_tasks.task_kind`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/extraction/worker.rs
+++ b/src/extraction/worker.rs
@@ -1,0 +1,334 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+use tokio::time::{sleep, Duration};
+
+use crate::extraction::{
+    claim_next_ready_task, mark_task_delayed, mark_task_done, mark_task_failed,
+    recover_expired_leases, ClaimedTask, TaskKind, DEFAULT_LEASE_SECS,
+};
+
+const TASK_TIMEOUT_SECS: u64 = 420;
+const TASK_LEASE_SECS: i64 = DEFAULT_LEASE_SECS;
+const MAX_TASK_ATTEMPTS: i64 = 5;
+pub const WORKER_HEARTBEAT_HEALTH_SECS: i64 = 480;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerHeartbeat {
+    pub owner: String,
+    pub pid: Option<i64>,
+    pub mode: String,
+    pub started_at_epoch: i64,
+    pub updated_at_epoch: i64,
+}
+
+enum TaskOutcome {
+    #[allow(dead_code)]
+    Done {
+        new_cursor: Option<i64>,
+    },
+    PermanentFailure(String),
+}
+
+fn retry_backoff_secs(attempt: i64) -> i64 {
+    match attempt {
+        0 | 1 => 5,
+        2 => 15,
+        3 => 45,
+        4 => 120,
+        _ => 300,
+    }
+}
+
+fn record_worker_heartbeat(
+    conn: &Connection,
+    owner: &str,
+    mode: &str,
+    started_at_epoch: i64,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "INSERT INTO worker_heartbeats(owner, pid, mode, started_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(owner) DO UPDATE SET
+             pid = excluded.pid,
+             mode = excluded.mode,
+             updated_at_epoch = excluded.updated_at_epoch",
+        params![
+            owner,
+            i64::from(std::process::id()),
+            mode,
+            started_at_epoch,
+            now
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn latest_worker_heartbeat(conn: &Connection) -> Result<Option<WorkerHeartbeat>> {
+    conn.query_row(
+        "SELECT owner, pid, mode, started_at_epoch, updated_at_epoch
+         FROM worker_heartbeats
+         ORDER BY updated_at_epoch DESC, owner ASC
+         LIMIT 1",
+        [],
+        |row| {
+            Ok(WorkerHeartbeat {
+                owner: row.get(0)?,
+                pid: row.get(1)?,
+                mode: row.get(2)?,
+                started_at_epoch: row.get(3)?,
+                updated_at_epoch: row.get(4)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub fn healthy_worker_heartbeat(conn: &Connection) -> Result<Option<WorkerHeartbeat>> {
+    let now = chrono::Utc::now().timestamp();
+    conn.query_row(
+        "SELECT owner, pid, mode, started_at_epoch, updated_at_epoch
+         FROM worker_heartbeats
+         WHERE mode = 'daemon' AND updated_at_epoch >= ?1
+         ORDER BY updated_at_epoch DESC, owner ASC
+         LIMIT 1",
+        params![now.saturating_sub(WORKER_HEARTBEAT_HEALTH_SECS)],
+        |row| {
+            Ok(WorkerHeartbeat {
+                owner: row.get(0)?,
+                pid: row.get(1)?,
+                mode: row.get(2)?,
+                started_at_epoch: row.get(3)?,
+                updated_at_epoch: row.get(4)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+async fn process_task(task: &ClaimedTask) -> Result<TaskOutcome> {
+    let message = match task.task_kind {
+        TaskKind::SessionRollup => "session_rollup handler is not implemented",
+        TaskKind::ObservationExtract => "observation_extract handler is not implemented",
+        TaskKind::MemoryCandidate => "memory_candidate handler is not implemented",
+        TaskKind::RuleCandidate => "rule_candidate handler is not implemented",
+        TaskKind::IndexUpdate => "index_update handler is not implemented",
+    };
+    Ok(TaskOutcome::PermanentFailure(message.to_string()))
+}
+
+fn fail_or_delay_task(
+    conn: &Connection,
+    task: &ClaimedTask,
+    message: &str,
+    now: i64,
+) -> Result<()> {
+    if task.attempts >= MAX_TASK_ATTEMPTS {
+        mark_task_failed(conn, task.id, message, now)
+    } else {
+        mark_task_delayed(
+            conn,
+            task.id,
+            now + retry_backoff_secs(task.attempts),
+            message,
+            now,
+        )
+    }
+}
+
+pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
+    let started_at_epoch = chrono::Utc::now().timestamp();
+    let owner = format!(
+        "worker-{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_millis()
+    );
+    let mode = if once { "once" } else { "daemon" };
+    crate::log::info("worker", &format!("start owner={} mode={}", owner, mode));
+
+    loop {
+        let conn = crate::db::schema::open()?;
+        record_worker_heartbeat(&conn, &owner, mode, started_at_epoch)?;
+
+        let now = chrono::Utc::now().timestamp();
+        let recovered = recover_expired_leases(&conn, now)?;
+        if recovered > 0 {
+            crate::log::warn(
+                "worker",
+                &format!("recovered {} expired extraction task lease(s)", recovered),
+            );
+        }
+
+        let Some(task) = claim_next_ready_task(&conn, &owner, TASK_LEASE_SECS, now)? else {
+            if once {
+                break;
+            }
+            sleep(Duration::from_millis(idle_sleep_ms.max(100))).await;
+            continue;
+        };
+
+        crate::log::info(
+            "worker",
+            &format!(
+                "claimed extraction task id={} kind={} attempt={}",
+                task.id,
+                task.task_kind.as_db_value(),
+                task.attempts
+            ),
+        );
+
+        let timed =
+            tokio::time::timeout(Duration::from_secs(TASK_TIMEOUT_SECS), process_task(&task)).await;
+        let conn = crate::db::schema::open()?;
+        let now = chrono::Utc::now().timestamp();
+        match timed {
+            Ok(Ok(TaskOutcome::Done { new_cursor })) => {
+                mark_task_done(&conn, task.id, new_cursor, now)?;
+                crate::log::info("worker", &format!("done extraction task id={}", task.id));
+            }
+            Ok(Ok(TaskOutcome::PermanentFailure(message))) => {
+                mark_task_failed(&conn, task.id, &message, now)?;
+                crate::log::warn(
+                    "worker",
+                    &format!("extraction task id={} failed: {}", task.id, message),
+                );
+            }
+            Ok(Err(error)) => {
+                let message = error.to_string();
+                fail_or_delay_task(&conn, &task, &message, now)?;
+                crate::log::warn(
+                    "worker",
+                    &format!("extraction task id={} error: {}", task.id, message),
+                );
+            }
+            Err(_) => {
+                let message = format!("task timed out after {}s", TASK_TIMEOUT_SECS);
+                fail_or_delay_task(&conn, &task, &message, now)?;
+                crate::log::warn("worker", &format!("extraction task id={} timeout", task.id));
+            }
+        }
+    }
+
+    let conn = crate::db::schema::open()?;
+    record_worker_heartbeat(&conn, &owner, mode, started_at_epoch)?;
+    crate::log::info("worker", "stopped");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{params, Connection};
+
+    use super::*;
+    use crate::db::test_support::ScopedTestDataDir;
+    use crate::extraction::{enqueue_extraction_task, EnqueueRequest};
+
+    fn seed_identity(conn: &Connection) -> (i64, i64, i64) {
+        conn.execute(
+            "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
+             VALUES ('/tmp/repo', 0, 0)",
+            [],
+        )
+        .unwrap();
+        let workspace_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO projects(workspace_id, project_path, project_key,
+                created_at_epoch, updated_at_epoch)
+             VALUES (?1, '/tmp/repo', '/tmp/repo', 0, 0)",
+            [workspace_id],
+        )
+        .unwrap();
+        let project_id = conn.last_insert_rowid();
+        let host_id: i64 = conn
+            .query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        (host_id, workspace_id, project_id)
+    }
+
+    fn enqueue_task(conn: &Connection, task_kind: TaskKind) -> i64 {
+        let (host_id, workspace_id, project_id) = seed_identity(conn);
+        enqueue_extraction_task(
+            conn,
+            EnqueueRequest {
+                task_kind,
+                host_id,
+                workspace_id,
+                project_id,
+                session_row_id: None,
+                priority: 100,
+                idempotency_key: task_kind.as_db_value(),
+                high_watermark_event_id: Some(7),
+                now: 1_000,
+            },
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn worker_marks_unimplemented_task_failed() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("extraction-worker-unimplemented");
+        let conn = crate::db::schema::open()?;
+        let task_id = enqueue_task(&conn, TaskKind::SessionRollup);
+        drop(conn);
+
+        run(true, 10).await?;
+
+        let conn = crate::db::schema::open()?;
+        let (status, last_error, owner): (String, String, Option<String>) = conn.query_row(
+            "SELECT status, last_error, lease_owner FROM extraction_tasks WHERE id = ?1",
+            [task_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(status, "failed");
+        assert!(last_error.contains("handler is not implemented"));
+        assert!(owner.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn worker_recovers_expired_lease_before_claiming() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("extraction-worker-recover");
+        let conn = crate::db::schema::open()?;
+        let task_id = enqueue_task(&conn, TaskKind::ObservationExtract);
+        conn.execute(
+            "UPDATE extraction_tasks
+             SET status = 'processing',
+                 lease_owner = 'old-worker',
+                 lease_expires_epoch = ?1
+             WHERE id = ?2",
+            params![chrono::Utc::now().timestamp() - 60, task_id],
+        )?;
+        drop(conn);
+
+        run(true, 10).await?;
+
+        let conn = crate::db::schema::open()?;
+        let (status, attempts): (String, i64) = conn.query_row(
+            "SELECT status, attempts FROM extraction_tasks WHERE id = ?1",
+            [task_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(status, "failed");
+        assert_eq!(attempts, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn daemon_records_healthy_heartbeat() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("extraction-worker-heartbeat");
+        let timed =
+            tokio::time::timeout(std::time::Duration::from_millis(40), run(false, 10)).await;
+        assert!(timed.is_err(), "daemon worker should keep running");
+
+        let conn = crate::db::schema::open()?;
+        let heartbeat = healthy_worker_heartbeat(&conn)?.expect("heartbeat should be healthy");
+        assert_eq!(heartbeat.mode, "daemon");
+        assert!(heartbeat.owner.starts_with("worker-"));
+        assert!(heartbeat.updated_at_epoch >= heartbeat.started_at_epoch);
+        Ok(())
+    }
+}

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -46,8 +46,8 @@ impl InstallHost {
 
     /// Resolve the install-time host from environment variables. Existing
     /// install paths already inject host identity per hook (the `--host`
-    /// CLI flag in v2.1 M2 is one option; the shipped install uses env
-    /// vars). Priority order matches the install layout:
+    /// CLI flag is one option; the shipped install uses env vars). Priority
+    /// order matches the install layout:
     ///   1. `REMEM_HOOK_ADAPTER` (set on observe hook command)
     ///   2. `REMEM_CONTEXT_HOST` (set on context / summarize hook command)
     ///   3. `REMEM_HOST` (explicit override for wrapper scripts)

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -43,6 +43,36 @@ impl InstallHost {
             )),
         }
     }
+
+    /// Resolve the install-time host from environment variables. Existing
+    /// install paths already inject host identity per hook (the `--host`
+    /// CLI flag in v2.1 M2 is one option; the shipped install uses env
+    /// vars). Priority order matches the install layout:
+    ///   1. `REMEM_HOOK_ADAPTER` (set on observe hook command)
+    ///   2. `REMEM_CONTEXT_HOST` (set on context / summarize hook command)
+    ///   3. `REMEM_HOST` (explicit override for wrapper scripts)
+    pub fn from_env() -> Result<Self> {
+        Self::from_env_reader(|key| std::env::var(key).ok())
+    }
+
+    /// Internal: closure-based variant so unit tests can pin env values
+    /// without racing against process-wide environment mutation.
+    pub(crate) fn from_env_reader<F>(read: F) -> Result<Self>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        for key in ["REMEM_HOOK_ADAPTER", "REMEM_CONTEXT_HOST", "REMEM_HOST"] {
+            if let Some(value) = read(key) {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    return Self::parse(trimmed).map_err(|e| anyhow!("env {key}: {e}"));
+                }
+            }
+        }
+        Err(anyhow!(
+            "no install host env var set; expected REMEM_HOOK_ADAPTER, REMEM_CONTEXT_HOST, or REMEM_HOST"
+        ))
+    }
 }
 
 /// Workspace identity synthesized from cwd + `git rev-parse
@@ -161,6 +191,70 @@ mod tests {
         let err = InstallHost::parse("unknown").unwrap_err().to_string();
         assert!(err.contains("invalid host"));
         assert!(InstallHost::parse("").is_err());
+    }
+
+    #[test]
+    fn from_env_reader_uses_hook_adapter_first() {
+        let host = InstallHost::from_env_reader(|key| match key {
+            "REMEM_HOOK_ADAPTER" => Some("codex-cli".into()),
+            "REMEM_CONTEXT_HOST" => Some("claude-code".into()),
+            _ => None,
+        })
+        .unwrap();
+        assert_eq!(host, InstallHost::CodexCli);
+    }
+
+    #[test]
+    fn from_env_reader_falls_back_to_context_host() {
+        let host = InstallHost::from_env_reader(|key| match key {
+            "REMEM_CONTEXT_HOST" => Some("claude-code".into()),
+            _ => None,
+        })
+        .unwrap();
+        assert_eq!(host, InstallHost::ClaudeCode);
+    }
+
+    #[test]
+    fn from_env_reader_falls_back_to_remem_host() {
+        let host = InstallHost::from_env_reader(|key| match key {
+            "REMEM_HOST" => Some("codex-cli".into()),
+            _ => None,
+        })
+        .unwrap();
+        assert_eq!(host, InstallHost::CodexCli);
+    }
+
+    #[test]
+    fn from_env_reader_returns_error_when_no_var_set() {
+        let err = InstallHost::from_env_reader(|_| None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no install host"), "got: {err}");
+    }
+
+    #[test]
+    fn from_env_reader_rejects_invalid_value() {
+        let err = InstallHost::from_env_reader(|key| {
+            if key == "REMEM_HOOK_ADAPTER" {
+                Some("bogus".into())
+            } else {
+                None
+            }
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("invalid host"), "got: {err}");
+    }
+
+    #[test]
+    fn from_env_reader_skips_empty_value() {
+        let host = InstallHost::from_env_reader(|key| match key {
+            "REMEM_HOOK_ADAPTER" => Some("".into()),
+            "REMEM_CONTEXT_HOST" => Some("codex-cli".into()),
+            _ => None,
+        })
+        .unwrap();
+        assert_eq!(host, InstallHost::CodexCli);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod db;
 pub mod doctor;
 pub mod dream;
 pub mod eval;
+pub mod extraction;
 pub mod git_util;
 pub mod identity;
 pub mod install;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod adapter;
 pub mod ai;
 pub mod api;
+pub mod capture;
 pub mod cli;
 pub mod context;
 pub mod db;


### PR DESCRIPTION
## Summary

- Add the captured event insertion path, including blob spill support for oversized payloads.
- Add extraction task enqueue, claim, lease recovery, completion, and failure handling.
- Add the extraction worker loop foundation for the new task queue.

## Scope

This PR lands the capture, queue, and worker-loop foundation. It does not complete the end-to-end extraction pipeline; task bodies, review flow, promotion, and hook cutover are tracked in #134.

The existing `remem worker` command remains on the current jobs worker until hook cutover and task bodies are ready, so current summarize/observe jobs continue to drain.

Refs #134.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
