### PR TITLE
fix(summary): persist workstream fields from summaries

### DIFF
--- a/src/summarize/parse.rs
+++ b/src/summarize/parse.rs
@@ -7,6 +7,10 @@ pub struct ParsedSummary {
     pub learned: Option<String>,
     pub next_steps: Option<String>,
     pub preferences: Option<String>,
+    pub workstream: Option<String>,
+    pub workstream_progress: Option<String>,
+    pub workstream_next: Option<String>,
+    pub workstream_blockers: Option<String>,
 }
 
 pub fn parse_summary(text: &str) -> Option<ParsedSummary> {
@@ -29,5 +33,9 @@ pub fn parse_summary(text: &str) -> Option<ParsedSummary> {
         learned: format::extract_field(&content, "learned"),
         next_steps: format::extract_field(&content, "next_steps"),
         preferences: format::extract_field(&content, "preferences"),
+        workstream: format::extract_field(&content, "workstream"),
+        workstream_progress: format::extract_field(&content, "workstream_progress"),
+        workstream_next: format::extract_field(&content, "workstream_next"),
+        workstream_blockers: format::extract_field(&content, "workstream_blockers"),
     })
 }

--- a/src/summarize/summary_job/persist.rs
+++ b/src/summarize/summary_job/persist.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
+use rusqlite::{params, OptionalExtension};
 
 use crate::db;
 use crate::memory::format;
+use crate::workstream::ParsedWorkStream;
 
 use super::super::parse::ParsedSummary;
 
@@ -10,17 +12,40 @@ pub(super) fn build_existing_summary_context(
     memory_sid: &str,
     project: &str,
 ) -> Result<String> {
-    let Some(prev) = db::get_summary_by_session(conn, memory_sid, project)? else {
+    let prev = db::get_summary_by_session(conn, memory_sid, project)?;
+    let prev_workstream = get_linked_workstream_context(conn, memory_sid, project)?;
+
+    if prev.is_none() && prev_workstream.is_none() {
         return Ok(String::new());
-    };
+    }
 
     let mut parts = Vec::new();
-    push_summary_tag(&mut parts, "request", prev.request.as_deref());
-    push_summary_tag(&mut parts, "completed", prev.completed.as_deref());
-    push_summary_tag(&mut parts, "decisions", prev.decisions.as_deref());
-    push_summary_tag(&mut parts, "learned", prev.learned.as_deref());
-    push_summary_tag(&mut parts, "next_steps", prev.next_steps.as_deref());
-    push_summary_tag(&mut parts, "preferences", prev.preferences.as_deref());
+    if let Some(prev) = prev {
+        push_summary_tag(&mut parts, "request", prev.request.as_deref());
+        push_summary_tag(&mut parts, "completed", prev.completed.as_deref());
+        push_summary_tag(&mut parts, "decisions", prev.decisions.as_deref());
+        push_summary_tag(&mut parts, "learned", prev.learned.as_deref());
+        push_summary_tag(&mut parts, "next_steps", prev.next_steps.as_deref());
+        push_summary_tag(&mut parts, "preferences", prev.preferences.as_deref());
+    }
+    if let Some(prev_workstream) = prev_workstream {
+        push_summary_tag(&mut parts, "workstream", Some(&prev_workstream.title));
+        push_summary_tag(
+            &mut parts,
+            "workstream_progress",
+            prev_workstream.progress.as_deref(),
+        );
+        push_summary_tag(
+            &mut parts,
+            "workstream_next",
+            prev_workstream.next_action.as_deref(),
+        );
+        push_summary_tag(
+            &mut parts,
+            "workstream_blockers",
+            prev_workstream.blockers.as_deref(),
+        );
+    }
 
     Ok(format!(
         "<existing_summary>\n{}\n</existing_summary>\n\n",
@@ -63,6 +88,22 @@ pub(super) fn finalize_summary(
         &format!("saved summary project={} session={}", project, session_id),
     );
 
+    if let Some(workstream) = parsed_workstream_from_summary(&summary) {
+        match crate::workstream::upsert_workstream(conn, project, memory_sid, &workstream) {
+            Ok(workstream_id) => crate::log::info(
+                "summary-job",
+                &format!(
+                    "upserted workstream id={} project={} session={}",
+                    workstream_id, project, session_id
+                ),
+            ),
+            Err(err) => crate::log::warn(
+                "summary-job",
+                &format!("workstream persistence failed: {}", err),
+            ),
+        }
+    }
+
     if let Err(err) = crate::memory::promote_summary_to_memories(
         conn,
         session_id,
@@ -103,6 +144,10 @@ fn summary_text_usage(summary: &ParsedSummary) -> i64 {
         summary.learned.as_deref(),
         summary.next_steps.as_deref(),
         summary.preferences.as_deref(),
+        summary.workstream.as_deref(),
+        summary.workstream_progress.as_deref(),
+        summary.workstream_next.as_deref(),
+        summary.workstream_blockers.as_deref(),
     ]
     .into_iter()
     .flatten()
@@ -122,6 +167,58 @@ fn release_lock_after_error(conn: &rusqlite::Connection, project: &str, reason: 
     }
 }
 
+#[derive(Debug)]
+struct ExistingWorkStreamContext {
+    title: String,
+    progress: Option<String>,
+    next_action: Option<String>,
+    blockers: Option<String>,
+}
+
+fn get_linked_workstream_context(
+    conn: &rusqlite::Connection,
+    memory_sid: &str,
+    project: &str,
+) -> Result<Option<ExistingWorkStreamContext>> {
+    conn.query_row(
+        "SELECT ws.title, ws.progress, ws.next_action, ws.blockers
+         FROM workstreams ws
+         JOIN workstream_sessions wss ON wss.workstream_id = ws.id
+         WHERE wss.memory_session_id = ?1 AND ws.project = ?2
+         ORDER BY wss.linked_at_epoch DESC, ws.updated_at_epoch DESC
+         LIMIT 1",
+        params![memory_sid, project],
+        |row| {
+            Ok(ExistingWorkStreamContext {
+                title: row.get(0)?,
+                progress: row.get(1)?,
+                next_action: row.get(2)?,
+                blockers: row.get(3)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn parsed_workstream_from_summary(summary: &ParsedSummary) -> Option<ParsedWorkStream> {
+    Some(ParsedWorkStream {
+        title: clean_field(summary.workstream.as_deref()),
+        progress: clean_field(summary.workstream_progress.as_deref()),
+        next_action: clean_field(summary.workstream_next.as_deref()),
+        blockers: clean_field(summary.workstream_blockers.as_deref()),
+        is_completed: false,
+    })
+    .filter(|workstream| workstream.title.is_some())
+}
+
+fn clean_field(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
@@ -129,12 +226,17 @@ mod tests {
 
     use crate::{db, summarize::ParsedSummary};
 
-    use super::finalize_summary;
+    use super::{build_existing_summary_context, finalize_summary};
+
+    fn setup_conn() -> Result<Connection> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        Ok(conn)
+    }
 
     #[test]
     fn promotion_failure_releases_lock_and_clears_retry_marker() -> Result<()> {
-        let mut conn = Connection::open_in_memory()?;
-        crate::migrate::run_migrations(&conn)?;
+        let mut conn = setup_conn()?;
 
         let project = "proj/promotion-failure";
         let session_id = "content-session-1";
@@ -160,6 +262,10 @@ mod tests {
                 learned: None,
                 next_steps: None,
                 preferences: None,
+                workstream: None,
+                workstream_progress: None,
+                workstream_next: None,
+                workstream_blockers: None,
             },
         )
         .expect_err("promotion failure should surface to the worker");
@@ -184,7 +290,120 @@ mod tests {
             !db::is_duplicate_message(&conn, project, msg_hash)?,
             "duplicate marker should not suppress retry after promotion failure"
         );
+        Ok(())
+    }
 
+    #[test]
+    fn build_existing_summary_context_includes_linked_workstream_fields() -> Result<()> {
+        let conn = setup_conn()?;
+        conn.execute(
+            "INSERT INTO session_summaries
+             (memory_session_id, project, request, completed, decisions, learned,
+              next_steps, preferences, created_at, created_at_epoch)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                "mem-ctx",
+                "test/proj",
+                "Repair summary capture",
+                "Saved summary row",
+                "Use WorkStream table as source of truth",
+                "Incremental summaries need linked task state",
+                "Run persistence test",
+                "Prefer evidence",
+                "2026-05-13T00:00:00Z",
+                1_768_000_000_i64,
+            ],
+        )?;
+        conn.execute(
+            "INSERT INTO workstreams
+             (project, title, status, progress, next_action, blockers,
+              created_at_epoch, updated_at_epoch)
+             VALUES (?1, ?2, 'active', ?3, ?4, ?5, ?6, ?7)",
+            params![
+                "test/proj",
+                "Summary WorkStream Persistence",
+                "Parsed fields wired",
+                "Finalize summary test",
+                "Need clippy",
+                1_768_000_000_i64,
+                1_768_000_010_i64,
+            ],
+        )?;
+        let workstream_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO workstream_sessions
+             (workstream_id, memory_session_id, linked_at_epoch)
+             VALUES (?1, ?2, ?3)",
+            params![workstream_id, "mem-ctx", 1_768_000_011_i64],
+        )?;
+
+        let context = build_existing_summary_context(&conn, "mem-ctx", "test/proj")?;
+
+        assert!(context.contains("<request>Repair summary capture</request>"));
+        assert!(context.contains("<workstream>Summary WorkStream Persistence</workstream>"));
+        assert!(context.contains("<workstream_progress>Parsed fields wired</workstream_progress>"));
+        assert!(context.contains("<workstream_next>Finalize summary test</workstream_next>"));
+        assert!(context.contains("<workstream_blockers>Need clippy</workstream_blockers>"));
+        Ok(())
+    }
+
+    #[test]
+    fn finalize_summary_persists_non_empty_workstream() -> Result<()> {
+        let mut conn = setup_conn()?;
+        let summary = ParsedSummary {
+            request: Some("Wire summary workstream fields".to_string()),
+            completed: Some("Added parser and persistence wiring".to_string()),
+            decisions: None,
+            learned: None,
+            next_steps: Some("Run full validation".to_string()),
+            preferences: None,
+            workstream: Some("Summary WorkStream Persistence".to_string()),
+            workstream_progress: Some("ParsedSummary now carries workstream fields".to_string()),
+            workstream_next: Some("Open PR for issue 136".to_string()),
+            workstream_blockers: Some("Waiting for review".to_string()),
+        };
+
+        finalize_summary(
+            &mut conn,
+            "content-session-1",
+            "mem-finalize",
+            "test/proj",
+            "hash-finalize",
+            summary,
+        )?;
+
+        let row: (String, Option<String>, Option<String>, Option<String>) = conn.query_row(
+            "SELECT title, progress, next_action, blockers
+             FROM workstreams
+             WHERE project = ?1",
+            params!["test/proj"],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+        assert_eq!(row.0, "Summary WorkStream Persistence");
+        assert_eq!(
+            row.1.as_deref(),
+            Some("ParsedSummary now carries workstream fields")
+        );
+        assert_eq!(row.2.as_deref(), Some("Open PR for issue 136"));
+        assert_eq!(row.3.as_deref(), Some("Waiting for review"));
+
+        let linked_count: i64 = conn.query_row(
+            "SELECT COUNT(*)
+             FROM workstream_sessions wss
+             JOIN workstreams ws ON ws.id = wss.workstream_id
+             WHERE wss.memory_session_id = ?1 AND ws.project = ?2",
+            params!["mem-finalize", "test/proj"],
+            |row| row.get(0),
+        )?;
+        assert_eq!(linked_count, 1);
+
+        let request: String = conn.query_row(
+            "SELECT request FROM session_summaries
+             WHERE memory_session_id = ?1 AND project = ?2",
+            params!["mem-finalize", "test/proj"],
+            |row| row.get(0),
+        )?;
+        assert_eq!(request, "Wire summary workstream fields");
         Ok(())
     }
 }

--- a/src/summarize/tests/parse.rs
+++ b/src/summarize/tests/parse.rs
@@ -10,6 +10,10 @@ fn parse_summary_extracts_fields() {
 <learned>FTS5 handles CJK</learned>
 <next_steps>Add benchmarks</next_steps>
 <preferences>Prefer concise output</preferences>
+<workstream>Search quality repair</workstream>
+<workstream_progress>Parser and ranking fixes landed</workstream_progress>
+<workstream_next>Add benchmark coverage</workstream_next>
+<workstream_blockers>Need larger CJK fixture set</workstream_blockers>
 </summary>
 "#;
     let parsed = parse_summary(xml).expect("summary should parse");
@@ -19,6 +23,19 @@ fn parse_summary_extracts_fields() {
     assert_eq!(parsed.learned.as_deref(), Some("FTS5 handles CJK"));
     assert_eq!(parsed.next_steps.as_deref(), Some("Add benchmarks"));
     assert_eq!(parsed.preferences.as_deref(), Some("Prefer concise output"));
+    assert_eq!(parsed.workstream.as_deref(), Some("Search quality repair"));
+    assert_eq!(
+        parsed.workstream_progress.as_deref(),
+        Some("Parser and ranking fixes landed")
+    );
+    assert_eq!(
+        parsed.workstream_next.as_deref(),
+        Some("Add benchmark coverage")
+    );
+    assert_eq!(
+        parsed.workstream_blockers.as_deref(),
+        Some("Need larger CJK fixture set")
+    );
 }
 
 #[test]
@@ -38,6 +55,7 @@ fn parse_summary_returns_some_for_empty_summary_block() {
     let parsed = parsed.unwrap();
     assert!(parsed.request.is_none());
     assert!(parsed.completed.is_none());
+    assert!(parsed.workstream.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse summary workstream fields into `ParsedSummary`
- include linked workstream context in incremental summary prompts
- persist non-empty parsed workstream fields through `finalize_summary`
- preserve promotion-failure retry behavior from #141

Fixes #136

## Tests
- cargo fmt --check
- git diff --check origin/main..HEAD
- cargo check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
