### PR TITLE
fix(observe): harden capture backlog pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "clap",
  "dirs",
  "getrandom 0.3.4",
+ "libc",
  "reqwest",
  "rmcp",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ axum = { version = "0.8.8", features = ["json"] }
 tower-http = { version = "0.6.8", features = ["cors"] }
 getrandom = "0.3"
 toml_edit = "0.22"
+libc = "0.2"
 
 [profile.release]
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ Codex workflow
 ```
 
 Codex does not install a high-frequency `PostToolUse(Bash)` observe hook by
-default. Shell-heavy sessions must use the coalesced v2 capture pipeline before
+default. Shell-heavy sessions must use the coalesced capture pipeline before
 per-command capture is enabled again; otherwise Bash output can create an
 unbounded backlog. Existing legacy hooks are also ignored unless
 `REMEM_ENABLE_CODEX_BASH_OBSERVE=1` is set explicitly.
 
-The v2 capture pipeline starts with an append-only ledger:
+The capture pipeline starts with an append-only ledger:
 `captured_events` stores raw hook/session evidence, `event_blobs` keeps large
 payloads out of prompt-sized rows, and `extraction_tasks` coalesces work by
 host/project/session instead of creating one LLM job per tool call. Curated

--- a/README.md
+++ b/README.md
@@ -66,11 +66,20 @@ Claude Code workflow
 Codex workflow
         |
         |- SessionStart      -> Inject memories + preferences
-        |- PostToolUse(Bash) -> Capture shell operations (queued, short timeout)
         '- Stop              -> Summarize in background with Codex CLI
 ```
 
-No manual capture is required.
+Codex does not install a high-frequency `PostToolUse(Bash)` observe hook by
+default. Shell-heavy sessions must use the coalesced v2 capture pipeline before
+per-command capture is enabled again; otherwise Bash output can create an
+unbounded backlog. Existing legacy hooks are also ignored unless
+`REMEM_ENABLE_CODEX_BASH_OBSERVE=1` is set explicitly.
+
+The v2 capture pipeline starts with an append-only ledger:
+`captured_events` stores raw hook/session evidence, `event_blobs` keeps large
+payloads out of prompt-sized rows, and `extraction_tasks` coalesces work by
+host/project/session instead of creating one LLM job per tool call. Curated
+memory remains the promoted output of this pipeline, not the raw event itself.
 
 ## Search Architecture
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,11 +66,12 @@ Claude Code 正常工作流
 Codex 正常工作流
         |
         |- SessionStart      -> 注入记忆与偏好
-        |- PostToolUse(Bash) -> 捕获 shell 操作（入队，短超时）
         '- Stop              -> 使用 Codex CLI 后台总结
 ```
 
-全程自动，不需要手动保存记忆。
+Codex 默认不再安装高频 `PostToolUse(Bash)` observe hook。Shell-heavy 会话必须等 v2 coalesced capture 管线接管后再开启逐命令捕获，否则 Bash 输出会制造无界 backlog。旧 hook 即使残留，也会被默认忽略；只有显式设置 `REMEM_ENABLE_CODEX_BASH_OBSERVE=1` 才会重新开启。
+
+v2 capture 管线从 append-only ledger 开始：`captured_events` 保存原始 hook/session evidence，`event_blobs` 承接大 payload，`extraction_tasks` 按 host/project/session 合并后台提炼任务，避免每个工具调用都生成一个 LLM job。长期记忆仍然是这条管线 promotion 后的结果，不是 raw event 本身。
 
 ## 检索架构
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,9 +69,9 @@ Codex 正常工作流
         '- Stop              -> 使用 Codex CLI 后台总结
 ```
 
-Codex 默认不再安装高频 `PostToolUse(Bash)` observe hook。Shell-heavy 会话必须等 v2 coalesced capture 管线接管后再开启逐命令捕获，否则 Bash 输出会制造无界 backlog。旧 hook 即使残留，也会被默认忽略；只有显式设置 `REMEM_ENABLE_CODEX_BASH_OBSERVE=1` 才会重新开启。
+Codex 默认不再安装高频 `PostToolUse(Bash)` observe hook。Shell-heavy 会话必须等 coalesced capture 管线接管后再开启逐命令捕获，否则 Bash 输出会制造无界 backlog。旧 hook 即使残留，也会被默认忽略；只有显式设置 `REMEM_ENABLE_CODEX_BASH_OBSERVE=1` 才会重新开启。
 
-v2 capture 管线从 append-only ledger 开始：`captured_events` 保存原始 hook/session evidence，`event_blobs` 承接大 payload，`extraction_tasks` 按 host/project/session 合并后台提炼任务，避免每个工具调用都生成一个 LLM job。长期记忆仍然是这条管线 promotion 后的结果，不是 raw event 本身。
+capture 管线从 append-only ledger 开始：`captured_events` 保存原始 hook/session evidence，`event_blobs` 承接大 payload，`extraction_tasks` 按 host/project/session 合并后台提炼任务，避免每个工具调用都生成一个 LLM job。长期记忆仍然是这条管线 promotion 后的结果，不是 raw event 本身。
 
 ## 检索架构
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,9 +42,9 @@
 Codex legacy `PostToolUse(Bash)` observe hooks are treated as opt-in only:
 they are skipped unless `REMEM_ENABLE_CODEX_BASH_OBSERVE=1` is set. This keeps
 Bash-heavy sessions from creating an unbounded pending-observation backlog
-before the v2 coalesced capture path is enabled.
+before the coalesced capture path is enabled.
 
-The v2 capture path is now present in the main database as a first production
+The capture path is now present in the main database as a first production
 slice: hooks write append-only `captured_events`, large evidence goes to
 `event_blobs`, and `extraction_tasks` coalesces pending extraction by
 host/project/session/task kind. This ledger is evidence and scheduling state;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,11 +7,11 @@
 │              Host Hooks (Claude Code / Codex)              │
 │                                                            │
 │  Claude Code: SessionStart/UserPromptSubmit/PostToolUse/Stop│
-│  Codex:       SessionStart/PostToolUse(Bash)/Stop           │
+│  Codex:       SessionStart/Stop                             │
 │                                                            │
 │  SessionStart ──────→ context       (inject memories)      │
 │  UserPromptSubmit ──→ session-init  (Claude Code only)     │
-│  PostToolUse ───────→ observe       (Claude all, Codex Bash)│
+│  PostToolUse ───────→ observe       (Claude Code)           │
 │  Stop ──────────────→ summarize     (3-gate + worker)      │
 └──────────────┬──────────────────────┬──────────────────────┘
                │                      │
@@ -38,6 +38,18 @@
 │  summarize_cooldown   ai_usage_events                      │
 └───────────────────────────────────────────────────────────┘
 ```
+
+Codex legacy `PostToolUse(Bash)` observe hooks are treated as opt-in only:
+they are skipped unless `REMEM_ENABLE_CODEX_BASH_OBSERVE=1` is set. This keeps
+Bash-heavy sessions from creating an unbounded pending-observation backlog
+before the v2 coalesced capture path is enabled.
+
+The v2 capture path is now present in the main database as a first production
+slice: hooks write append-only `captured_events`, large evidence goes to
+`event_blobs`, and `extraction_tasks` coalesces pending extraction by
+host/project/session/task kind. This ledger is evidence and scheduling state;
+durable memory is still created only after extraction, candidate review, and
+promotion.
 
 ## Module Overview (~9000 lines Rust)
 
@@ -76,7 +88,20 @@
 
 ## Data Flow
 
-### 1. Observation Capture (PostToolUse → observe)
+### 1. Capture Ledger (hook/session evidence → captured_events)
+
+```
+Hook/session payload
+       │
+       ├─ Normalize host/workspace/project/session identity
+       ├─ Store raw evidence in captured_events/event_blobs
+       └─ Coalesce extraction_tasks by host/project/session/task kind
+```
+
+This path is intentionally light: it does not call an LLM and it does not
+create one job per tool call.
+
+### 2. Legacy Observation Capture (Claude PostToolUse → observe)
 
 ```
 Tool call ──→ Type check ──→ Bash filter ──→ Queue to SQLite
@@ -84,14 +109,13 @@ Tool call ──→ Type check ──→ Bash filter ──→ Queue to SQLite
                │              └─ Skip: git status/log/diff, ls, cat,
                │                      npm install, cargo build (read-only)
                │
-               └─ Accept: Claude Write/Edit/NotebookEdit/Bash/Task/Agent,
-                          Codex Bash
+               └─ Accept: Claude Write/Edit/NotebookEdit/Bash/Task/Agent
                   Skip: Read, Glob, Grep, metadata-only tools
 ```
 
 Each queued event stores: session_id, project, tool_name, tool_input, tool_response (truncated to 4KB).
 
-### 2. Batch Distillation (Stop → summarize → flush)
+### 3. Batch Distillation (Stop → summarize → flush)
 
 ```
 Stop hook fires

--- a/docs/spec-context-compiler.md
+++ b/docs/spec-context-compiler.md
@@ -149,7 +149,7 @@ Expected initial profiles:
 | Profile | Notes |
 | --- | --- |
 | `ClaudeCodeContextProfile` | Claude has broader hooks and UserPromptSubmit. It can mention Claude-facing hook behavior and the same MCP retrieval tools. |
-| `CodexCliContextProfile` | Codex currently observes mainly Bash through hooks. Its hints should emphasize `search` / `get_observations` and avoid implying full tool coverage. |
+| `CodexCliContextProfile` | Codex currently uses SessionStart/Stop hooks by default. Its hints should emphasize `search` / `get_observations` and explicit decision/bugfix saves instead of implying full tool coverage. |
 | `UnknownContextProfile` | Conservative defaults, no host-specific claims. |
 
 ### 6.4 HostCapabilities

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -97,3 +97,21 @@ fn executor_from_env(key: &str) -> Option<AiExecutor> {
         _ => None,
     }
 }
+
+fn stable_working_dir() -> std::path::PathBuf {
+    let data_dir = crate::db::data_dir();
+    match std::fs::create_dir_all(&data_dir) {
+        Ok(()) => data_dir,
+        Err(err) => {
+            crate::log::warn(
+                "ai",
+                &format!(
+                    "failed to create AI working dir {}: {}; falling back to temp dir",
+                    data_dir.display(),
+                    err
+                ),
+            );
+            std::env::temp_dir()
+        }
+    }
+}

--- a/src/ai/cli.rs
+++ b/src/ai/cli.rs
@@ -7,6 +7,7 @@ use crate::ai::types::{AiCallResult, AI_TIMEOUT_SECS};
 pub(super) async fn call_cli(system: &str, user_message: &str) -> Result<AiCallResult> {
     let model = get_model_raw();
     let claude = get_claude_path();
+    let working_dir = super::stable_working_dir();
 
     let mut child = Command::new(&claude)
         .args([
@@ -19,6 +20,7 @@ pub(super) async fn call_cli(system: &str, user_message: &str) -> Result<AiCallR
             "text",
             "--no-session-persistence",
         ])
+        .current_dir(&working_dir)
         .env_remove("CLAUDECODE")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())

--- a/src/ai/codex_cli.rs
+++ b/src/ai/codex_cli.rs
@@ -16,10 +16,12 @@ pub(super) async fn call_codex_cli(system: &str, user_message: &str) -> Result<A
         chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
     ));
     let prompt = build_prompt(system, user_message);
+    let working_dir = super::stable_working_dir();
 
     let mut command = Command::new(&codex);
     command.args(build_codex_args(&output_path, model.as_deref()));
     command
+        .current_dir(&working_dir)
         .env("REMEM_DISABLE_HOOKS", "1")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::null())

--- a/src/ai/tests.rs
+++ b/src/ai/tests.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 
 use super::config::resolve_model_for_api;
 use super::pricing::{estimate_cost_usd, pricing_for_model};
-use super::{executor_for_operation, AiExecutor};
+use super::{executor_for_operation, stable_working_dir, AiExecutor};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -176,4 +176,14 @@ fn legacy_global_executor_still_only_affects_summary_directly() {
             assert_eq!(executor_for_operation("dream"), None);
         },
     );
+}
+
+#[test]
+fn stable_working_dir_uses_data_dir_even_if_caller_cwd_disappears() {
+    let data_dir = crate::db::test_support::ScopedTestDataDir::new("ai-stable-cwd");
+
+    let got = stable_working_dir();
+
+    assert_eq!(got, data_dir.path);
+    assert!(got.is_dir());
 }

--- a/src/api/handlers/status.rs
+++ b/src/api/handlers/status.rs
@@ -26,6 +26,9 @@ pub(in crate::api) async fn handle_status(State(_state): State<DbState>) -> impl
         "version": env!("CARGO_PKG_VERSION"),
         "memories": stats.active_memories,
         "observations": stats.active_observations,
+        "captured_events": stats.captured_events,
+        "pending_extraction_tasks": stats.pending_extraction_tasks,
+        "pending_memory_candidates": stats.pending_memory_candidates,
     }))
     .into_response()
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -157,4 +157,9 @@ async fn status_handler_matches_shared_system_stats() {
         serde_json::from_slice(&body).expect("status response should be valid json");
     assert_eq!(payload["memories"], stats.active_memories);
     assert_eq!(payload["observations"], stats.active_observations);
+    assert_eq!(payload["captured_events"], stats.captured_events);
+    assert_eq!(
+        payload["pending_extraction_tasks"],
+        stats.pending_extraction_tasks
+    );
 }

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -31,6 +31,17 @@ pub(in crate::cli) fn run_status() -> Result<()> {
     println!("  Sessions:      {:>6}", stats.session_summaries);
     println!("  Raw messages:  {:>6}", stats.raw_messages);
     println!();
+    println!("Capture pipeline:");
+    println!("  Captured:     {:>6}", stats.captured_events);
+    println!("  Extract todo: {:>6}", stats.pending_extraction_tasks);
+    println!("  Extract run:  {:>6}", stats.processing_extraction_tasks);
+    println!("  Extract fail: {:>6}", stats.failed_extraction_tasks);
+    println!("  Candidates:   {:>6}", stats.pending_memory_candidates);
+    if let Some(epoch) = stats.oldest_pending_extraction_epoch {
+        let age_secs = chrono::Utc::now().timestamp().saturating_sub(epoch);
+        println!("  Oldest task:  {:>6}s", age_secs);
+    }
+    println!();
     println!("Pending observations:");
     println!("  Ready:        {:>6}", stats.ready_pending_observations);
     println!("  Delayed:      {:>6}", stats.delayed_pending_observations);

--- a/src/context/host.rs
+++ b/src/context/host.rs
@@ -86,7 +86,7 @@ impl ContextHostProfile for CodexCliContextProfile {
             has_session_start_hook: true,
             has_user_prompt_submit_hook: false,
             observes_native_file_edits: false,
-            observes_bash: true,
+            observes_bash: false,
         }
     }
 
@@ -96,7 +96,7 @@ impl ContextHostProfile for CodexCliContextProfile {
 
     fn retrieval_hints(&self) -> RetrievalHints {
         RetrievalHints {
-            line: "Use `search`/`get_observations` for details. Codex hook capture is Bash-focused, so save explicit decisions/bugfixes when they matter.",
+            line: "Use `search`/`get_observations` for details. Codex automatic capture is Stop/context-focused, so save explicit decisions/bugfixes when they matter.",
         }
     }
 }
@@ -159,12 +159,15 @@ mod tests {
     }
 
     #[test]
-    fn codex_profile_reports_bash_focused_capture() {
+    fn codex_profile_reports_stop_focused_capture() {
         let profile = CodexCliContextProfile;
         let capabilities = profile.capabilities();
         assert!(capabilities.has_mcp_tools);
-        assert!(capabilities.observes_bash);
+        assert!(!capabilities.observes_bash);
         assert!(!capabilities.observes_native_file_edits);
-        assert!(profile.retrieval_hints().line.contains("Bash-focused"));
+        assert!(profile
+            .retrieval_hints()
+            .line
+            .contains("Stop/context-focused"));
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,4 @@
+pub mod capture;
 pub mod core;
 pub mod crypto;
 pub mod job;
@@ -12,6 +13,7 @@ pub mod test_support;
 pub mod usage;
 pub mod worker;
 
+pub use capture::*;
 pub use core::*;
 pub use crypto::*;
 pub use job::*;

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 
 const DIRECT_CONTENT_BYTES: usize = 16 * 1024;
@@ -132,7 +132,7 @@ fn upsert_identity(
     input: &CaptureEventInput<'_>,
     now: i64,
 ) -> Result<IdentityIds> {
-    let host_id = upsert_host(conn, normalize_host(input.host), now)?;
+    let host_id = upsert_host(conn, normalize_host(input.host)?, now)?;
     let root_path = input
         .cwd
         .map(|cwd| crate::db::canonical_project_path(cwd).display().to_string())
@@ -156,10 +156,10 @@ fn upsert_identity(
     })
 }
 
-fn normalize_host(host: &str) -> &str {
+fn normalize_host(host: &str) -> Result<&str> {
     match host {
-        "claude-code" | "codex-cli" => host,
-        _ => "unknown",
+        "claude-code" | "codex-cli" => Ok(host),
+        other => bail!("invalid capture host '{other}'; expected claude-code or codex-cli"),
     }
 }
 
@@ -460,5 +460,27 @@ mod tests {
         assert_eq!(retention, "raw_compact");
         assert!(blob_id.is_some());
         assert_eq!(blob_count, 1);
+    }
+
+    #[test]
+    fn capture_rejects_unknown_host() {
+        let conn = setup_conn();
+        let err = record_captured_event(
+            &conn,
+            &CaptureEventInput {
+                host: "unknown",
+                session_id: "sess-host",
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Task"),
+                content: "{}",
+                task_kind: None,
+            },
+        )
+        .expect_err("unknown host should fail closed");
+
+        assert!(err.to_string().contains("invalid capture host"));
     }
 }

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -1,0 +1,464 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+
+const DIRECT_CONTENT_BYTES: usize = 16 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtractionTaskKind {
+    SessionRollup,
+    ObservationExtract,
+    MemoryCandidate,
+    RuleCandidate,
+    IndexUpdate,
+}
+
+impl ExtractionTaskKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionRollup => "session_rollup",
+            Self::ObservationExtract => "observation_extract",
+            Self::MemoryCandidate => "memory_candidate",
+            Self::RuleCandidate => "rule_candidate",
+            Self::IndexUpdate => "index_update",
+        }
+    }
+
+    fn priority(self) -> i64 {
+        match self {
+            Self::SessionRollup => 10,
+            Self::MemoryCandidate => 20,
+            Self::ObservationExtract => 40,
+            Self::RuleCandidate => 60,
+            Self::IndexUpdate => 80,
+        }
+    }
+}
+
+pub struct CaptureEventInput<'a> {
+    pub host: &'a str,
+    pub session_id: &'a str,
+    pub project: &'a str,
+    pub cwd: Option<&'a str>,
+    pub event_type: &'a str,
+    pub role: Option<&'a str>,
+    pub tool_name: Option<&'a str>,
+    pub content: &'a str,
+    pub task_kind: Option<ExtractionTaskKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureEventOutcome {
+    pub event_row_id: i64,
+    pub event_id: String,
+    pub extraction_task_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IdentityIds {
+    host_id: i64,
+    workspace_id: i64,
+    project_id: i64,
+    session_row_id: i64,
+}
+
+pub fn record_captured_event(
+    conn: &Connection,
+    input: &CaptureEventInput<'_>,
+) -> Result<CaptureEventOutcome> {
+    let now = chrono::Utc::now().timestamp();
+    let inserted_at = now;
+    let content_hash = exact_hash(input.content);
+    let event_id = synthesize_event_id(input.event_type, &content_hash);
+    let identity = upsert_identity(conn, input, now)?;
+    let (content_text, content_blob_id, retention_class) =
+        store_content(conn, input.content, &content_hash, now)?;
+    let token_estimate = estimate_tokens(input.content);
+
+    conn.execute(
+        "INSERT INTO captured_events
+         (host_id, workspace_id, project_id, session_row_id, session_id, turn_id,
+          event_id, event_type, role, tool_name, content_text, content_blob_id,
+          content_hash, token_estimate, retention_class, created_at_epoch, inserted_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+         ON CONFLICT(host_id, session_id, event_id) DO UPDATE SET
+             inserted_at_epoch = excluded.inserted_at_epoch",
+        params![
+            identity.host_id,
+            identity.workspace_id,
+            identity.project_id,
+            identity.session_row_id,
+            input.session_id,
+            event_id,
+            input.event_type,
+            input.role,
+            input.tool_name,
+            content_text,
+            content_blob_id,
+            content_hash,
+            token_estimate,
+            retention_class,
+            now,
+            inserted_at
+        ],
+    )?;
+
+    let event_row_id = conn.query_row(
+        "SELECT id FROM captured_events WHERE host_id = ?1 AND session_id = ?2 AND event_id = ?3",
+        params![identity.host_id, input.session_id, event_id],
+        |row| row.get(0),
+    )?;
+
+    let extraction_task_id = if let Some(kind) = input.task_kind {
+        Some(coalesce_extraction_task(
+            conn,
+            identity,
+            kind,
+            event_row_id,
+            now,
+        )?)
+    } else {
+        None
+    };
+
+    Ok(CaptureEventOutcome {
+        event_row_id,
+        event_id,
+        extraction_task_id,
+    })
+}
+
+fn upsert_identity(
+    conn: &Connection,
+    input: &CaptureEventInput<'_>,
+    now: i64,
+) -> Result<IdentityIds> {
+    let host_id = upsert_host(conn, normalize_host(input.host), now)?;
+    let root_path = input
+        .cwd
+        .map(|cwd| crate::db::canonical_project_path(cwd).display().to_string())
+        .unwrap_or_else(|| input.project.to_string());
+    let git_branch = input.cwd.and_then(crate::db::detect_git_branch);
+    let workspace_id = upsert_workspace(conn, &root_path, git_branch.as_deref(), now)?;
+    let project_id = upsert_project(conn, workspace_id, input.project, now)?;
+    let session_row_id = upsert_session_row(
+        conn,
+        host_id,
+        workspace_id,
+        project_id,
+        input.session_id,
+        now,
+    )?;
+    Ok(IdentityIds {
+        host_id,
+        workspace_id,
+        project_id,
+        session_row_id,
+    })
+}
+
+fn normalize_host(host: &str) -> &str {
+    match host {
+        "claude-code" | "codex-cli" => host,
+        _ => "unknown",
+    }
+}
+
+fn upsert_host(conn: &Connection, name: &str, now: i64) -> Result<i64> {
+    conn.execute(
+        "INSERT OR IGNORE INTO hosts(name, enabled, created_at_epoch) VALUES (?1, 1, ?2)",
+        params![name, now],
+    )?;
+    Ok(conn.query_row(
+        "SELECT id FROM hosts WHERE name = ?1",
+        params![name],
+        |row| row.get(0),
+    )?)
+}
+
+fn upsert_workspace(
+    conn: &Connection,
+    root_path: &str,
+    git_branch: Option<&str>,
+    now: i64,
+) -> Result<i64> {
+    conn.execute(
+        "INSERT INTO workspaces(root_path, git_remote, git_branch, created_at_epoch, updated_at_epoch)
+         VALUES (?1, NULL, ?2, ?3, ?3)
+         ON CONFLICT(root_path) DO UPDATE SET
+             git_branch = COALESCE(excluded.git_branch, workspaces.git_branch),
+             updated_at_epoch = excluded.updated_at_epoch",
+        params![root_path, git_branch, now],
+    )?;
+    Ok(conn.query_row(
+        "SELECT id FROM workspaces WHERE root_path = ?1",
+        params![root_path],
+        |row| row.get(0),
+    )?)
+}
+
+fn upsert_project(
+    conn: &Connection,
+    workspace_id: i64,
+    project_path: &str,
+    now: i64,
+) -> Result<i64> {
+    let project_key = project_path
+        .rsplit('/')
+        .find(|part| !part.is_empty())
+        .unwrap_or(project_path);
+    conn.execute(
+        "INSERT INTO projects(workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?4)
+         ON CONFLICT(workspace_id, project_path) DO UPDATE SET
+             project_key = excluded.project_key,
+             updated_at_epoch = excluded.updated_at_epoch",
+        params![workspace_id, project_path, project_key, now],
+    )?;
+    Ok(conn.query_row(
+        "SELECT id FROM projects WHERE workspace_id = ?1 AND project_path = ?2",
+        params![workspace_id, project_path],
+        |row| row.get(0),
+    )?)
+}
+
+fn upsert_session_row(
+    conn: &Connection,
+    host_id: i64,
+    workspace_id: i64,
+    project_id: i64,
+    session_id: &str,
+    now: i64,
+) -> Result<i64> {
+    conn.execute(
+        "INSERT INTO sessions(host_id, workspace_id, project_id, session_id, started_at_epoch, last_seen_at_epoch, status)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'active')
+         ON CONFLICT(host_id, project_id, session_id) DO UPDATE SET
+             last_seen_at_epoch = excluded.last_seen_at_epoch,
+             status = 'active'",
+        params![host_id, workspace_id, project_id, session_id, now],
+    )?;
+    Ok(conn.query_row(
+        "SELECT id FROM sessions WHERE host_id = ?1 AND project_id = ?2 AND session_id = ?3",
+        params![host_id, project_id, session_id],
+        |row| row.get(0),
+    )?)
+}
+
+fn store_content(
+    conn: &Connection,
+    content: &str,
+    content_hash: &str,
+    now: i64,
+) -> Result<(String, Option<i64>, &'static str)> {
+    if content.len() <= DIRECT_CONTENT_BYTES {
+        return Ok((content.to_string(), None, "raw_keep"));
+    }
+
+    let bytes = content.as_bytes();
+    conn.execute(
+        "INSERT INTO event_blobs(content_hash, content_encoding, content_bytes, original_bytes, stored_bytes, created_at_epoch)
+         VALUES (?1, 'plain', ?2, ?3, ?3, ?4)
+         ON CONFLICT(content_hash) DO NOTHING",
+        params![content_hash, bytes, bytes.len() as i64, now],
+    )?;
+    let blob_id: i64 = conn
+        .query_row(
+            "SELECT id FROM event_blobs WHERE content_hash = ?1",
+            params![content_hash],
+            |row| row.get(0),
+        )
+        .optional()?
+        .expect("event blob row should exist after insert");
+    Ok((
+        compact_preview(content, DIRECT_CONTENT_BYTES),
+        Some(blob_id),
+        "raw_compact",
+    ))
+}
+
+fn coalesce_extraction_task(
+    conn: &Connection,
+    identity: IdentityIds,
+    kind: ExtractionTaskKind,
+    event_row_id: i64,
+    now: i64,
+) -> Result<i64> {
+    let idempotency_key = format!(
+        "{}:{}:{}:{}",
+        identity.host_id,
+        identity.project_id,
+        identity.session_row_id,
+        kind.as_str()
+    );
+    conn.execute(
+        "INSERT INTO extraction_tasks
+         (task_kind, host_id, workspace_id, project_id, session_row_id, priority, status,
+          idempotency_key, cursor_event_id, high_watermark_event_id, attempts,
+          next_retry_epoch, lease_owner, lease_expires_epoch, last_error, created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7, NULL, ?8, 0, NULL, NULL, NULL, NULL, ?9, ?9)
+         ON CONFLICT(idempotency_key) DO UPDATE SET
+             high_watermark_event_id = MAX(COALESCE(extraction_tasks.high_watermark_event_id, 0), excluded.high_watermark_event_id),
+             status = CASE
+                 WHEN extraction_tasks.status IN ('done', 'failed') THEN 'pending'
+                 ELSE extraction_tasks.status
+             END,
+             next_retry_epoch = CASE
+                 WHEN extraction_tasks.status IN ('done', 'failed') THEN NULL
+                 ELSE extraction_tasks.next_retry_epoch
+             END,
+             updated_at_epoch = excluded.updated_at_epoch",
+        params![
+            kind.as_str(),
+            identity.host_id,
+            identity.workspace_id,
+            identity.project_id,
+            identity.session_row_id,
+            kind.priority(),
+            idempotency_key,
+            event_row_id,
+            now
+        ],
+    )?;
+    Ok(conn.query_row(
+        "SELECT id FROM extraction_tasks WHERE idempotency_key = ?1",
+        params![idempotency_key],
+        |row| row.get(0),
+    )?)
+}
+
+fn exact_hash(content: &str) -> String {
+    format!("{:016x}", crate::db::deterministic_hash(content.as_bytes()))
+}
+
+fn synthesize_event_id(event_type: &str, content_hash: &str) -> String {
+    let nanos = chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| chrono::Utc::now().timestamp() * 1_000_000_000);
+    format!("{}-{}-{}", event_type, nanos, content_hash)
+}
+
+fn estimate_tokens(content: &str) -> i64 {
+    ((content.len() as i64) + 3) / 4
+}
+
+fn compact_preview(content: &str, max_bytes: usize) -> String {
+    let half = (max_bytes / 2).saturating_sub(128);
+    let prefix = crate::db::truncate_str(content, half).to_string();
+    let suffix_start = content.len().saturating_sub(half);
+    let suffix = if content.is_char_boundary(suffix_start) {
+        &content[suffix_start..]
+    } else {
+        let mut start = suffix_start;
+        while start < content.len() && !content.is_char_boundary(start) {
+            start += 1;
+        }
+        &content[start..]
+    };
+    format!(
+        "{}\n\n[remem raw event compacted: original_bytes={}]\n\n{}",
+        prefix,
+        content.len(),
+        suffix
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db should open");
+        crate::migrate::run_migrations(&conn).expect("migrations should run");
+        conn
+    }
+
+    #[test]
+    fn record_captured_event_coalesces_extraction_task_by_session() {
+        let conn = setup_conn();
+        let first = record_captured_event(
+            &conn,
+            &CaptureEventInput {
+                host: "codex-cli",
+                session_id: "sess-1",
+                project: "/tmp/remem",
+                cwd: Some("/tmp/remem"),
+                event_type: "session_stop",
+                role: None,
+                tool_name: None,
+                content: r#"{"session_id":"sess-1"}"#,
+                task_kind: Some(ExtractionTaskKind::SessionRollup),
+            },
+        )
+        .expect("first capture should insert");
+        let second = record_captured_event(
+            &conn,
+            &CaptureEventInput {
+                host: "codex-cli",
+                session_id: "sess-1",
+                project: "/tmp/remem",
+                cwd: Some("/tmp/remem"),
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Bash"),
+                content: r#"{"tool_name":"Bash","command":"cargo test"}"#,
+                task_kind: Some(ExtractionTaskKind::SessionRollup),
+            },
+        )
+        .expect("second capture should insert");
+
+        assert_eq!(first.extraction_task_id, second.extraction_task_id);
+        let event_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))
+            .unwrap();
+        let task_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM extraction_tasks", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        let high_watermark: i64 = conn
+            .query_row(
+                "SELECT high_watermark_event_id FROM extraction_tasks",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(event_count, 2);
+        assert_eq!(task_count, 1);
+        assert_eq!(high_watermark, second.event_row_id);
+    }
+
+    #[test]
+    fn large_capture_uses_blob_and_compact_preview() {
+        let conn = setup_conn();
+        let content = "x".repeat(DIRECT_CONTENT_BYTES + 2048);
+        let outcome = record_captured_event(
+            &conn,
+            &CaptureEventInput {
+                host: "claude-code",
+                session_id: "sess-large",
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Task"),
+                content: &content,
+                task_kind: Some(ExtractionTaskKind::ObservationExtract),
+            },
+        )
+        .expect("large capture should insert");
+
+        let (retention, blob_id): (String, Option<i64>) = conn
+            .query_row(
+                "SELECT retention_class, content_blob_id FROM captured_events WHERE id = ?1",
+                params![outcome.event_row_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let blob_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM event_blobs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(retention, "raw_compact");
+        assert!(blob_id.is_some());
+        assert_eq!(blob_count, 1);
+    }
+}

--- a/src/db/pending/queue.rs
+++ b/src/db/pending/queue.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
+pub(super) const MAX_PENDING_FIELD_BYTES: usize = 16 * 1024;
+
 pub fn enqueue_pending(
     conn: &Connection,
     host: &str,
@@ -12,6 +14,8 @@ pub fn enqueue_pending(
     cwd: Option<&str>,
 ) -> Result<i64> {
     let epoch = chrono::Utc::now().timestamp();
+    let tool_input = bound_pending_field(tool_input);
+    let tool_response = bound_pending_field(tool_response);
     conn.execute(
         "INSERT INTO pending_observations \
          (host, session_id, project, tool_name, tool_input, tool_response, cwd, created_at_epoch, updated_at_epoch, \
@@ -22,11 +26,27 @@ pub fn enqueue_pending(
             session_id,
             project,
             tool_name,
-            tool_input,
-            tool_response,
+            tool_input.as_deref(),
+            tool_response.as_deref(),
             cwd,
             epoch
         ],
     )?;
     Ok(conn.last_insert_rowid())
+}
+
+fn bound_pending_field(value: Option<&str>) -> Option<String> {
+    value.map(|value| {
+        if value.len() <= MAX_PENDING_FIELD_BYTES {
+            return value.to_string();
+        }
+
+        let marker = format!(
+            "\n[remem truncated legacy pending field: original_bytes={}]\n",
+            value.len()
+        );
+        let keep_bytes = MAX_PENDING_FIELD_BYTES.saturating_sub(marker.len());
+        let kept = crate::db::truncate_str(value, keep_bytes);
+        format!("{}{}", kept, marker)
+    })
 }

--- a/src/db/pending/tests.rs
+++ b/src/db/pending/tests.rs
@@ -1,5 +1,6 @@
 use rusqlite::{params, Connection};
 
+use super::queue::MAX_PENDING_FIELD_BYTES;
 use super::{
     claim_pending, delete_pending_claimed, enqueue_pending, release_expired_pending_claims,
     retry_pending_claimed,
@@ -48,6 +49,38 @@ fn claim_pending_only_returns_requested_session_rows() {
     assert_eq!(claimed[0].id, expected_id);
     assert_eq!(claimed[0].session_id, "session-a");
     assert_eq!(claimed[0].status, "processing");
+}
+
+#[test]
+fn enqueue_pending_bounds_large_tool_payloads() {
+    let conn = setup_conn();
+    let oversized_input = "input ".repeat(MAX_PENDING_FIELD_BYTES);
+    let oversized_response = "响应".repeat(MAX_PENDING_FIELD_BYTES);
+
+    let id = enqueue_pending(
+        &conn,
+        "claude-code",
+        "session-a",
+        "proj",
+        "Edit",
+        Some(&oversized_input),
+        Some(&oversized_response),
+        Some("/tmp/proj"),
+    )
+    .expect("large pending row should be queued");
+
+    let (stored_input, stored_response): (String, String) = conn
+        .query_row(
+            "SELECT tool_input, tool_response FROM pending_observations WHERE id = ?1",
+            params![id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("stored payload should load");
+
+    assert!(stored_input.len() <= MAX_PENDING_FIELD_BYTES);
+    assert!(stored_response.len() <= MAX_PENDING_FIELD_BYTES);
+    assert!(stored_input.contains("remem truncated legacy pending field"));
+    assert!(stored_response.contains("remem truncated legacy pending field"));
 }
 
 #[test]

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -9,6 +9,12 @@ pub struct SystemStats {
     pub active_observations: i64,
     pub session_summaries: i64,
     pub raw_messages: i64,
+    pub captured_events: i64,
+    pub pending_extraction_tasks: i64,
+    pub processing_extraction_tasks: i64,
+    pub failed_extraction_tasks: i64,
+    pub oldest_pending_extraction_epoch: Option<i64>,
+    pub pending_memory_candidates: i64,
     pub pending_observations: i64,
     pub ready_pending_observations: i64,
     pub delayed_pending_observations: i64,
@@ -40,12 +46,14 @@ pub struct ProjectCount {
 pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
     let now = chrono::Utc::now().timestamp();
     let worker_heartbeat = crate::db::worker::latest_worker_heartbeat(conn)?;
+    let healthy_worker_heartbeat = crate::db::worker::healthy_worker_heartbeat(
+        conn,
+        crate::db::worker::WORKER_HEARTBEAT_HEALTH_SECS,
+    )?;
     let worker_heartbeat_age_secs = worker_heartbeat
         .as_ref()
         .map(|heartbeat| now.saturating_sub(heartbeat.updated_at_epoch));
-    let worker_daemon_healthy = worker_heartbeat_age_secs
-        .map(|age| age <= crate::db::worker::WORKER_HEARTBEAT_HEALTH_SECS)
-        .unwrap_or(false);
+    let worker_daemon_healthy = healthy_worker_heartbeat.is_some();
     Ok(SystemStats {
         active_memories: conn.query_row(
             "SELECT COUNT(*) FROM memories WHERE status = 'active'",
@@ -61,6 +69,34 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
             row.get(0)
         })?,
         raw_messages: conn.query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))?,
+        captured_events: conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| {
+            row.get(0)
+        })?,
+        pending_extraction_tasks: conn.query_row(
+            "SELECT COUNT(*) FROM extraction_tasks WHERE status = 'pending'",
+            [],
+            |row| row.get(0),
+        )?,
+        processing_extraction_tasks: conn.query_row(
+            "SELECT COUNT(*) FROM extraction_tasks WHERE status = 'processing'",
+            [],
+            |row| row.get(0),
+        )?,
+        failed_extraction_tasks: conn.query_row(
+            "SELECT COUNT(*) FROM extraction_tasks WHERE status = 'failed'",
+            [],
+            |row| row.get(0),
+        )?,
+        oldest_pending_extraction_epoch: conn.query_row(
+            "SELECT MIN(created_at_epoch) FROM extraction_tasks WHERE status = 'pending'",
+            [],
+            |row| row.get(0),
+        )?,
+        pending_memory_candidates: conn.query_row(
+            "SELECT COUNT(*) FROM memory_candidates WHERE review_status = 'pending_review'",
+            [],
+            |row| row.get(0),
+        )?,
         pending_observations: conn.query_row(
             "SELECT COUNT(*) FROM pending_observations WHERE status = 'pending'",
             [],

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -23,6 +23,18 @@ fn setup_stats_schema(conn: &Connection) {
         CREATE TABLE raw_messages (
             id INTEGER PRIMARY KEY
         );
+        CREATE TABLE captured_events (
+            id INTEGER PRIMARY KEY
+        );
+        CREATE TABLE extraction_tasks (
+            id INTEGER PRIMARY KEY,
+            status TEXT NOT NULL,
+            created_at_epoch INTEGER NOT NULL
+        );
+        CREATE TABLE memory_candidates (
+            id INTEGER PRIMARY KEY,
+            review_status TEXT NOT NULL
+        );
         CREATE TABLE pending_observations (
             id INTEGER PRIMARY KEY,
             status TEXT NOT NULL,
@@ -78,6 +90,28 @@ fn query_system_stats_and_related_views_share_one_definition() {
     .expect("stale observation insert should succeed");
     conn.execute("INSERT INTO session_summaries (id) VALUES (1)", [])
         .expect("summary insert should succeed");
+    conn.execute("INSERT INTO captured_events (id) VALUES (1)", [])
+        .expect("captured event insert should succeed");
+    conn.execute(
+        "INSERT INTO extraction_tasks (status, created_at_epoch) VALUES ('pending', 90)",
+        [],
+    )
+    .expect("pending extraction task insert should succeed");
+    conn.execute(
+        "INSERT INTO extraction_tasks (status, created_at_epoch) VALUES ('processing', 95)",
+        [],
+    )
+    .expect("processing extraction task insert should succeed");
+    conn.execute(
+        "INSERT INTO extraction_tasks (status, created_at_epoch) VALUES ('failed', 96)",
+        [],
+    )
+    .expect("failed extraction task insert should succeed");
+    conn.execute(
+        "INSERT INTO memory_candidates (review_status) VALUES ('pending_review')",
+        [],
+    )
+    .expect("memory candidate insert should succeed");
     conn.execute(
         "INSERT INTO pending_observations (status, created_at_epoch) VALUES ('pending', 100)",
         [],
@@ -121,8 +155,8 @@ fn query_system_stats_and_related_views_share_one_definition() {
     .expect("failed job insert should succeed");
     conn.execute(
         "INSERT INTO worker_heartbeats (owner, pid, started_at_epoch, updated_at_epoch)
-         VALUES ('worker-a', 123, strftime('%s', 'now') - 10, strftime('%s', 'now') - 10)",
-        [],
+         VALUES ('worker-a', ?1, strftime('%s', 'now') - 10, strftime('%s', 'now') - 10)",
+        [i64::from(std::process::id())],
     )
     .expect("heartbeat insert should succeed");
 
@@ -134,6 +168,12 @@ fn query_system_stats_and_related_views_share_one_definition() {
             active_observations: 1,
             session_summaries: 1,
             raw_messages: 0,
+            captured_events: 1,
+            pending_extraction_tasks: 1,
+            processing_extraction_tasks: 1,
+            failed_extraction_tasks: 1,
+            oldest_pending_extraction_epoch: Some(90),
+            pending_memory_candidates: 1,
             pending_observations: 2,
             ready_pending_observations: 1,
             delayed_pending_observations: 1,

--- a/src/db/worker.rs
+++ b/src/db/worker.rs
@@ -54,24 +54,57 @@ pub fn healthy_worker_heartbeat(
     max_age_secs: i64,
 ) -> Result<Option<WorkerHeartbeat>> {
     let now = chrono::Utc::now().timestamp();
-    conn.query_row(
+    let mut stmt = conn.prepare(
         "SELECT owner, pid, started_at_epoch, updated_at_epoch
          FROM worker_heartbeats
          WHERE updated_at_epoch >= ?1
          ORDER BY updated_at_epoch DESC, owner ASC
-         LIMIT 1",
-        params![now.saturating_sub(max_age_secs)],
-        |row| {
-            Ok(WorkerHeartbeat {
-                owner: row.get(0)?,
-                pid: row.get(1)?,
-                started_at_epoch: row.get(2)?,
-                updated_at_epoch: row.get(3)?,
-            })
-        },
-    )
-    .optional()
-    .map_err(Into::into)
+         LIMIT 10",
+    )?;
+    let rows = stmt.query_map(params![now.saturating_sub(max_age_secs)], |row| {
+        Ok(WorkerHeartbeat {
+            owner: row.get(0)?,
+            pid: row.get(1)?,
+            started_at_epoch: row.get(2)?,
+            updated_at_epoch: row.get(3)?,
+        })
+    })?;
+
+    for row in rows {
+        let heartbeat = row?;
+        if heartbeat_process_alive(heartbeat.pid) {
+            return Ok(Some(heartbeat));
+        }
+    }
+    Ok(None)
+}
+
+fn heartbeat_process_alive(pid: Option<i64>) -> bool {
+    let Some(pid) = pid else {
+        return false;
+    };
+    if pid <= 0 || pid > i64::from(i32::MAX) {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if result == 0 {
+            return true;
+        }
+        std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_heartbeat_process_alive(pid: Option<i64>) -> bool {
+    heartbeat_process_alive(pid)
 }
 
 #[cfg(test)]
@@ -79,8 +112,8 @@ mod tests {
     use rusqlite::Connection;
 
     use super::{
-        healthy_worker_heartbeat, latest_worker_heartbeat, upsert_worker_heartbeat,
-        WORKER_HEARTBEAT_HEALTH_SECS,
+        healthy_worker_heartbeat, latest_worker_heartbeat, test_heartbeat_process_alive,
+        upsert_worker_heartbeat, WORKER_HEARTBEAT_HEALTH_SECS,
     };
 
     fn setup(conn: &Connection) {
@@ -94,9 +127,11 @@ mod tests {
         setup(&conn);
         let now = chrono::Utc::now().timestamp();
 
-        upsert_worker_heartbeat(&conn, "worker-old", 10, now - 900, now - 900)
+        let current_pid = i64::from(std::process::id());
+
+        upsert_worker_heartbeat(&conn, "worker-old", current_pid, now - 900, now - 900)
             .expect("old heartbeat should insert");
-        upsert_worker_heartbeat(&conn, "worker-new", 11, now - 10, now - 10)
+        upsert_worker_heartbeat(&conn, "worker-new", current_pid, now - 10, now - 10)
             .expect("new heartbeat should insert");
 
         let latest = latest_worker_heartbeat(&conn)
@@ -122,5 +157,26 @@ mod tests {
         let healthy = healthy_worker_heartbeat(&conn, WORKER_HEARTBEAT_HEALTH_SECS)
             .expect("healthy heartbeat query should run");
         assert!(healthy.is_none());
+    }
+
+    #[test]
+    fn recent_heartbeat_with_dead_pid_is_not_healthy() {
+        let conn = Connection::open_in_memory().expect("db should open");
+        setup(&conn);
+        let now = chrono::Utc::now().timestamp();
+
+        upsert_worker_heartbeat(&conn, "worker-dead", i64::from(i32::MAX), now, now)
+            .expect("dead heartbeat should insert");
+
+        let healthy = healthy_worker_heartbeat(&conn, WORKER_HEARTBEAT_HEALTH_SECS)
+            .expect("healthy heartbeat query should run");
+        assert!(healthy.is_none());
+    }
+
+    #[test]
+    fn current_process_pid_is_alive() {
+        assert!(test_heartbeat_process_alive(Some(i64::from(
+            std::process::id()
+        ))));
     }
 }

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -138,8 +138,22 @@ fn probe_hooks(probe: HostProbe) -> Check {
         .iter()
         .filter(|event| event_has_remem_hook(&doc, event))
         .count();
+    let deprecated_codex_observe =
+        probe.name == "codex" && event_has_remem_observe_hook(&doc, "PostToolUse");
 
     if found == events.len() {
+        if deprecated_codex_observe {
+            return Check {
+                name,
+                status: Status::Warn,
+                detail: format!(
+                    "{}/{} registered in {}; remove Codex PostToolUse observe to avoid unbounded Bash backlog",
+                    found,
+                    events.len(),
+                    probe.hooks_path.display()
+                ),
+            };
+        }
         Check {
             name,
             status: Status::Ok,
@@ -240,7 +254,7 @@ fn display_mcp_paths(paths: &[PathBuf]) -> String {
 
 fn expected_hook_events(host: &str) -> &'static [&'static str] {
     match host {
-        "codex" => &["SessionStart", "PostToolUse", "Stop"],
+        "codex" => &["SessionStart", "Stop"],
         _ => &["PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"],
     }
 }
@@ -287,6 +301,28 @@ fn entry_has_remem_hook(entry: &Value) -> bool {
             hook.get("command")
                 .and_then(|command| command.as_str())
                 .is_some_and(|command| command.contains("remem"))
+        })
+}
+
+fn event_has_remem_observe_hook(doc: &Value, event: &str) -> bool {
+    doc.get("hooks")
+        .and_then(|hooks| hooks.get(event))
+        .and_then(|entries| entries.as_array())
+        .into_iter()
+        .flatten()
+        .any(entry_has_remem_observe_hook)
+}
+
+fn entry_has_remem_observe_hook(entry: &Value) -> bool {
+    entry
+        .get("hooks")
+        .and_then(|hooks| hooks.as_array())
+        .into_iter()
+        .flatten()
+        .any(|hook| {
+            hook.get("command")
+                .and_then(|command| command.as_str())
+                .is_some_and(|command| command.contains("remem") && command.contains(" observe"))
         })
 }
 
@@ -340,12 +376,37 @@ mod tests {
         });
 
         assert!(matches!(check.status, Status::Warn));
-        assert!(check.detail.contains("1/3 registered"), "{}", check.detail);
+        assert!(check.detail.contains("1/2 registered"), "{}", check.detail);
     }
 
     #[test]
     fn probe_hooks_accepts_codex_strategy() {
         let dir = temp_path("doctor-codex-hooks");
+        let hooks_path = dir.join("hooks.json");
+        std::fs::write(
+            &hooks_path,
+            r#"{
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context" }] }],
+    "Stop": [{ "hooks": [{ "command": "REMEM_SUMMARY_EXECUTOR=codex-cli /tmp/remem summarize" }] }]
+  }
+}"#,
+        )
+        .unwrap();
+
+        let check = probe_hooks(HostProbe {
+            name: "codex",
+            hooks_path,
+            mcp_paths: vec![dir.join("config.toml")],
+        });
+
+        assert!(matches!(check.status, Status::Ok));
+        assert!(check.detail.contains("2/2 registered"), "{}", check.detail);
+    }
+
+    #[test]
+    fn probe_hooks_warns_on_codex_posttool_observe() {
+        let dir = temp_path("doctor-codex-observe-warning");
         let hooks_path = dir.join("hooks.json");
         std::fs::write(
             &hooks_path,
@@ -365,8 +426,12 @@ mod tests {
             mcp_paths: vec![dir.join("config.toml")],
         });
 
-        assert!(matches!(check.status, Status::Ok));
-        assert!(check.detail.contains("3/3 registered"), "{}", check.detail);
+        assert!(matches!(check.status, Status::Warn));
+        assert!(
+            check.detail.contains("PostToolUse observe"),
+            "{}",
+            check.detail
+        );
     }
 
     #[test]
@@ -433,7 +498,6 @@ command = "/tmp/remem"
             r#"{
   "hooks": {
     "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context" }] }],
-    "PostToolUse": [{ "hooks": [{ "command": "/tmp/remem observe" }] }],
     "Stop": [{ "hooks": [{ "command": "/tmp/remem summarize" }] }]
   }
 }"#,

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -194,8 +194,14 @@ fn check_worker_daemon_reports_healthy_heartbeat() {
     let _test_dir = ScopedTestDataDir::new("doctor-worker-healthy");
     let conn = db::open_db().expect("db should open");
     let now = chrono::Utc::now().timestamp();
-    db::upsert_worker_heartbeat(&conn, "worker-daemon", 123, now - 5, now - 5)
-        .expect("heartbeat should insert");
+    db::upsert_worker_heartbeat(
+        &conn,
+        "worker-daemon",
+        i64::from(std::process::id()),
+        now - 5,
+        now - 5,
+    )
+    .expect("heartbeat should insert");
     drop(conn);
 
     let check = check_worker_daemon();

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -30,7 +30,7 @@ impl HookStrategy {
     }
 
     fn include_observe(self) -> bool {
-        true
+        matches!(self, Self::ClaudeCode)
     }
 
     fn observe_matcher(self) -> &'static str {

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -65,7 +65,7 @@ impl InstallHost for CodexHost {
                 SERVER_KEY
             ),
             format!(
-                "  hooks  -> {} (SessionStart/PostToolUse(Bash)/Stop)",
+                "  hooks  -> {} (SessionStart/Stop)",
                 codex_hooks_path().display()
             ),
             format!("  binary -> {}", bin),
@@ -163,7 +163,8 @@ fn enable_codex_hooks(doc: &mut DocumentMut) -> Result<()> {
         .or_insert(Item::Table(Table::new()))
         .as_table_mut()
         .context("features 存在但不是 table，拒绝覆盖")?;
-    features["codex_hooks"] = value(true);
+    features.remove("codex_hooks");
+    features["hooks"] = value(true);
     Ok(())
 }
 
@@ -269,19 +270,28 @@ startup_timeout_sec = 5
         enable_codex_hooks(&mut doc).unwrap();
         let rendered = doc.to_string();
         assert!(rendered.contains("[features]"), "{rendered}");
-        assert!(rendered.contains("codex_hooks = true"), "{rendered}");
+        assert!(rendered.contains("hooks = true"), "{rendered}");
+        assert!(!rendered.contains("codex_hooks"), "{rendered}");
+    }
+
+    #[test]
+    fn enable_codex_hooks_removes_deprecated_feature_flag() {
+        let mut doc: DocumentMut = r#"[features]
+codex_hooks = true
+"#
+        .parse()
+        .unwrap();
+        enable_codex_hooks(&mut doc).unwrap();
+        let rendered = doc.to_string();
+        assert!(rendered.contains("hooks = true"), "{rendered}");
+        assert!(!rendered.contains("codex_hooks"), "{rendered}");
     }
 
     #[test]
     fn build_codex_hooks_uses_second_timeouts() {
         let hooks = build_codex_hooks("/tmp/remem");
         assert_eq!(hooks["SessionStart"][0]["hooks"][0]["timeout"], 15);
-        assert_eq!(hooks["PostToolUse"][0]["hooks"][0]["timeout"], 3);
-        assert_eq!(hooks["PostToolUse"][0]["matcher"], "Bash");
-        assert_eq!(
-            hooks["PostToolUse"][0]["hooks"][0]["command"],
-            "REMEM_HOOK_ADAPTER=codex-cli /tmp/remem observe"
-        );
+        assert!(hooks.get("PostToolUse").is_none());
         assert_eq!(hooks["Stop"][0]["hooks"][0]["timeout"], 120);
         assert!(hooks.get("UserPromptSubmit").is_none());
         assert_eq!(

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -35,12 +35,7 @@ fn build_hooks_contains_expected_codex_commands() {
         "REMEM_CONTEXT_HOST=codex-cli /tmp/remem context"
     );
     assert!(hooks.get("UserPromptSubmit").is_none());
-    assert_eq!(hooks["PostToolUse"][0]["matcher"], "Bash");
-    assert_eq!(
-        hooks["PostToolUse"][0]["hooks"][0]["command"],
-        "REMEM_HOOK_ADAPTER=codex-cli /tmp/remem observe"
-    );
-    assert_eq!(hooks["PostToolUse"][0]["hooks"][0]["timeout"], 3000);
+    assert!(hooks.get("PostToolUse").is_none());
     assert_eq!(
         hooks["Stop"][0]["hooks"][0]["command"],
         "REMEM_SUMMARY_EXECUTOR=codex-cli REMEM_FLUSH_EXECUTOR=codex-cli /tmp/remem summarize"

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -62,10 +62,10 @@ fn full_migration_on_empty_db() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 17);
+    assert_eq!(user_version, 18);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -78,6 +78,26 @@ fn full_migration_on_empty_db() -> Result<()> {
         has_worker_heartbeats,
         "worker_heartbeats table should exist after migration"
     );
+    for table in [
+        "hosts",
+        "workspaces",
+        "projects",
+        "sessions",
+        "event_blobs",
+        "captured_events",
+        "extraction_tasks",
+        "memory_candidates",
+        "rule_candidates",
+    ] {
+        let exists: bool = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+                [table],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        assert!(exists, "{table} table should exist after migration");
+    }
     Ok(())
 }
 
@@ -103,7 +123,7 @@ fn transition_from_old_system_skips_baseline() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6]);
     Ok(())
 }
 
@@ -128,10 +148,10 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
 
     // Should have auto-upgraded and marked all v1 migrations as applied.
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 17);
+    assert_eq!(user_version, 18);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -171,7 +191,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 17);
+    assert_eq!(result.current_version, 18);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())
@@ -184,7 +204,7 @@ fn dry_run_pending_reports_pending_for_new_db() -> Result<()> {
     let result = dry_run_pending(&conn)?;
 
     assert_eq!(result.current_version, 0);
-    assert_eq!(result.pending_count, 5);
+    assert_eq!(result.pending_count, 6);
     assert!(result.error.is_none());
     Ok(())
 }
@@ -243,7 +263,7 @@ fn dry_run_pending_reports_backfill_error_for_broken_schema() -> Result<()> {
     let result = dry_run_pending(&conn)?;
     // After broken baseline backfill fails, dry_run reports the still-unapplied
     // migrations (v2+ remain pending in _schema_migrations).
-    assert_eq!(result.pending_count, 4);
+    assert_eq!(result.pending_count, 5);
     let error = result
         .error
         .expect("broken schema should surface in dry-run");

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -30,6 +30,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "memories_fts_active_filter",
         sql: include_str!("../migrations/v005_memories_fts_active_filter.sql"),
     },
+    Migration {
+        version: 6,
+        name: "capture_pipeline",
+        sql: include_str!("../migrations/v006_capture_pipeline.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v006_capture_pipeline.sql
+++ b/src/migrations/v006_capture_pipeline.sql
@@ -1,0 +1,150 @@
+-- v006_capture_pipeline: append-only capture ledger + coalesced extraction tasks.
+-- This is the first production slice of the v2 memory design. It keeps raw
+-- events and task scheduling separate from the legacy pending_observations
+-- queue so high-frequency tools cannot create one LLM job per event.
+
+CREATE TABLE IF NOT EXISTS hosts (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workspaces (
+    id INTEGER PRIMARY KEY,
+    root_path TEXT NOT NULL UNIQUE,
+    git_remote TEXT,
+    git_branch TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS projects (
+    id INTEGER PRIMARY KEY,
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_path TEXT NOT NULL,
+    project_key TEXT NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    UNIQUE(workspace_id, project_path)
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_id TEXT NOT NULL,
+    started_at_epoch INTEGER,
+    last_seen_at_epoch INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    UNIQUE(host_id, project_id, session_id)
+);
+
+CREATE TABLE IF NOT EXISTS event_blobs (
+    id INTEGER PRIMARY KEY,
+    content_hash TEXT NOT NULL UNIQUE,
+    content_encoding TEXT NOT NULL,
+    content_bytes BLOB NOT NULL,
+    original_bytes INTEGER NOT NULL,
+    stored_bytes INTEGER NOT NULL,
+    created_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS captured_events (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+    session_id TEXT NOT NULL,
+    turn_id TEXT,
+    event_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    role TEXT,
+    tool_name TEXT,
+    content_text TEXT,
+    content_blob_id INTEGER REFERENCES event_blobs(id),
+    content_hash TEXT NOT NULL,
+    token_estimate INTEGER NOT NULL DEFAULT 0,
+    retention_class TEXT NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    inserted_at_epoch INTEGER NOT NULL,
+    UNIQUE(host_id, session_id, event_id)
+);
+
+CREATE TABLE IF NOT EXISTS extraction_tasks (
+    id INTEGER PRIMARY KEY,
+    task_kind TEXT NOT NULL,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER REFERENCES sessions(id),
+    priority INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    cursor_event_id INTEGER,
+    high_watermark_event_id INTEGER,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_retry_epoch INTEGER,
+    lease_owner TEXT,
+    lease_expires_epoch INTEGER,
+    last_error TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS memory_candidates (
+    id INTEGER PRIMARY KEY,
+    project_id INTEGER REFERENCES projects(id),
+    scope TEXT NOT NULL,
+    memory_type TEXT NOT NULL,
+    topic_key TEXT NOT NULL,
+    text TEXT NOT NULL,
+    evidence_event_ids TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    risk_class TEXT NOT NULL,
+    review_status TEXT NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS rule_candidates (
+    id INTEGER PRIMARY KEY,
+    workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+    project_id INTEGER REFERENCES projects(id),
+    rule_path TEXT,
+    rule_text TEXT NOT NULL,
+    proposed_diff TEXT,
+    evidence_event_ids TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    review_status TEXT NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_host_project_seen
+    ON sessions(host_id, project_id, last_seen_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_captured_events_session_event
+    ON captured_events(session_row_id, event_id);
+CREATE INDEX IF NOT EXISTS idx_captured_events_project_created
+    ON captured_events(project_id, created_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_captured_events_event_type
+    ON captured_events(event_type, retention_class);
+CREATE INDEX IF NOT EXISTS idx_extraction_tasks_claim
+    ON extraction_tasks(host_id, project_id, status, priority, next_retry_epoch, id);
+CREATE INDEX IF NOT EXISTS idx_extraction_tasks_lease
+    ON extraction_tasks(status, lease_expires_epoch);
+CREATE INDEX IF NOT EXISTS idx_extraction_tasks_kind
+    ON extraction_tasks(task_kind, status, created_at_epoch);
+CREATE INDEX IF NOT EXISTS idx_memory_candidates_review
+    ON memory_candidates(review_status, created_at_epoch);
+CREATE INDEX IF NOT EXISTS idx_memory_candidates_project
+    ON memory_candidates(project_id, scope, memory_type);
+CREATE INDEX IF NOT EXISTS idx_rule_candidates_review
+    ON rule_candidates(workspace_id, review_status);
+
+INSERT OR IGNORE INTO hosts(name, enabled, created_at_epoch) VALUES
+    ('claude-code', 1, strftime('%s', 'now')),
+    ('codex-cli', 1, strftime('%s', 'now')),
+    ('unknown', 1, strftime('%s', 'now'));

--- a/src/migrations/v006_capture_pipeline.sql
+++ b/src/migrations/v006_capture_pipeline.sql
@@ -1,7 +1,7 @@
 -- v006_capture_pipeline: append-only capture ledger + coalesced extraction tasks.
--- This is the first production slice of the v2 memory design. It keeps raw
--- events and task scheduling separate from the legacy pending_observations
--- queue so high-frequency tools cannot create one LLM job per event.
+-- This is the first production slice of the memory pipeline. It keeps raw
+-- events and task scheduling separate from pending_observations so high-frequency
+-- tools cannot create one LLM job per event.
 
 CREATE TABLE IF NOT EXISTS hosts (
     id INTEGER PRIMARY KEY,
@@ -146,5 +146,4 @@ CREATE INDEX IF NOT EXISTS idx_rule_candidates_review
 
 INSERT OR IGNORE INTO hosts(name, enabled, created_at_epoch) VALUES
     ('claude-code', 1, strftime('%s', 'now')),
-    ('codex-cli', 1, strftime('%s', 'now')),
-    ('unknown', 1, strftime('%s', 'now'));
+    ('codex-cli', 1, strftime('%s', 'now'));

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -43,6 +43,7 @@ pub async fn observe() -> Result<()> {
     };
 
     let conn = db::open_db()?;
+    record_capture_event(&conn, adapter.name(), &event, &summary)?;
     crate::memory::insert_event(
         &conn,
         &event.session_id,
@@ -98,6 +99,40 @@ pub async fn observe() -> Result<()> {
     Ok(())
 }
 
+fn record_capture_event(
+    conn: &rusqlite::Connection,
+    host: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> Result<()> {
+    let content = serde_json::json!({
+        "summary": &summary.summary,
+        "event_type": &summary.event_type,
+        "detail": summary.detail.as_deref(),
+        "files": summary.files_json.as_deref(),
+        "exit_code": summary.exit_code,
+        "tool_name": &event.tool_name,
+        "tool_input": event.tool_input.as_ref(),
+        "tool_response": event.tool_response.as_ref(),
+    })
+    .to_string();
+    db::record_captured_event(
+        conn,
+        &db::CaptureEventInput {
+            host,
+            session_id: &event.session_id,
+            project: &event.project,
+            cwd: event.cwd.as_deref(),
+            event_type: "tool_result",
+            role: None,
+            tool_name: Some(&event.tool_name),
+            content: &content,
+            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
+        },
+    )?;
+    Ok(())
+}
+
 fn should_skip_bash_event(
     adapter: &dyn crate::adapter::ToolAdapter,
     event: &crate::adapter::ParsedHookEvent,
@@ -106,9 +141,96 @@ fn should_skip_bash_event(
         return false;
     }
 
+    if adapter.name() == "codex-cli" && !codex_bash_observe_enabled() {
+        return true;
+    }
+
     event
         .tool_input
         .as_ref()
         .and_then(|value| value["command"].as_str())
         .is_some_and(|command| adapter.should_skip_bash(command))
+}
+
+fn codex_bash_observe_enabled() -> bool {
+    std::env::var("REMEM_ENABLE_CODEX_BASH_OBSERVE")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use crate::adapter::{codex::CodexAdapter, EventSummary, ParsedHookEvent};
+    use crate::db::{self, test_support::ScopedTestDataDir};
+
+    use super::{record_capture_event, should_skip_bash_event};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn codex_bash_event() -> ParsedHookEvent {
+        ParsedHookEvent {
+            session_id: "session".to_string(),
+            cwd: Some("/tmp".to_string()),
+            project: "/tmp".to_string(),
+            tool_name: "Bash".to_string(),
+            tool_input: Some(serde_json::json!({ "command": "cargo test" })),
+            tool_response: Some(serde_json::json!({ "exitCode": 0 })),
+        }
+    }
+
+    #[test]
+    fn codex_bash_observe_skips_by_default() {
+        let _guard = ENV_LOCK.lock().expect("env lock should acquire");
+        unsafe { std::env::remove_var("REMEM_ENABLE_CODEX_BASH_OBSERVE") };
+
+        assert!(should_skip_bash_event(&CodexAdapter, &codex_bash_event()));
+    }
+
+    #[test]
+    fn codex_bash_observe_can_be_enabled_explicitly() {
+        let _guard = ENV_LOCK.lock().expect("env lock should acquire");
+        unsafe { std::env::set_var("REMEM_ENABLE_CODEX_BASH_OBSERVE", "1") };
+        let event = codex_bash_event();
+        let skipped = should_skip_bash_event(&CodexAdapter, &event);
+        unsafe { std::env::remove_var("REMEM_ENABLE_CODEX_BASH_OBSERVE") };
+
+        assert!(!skipped);
+    }
+
+    #[test]
+    fn record_capture_event_writes_ledger_and_coalesced_task() {
+        let _test_dir = ScopedTestDataDir::new("observe-capture-ledger");
+        let conn = db::open_db().expect("db should open");
+        let event = ParsedHookEvent {
+            session_id: "sess-observe".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Edit".to_string(),
+            tool_input: Some(serde_json::json!({ "file_path": "src/lib.rs" })),
+            tool_response: None,
+        };
+        let summary = EventSummary {
+            event_type: "file_edit".to_string(),
+            summary: "Edit src/lib.rs".to_string(),
+            detail: None,
+            files_json: Some(r#"["src/lib.rs"]"#.to_string()),
+            exit_code: None,
+        };
+
+        record_capture_event(&conn, "claude-code", &event, &summary)
+            .expect("capture event should write");
+
+        let captured_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))
+            .expect("captured count should query");
+        let task_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM extraction_tasks", [], |row| {
+                row.get(0)
+            })
+            .expect("task count should query");
+        assert_eq!(captured_count, 1);
+        assert_eq!(task_count, 1);
+    }
 }

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -28,6 +28,20 @@ pub async fn summarize() -> Result<()> {
     let host = resolve_hook_host();
     let conn = db::open_db()?;
 
+    db::record_captured_event(
+        &conn,
+        &db::CaptureEventInput {
+            host: &host,
+            session_id,
+            project: &project,
+            cwd: Some(cwd),
+            event_type: "session_stop",
+            role: None,
+            tool_name: None,
+            content: &input,
+            task_kind: Some(db::ExtractionTaskKind::SessionRollup),
+        },
+    )?;
     enqueue_summary_jobs(&conn, &host, session_id, &project, &input)?;
     if should_spawn_worker_once(&conn)? {
         spawn_worker_once()?;
@@ -47,20 +61,23 @@ fn enqueue_summary_jobs(
     project: &str,
     input: &str,
 ) -> Result<()> {
-    let obs_payload = serde_json::json!({
-        "host": host,
-        "session_id": session_id,
-        "project": project,
-    });
-    db::enqueue_job(
-        conn,
-        host,
-        db::JobType::Observation,
-        project,
-        Some(session_id),
-        &obs_payload.to_string(),
-        50,
-    )?;
+    let ready_pending = db::count_pending_for_identity(conn, host, project, session_id)?;
+    if ready_pending > 0 {
+        let obs_payload = serde_json::json!({
+            "host": host,
+            "session_id": session_id,
+            "project": project,
+        });
+        db::enqueue_job(
+            conn,
+            host,
+            db::JobType::Observation,
+            project,
+            Some(session_id),
+            &obs_payload.to_string(),
+            50,
+        )?;
+    }
     db::enqueue_job(
         conn,
         host,
@@ -74,8 +91,8 @@ fn enqueue_summary_jobs(
     crate::log::info(
         "summarize",
         &format!(
-            "QUEUED observation+summary session={} project={}",
-            session_id, project
+            "QUEUED summary session={} project={} observation_pending={}",
+            session_id, project, ready_pending
         ),
     );
     Ok(())
@@ -108,6 +125,7 @@ fn should_spawn_worker_once(conn: &rusqlite::Connection) -> Result<bool> {
 
 fn spawn_worker_once() -> Result<()> {
     let exe = std::env::current_exe()?;
+    let worker_dir = stable_worker_dir();
     let stderr_file = crate::log::open_log_append();
     let stderr_cfg = match stderr_file {
         Some(file) => std::process::Stdio::from(file),
@@ -117,6 +135,7 @@ fn spawn_worker_once() -> Result<()> {
     command
         .arg("worker")
         .arg("--once")
+        .current_dir(&worker_dir)
         .env("REMEM_STDERR_TO_LOG", "1")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
@@ -124,6 +143,22 @@ fn spawn_worker_once() -> Result<()> {
     configure_worker_executor_env(&mut command);
     let _child = command.spawn()?;
     Ok(())
+}
+
+fn stable_worker_dir() -> std::path::PathBuf {
+    let data_dir = crate::db::data_dir();
+    if let Err(err) = std::fs::create_dir_all(&data_dir) {
+        crate::log::warn(
+            "summarize",
+            &format!(
+                "failed to create worker dir {}: {}; falling back to temp dir",
+                data_dir.display(),
+                err
+            ),
+        );
+        return std::env::temp_dir();
+    }
+    data_dir
 }
 
 fn configure_worker_executor_env(command: &mut std::process::Command) {
@@ -141,7 +176,10 @@ mod tests {
 
     use crate::db::{self, test_support::ScopedTestDataDir};
 
-    use super::{configure_worker_executor_env, should_spawn_worker_once};
+    use super::{
+        configure_worker_executor_env, enqueue_summary_jobs, should_spawn_worker_once,
+        stable_worker_dir,
+    };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -231,8 +269,14 @@ mod tests {
         let _test_dir = ScopedTestDataDir::new("summary-healthy-daemon");
         let conn = db::open_db().expect("db should open");
         let now = chrono::Utc::now().timestamp();
-        db::upsert_worker_heartbeat(&conn, "worker-daemon", 123, now - 5, now - 5)
-            .expect("heartbeat should insert");
+        db::upsert_worker_heartbeat(
+            &conn,
+            "worker-daemon",
+            i64::from(std::process::id()),
+            now - 5,
+            now - 5,
+        )
+        .expect("heartbeat should insert");
 
         assert!(
             !should_spawn_worker_once(&conn).expect("daemon check should run"),
@@ -252,5 +296,79 @@ mod tests {
             should_spawn_worker_once(&conn).expect("daemon check should run"),
             "stale heartbeat should keep worker --once fallback"
         );
+    }
+
+    #[test]
+    fn stable_worker_dir_uses_data_dir() {
+        let data_dir = ScopedTestDataDir::new("summary-worker-dir");
+
+        let got = stable_worker_dir();
+
+        assert_eq!(got, data_dir.path);
+        assert!(got.is_dir());
+    }
+
+    #[test]
+    fn enqueue_summary_jobs_skips_observation_job_when_no_pending_events() {
+        let _test_dir = ScopedTestDataDir::new("summary-no-pending-observation");
+        let conn = db::open_db().expect("db should open");
+
+        enqueue_summary_jobs(
+            &conn,
+            "codex-cli",
+            "sess-no-pending",
+            "/tmp/remem",
+            r#"{"session_id":"sess-no-pending"}"#,
+        )
+        .expect("summary jobs should enqueue");
+
+        let jobs = job_types(&conn);
+        assert_eq!(jobs, vec!["summary".to_string(), "compress".to_string()]);
+    }
+
+    #[test]
+    fn enqueue_summary_jobs_keeps_observation_job_when_pending_events_exist() {
+        let _test_dir = ScopedTestDataDir::new("summary-with-pending-observation");
+        let conn = db::open_db().expect("db should open");
+        db::enqueue_pending(
+            &conn,
+            "claude-code",
+            "sess-with-pending",
+            "/tmp/remem",
+            "Edit",
+            Some(r#"{"file_path":"src/lib.rs"}"#),
+            None,
+            Some("/tmp/remem"),
+        )
+        .expect("pending observation should insert");
+
+        enqueue_summary_jobs(
+            &conn,
+            "claude-code",
+            "sess-with-pending",
+            "/tmp/remem",
+            r#"{"session_id":"sess-with-pending"}"#,
+        )
+        .expect("summary jobs should enqueue");
+
+        let jobs = job_types(&conn);
+        assert_eq!(
+            jobs,
+            vec![
+                "observation".to_string(),
+                "summary".to_string(),
+                "compress".to_string()
+            ]
+        );
+    }
+
+    fn job_types(conn: &rusqlite::Connection) -> Vec<String> {
+        let mut stmt = conn
+            .prepare("SELECT job_type FROM jobs ORDER BY id ASC")
+            .expect("job query should prepare");
+        stmt.query_map([], |row| row.get(0))
+            .expect("job query should run")
+            .collect::<rusqlite::Result<Vec<String>>>()
+            .expect("job rows should collect")
     }
 }

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -23,26 +23,14 @@ pub async fn summarize() -> Result<()> {
     let Some(session_id) = &hook.session_id else {
         return Ok(());
     };
-    let cwd = hook.cwd.as_deref().unwrap_or(".");
-    let project = db::project_from_cwd(cwd);
+    let cwd = effective_cwd(&hook)?;
+    let project = db::project_from_cwd(&cwd);
     let host = resolve_hook_host();
     let conn = db::open_db()?;
+    let summary_payload = summary_payload_with_cwd(&input, &cwd)?;
 
-    db::record_captured_event(
-        &conn,
-        &db::CaptureEventInput {
-            host: &host,
-            session_id,
-            project: &project,
-            cwd: Some(cwd),
-            event_type: "session_stop",
-            role: None,
-            tool_name: None,
-            content: &input,
-            task_kind: Some(db::ExtractionTaskKind::SessionRollup),
-        },
-    )?;
-    enqueue_summary_jobs(&conn, &host, session_id, &project, &input)?;
+    record_summary_capture_event(&conn, &host, session_id, &project, &cwd, &summary_payload);
+    enqueue_summary_jobs(&conn, &host, session_id, &project, &summary_payload)?;
     if should_spawn_worker_once(&conn)? {
         spawn_worker_once()?;
     } else {
@@ -52,6 +40,67 @@ pub async fn summarize() -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn effective_cwd(hook: &SummarizeInput) -> Result<String> {
+    if let Some(cwd) = hook.cwd.as_deref().filter(|cwd| !cwd.trim().is_empty()) {
+        return Ok(cwd.to_string());
+    }
+    Ok(std::env::current_dir()?.display().to_string())
+}
+
+fn summary_payload_with_cwd(input: &str, cwd: &str) -> Result<String> {
+    let mut payload: serde_json::Value = serde_json::from_str(input)?;
+    let Some(obj) = payload.as_object_mut() else {
+        return Ok(input.to_string());
+    };
+    let needs_cwd = obj
+        .get("cwd")
+        .and_then(|value| value.as_str())
+        .is_none_or(|value| value.trim().is_empty());
+    if needs_cwd {
+        obj.insert(
+            "cwd".to_string(),
+            serde_json::Value::String(cwd.to_string()),
+        );
+    }
+    Ok(serde_json::to_string(&payload)?)
+}
+
+fn record_summary_capture_event(
+    conn: &rusqlite::Connection,
+    host: &str,
+    session_id: &str,
+    project: &str,
+    cwd: &str,
+    content: &str,
+) -> bool {
+    match db::record_captured_event(
+        conn,
+        &db::CaptureEventInput {
+            host,
+            session_id,
+            project,
+            cwd: Some(cwd),
+            event_type: "session_stop",
+            role: None,
+            tool_name: None,
+            content,
+            task_kind: Some(db::ExtractionTaskKind::SessionRollup),
+        },
+    ) {
+        Ok(_) => true,
+        Err(err) => {
+            crate::log::warn(
+                "summarize",
+                &format!(
+                    "capture ledger record failed; continuing summary enqueue: {}",
+                    err
+                ),
+            );
+            false
+        }
+    }
 }
 
 fn enqueue_summary_jobs(
@@ -177,8 +226,8 @@ mod tests {
     use crate::db::{self, test_support::ScopedTestDataDir};
 
     use super::{
-        configure_worker_executor_env, enqueue_summary_jobs, should_spawn_worker_once,
-        stable_worker_dir,
+        configure_worker_executor_env, enqueue_summary_jobs, record_summary_capture_event,
+        should_spawn_worker_once, stable_worker_dir, summary_payload_with_cwd,
     };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -251,6 +300,55 @@ mod tests {
                 assert_eq!(command_env(&command, "REMEM_EXECUTOR"), None);
             },
         );
+    }
+
+    #[test]
+    fn summary_payload_with_cwd_fills_missing_cwd() {
+        let payload = summary_payload_with_cwd(r#"{"session_id":"sess-cwd"}"#, "/tmp/project")
+            .expect("payload should serialize");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&payload).expect("payload should parse");
+
+        assert_eq!(parsed["session_id"].as_str(), Some("sess-cwd"));
+        assert_eq!(parsed["cwd"].as_str(), Some("/tmp/project"));
+    }
+
+    #[test]
+    fn summary_payload_with_cwd_preserves_existing_cwd() {
+        let payload =
+            summary_payload_with_cwd(r#"{"session_id":"sess-cwd","cwd":"/repo"}"#, "/tmp/project")
+                .expect("payload should serialize");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&payload).expect("payload should parse");
+
+        assert_eq!(parsed["cwd"].as_str(), Some("/repo"));
+    }
+
+    #[test]
+    fn capture_ledger_failure_does_not_block_legacy_summary_hook() {
+        let _test_dir = ScopedTestDataDir::new("summary-legacy-unknown-host");
+        let conn = db::open_db().expect("db should open");
+
+        let captured = record_summary_capture_event(
+            &conn,
+            "unknown",
+            "sess-legacy",
+            "/tmp/remem",
+            "/tmp/remem",
+            r#"{"session_id":"sess-legacy","cwd":"/tmp/remem"}"#,
+        );
+        enqueue_summary_jobs(
+            &conn,
+            "unknown",
+            "sess-legacy",
+            "/tmp/remem",
+            r#"{"session_id":"sess-legacy","cwd":"/tmp/remem"}"#,
+        )
+        .expect("legacy summary jobs should still enqueue");
+
+        assert!(!captured);
+        let jobs = job_types(&conn);
+        assert_eq!(jobs, vec!["summary".to_string(), "compress".to_string()]);
     }
 
     #[test]

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -158,11 +158,13 @@ fn resolve_hook_host() -> String {
             return host;
         }
     }
-    if let Ok(executor) = std::env::var("REMEM_SUMMARY_EXECUTOR") {
-        match executor.as_str() {
-            "codex-cli" => return "codex-cli".to_string(),
-            "claude-cli" => return "claude-code".to_string(),
-            _ => {}
+    for key in ["REMEM_SUMMARY_EXECUTOR", "REMEM_EXECUTOR"] {
+        if let Ok(executor) = std::env::var(key) {
+            match executor.as_str() {
+                "codex-cli" | "codex" => return "codex-cli".to_string(),
+                "claude-cli" | "claude" | "cli" => return "claude-code".to_string(),
+                _ => {}
+            }
         }
     }
     "unknown".to_string()
@@ -227,7 +229,7 @@ mod tests {
 
     use super::{
         configure_worker_executor_env, enqueue_summary_jobs, record_summary_capture_event,
-        should_spawn_worker_once, stable_worker_dir, summary_payload_with_cwd,
+        resolve_hook_host, should_spawn_worker_once, stable_worker_dir, summary_payload_with_cwd,
     };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -298,6 +300,36 @@ mod tests {
 
                 assert_eq!(command_env(&command, "REMEM_SUMMARY_EXECUTOR"), None);
                 assert_eq!(command_env(&command, "REMEM_EXECUTOR"), None);
+            },
+        );
+    }
+
+    #[test]
+    fn hook_host_uses_global_executor_when_summary_override_is_missing() {
+        with_env_vars(
+            &[
+                ("REMEM_HOOK_HOST", None),
+                ("REMEM_CONTEXT_HOST", None),
+                ("REMEM_SUMMARY_EXECUTOR", None),
+                ("REMEM_EXECUTOR", Some("codex-cli")),
+            ],
+            || {
+                assert_eq!(resolve_hook_host(), "codex-cli");
+            },
+        );
+    }
+
+    #[test]
+    fn hook_host_prefers_summary_executor_over_global_executor() {
+        with_env_vars(
+            &[
+                ("REMEM_HOOK_HOST", None),
+                ("REMEM_CONTEXT_HOST", None),
+                ("REMEM_SUMMARY_EXECUTOR", Some("claude-cli")),
+                ("REMEM_EXECUTOR", Some("codex-cli")),
+            ],
+            || {
+                assert_eq!(resolve_hook_host(), "claude-code");
             },
         );
     }


### PR DESCRIPTION
## Summary
- disable Codex PostToolUse observe generation by default while keeping SessionStop capture and manual MCP memory tools available
- add capture ledger/extraction-task tables so hooks record bounded capture events without flooding pending_observations
- reject unsupported capture hosts instead of silently falling back to unknown
- cap pending payloads, skip empty observation jobs, harden worker heartbeat checks, and use a stable AI CLI working directory
- surface pending capture/task counts in status/doctor/docs so backlog health is visible

Fixes #149.

## Verification
- cargo fmt --check
- git diff --check
- cargo check
- cargo test
- cargo build --release

## Notes
This PR intentionally does not include the local demo assets or README branding WIP from the original dirty checkout.