### PR TITLE
feat(worker): consume extraction tasks

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,7 @@
 pub mod capture;
 pub mod core;
 pub mod crypto;
+mod extraction;
 pub mod job;
 pub mod models;
 pub mod observation;
@@ -16,6 +17,7 @@ pub mod worker;
 pub use capture::*;
 pub use core::*;
 pub use crypto::*;
+pub use extraction::*;
 pub use job::*;
 pub use models::*;
 pub use observation::*;

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -23,6 +23,17 @@ impl ExtractionTaskKind {
         }
     }
 
+    pub fn from_db(raw: &str) -> Result<Self> {
+        match raw {
+            "session_rollup" => Ok(Self::SessionRollup),
+            "observation_extract" => Ok(Self::ObservationExtract),
+            "memory_candidate" => Ok(Self::MemoryCandidate),
+            "rule_candidate" => Ok(Self::RuleCandidate),
+            "index_update" => Ok(Self::IndexUpdate),
+            _ => bail!("unknown extraction task kind: {raw}"),
+        }
+    }
+
     fn priority(self) -> i64 {
         match self {
             Self::SessionRollup => 10,

--- a/src/db/extraction.rs
+++ b/src/db/extraction.rs
@@ -132,6 +132,34 @@ pub fn mark_extraction_task_failed(
     ensure_task_updated(updated, task_id)
 }
 
+pub fn defer_extraction_task(
+    conn: &Connection,
+    task_id: i64,
+    lease_owner: &str,
+    reason: &str,
+    backoff_secs: i64,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let updated = conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'pending',
+             lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             next_retry_epoch = ?1,
+             last_error = ?2,
+             updated_at_epoch = ?3
+         WHERE id = ?4 AND lease_owner = ?5 AND status = 'processing'",
+        params![
+            now + backoff_secs.max(1),
+            crate::db::truncate_str(reason, 2000),
+            now,
+            task_id,
+            lease_owner
+        ],
+    )?;
+    ensure_task_updated(updated, task_id)
+}
+
 pub fn mark_extraction_task_failed_or_retry(
     conn: &Connection,
     task_id: i64,
@@ -478,6 +506,25 @@ mod tests {
         assert_eq!(status, "failed");
         assert_eq!(attempts, 1);
         assert!(next_retry.is_none());
+        assert_eq!(last_error.as_deref(), Some("not implemented"));
+    }
+
+    #[test]
+    fn defer_extraction_task_requeues_without_incrementing_attempts() {
+        let mut conn = setup_conn();
+        let task_id = insert_task(&conn, "sess-defer", ExtractionTaskKind::SessionRollup)
+            .expect("task should insert");
+        claim_next_extraction_task(&mut conn, "worker-a", 60)
+            .expect("claim should succeed")
+            .expect("task should be claimed");
+
+        defer_extraction_task(&conn, task_id, "worker-a", "not implemented", 30)
+            .expect("defer should succeed");
+
+        let (status, attempts, next_retry, last_error) = task_status(&conn, task_id);
+        assert_eq!(status, "pending");
+        assert_eq!(attempts, 0);
+        assert!(next_retry.is_some());
         assert_eq!(last_error.as_deref(), Some("not implemented"));
     }
 }

--- a/src/db/extraction.rs
+++ b/src/db/extraction.rs
@@ -1,0 +1,438 @@
+use anyhow::{bail, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::db::ExtractionTaskKind;
+
+pub const EXTRACTION_TASK_MAX_ATTEMPTS: i64 = 5;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractionTask {
+    pub id: i64,
+    pub task_kind: ExtractionTaskKind,
+    pub host: String,
+    pub project: String,
+    pub session_id: Option<String>,
+    pub priority: i64,
+    pub cursor_event_id: Option<i64>,
+    pub high_watermark_event_id: Option<i64>,
+    pub attempts: i64,
+}
+
+pub fn claim_next_extraction_task(
+    conn: &mut Connection,
+    lease_owner: &str,
+    lease_secs: i64,
+) -> Result<Option<ExtractionTask>> {
+    let now = chrono::Utc::now().timestamp();
+    let lease_expires = now + lease_secs.max(1);
+    let tx = conn.transaction()?;
+    let candidate: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM extraction_tasks
+             WHERE status = 'pending'
+               AND (next_retry_epoch IS NULL OR next_retry_epoch <= ?1)
+             ORDER BY priority ASC, created_at_epoch ASC, id ASC
+             LIMIT 1",
+            params![now],
+            |row| row.get(0),
+        )
+        .optional()?;
+
+    let Some(task_id) = candidate else {
+        tx.commit()?;
+        return Ok(None);
+    };
+
+    let updated = tx.execute(
+        "UPDATE extraction_tasks
+         SET status = 'processing',
+             lease_owner = ?1,
+             lease_expires_epoch = ?2,
+             updated_at_epoch = ?3
+         WHERE id = ?4 AND status = 'pending'",
+        params![lease_owner, lease_expires, now, task_id],
+    )?;
+    if updated == 0 {
+        tx.commit()?;
+        return Ok(None);
+    }
+
+    let task = load_claimed_extraction_task(&tx, task_id)?;
+    tx.commit()?;
+    Ok(Some(task))
+}
+
+pub fn release_expired_extraction_task_leases(conn: &Connection) -> Result<usize> {
+    let now = chrono::Utc::now().timestamp();
+    let count = conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'pending',
+             lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             updated_at_epoch = ?1
+         WHERE status = 'processing'
+           AND lease_expires_epoch IS NOT NULL
+           AND lease_expires_epoch < ?1",
+        params![now],
+    )?;
+    Ok(count)
+}
+
+pub fn mark_extraction_task_done(conn: &Connection, task_id: i64, lease_owner: &str) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let updated = conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'done',
+             cursor_event_id = high_watermark_event_id,
+             lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             next_retry_epoch = NULL,
+             last_error = NULL,
+             updated_at_epoch = ?1
+         WHERE id = ?2 AND lease_owner = ?3 AND status = 'processing'",
+        params![now, task_id, lease_owner],
+    )?;
+    ensure_task_updated(updated, task_id)
+}
+
+pub fn mark_extraction_task_failed(
+    conn: &Connection,
+    task_id: i64,
+    lease_owner: &str,
+    err: &str,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let updated = conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'failed',
+             attempts = attempts + 1,
+             lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             next_retry_epoch = NULL,
+             last_error = ?1,
+             updated_at_epoch = ?2
+         WHERE id = ?3 AND lease_owner = ?4 AND status = 'processing'",
+        params![
+            crate::db::truncate_str(err, 2000),
+            now,
+            task_id,
+            lease_owner
+        ],
+    )?;
+    ensure_task_updated(updated, task_id)
+}
+
+pub fn mark_extraction_task_failed_or_retry(
+    conn: &Connection,
+    task_id: i64,
+    lease_owner: &str,
+    err: &str,
+    backoff_secs: i64,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let attempts: i64 = conn.query_row(
+        "SELECT attempts FROM extraction_tasks WHERE id = ?1",
+        params![task_id],
+        |row| row.get(0),
+    )?;
+    let next_attempt = attempts + 1;
+    if next_attempt >= EXTRACTION_TASK_MAX_ATTEMPTS {
+        let updated = conn.execute(
+            "UPDATE extraction_tasks
+             SET status = 'failed',
+                 attempts = ?1,
+                 lease_owner = NULL,
+                 lease_expires_epoch = NULL,
+                 next_retry_epoch = NULL,
+                 last_error = ?2,
+                 updated_at_epoch = ?3
+             WHERE id = ?4 AND lease_owner = ?5 AND status = 'processing'",
+            params![
+                next_attempt,
+                crate::db::truncate_str(err, 2000),
+                now,
+                task_id,
+                lease_owner
+            ],
+        )?;
+        return ensure_task_updated(updated, task_id);
+    }
+
+    let updated = conn.execute(
+        "UPDATE extraction_tasks
+         SET status = 'pending',
+             attempts = ?1,
+             next_retry_epoch = ?2,
+             lease_owner = NULL,
+             lease_expires_epoch = NULL,
+             last_error = ?3,
+             updated_at_epoch = ?4
+         WHERE id = ?5 AND lease_owner = ?6 AND status = 'processing'",
+        params![
+            next_attempt,
+            now + backoff_secs.max(1),
+            crate::db::truncate_str(err, 2000),
+            now,
+            task_id,
+            lease_owner
+        ],
+    )?;
+    ensure_task_updated(updated, task_id)
+}
+
+fn load_claimed_extraction_task(conn: &Connection, task_id: i64) -> Result<ExtractionTask> {
+    let row = conn.query_row(
+        "SELECT t.id, t.task_kind, h.name, p.project_path, s.session_id,
+                t.priority, t.cursor_event_id, t.high_watermark_event_id, t.attempts
+         FROM extraction_tasks t
+         JOIN hosts h ON h.id = t.host_id
+         JOIN projects p ON p.id = t.project_id
+         LEFT JOIN sessions s ON s.id = t.session_row_id
+         WHERE t.id = ?1",
+        params![task_id],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, Option<i64>>(6)?,
+                row.get::<_, Option<i64>>(7)?,
+                row.get::<_, i64>(8)?,
+            ))
+        },
+    )?;
+
+    Ok(ExtractionTask {
+        id: row.0,
+        task_kind: ExtractionTaskKind::from_db(&row.1)?,
+        host: row.2,
+        project: row.3,
+        session_id: row.4,
+        priority: row.5,
+        cursor_event_id: row.6,
+        high_watermark_event_id: row.7,
+        attempts: row.8,
+    })
+}
+
+fn ensure_task_updated(updated: usize, task_id: i64) -> Result<()> {
+    if updated == 0 {
+        bail!("extraction task {task_id} is not leased by this worker");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use crate::db::{record_captured_event, CaptureEventInput};
+
+    use super::*;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db should open");
+        crate::migrate::run_migrations(&conn).expect("migrations should run");
+        conn
+    }
+
+    fn insert_task(
+        conn: &Connection,
+        session_id: &str,
+        task_kind: ExtractionTaskKind,
+    ) -> Result<i64> {
+        let outcome = record_captured_event(
+            conn,
+            &CaptureEventInput {
+                host: "codex-cli",
+                session_id,
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Task"),
+                content: session_id,
+                task_kind: Some(task_kind),
+            },
+        )?;
+        outcome
+            .extraction_task_id
+            .ok_or_else(|| anyhow::anyhow!("expected extraction task id"))
+    }
+
+    fn task_status(conn: &Connection, task_id: i64) -> (String, i64, Option<i64>, Option<String>) {
+        conn.query_row(
+            "SELECT status, attempts, next_retry_epoch, last_error
+             FROM extraction_tasks WHERE id = ?1",
+            params![task_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("task state should query")
+    }
+
+    #[test]
+    fn claim_next_extraction_task_orders_by_priority_and_age() {
+        let mut conn = setup_conn();
+        let observation_id = insert_task(
+            &conn,
+            "sess-observation",
+            ExtractionTaskKind::ObservationExtract,
+        )
+        .expect("observation task should insert");
+        let rollup_id = insert_task(&conn, "sess-rollup", ExtractionTaskKind::SessionRollup)
+            .expect("rollup task should insert");
+
+        let claimed = claim_next_extraction_task(&mut conn, "worker-a", 60)
+            .expect("claim should succeed")
+            .expect("task should be claimed");
+
+        assert_eq!(claimed.id, rollup_id);
+        assert_eq!(claimed.task_kind, ExtractionTaskKind::SessionRollup);
+        assert_eq!(claimed.host, "codex-cli");
+        assert_eq!(claimed.session_id.as_deref(), Some("sess-rollup"));
+
+        let status = task_status(&conn, observation_id).0;
+        assert_eq!(status, "pending");
+    }
+
+    #[test]
+    fn claim_next_extraction_task_does_not_double_claim_active_task() {
+        let mut conn = setup_conn();
+        let task_id = insert_task(&conn, "sess-single", ExtractionTaskKind::SessionRollup)
+            .expect("task should insert");
+
+        let first = claim_next_extraction_task(&mut conn, "worker-a", 60)
+            .expect("first claim should succeed")
+            .expect("first claim should return task");
+        let second = claim_next_extraction_task(&mut conn, "worker-b", 60)
+            .expect("second claim should succeed");
+
+        assert_eq!(first.id, task_id);
+        assert!(second.is_none());
+    }
+
+    #[test]
+    fn release_expired_extraction_task_leases_requeues_only_expired_tasks() {
+        let mut conn = setup_conn();
+        let expired_id = insert_task(&conn, "sess-expired", ExtractionTaskKind::SessionRollup)
+            .expect("expired task should insert");
+        let fresh_id = insert_task(&conn, "sess-fresh", ExtractionTaskKind::ObservationExtract)
+            .expect("fresh task should insert");
+
+        claim_next_extraction_task(&mut conn, "worker-expired", 60)
+            .expect("expired worker claim should succeed")
+            .expect("expired task should be claimed");
+        claim_next_extraction_task(&mut conn, "worker-fresh", 60)
+            .expect("fresh worker claim should succeed")
+            .expect("fresh task should be claimed");
+        let now = chrono::Utc::now().timestamp();
+        conn.execute(
+            "UPDATE extraction_tasks
+             SET lease_expires_epoch = ?1
+             WHERE id = ?2",
+            params![now - 1, expired_id],
+        )
+        .expect("expired lease should update");
+
+        let released =
+            release_expired_extraction_task_leases(&conn).expect("release should succeed");
+
+        assert_eq!(released, 1);
+        assert_eq!(task_status(&conn, expired_id).0, "pending");
+        assert_eq!(task_status(&conn, fresh_id).0, "processing");
+    }
+
+    #[test]
+    fn mark_extraction_task_done_clears_lease_and_advances_cursor() {
+        let mut conn = setup_conn();
+        let task_id = insert_task(&conn, "sess-done", ExtractionTaskKind::SessionRollup)
+            .expect("task should insert");
+        let task = claim_next_extraction_task(&mut conn, "worker-a", 60)
+            .expect("claim should succeed")
+            .expect("task should be claimed");
+
+        mark_extraction_task_done(&conn, task.id, "worker-a").expect("done should succeed");
+
+        let (status, lease_owner, cursor, high_watermark): (
+            String,
+            Option<String>,
+            Option<i64>,
+            Option<i64>,
+        ) = conn
+            .query_row(
+                "SELECT status, lease_owner, cursor_event_id, high_watermark_event_id
+                 FROM extraction_tasks WHERE id = ?1",
+                params![task_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("task should query");
+        assert_eq!(status, "done");
+        assert!(lease_owner.is_none());
+        assert_eq!(cursor, high_watermark);
+    }
+
+    #[test]
+    fn mark_extraction_task_failed_or_retry_keeps_retryable_task_visible() {
+        let mut conn = setup_conn();
+        let task_id = insert_task(&conn, "sess-retry", ExtractionTaskKind::SessionRollup)
+            .expect("task should insert");
+        claim_next_extraction_task(&mut conn, "worker-a", 60)
+            .expect("claim should succeed")
+            .expect("task should be claimed");
+
+        mark_extraction_task_failed_or_retry(&conn, task_id, "worker-a", "temporary", 30)
+            .expect("retry should succeed");
+
+        let (status, attempts, next_retry, last_error) = task_status(&conn, task_id);
+        assert_eq!(status, "pending");
+        assert_eq!(attempts, 1);
+        assert!(next_retry.is_some());
+        assert_eq!(last_error.as_deref(), Some("temporary"));
+    }
+
+    #[test]
+    fn mark_extraction_task_failed_or_retry_exhausts_after_max_attempts() {
+        let mut conn = setup_conn();
+        let task_id = insert_task(&conn, "sess-failed", ExtractionTaskKind::SessionRollup)
+            .expect("task should insert");
+        conn.execute(
+            "UPDATE extraction_tasks SET attempts = ?1 WHERE id = ?2",
+            params![EXTRACTION_TASK_MAX_ATTEMPTS - 1, task_id],
+        )
+        .expect("attempt count should update");
+        claim_next_extraction_task(&mut conn, "worker-a", 60)
+            .expect("claim should succeed")
+            .expect("task should be claimed");
+
+        mark_extraction_task_failed_or_retry(&conn, task_id, "worker-a", "exhausted", 30)
+            .expect("failure should succeed");
+
+        let (status, attempts, next_retry, last_error) = task_status(&conn, task_id);
+        assert_eq!(status, "failed");
+        assert_eq!(attempts, EXTRACTION_TASK_MAX_ATTEMPTS);
+        assert!(next_retry.is_none());
+        assert_eq!(last_error.as_deref(), Some("exhausted"));
+    }
+
+    #[test]
+    fn mark_extraction_task_failed_records_permanent_failure_without_retry() {
+        let mut conn = setup_conn();
+        let task_id = insert_task(&conn, "sess-permanent", ExtractionTaskKind::SessionRollup)
+            .expect("task should insert");
+        claim_next_extraction_task(&mut conn, "worker-a", 60)
+            .expect("claim should succeed")
+            .expect("task should be claimed");
+
+        mark_extraction_task_failed(&conn, task_id, "worker-a", "not implemented")
+            .expect("permanent failure should succeed");
+
+        let (status, attempts, next_retry, last_error) = task_status(&conn, task_id);
+        assert_eq!(status, "failed");
+        assert_eq!(attempts, 1);
+        assert!(next_retry.is_none());
+        assert_eq!(last_error.as_deref(), Some("not implemented"));
+    }
+}

--- a/src/db/extraction.rs
+++ b/src/db/extraction.rs
@@ -78,19 +78,29 @@ pub fn release_expired_extraction_task_leases(conn: &Connection) -> Result<usize
     Ok(count)
 }
 
-pub fn mark_extraction_task_done(conn: &Connection, task_id: i64, lease_owner: &str) -> Result<()> {
+pub fn mark_extraction_task_done(
+    conn: &Connection,
+    task_id: i64,
+    lease_owner: &str,
+    completed_high_watermark_event_id: Option<i64>,
+) -> Result<()> {
     let now = chrono::Utc::now().timestamp();
     let updated = conn.execute(
         "UPDATE extraction_tasks
-         SET status = 'done',
-             cursor_event_id = high_watermark_event_id,
+         SET status = CASE
+                 WHEN ?4 IS NOT NULL
+                  AND high_watermark_event_id IS NOT NULL
+                  AND high_watermark_event_id > ?4 THEN 'pending'
+                 ELSE 'done'
+             END,
+             cursor_event_id = ?4,
              lease_owner = NULL,
              lease_expires_epoch = NULL,
              next_retry_epoch = NULL,
              last_error = NULL,
              updated_at_epoch = ?1
          WHERE id = ?2 AND lease_owner = ?3 AND status = 'processing'",
-        params![now, task_id, lease_owner],
+        params![now, task_id, lease_owner, completed_high_watermark_event_id],
     )?;
     ensure_task_updated(updated, task_id)
 }
@@ -354,7 +364,8 @@ mod tests {
             .expect("claim should succeed")
             .expect("task should be claimed");
 
-        mark_extraction_task_done(&conn, task.id, "worker-a").expect("done should succeed");
+        mark_extraction_task_done(&conn, task.id, "worker-a", task.high_watermark_event_id)
+            .expect("done should succeed");
 
         let (status, lease_owner, cursor, high_watermark): (
             String,
@@ -372,6 +383,40 @@ mod tests {
         assert_eq!(status, "done");
         assert!(lease_owner.is_none());
         assert_eq!(cursor, high_watermark);
+    }
+
+    #[test]
+    fn mark_extraction_task_done_requeues_when_watermark_advanced_after_claim() {
+        let mut conn = setup_conn();
+        let task_id = insert_task(&conn, "sess-coalesce", ExtractionTaskKind::SessionRollup)
+            .expect("task should insert");
+        let task = claim_next_extraction_task(&mut conn, "worker-a", 60)
+            .expect("claim should succeed")
+            .expect("task should be claimed");
+        let claimed_high_watermark = task.high_watermark_event_id;
+        insert_task(&conn, "sess-coalesce", ExtractionTaskKind::SessionRollup)
+            .expect("coalesced task should update high watermark");
+
+        mark_extraction_task_done(&conn, task.id, "worker-a", claimed_high_watermark)
+            .expect("done should succeed");
+
+        let (status, lease_owner, cursor, high_watermark): (
+            String,
+            Option<String>,
+            Option<i64>,
+            Option<i64>,
+        ) = conn
+            .query_row(
+                "SELECT status, lease_owner, cursor_event_id, high_watermark_event_id
+                 FROM extraction_tasks WHERE id = ?1",
+                params![task_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("task should query");
+        assert_eq!(status, "pending");
+        assert!(lease_owner.is_none());
+        assert_eq!(cursor, claimed_high_watermark);
+        assert!(high_watermark > cursor);
     }
 
     #[test]

--- a/src/extraction_worker.rs
+++ b/src/extraction_worker.rs
@@ -1,0 +1,94 @@
+use anyhow::Result;
+use tokio::time::Duration;
+
+use crate::db;
+
+enum ExtractionTaskOutcome {
+    PermanentFailure(String),
+}
+
+pub(crate) async fn run_next(
+    lease_owner: &str,
+    lease_secs: i64,
+    timeout_secs: u64,
+) -> Result<bool> {
+    let mut conn = db::open_db()?;
+    let Some(task) = db::claim_next_extraction_task(&mut conn, lease_owner, lease_secs)? else {
+        return Ok(false);
+    };
+
+    crate::log::info(
+        "worker",
+        &format!(
+            "claimed extraction id={} kind={} project={} attempt={}/{}",
+            task.id,
+            task.task_kind.as_str(),
+            task.project,
+            task.attempts + 1,
+            db::EXTRACTION_TASK_MAX_ATTEMPTS
+        ),
+    );
+
+    let timed = tokio::time::timeout(
+        Duration::from_secs(timeout_secs),
+        process_extraction_task(&task),
+    )
+    .await;
+    let conn = db::open_db()?;
+    match timed {
+        Ok(Ok(ExtractionTaskOutcome::PermanentFailure(msg))) => {
+            db::mark_extraction_task_failed(&conn, task.id, lease_owner, &msg)?;
+            crate::log::warn(
+                "worker",
+                &format!(
+                    "extraction id={} failed permanently: {}",
+                    task.id,
+                    crate::db::truncate_str(&msg, 300)
+                ),
+            );
+        }
+        Ok(Err(e)) => {
+            let msg = e.to_string();
+            let backoff = retry_backoff_secs(task.attempts);
+            db::mark_extraction_task_failed_or_retry(&conn, task.id, lease_owner, &msg, backoff)?;
+            crate::log::warn(
+                "worker",
+                &format!(
+                    "extraction id={} failed: {} (retry in {}s)",
+                    task.id,
+                    crate::db::truncate_str(&msg, 300),
+                    backoff
+                ),
+            );
+        }
+        Err(_) => {
+            let msg = format!("extraction task timed out after {}s", timeout_secs);
+            let backoff = retry_backoff_secs(task.attempts);
+            db::mark_extraction_task_failed_or_retry(&conn, task.id, lease_owner, &msg, backoff)?;
+            crate::log::warn(
+                "worker",
+                &format!("extraction id={} timeout (retry in {}s)", task.id, backoff),
+            );
+        }
+    }
+
+    Ok(true)
+}
+
+async fn process_extraction_task(task: &db::ExtractionTask) -> Result<ExtractionTaskOutcome> {
+    Ok(ExtractionTaskOutcome::PermanentFailure(format!(
+        "extraction task kind '{}' is not implemented",
+        task.task_kind.as_str()
+    )))
+}
+
+fn retry_backoff_secs(attempt: i64) -> i64 {
+    match attempt {
+        0 => 5,
+        1 => 15,
+        2 => 45,
+        3 => 120,
+        4 => 300,
+        _ => 900,
+    }
+}

--- a/src/extraction_worker.rs
+++ b/src/extraction_worker.rs
@@ -4,7 +4,7 @@ use tokio::time::Duration;
 use crate::db;
 
 enum ExtractionTaskOutcome {
-    PermanentFailure(String),
+    Deferred(String),
 }
 
 pub(crate) async fn run_next(
@@ -36,14 +36,16 @@ pub(crate) async fn run_next(
     .await;
     let conn = db::open_db()?;
     match timed {
-        Ok(Ok(ExtractionTaskOutcome::PermanentFailure(msg))) => {
-            db::mark_extraction_task_failed(&conn, task.id, lease_owner, &msg)?;
+        Ok(Ok(ExtractionTaskOutcome::Deferred(msg))) => {
+            let backoff = retry_backoff_secs(task.attempts);
+            db::defer_extraction_task(&conn, task.id, lease_owner, &msg, backoff)?;
             crate::log::warn(
                 "worker",
                 &format!(
-                    "extraction id={} failed permanently: {}",
+                    "extraction id={} deferred: {} (retry in {}s)",
                     task.id,
-                    crate::db::truncate_str(&msg, 300)
+                    crate::db::truncate_str(&msg, 300),
+                    backoff
                 ),
             );
         }
@@ -76,7 +78,7 @@ pub(crate) async fn run_next(
 }
 
 async fn process_extraction_task(task: &db::ExtractionTask) -> Result<ExtractionTaskOutcome> {
-    Ok(ExtractionTaskOutcome::PermanentFailure(format!(
+    Ok(ExtractionTaskOutcome::Deferred(format!(
         "extraction task kind '{}' is not implemented",
         task.task_kind.as_str()
     )))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod db;
 pub mod doctor;
 pub mod dream;
 pub mod eval;
+mod extraction_worker;
 pub mod git_util;
 pub mod identity;
 pub mod install;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -637,7 +637,7 @@ EOF
     }
 
     #[tokio::test]
-    async fn worker_marks_unimplemented_extraction_task_failed() -> anyhow::Result<()> {
+    async fn worker_defers_unimplemented_extraction_task() -> anyhow::Result<()> {
         let _data_dir = ScopedTestDataDir::new("worker-extraction-unimplemented");
         let conn = db::open_db()?;
         let outcome = db::record_captured_event(
@@ -661,13 +661,14 @@ EOF
         run(true, 10).await?;
 
         let conn = db::open_db()?;
-        let (status, attempts, last_error): (String, i64, Option<String>) = conn.query_row(
-            "SELECT status, attempts, last_error FROM extraction_tasks WHERE id = ?1",
+        let (status, attempts, next_retry, last_error): (String, i64, Option<i64>, Option<String>) = conn.query_row(
+            "SELECT status, attempts, next_retry_epoch, last_error FROM extraction_tasks WHERE id = ?1",
             params![task_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )?;
-        anyhow::ensure!(status == "failed", "expected failed task, got {status}");
-        anyhow::ensure!(attempts == 1, "expected one attempt, got {attempts}");
+        anyhow::ensure!(status == "pending", "expected pending task, got {status}");
+        anyhow::ensure!(attempts == 0, "expected zero attempts, got {attempts}");
+        anyhow::ensure!(next_retry.is_some(), "expected retry delay");
         anyhow::ensure!(
             last_error
                 .as_deref()

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -14,6 +14,7 @@ use crate::{db, observe, summarize};
 const JOB_TIMEOUT_SECS: u64 = 420;
 const JOB_LEASE_SECS: i64 = (JOB_TIMEOUT_SECS as i64) + 60;
 const _: () = assert!(JOB_LEASE_SECS > JOB_TIMEOUT_SECS as i64);
+const EXTRACTION_TASK_TIMEOUT_SECS: u64 = JOB_TIMEOUT_SECS;
 const STALE_PENDING_AGE_SECS: i64 = 60;
 const STALE_PENDING_SCAN_LIMIT: i64 = 8;
 
@@ -190,6 +191,16 @@ pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
                 &format!("released {} expired pending claim(s)", recovered_pending),
             );
         }
+        let recovered_extraction = db::release_expired_extraction_task_leases(&conn)?;
+        if recovered_extraction > 0 {
+            crate::log::warn(
+                "worker",
+                &format!(
+                    "released {} expired extraction task lease(s)",
+                    recovered_extraction
+                ),
+            );
+        }
         let queued_stale = enqueue_stale_observation_jobs(&conn)?;
         if queued_stale > 0 {
             crate::log::info(
@@ -198,81 +209,93 @@ pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
             );
         }
 
-        let Some(job) = db::claim_next_job(&mut conn, &lease_owner, JOB_LEASE_SECS)? else {
-            if once {
-                break;
-            }
-            sleep(Duration::from_millis(idle_sleep_ms.max(100))).await;
-            continue;
-        };
+        if let Some(job) = db::claim_next_job(&mut conn, &lease_owner, JOB_LEASE_SECS)? {
+            crate::log::info(
+                "worker",
+                &format!(
+                    "claimed id={} type={} project={} attempt={}/{}",
+                    job.id,
+                    job.job_type.as_str(),
+                    job.project,
+                    job.attempt_count + 1,
+                    job.max_attempts
+                ),
+            );
 
-        crate::log::info(
-            "worker",
-            &format!(
-                "claimed id={} type={} project={} attempt={}/{}",
-                job.id,
-                job.job_type.as_str(),
-                job.project,
-                job.attempt_count + 1,
-                job.max_attempts
-            ),
-        );
-
-        let scoped_executor = ScopedExecutorEnv::for_job(&job);
-        let timed =
-            tokio::time::timeout(Duration::from_secs(JOB_TIMEOUT_SECS), process_job(&job)).await;
-        drop(scoped_executor);
-        let conn = db::open_db()?;
-        match timed {
-            Ok(Ok(outcome)) => {
-                db::mark_job_done(&conn, job.id, &lease_owner)?;
-                crate::log::info("worker", &format!("done id={}", job.id));
-                if let JobOutcome::ObservationNeedsFollowUp {
-                    host,
-                    session_id,
-                    project,
-                    payload_json,
-                } = outcome
-                {
-                    let follow_up_id = db::enqueue_job(
-                        &conn,
-                        &host,
-                        db::JobType::Observation,
-                        &project,
-                        Some(&session_id),
-                        &payload_json,
-                        observe::flush::OBSERVATION_FOLLOW_UP_PRIORITY,
-                    )?;
-                    crate::log::info(
+            let scoped_executor = ScopedExecutorEnv::for_job(&job);
+            let timed =
+                tokio::time::timeout(Duration::from_secs(JOB_TIMEOUT_SECS), process_job(&job))
+                    .await;
+            drop(scoped_executor);
+            let conn = db::open_db()?;
+            match timed {
+                Ok(Ok(outcome)) => {
+                    db::mark_job_done(&conn, job.id, &lease_owner)?;
+                    crate::log::info("worker", &format!("done id={}", job.id));
+                    if let JobOutcome::ObservationNeedsFollowUp {
+                        host,
+                        session_id,
+                        project,
+                        payload_json,
+                    } = outcome
+                    {
+                        let follow_up_id = db::enqueue_job(
+                            &conn,
+                            &host,
+                            db::JobType::Observation,
+                            &project,
+                            Some(&session_id),
+                            &payload_json,
+                            observe::flush::OBSERVATION_FOLLOW_UP_PRIORITY,
+                        )?;
+                        crate::log::info(
+                            "worker",
+                            &format!("queued observation follow-up id={}", follow_up_id),
+                        );
+                    }
+                }
+                Ok(Err(e)) => {
+                    let msg = e.to_string();
+                    let backoff = retry_backoff_secs(job.attempt_count);
+                    db::mark_job_failed_or_retry(&conn, job.id, &lease_owner, &msg, backoff)?;
+                    crate::log::warn(
                         "worker",
-                        &format!("queued observation follow-up id={}", follow_up_id),
+                        &format!(
+                            "job id={} failed: {} (retry in {}s)",
+                            job.id,
+                            crate::db::truncate_str(&msg, 300),
+                            backoff
+                        ),
+                    );
+                }
+                Err(_) => {
+                    let msg = format!("job timed out after {}s", JOB_TIMEOUT_SECS);
+                    let backoff = retry_backoff_secs(job.attempt_count);
+                    db::mark_job_failed_or_retry(&conn, job.id, &lease_owner, &msg, backoff)?;
+                    crate::log::warn(
+                        "worker",
+                        &format!("job id={} timeout (retry in {}s)", job.id, backoff),
                     );
                 }
             }
-            Ok(Err(e)) => {
-                let msg = e.to_string();
-                let backoff = retry_backoff_secs(job.attempt_count);
-                db::mark_job_failed_or_retry(&conn, job.id, &lease_owner, &msg, backoff)?;
-                crate::log::warn(
-                    "worker",
-                    &format!(
-                        "job id={} failed: {} (retry in {}s)",
-                        job.id,
-                        crate::db::truncate_str(&msg, 300),
-                        backoff
-                    ),
-                );
-            }
-            Err(_) => {
-                let msg = format!("job timed out after {}s", JOB_TIMEOUT_SECS);
-                let backoff = retry_backoff_secs(job.attempt_count);
-                db::mark_job_failed_or_retry(&conn, job.id, &lease_owner, &msg, backoff)?;
-                crate::log::warn(
-                    "worker",
-                    &format!("job id={} timeout (retry in {}s)", job.id, backoff),
-                );
-            }
+            continue;
         }
+
+        if crate::extraction_worker::run_next(
+            &lease_owner,
+            JOB_LEASE_SECS,
+            EXTRACTION_TASK_TIMEOUT_SECS,
+        )
+        .await?
+        {
+            continue;
+        }
+
+        if once {
+            break;
+        }
+        sleep(Duration::from_millis(idle_sleep_ms.max(100))).await;
+        continue;
     }
 
     if !once {
@@ -611,6 +634,47 @@ EOF
 
         let _ = std::fs::remove_file(&stub_codex);
         test_result
+    }
+
+    #[tokio::test]
+    async fn worker_marks_unimplemented_extraction_task_failed() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-extraction-unimplemented");
+        let conn = db::open_db()?;
+        let outcome = db::record_captured_event(
+            &conn,
+            &db::CaptureEventInput {
+                host: "codex-cli",
+                session_id: "sess-extract",
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "session_stop",
+                role: None,
+                tool_name: None,
+                content: r#"{"session_id":"sess-extract"}"#,
+                task_kind: Some(db::ExtractionTaskKind::SessionRollup),
+            },
+        )?;
+        let task_id = outcome
+            .extraction_task_id
+            .expect("capture should coalesce extraction task");
+
+        run(true, 10).await?;
+
+        let conn = db::open_db()?;
+        let (status, attempts, last_error): (String, i64, Option<String>) = conn.query_row(
+            "SELECT status, attempts, last_error FROM extraction_tasks WHERE id = ?1",
+            params![task_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        anyhow::ensure!(status == "failed", "expected failed task, got {status}");
+        anyhow::ensure!(attempts == 1, "expected one attempt, got {attempts}");
+        anyhow::ensure!(
+            last_error
+                .as_deref()
+                .is_some_and(|err| err.contains("not implemented")),
+            "expected explicit unimplemented error"
+        );
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add extraction_tasks claim, lease recovery, completion, retry, and permanent-failure state helpers
- make remem worker multiplex the existing jobs queue and the extraction task queue without changing existing job handling
- record unimplemented extraction task kinds as explicit permanent failures instead of retrying forever
- split extraction task execution into an internal worker module so src/worker.rs stays below the hard file-size limit

Fixes #150.
Stacked on #147 / #149.

## Verification
- cargo fmt --check
- git diff --check
- cargo check
- cargo clippy -- -D warnings
- cargo test
- cargo build --release
