### PR TITLE
feat(extraction): promote memory candidates

### DIFF
--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -34,11 +34,11 @@ impl ExtractionTaskKind {
         }
     }
 
-    fn priority(self) -> i64 {
+    pub(crate) fn priority(self) -> i64 {
         match self {
             Self::SessionRollup => 10,
-            Self::MemoryCandidate => 20,
-            Self::ObservationExtract => 40,
+            Self::ObservationExtract => 20,
+            Self::MemoryCandidate => 40,
             Self::RuleCandidate => 60,
             Self::IndexUpdate => 80,
         }

--- a/src/db/extraction.rs
+++ b/src/db/extraction.rs
@@ -10,6 +10,7 @@ pub struct ExtractionTask {
     pub id: i64,
     pub task_kind: ExtractionTaskKind,
     pub host_id: i64,
+    pub workspace_id: i64,
     pub project_id: i64,
     pub session_row_id: Option<i64>,
     pub host: String,
@@ -19,6 +20,59 @@ pub struct ExtractionTask {
     pub cursor_event_id: Option<i64>,
     pub high_watermark_event_id: Option<i64>,
     pub attempts: i64,
+}
+
+pub fn enqueue_followup_extraction_task(
+    conn: &Connection,
+    source: &ExtractionTask,
+    task_kind: ExtractionTaskKind,
+    high_watermark_event_id: i64,
+) -> Result<i64> {
+    let session_row_id = source
+        .session_row_id
+        .ok_or_else(|| anyhow::anyhow!("follow-up extraction task requires session_row_id"))?;
+    let now = chrono::Utc::now().timestamp();
+    let idempotency_key = format!(
+        "{}:{}:{}:{}",
+        source.host_id,
+        source.project_id,
+        session_row_id,
+        task_kind.as_str()
+    );
+    conn.execute(
+        "INSERT INTO extraction_tasks
+         (task_kind, host_id, workspace_id, project_id, session_row_id, priority, status,
+          idempotency_key, cursor_event_id, high_watermark_event_id, attempts,
+          next_retry_epoch, lease_owner, lease_expires_epoch, last_error, created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7, NULL, ?8, 0, NULL, NULL, NULL, NULL, ?9, ?9)
+         ON CONFLICT(idempotency_key) DO UPDATE SET
+             high_watermark_event_id = MAX(COALESCE(extraction_tasks.high_watermark_event_id, 0), excluded.high_watermark_event_id),
+             status = CASE
+                 WHEN extraction_tasks.status IN ('done', 'failed') THEN 'pending'
+                 ELSE extraction_tasks.status
+             END,
+             next_retry_epoch = CASE
+                 WHEN extraction_tasks.status IN ('done', 'failed') THEN NULL
+                 ELSE extraction_tasks.next_retry_epoch
+             END,
+             updated_at_epoch = excluded.updated_at_epoch",
+        params![
+            task_kind.as_str(),
+            source.host_id,
+            source.workspace_id,
+            source.project_id,
+            session_row_id,
+            task_kind.priority(),
+            idempotency_key,
+            high_watermark_event_id,
+            now
+        ],
+    )?;
+    Ok(conn.query_row(
+        "SELECT id FROM extraction_tasks WHERE idempotency_key = ?1",
+        params![idempotency_key],
+        |row| row.get(0),
+    )?)
 }
 
 pub fn claim_next_extraction_task(
@@ -223,7 +277,7 @@ pub fn mark_extraction_task_failed_or_retry(
 
 fn load_claimed_extraction_task(conn: &Connection, task_id: i64) -> Result<ExtractionTask> {
     let row = conn.query_row(
-        "SELECT t.id, t.task_kind, t.host_id, t.project_id, t.session_row_id,
+        "SELECT t.id, t.task_kind, t.host_id, t.workspace_id, t.project_id, t.session_row_id,
                 h.name, p.project_path, s.session_id,
                 t.priority, t.cursor_event_id, t.high_watermark_event_id, t.attempts
          FROM extraction_tasks t
@@ -238,14 +292,15 @@ fn load_claimed_extraction_task(conn: &Connection, task_id: i64) -> Result<Extra
                 row.get::<_, String>(1)?,
                 row.get::<_, i64>(2)?,
                 row.get::<_, i64>(3)?,
-                row.get::<_, Option<i64>>(4)?,
-                row.get::<_, String>(5)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, Option<i64>>(5)?,
                 row.get::<_, String>(6)?,
-                row.get::<_, Option<String>>(7)?,
-                row.get::<_, i64>(8)?,
-                row.get::<_, Option<i64>>(9)?,
+                row.get::<_, String>(7)?,
+                row.get::<_, Option<String>>(8)?,
+                row.get::<_, i64>(9)?,
                 row.get::<_, Option<i64>>(10)?,
-                row.get::<_, i64>(11)?,
+                row.get::<_, Option<i64>>(11)?,
+                row.get::<_, i64>(12)?,
             ))
         },
     )?;
@@ -254,15 +309,16 @@ fn load_claimed_extraction_task(conn: &Connection, task_id: i64) -> Result<Extra
         id: row.0,
         task_kind: ExtractionTaskKind::from_db(&row.1)?,
         host_id: row.2,
-        project_id: row.3,
-        session_row_id: row.4,
-        host: row.5,
-        project: row.6,
-        session_id: row.7,
-        priority: row.8,
-        cursor_event_id: row.9,
-        high_watermark_event_id: row.10,
-        attempts: row.11,
+        workspace_id: row.3,
+        project_id: row.4,
+        session_row_id: row.5,
+        host: row.6,
+        project: row.7,
+        session_id: row.8,
+        priority: row.9,
+        cursor_event_id: row.10,
+        high_watermark_event_id: row.11,
+        attempts: row.12,
     })
 }
 

--- a/src/extraction_worker.rs
+++ b/src/extraction_worker.rs
@@ -97,6 +97,10 @@ async fn process_extraction_task(task: &db::ExtractionTask) -> Result<Extraction
             crate::observation_extract::process(task).await?;
             Ok(ExtractionTaskOutcome::Done)
         }
+        db::ExtractionTaskKind::MemoryCandidate => {
+            crate::memory_candidate::process(task).await?;
+            Ok(ExtractionTaskOutcome::Done)
+        }
         _ => Ok(ExtractionTaskOutcome::Deferred(format!(
             "extraction task kind '{}' is not implemented",
             task.task_kind.as_str()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod install;
 pub mod log;
 pub mod mcp;
 pub mod memory;
+mod memory_candidate;
 pub mod migrate;
 mod observation_extract;
 pub mod observe;

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -1,0 +1,695 @@
+use std::collections::BTreeSet;
+use std::future::Future;
+
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::db;
+use crate::memory::format::{extract_field, xml_escape_attr, xml_escape_text};
+
+const MEMORY_CANDIDATE_SYSTEM: &str = "\
+Generate durable memory candidates from extracted observations.
+Return zero or more <memory_candidate> blocks.
+Each block must include <scope>, <type>, <topic_key>, <risk_class>, <confidence>, and <text>.
+Use scope=project unless the observation is explicitly a stable user preference.
+Use risk_class=low only for factual project-scoped information that can be promoted without review.
+If there is no durable memory candidate, return exactly <no_candidates reason=\"...\"/>.
+Use only provided observations and evidence; do not invent files, outcomes, decisions, or facts.";
+
+const AUTO_PROMOTE_MIN_CONFIDENCE: f64 = 0.80;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MemoryCandidateResult {
+    EmptyRange,
+    NoCandidates,
+    Written {
+        candidates: usize,
+        promoted: usize,
+        pending_review: usize,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct SourceObservation {
+    id: i64,
+    observation_type: String,
+    text: String,
+    evidence_event_ids: Vec<i64>,
+    confidence: f64,
+}
+
+struct ObservationBatch {
+    from_event_id: i64,
+    to_event_id: i64,
+    evidence_event_ids: Vec<i64>,
+    observations: Vec<SourceObservation>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ParsedMemoryCandidate {
+    scope: String,
+    memory_type: String,
+    topic_key: String,
+    text: String,
+    confidence: f64,
+    risk_class: String,
+}
+
+pub(crate) async fn process(task: &db::ExtractionTask) -> Result<MemoryCandidateResult> {
+    let mut conn = db::open_db()?;
+    let project = task.project.clone();
+    process_with_generator(&mut conn, task, move |prompt| {
+        let project = project.clone();
+        async move {
+            crate::ai::call_ai(
+                MEMORY_CANDIDATE_SYSTEM,
+                &prompt,
+                crate::ai::UsageContext {
+                    project: Some(project.as_str()),
+                    operation: "memory_candidate",
+                },
+            )
+            .await
+        }
+    })
+    .await
+}
+
+async fn process_with_generator<F, Fut>(
+    conn: &mut Connection,
+    task: &db::ExtractionTask,
+    generate: F,
+) -> Result<MemoryCandidateResult>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<String>>,
+{
+    let Some(batch) = load_observation_batch(conn, task)? else {
+        return Ok(MemoryCandidateResult::EmptyRange);
+    };
+
+    let prompt = build_candidate_prompt(task, &batch);
+    let response = generate(prompt).await?;
+    let candidates = parse_memory_candidates(&response)?;
+    if candidates.is_empty() {
+        if response.contains("<no_candidates") {
+            return Ok(MemoryCandidateResult::NoCandidates);
+        }
+        bail!("malformed memory_candidate output: no candidates parsed");
+    }
+
+    let result = persist_candidates(conn, task, &batch, &candidates)?;
+    crate::log::info(
+        "memory-candidate",
+        &format!(
+            "session={} range={}..{} candidates={} promoted={} pending_review={}",
+            task.session_id.as_deref().unwrap_or("<unknown>"),
+            batch.from_event_id,
+            batch.to_event_id,
+            result.candidates,
+            result.promoted,
+            result.pending_review
+        ),
+    );
+    Ok(MemoryCandidateResult::Written {
+        candidates: result.candidates,
+        promoted: result.promoted,
+        pending_review: result.pending_review,
+    })
+}
+
+fn load_observation_batch(
+    conn: &Connection,
+    task: &db::ExtractionTask,
+) -> Result<Option<ObservationBatch>> {
+    let Some(session_row_id) = task.session_row_id else {
+        return Ok(None);
+    };
+    let Some(high_watermark) = task.high_watermark_event_id else {
+        return Ok(None);
+    };
+    let cursor = task.cursor_event_id.unwrap_or(0);
+    if high_watermark <= cursor {
+        return Ok(None);
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT id,
+                COALESCE(observation_type, type, 'discovery') AS observation_type,
+                COALESCE(text, narrative, title, '') AS text,
+                evidence_event_ids,
+                COALESCE(confidence, 0.5) AS confidence
+         FROM observations
+         WHERE session_row_id = ?1
+           AND evidence_event_ids IS NOT NULL
+           AND text IS NOT NULL
+         ORDER BY id ASC",
+    )?;
+    let rows = stmt
+        .query_map(params![session_row_id], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, f64>(4)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut observations = Vec::new();
+    let mut evidence_set = BTreeSet::new();
+    for (id, observation_type, text, evidence_json, confidence) in rows {
+        let event_ids: Vec<i64> = serde_json::from_str(&evidence_json)
+            .with_context(|| format!("observation {id} has malformed evidence_event_ids"))?;
+        let in_range = event_ids
+            .iter()
+            .any(|event_id| *event_id > cursor && *event_id <= high_watermark);
+        if !in_range {
+            continue;
+        }
+        for event_id in &event_ids {
+            evidence_set.insert(*event_id);
+        }
+        observations.push(SourceObservation {
+            id,
+            observation_type,
+            text,
+            evidence_event_ids: event_ids,
+            confidence,
+        });
+    }
+
+    if observations.is_empty() || evidence_set.is_empty() {
+        return Ok(None);
+    }
+    let from_event_id = *evidence_set.iter().next().unwrap_or(&0);
+    let to_event_id = *evidence_set.iter().next_back().unwrap_or(&0);
+    Ok(Some(ObservationBatch {
+        from_event_id,
+        to_event_id,
+        evidence_event_ids: evidence_set.into_iter().collect(),
+        observations,
+    }))
+}
+
+fn persist_candidates(
+    conn: &mut Connection,
+    task: &db::ExtractionTask,
+    batch: &ObservationBatch,
+    candidates: &[ParsedMemoryCandidate],
+) -> Result<PersistSummary> {
+    let evidence_json = serde_json::to_string(&batch.evidence_event_ids)?;
+    let tx = conn.transaction()?;
+    let mut summary = PersistSummary::default();
+    for candidate in candidates {
+        if candidate_exists(&tx, task.project_id, candidate)? {
+            continue;
+        }
+
+        let review_status = if should_auto_promote(candidate) {
+            "auto_promoted"
+        } else {
+            "pending_review"
+        };
+        let now = chrono::Utc::now().timestamp();
+        tx.execute(
+            "INSERT INTO memory_candidates
+             (project_id, scope, memory_type, topic_key, text, evidence_event_ids,
+              confidence, risk_class, review_status, created_at_epoch, updated_at_epoch)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10)",
+            params![
+                task.project_id,
+                candidate.scope,
+                candidate.memory_type,
+                candidate.topic_key,
+                candidate.text,
+                evidence_json,
+                candidate.confidence,
+                candidate.risk_class,
+                review_status,
+                now
+            ],
+        )?;
+        let candidate_id = tx.last_insert_rowid();
+        summary.candidates += 1;
+
+        if review_status == "auto_promoted" {
+            promote_candidate(&tx, task, candidate_id, candidate, &evidence_json)?;
+            summary.promoted += 1;
+        } else {
+            summary.pending_review += 1;
+        }
+    }
+    tx.commit()?;
+    Ok(summary)
+}
+
+#[derive(Default)]
+struct PersistSummary {
+    candidates: usize,
+    promoted: usize,
+    pending_review: usize,
+}
+
+fn candidate_exists(
+    conn: &Connection,
+    project_id: i64,
+    candidate: &ParsedMemoryCandidate,
+) -> Result<bool> {
+    let existing: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM memory_candidates
+             WHERE project_id = ?1
+               AND scope = ?2
+               AND memory_type = ?3
+               AND topic_key = ?4
+               AND text = ?5
+             LIMIT 1",
+            params![
+                project_id,
+                candidate.scope,
+                candidate.memory_type,
+                candidate.topic_key,
+                candidate.text
+            ],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(existing.is_some())
+}
+
+fn promote_candidate(
+    conn: &Connection,
+    task: &db::ExtractionTask,
+    candidate_id: i64,
+    candidate: &ParsedMemoryCandidate,
+    evidence_json: &str,
+) -> Result<()> {
+    let title = candidate_title(candidate);
+    let memory_id = crate::memory::insert_memory_full(
+        conn,
+        task.session_id.as_deref(),
+        &task.project,
+        Some(&candidate.topic_key),
+        &title,
+        &candidate.text,
+        &candidate.memory_type,
+        None,
+        None,
+        &candidate.scope,
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET evidence_event_ids = ?1,
+             source_candidate_id = ?2,
+             confidence = ?3
+         WHERE id = ?4",
+        params![evidence_json, candidate_id, candidate.confidence, memory_id],
+    )?;
+    Ok(())
+}
+
+fn should_auto_promote(candidate: &ParsedMemoryCandidate) -> bool {
+    candidate.scope == "project"
+        && candidate.risk_class == "low"
+        && candidate.confidence >= AUTO_PROMOTE_MIN_CONFIDENCE
+}
+
+fn candidate_title(candidate: &ParsedMemoryCandidate) -> String {
+    let first_line = candidate
+        .text
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or(&candidate.topic_key);
+    crate::db::truncate_str(first_line, 96).to_string()
+}
+
+fn build_candidate_prompt(task: &db::ExtractionTask, batch: &ObservationBatch) -> String {
+    let mut prompt = format!(
+        "Task: memory_candidate\nProject: {}\nHost: {}\nSession: {}\nCovered evidence events: {}..{}\n\n",
+        task.project,
+        task.host,
+        task.session_id.as_deref().unwrap_or("<unknown>"),
+        batch.from_event_id,
+        batch.to_event_id
+    );
+    for observation in &batch.observations {
+        let evidence = observation
+            .evidence_event_ids
+            .iter()
+            .map(i64::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        prompt.push_str(&format!(
+            "<observation id=\"{}\" type=\"{}\" confidence=\"{}\" evidence_event_ids=\"{}\">\n",
+            observation.id,
+            xml_escape_attr(&observation.observation_type),
+            observation.confidence,
+            xml_escape_attr(&evidence)
+        ));
+        prompt.push_str(&xml_escape_text(&observation.text));
+        prompt.push_str("\n</observation>\n\n");
+    }
+    prompt
+}
+
+fn parse_memory_candidates(text: &str) -> Result<Vec<ParsedMemoryCandidate>> {
+    let mut candidates = Vec::new();
+    let mut pos = 0;
+    while let Some(tag_start_rel) = find_ascii_ci(&text[pos..], "<memory_candidate") {
+        let tag_start = pos + tag_start_rel;
+        let Some(open_end_rel) = text[tag_start..].find('>') else {
+            bail!("malformed memory_candidate output: unterminated opening tag");
+        };
+        let content_start = tag_start + open_end_rel + 1;
+        let Some(close_rel) = find_ascii_ci(&text[content_start..], "</memory_candidate>") else {
+            bail!("malformed memory_candidate output: missing closing tag");
+        };
+        let content_end = content_start + close_rel;
+        candidates.push(parse_candidate_content(&text[content_start..content_end])?);
+        pos = content_end + "</memory_candidate>".len();
+    }
+    Ok(candidates)
+}
+
+fn parse_candidate_content(content: &str) -> Result<ParsedMemoryCandidate> {
+    let scope = normalize_scope(required_field(content, "scope")?.as_str())?;
+    let memory_type = normalize_memory_type(required_field(content, "type")?.as_str())?;
+    let topic_key = normalize_topic_key(required_field(content, "topic_key")?.as_str())?;
+    let risk_class = normalize_risk_class(required_field(content, "risk_class")?.as_str())?;
+    let confidence = parse_confidence(required_field(content, "confidence")?.as_str())?;
+    let text = required_field(content, "text")?;
+    Ok(ParsedMemoryCandidate {
+        scope,
+        memory_type,
+        topic_key,
+        text,
+        confidence,
+        risk_class,
+    })
+}
+
+fn required_field(content: &str, field: &str) -> Result<String> {
+    extract_field(content, field)
+        .with_context(|| format!("malformed memory_candidate output: missing <{field}>"))
+}
+
+fn normalize_scope(raw: &str) -> Result<String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "global" | "workspace" | "project" => Ok(raw.trim().to_ascii_lowercase()),
+        other => bail!("malformed memory_candidate output: invalid scope '{other}'"),
+    }
+}
+
+fn normalize_memory_type(raw: &str) -> Result<String> {
+    let value = raw.trim().to_ascii_lowercase();
+    if crate::memory::MEMORY_TYPES.contains(&value.as_str()) && value != "session_activity" {
+        Ok(value)
+    } else {
+        bail!("malformed memory_candidate output: invalid memory type '{value}'")
+    }
+}
+
+fn normalize_topic_key(raw: &str) -> Result<String> {
+    let value = crate::memory::slugify_for_topic(raw.trim(), 96);
+    if value.is_empty() {
+        bail!("malformed memory_candidate output: empty topic_key");
+    }
+    Ok(value)
+}
+
+fn normalize_risk_class(raw: &str) -> Result<String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "low" | "medium" | "high" => Ok(raw.trim().to_ascii_lowercase()),
+        other => bail!("malformed memory_candidate output: invalid risk_class '{other}'"),
+    }
+}
+
+fn parse_confidence(raw: &str) -> Result<f64> {
+    let confidence: f64 = raw
+        .trim()
+        .parse()
+        .with_context(|| "malformed memory_candidate output: invalid confidence")?;
+    if !(0.0..=1.0).contains(&confidence) {
+        bail!("malformed memory_candidate output: confidence out of range");
+    }
+    Ok(confidence)
+}
+
+fn find_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
+    let needle = needle.as_bytes();
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .position(|window| window.eq_ignore_ascii_case(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use crate::db::{record_captured_event, CaptureEventInput, ExtractionTaskKind};
+
+    use super::*;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db should open");
+        crate::migrate::run_migrations(&conn).expect("migrations should run");
+        conn
+    }
+
+    fn setup_task(conn: &mut Connection, session_id: &str) -> Result<db::ExtractionTask> {
+        record_captured_event(
+            conn,
+            &CaptureEventInput {
+                host: "codex-cli",
+                session_id,
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Bash"),
+                content: "cargo test passed",
+                task_kind: Some(ExtractionTaskKind::MemoryCandidate),
+            },
+        )?;
+        db::claim_next_extraction_task(conn, "worker-a", 60)?
+            .ok_or_else(|| anyhow::anyhow!("expected memory candidate task"))
+    }
+
+    fn insert_source_observation(
+        conn: &Connection,
+        task: &db::ExtractionTask,
+        text: &str,
+    ) -> Result<()> {
+        let obs_id = db::insert_observation_with_branch(
+            conn,
+            "capture-observation-test",
+            &task.project,
+            "decision",
+            Some("Worker loop decision"),
+            None,
+            Some(text),
+            None,
+            None,
+            None,
+            None,
+            None,
+            12,
+            None,
+            None,
+        )?;
+        let event_id = task.high_watermark_event_id.unwrap_or(1);
+        conn.execute(
+            "UPDATE observations
+             SET host_id = ?1,
+                 project_id = ?2,
+                 session_row_id = ?3,
+                 observation_type = 'decision',
+                 text = ?4,
+                 evidence_event_ids = ?5,
+                 confidence = 0.91
+             WHERE id = ?6",
+            params![
+                task.host_id,
+                task.project_id,
+                task.session_row_id,
+                text,
+                serde_json::to_string(&vec![event_id])?,
+                obs_id
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn low_risk_candidate_xml() -> String {
+        "<memory_candidate>\
+            <scope>project</scope>\
+            <type>decision</type>\
+            <topic_key>decision-worker-loop</topic_key>\
+            <risk_class>low</risk_class>\
+            <confidence>0.92</confidence>\
+            <text>Use the worker loop to process extraction tasks after observation extraction.</text>\
+         </memory_candidate>"
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn memory_candidate_auto_promotes_low_risk_project_candidate() -> Result<()> {
+        let mut conn = setup_conn();
+        let task = setup_task(&mut conn, "sess-candidate-auto")?;
+        insert_source_observation(
+            &conn,
+            &task,
+            "Use the worker loop to process extraction tasks after observation extraction.",
+        )?;
+
+        let result = process_with_generator(&mut conn, &task, |_prompt| async {
+            Ok(low_risk_candidate_xml())
+        })
+        .await?;
+
+        assert_eq!(
+            result,
+            MemoryCandidateResult::Written {
+                candidates: 1,
+                promoted: 1,
+                pending_review: 0
+            }
+        );
+        let (candidate_id, review_status): (i64, String) = conn.query_row(
+            "SELECT id, review_status FROM memory_candidates",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(review_status, "auto_promoted");
+        let (memory_type, topic_key, evidence, source_candidate_id, confidence): (
+            String,
+            String,
+            String,
+            i64,
+            f64,
+        ) = conn.query_row(
+            "SELECT memory_type, topic_key, evidence_event_ids, source_candidate_id, confidence
+             FROM memories WHERE source_candidate_id = ?1",
+            params![candidate_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )?;
+        assert_eq!(memory_type, "decision");
+        assert_eq!(topic_key, "decision-worker-loop");
+        assert_eq!(source_candidate_id, candidate_id);
+        assert!(evidence.contains('1'));
+        assert_eq!(confidence, 0.92);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn memory_candidate_leaves_high_risk_candidate_pending_review() -> Result<()> {
+        let mut conn = setup_conn();
+        let task = setup_task(&mut conn, "sess-candidate-pending")?;
+        insert_source_observation(&conn, &task, "User prefers global editor behavior.")?;
+
+        let result = process_with_generator(&mut conn, &task, |_prompt| async {
+            Ok("<memory_candidate><scope>global</scope><type>preference</type><topic_key>global-editor</topic_key><risk_class>high</risk_class><confidence>0.95</confidence><text>User prefers global editor behavior.</text></memory_candidate>".to_string())
+        })
+        .await?;
+
+        assert_eq!(
+            result,
+            MemoryCandidateResult::Written {
+                candidates: 1,
+                promoted: 0,
+                pending_review: 1
+            }
+        );
+        let review_status: String =
+            conn.query_row("SELECT review_status FROM memory_candidates", [], |row| {
+                row.get(0)
+            })?;
+        let memory_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+        assert_eq!(review_status, "pending_review");
+        assert_eq!(memory_count, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn memory_candidate_duplicate_output_is_idempotent() -> Result<()> {
+        let mut conn = setup_conn();
+        let task = setup_task(&mut conn, "sess-candidate-dup")?;
+        insert_source_observation(
+            &conn,
+            &task,
+            "Use a deterministic topic key for duplicates.",
+        )?;
+
+        process_with_generator(&mut conn, &task, |_prompt| async {
+            Ok(low_risk_candidate_xml())
+        })
+        .await?;
+        let second = process_with_generator(&mut conn, &task, |_prompt| async {
+            Ok(low_risk_candidate_xml())
+        })
+        .await?;
+
+        assert_eq!(
+            second,
+            MemoryCandidateResult::Written {
+                candidates: 0,
+                promoted: 0,
+                pending_review: 0
+            }
+        );
+        let candidate_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+                row.get(0)
+            })?;
+        let memory_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+        assert_eq!(candidate_count, 1);
+        assert_eq!(memory_count, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn memory_candidate_accepts_explicit_no_candidates() -> Result<()> {
+        let mut conn = setup_conn();
+        let task = setup_task(&mut conn, "sess-candidate-none")?;
+        insert_source_observation(&conn, &task, "Low signal output.")?;
+
+        let result = process_with_generator(&mut conn, &task, |_prompt| async {
+            Ok("<no_candidates reason=\"low signal\"/>".to_string())
+        })
+        .await?;
+
+        assert_eq!(result, MemoryCandidateResult::NoCandidates);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn memory_candidate_malformed_output_fails_closed() -> Result<()> {
+        let mut conn = setup_conn();
+        let task = setup_task(&mut conn, "sess-candidate-bad")?;
+        insert_source_observation(&conn, &task, "Important durable decision.")?;
+
+        let err = process_with_generator(&mut conn, &task, |_prompt| async {
+            Ok("not xml".to_string())
+        })
+        .await
+        .expect_err("malformed output should fail");
+
+        assert!(err.to_string().contains("malformed memory_candidate"));
+        Ok(())
+    }
+}

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -62,10 +62,10 @@ fn full_migration_on_empty_db() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 20);
+    assert_eq!(user_version, 21);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -123,7 +123,7 @@ fn transition_from_old_system_skips_baseline() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
     Ok(())
 }
 
@@ -148,10 +148,10 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
 
     // Should have auto-upgraded and marked all v1 migrations as applied.
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 20);
+    assert_eq!(user_version, 21);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -191,7 +191,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 20);
+    assert_eq!(result.current_version, 21);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())
@@ -204,7 +204,7 @@ fn dry_run_pending_reports_pending_for_new_db() -> Result<()> {
     let result = dry_run_pending(&conn)?;
 
     assert_eq!(result.current_version, 0);
-    assert_eq!(result.pending_count, 8);
+    assert_eq!(result.pending_count, 9);
     assert!(result.error.is_none());
     Ok(())
 }
@@ -263,7 +263,7 @@ fn dry_run_pending_reports_backfill_error_for_broken_schema() -> Result<()> {
     let result = dry_run_pending(&conn)?;
     // After broken baseline backfill fails, dry_run reports the still-unapplied
     // migrations (v2+ remain pending in _schema_migrations).
-    assert_eq!(result.pending_count, 7);
+    assert_eq!(result.pending_count, 8);
     let error = result
         .error
         .expect("broken schema should surface in dry-run");

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -45,6 +45,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "observation_evidence",
         sql: include_str!("../migrations/v008_observation_evidence.sql"),
     },
+    Migration {
+        version: 9,
+        name: "memory_candidate_promotion",
+        sql: include_str!("../migrations/v009_memory_candidate_promotion.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v009_memory_candidate_promotion.sql
+++ b/src/migrations/v009_memory_candidate_promotion.sql
@@ -1,0 +1,11 @@
+-- v009_memory_candidate_promotion: preserve candidate evidence on promoted memories.
+
+ALTER TABLE memories ADD COLUMN evidence_event_ids TEXT;
+ALTER TABLE memories ADD COLUMN source_candidate_id INTEGER;
+ALTER TABLE memories ADD COLUMN confidence REAL;
+
+CREATE INDEX IF NOT EXISTS idx_memories_source_candidate
+    ON memories(source_candidate_id);
+
+CREATE INDEX IF NOT EXISTS idx_memory_candidates_dedupe
+    ON memory_candidates(project_id, scope, memory_type, topic_key, text);

--- a/src/observation_extract.rs
+++ b/src/observation_extract.rs
@@ -83,6 +83,14 @@ where
     }
 
     let inserted = persist_observations(conn, task, &range, &observations)?;
+    if inserted > 0 {
+        db::enqueue_followup_extraction_task(
+            conn,
+            task,
+            db::ExtractionTaskKind::MemoryCandidate,
+            range.to_event_id,
+        )?;
+    }
     Ok(ObservationExtractResult::Written(inserted))
 }
 

--- a/src/observation_extract.rs
+++ b/src/observation_extract.rs
@@ -83,14 +83,12 @@ where
     }
 
     let inserted = persist_observations(conn, task, &range, &observations)?;
-    if inserted > 0 {
-        db::enqueue_followup_extraction_task(
-            conn,
-            task,
-            db::ExtractionTaskKind::MemoryCandidate,
-            range.to_event_id,
-        )?;
-    }
+    db::enqueue_followup_extraction_task(
+        conn,
+        task,
+        db::ExtractionTaskKind::MemoryCandidate,
+        range.to_event_id,
+    )?;
     Ok(ObservationExtractResult::Written(inserted))
 }
 
@@ -399,6 +397,37 @@ mod tests {
         })
         .await?;
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observation_extract_replay_enqueues_candidate_for_existing_observation() -> Result<()>
+    {
+        let mut conn = setup_conn();
+        capture(&conn, "sess-replay", "cargo test fixed the failure")?;
+        let task = claim_extract_task(&mut conn)?;
+        let response = || async {
+            Ok("<observation><type>discovery</type><title>Tests fixed</title><narrative>cargo test fixed the failure</narrative></observation>".to_string())
+        };
+
+        let first = process_with_extractor(&mut conn, &task, |_prompt| response()).await?;
+        conn.execute(
+            "DELETE FROM extraction_tasks WHERE task_kind = 'memory_candidate'",
+            [],
+        )?;
+        let replay = process_with_extractor(&mut conn, &task, |_prompt| response()).await?;
+
+        assert_eq!(first, ObservationExtractResult::Written(1));
+        assert_eq!(replay, ObservationExtractResult::Written(0));
+        let pending_candidate_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM extraction_tasks
+             WHERE task_kind = 'memory_candidate'
+               AND status = 'pending'
+               AND high_watermark_event_id = ?1",
+            params![task.high_watermark_event_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(pending_candidate_count, 1);
         Ok(())
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -572,7 +572,7 @@ mod tests {
                 role: None,
                 tool_name: Some("Bash"),
                 content: r#"{"tool_name":"Bash"}"#,
-                task_kind: Some(db::ExtractionTaskKind::MemoryCandidate),
+                task_kind: Some(db::ExtractionTaskKind::RuleCandidate),
             },
         )?;
         let task_id = outcome
@@ -734,6 +734,11 @@ mod tests {
                 [],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )?;
+            let unfinished_tasks: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM extraction_tasks WHERE status != 'done'",
+                [],
+                |row| row.get(0),
+            )?;
 
             anyhow::ensure!(status == "done", "expected done task, got {status}");
             anyhow::ensure!(cursor == high_watermark, "expected cursor to advance");
@@ -742,6 +747,10 @@ mod tests {
                 "expected stub observation text"
             );
             anyhow::ensure!(evidence.contains('1'), "expected captured event evidence");
+            anyhow::ensure!(
+                unfinished_tasks == 0,
+                "expected all extraction follow-up tasks done"
+            );
             Ok::<(), anyhow::Error>(())
         }
         .await;

--- a/src/worker/tests/test_support.rs
+++ b/src/worker/tests/test_support.rs
@@ -59,10 +59,25 @@ for arg in "$@"; do
   fi
   prev="$arg"
 done
-cat >/dev/null
 if [ -z "$output_path" ]; then
   echo "missing output path" >&2
   exit 1
+fi
+stdin_path="${TMPDIR:-/tmp}/remem-stub-codex-$$.txt"
+cat > "$stdin_path"
+if grep -q "Task: memory_candidate" "$stdin_path"; then
+cat <<'EOF' > "$output_path"
+<memory_candidate>
+  <scope>project</scope>
+  <type>decision</type>
+  <topic_key>codex-worker-flush</topic_key>
+  <risk_class>low</risk_class>
+  <confidence>0.91</confidence>
+  <text>Queued Codex observation persisted.</text>
+</memory_candidate>
+EOF
+rm -f "$stdin_path"
+exit 0
 fi
 cat <<'EOF' > "$output_path"
 <observation>
@@ -71,6 +86,7 @@ cat <<'EOF' > "$output_path"
   <narrative>Queued Codex observation persisted.</narrative>
 </observation>
 EOF
+rm -f "$stdin_path"
 "#;
     std::fs::write(path, script).expect("stub codex script should be written");
     let mut perms = std::fs::metadata(path)


### PR DESCRIPTION
## Summary
- implement memory_candidate extraction task processing
- generate and validate candidate XML output, failing closed on malformed responses
- persist memory_candidates with evidence and auto-promote low-risk project candidates into memories
- carry source_candidate_id, evidence_event_ids, and confidence onto promoted memories
- enqueue memory_candidate follow-up tasks after observation extraction writes observations

Fixes #153

## Validation
- cargo fmt --check
- cargo check
- cargo test memory_candidate -- --nocapture
- cargo test worker_processes_observation_extract_task_on_codex_stub -- --nocapture
- cargo test migrate:: -- --nocapture
- git diff --check
- cargo clippy -- -D warnings
- cargo test
- cargo build --release
