### PR TITLE
feat(cli): review memory candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ remem status
 remem pending list-failed
 remem pending retry-failed
 remem pending purge-failed
+remem review list
+remem review approve <id>
+remem review discard <id>
+remem review edit <id> --text "updated memory"
 remem preferences list
 remem preferences add "text"
 remem preferences remove 42

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,6 +158,10 @@ remem status
 remem pending list-failed
 remem pending retry-failed
 remem pending purge-failed
+remem review list
+remem review approve <id>
+remem review discard <id>
+remem review edit <id> --text "updated memory"
 remem preferences list
 remem preferences add "text"
 remem preferences remove 42

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -5,6 +5,7 @@ mod maintenance;
 mod pending;
 mod preferences;
 mod query;
+mod review;
 mod shared;
 
 pub(super) use admin::run_admin;
@@ -14,3 +15,4 @@ pub(super) use maintenance::{run_cleanup, run_dream, run_encrypt};
 pub(super) use pending::run_pending;
 pub(super) use preferences::run_preferences;
 pub(super) use query::{run_backfill_entities, run_search, run_show, run_status};
+pub(super) use review::run_review;

--- a/src/cli/actions/review.rs
+++ b/src/cli/actions/review.rs
@@ -1,0 +1,71 @@
+use anyhow::{bail, Result};
+
+use crate::cli::types::ReviewAction;
+use crate::db;
+use crate::memory_candidate::review::{self, CandidateEdit};
+
+pub(in crate::cli) fn run_review(action: ReviewAction) -> Result<()> {
+    let mut conn = db::open_db()?;
+
+    match action {
+        ReviewAction::List { project, limit } => {
+            let rows = review::list_pending(&conn, project.as_deref(), limit)?;
+            if rows.is_empty() {
+                println!("No pending memory candidates.");
+                return Ok(());
+            }
+            println!("Pending memory candidates ({}):", rows.len());
+            for row in rows {
+                let project = row.project.as_deref().unwrap_or("<unknown project>");
+                println!(
+                    "  [{}] {} {} {} confidence={:.2} risk={} project={}",
+                    row.id,
+                    row.scope,
+                    row.memory_type,
+                    row.topic_key,
+                    row.confidence,
+                    row.risk_class,
+                    project
+                );
+                println!("      text: {}", db::truncate_str(&row.text, 180));
+                println!("      evidence: {}", row.evidence_event_ids);
+                for evidence in row.evidence_preview {
+                    println!("        {}", evidence);
+                }
+            }
+        }
+        ReviewAction::Approve { id } => {
+            let Some(memory_id) = review::approve_candidate(&mut conn, id)? else {
+                bail!("candidate {} not found", id);
+            };
+            println!("Approved candidate {}; promoted memory {}.", id, memory_id);
+        }
+        ReviewAction::Discard { id } => {
+            if review::discard_candidate(&conn, id)? {
+                println!("Discarded candidate {}.", id);
+            } else {
+                bail!("candidate {} not found or not pending_review", id);
+            }
+        }
+        ReviewAction::Edit {
+            id,
+            text,
+            topic_key,
+            memory_type,
+            scope,
+        } => {
+            let edit = CandidateEdit {
+                scope,
+                memory_type,
+                topic_key,
+                text,
+            };
+            let Some(memory_id) = review::edit_candidate(&mut conn, id, edit)? else {
+                bail!("candidate {} not found", id);
+            };
+            println!("Edited candidate {}; promoted memory {}.", id, memory_id);
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -4,7 +4,8 @@ use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 
 use super::actions::{
     run_admin, run_backfill_entities, run_cleanup, run_dream, run_encrypt, run_eval,
-    run_eval_local, run_import, run_pending, run_preferences, run_search, run_show, run_status,
+    run_eval_local, run_import, run_pending, run_preferences, run_review, run_search, run_show,
+    run_status,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands};
@@ -53,6 +54,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         }
         Commands::Preferences { action } => run_preferences(action)?,
         Commands::Pending { action } => run_pending(action)?,
+        Commands::Review { action } => run_review(action)?,
         Commands::Status => run_status()?,
         Commands::Doctor { json, quiet } => {
             let outcome = doctor::run_doctor(doctor::DoctorOptions { json, quiet })?;

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,4 +1,6 @@
 use super::cwd::resolve_cwd_arg;
+use super::types::{Cli, Commands, ReviewAction};
+use clap::Parser;
 
 #[test]
 fn cli_resolve_cwd_arg_prefers_explicit_value() {
@@ -15,4 +17,40 @@ fn cli_resolve_cwd_arg_falls_back_to_current_dir() {
         .to_string_lossy()
         .to_string();
     assert_eq!(resolve_cwd_arg(None), expected);
+}
+
+#[test]
+fn cli_parses_review_edit_options() {
+    let cli = Cli::parse_from([
+        "remem",
+        "review",
+        "edit",
+        "42",
+        "--text",
+        "edited memory",
+        "--topic-key",
+        "edited-topic",
+        "--type",
+        "architecture",
+    ]);
+
+    match cli.command {
+        Commands::Review {
+            action:
+                ReviewAction::Edit {
+                    id,
+                    text,
+                    topic_key,
+                    memory_type,
+                    scope,
+                },
+        } => {
+            assert_eq!(id, 42);
+            assert_eq!(text.as_deref(), Some("edited memory"));
+            assert_eq!(topic_key.as_deref(), Some("edited-topic"));
+            assert_eq!(memory_type.as_deref(), Some("architecture"));
+            assert!(scope.is_none());
+        }
+        _ => panic!("expected review edit command"),
+    }
 }

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -63,6 +63,10 @@ pub(super) enum Commands {
         #[command(subcommand)]
         action: PendingAction,
     },
+    Review {
+        #[command(subcommand)]
+        action: ReviewAction,
+    },
     Status,
     Doctor {
         /// Emit a single JSON object with per-check status. Stable shape;
@@ -186,5 +190,32 @@ pub(in crate::cli) enum PendingAction {
         project: Option<String>,
         #[arg(long, default_value = "7")]
         older_than_days: i64,
+    },
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum ReviewAction {
+    List {
+        #[arg(long, short)]
+        project: Option<String>,
+        #[arg(long, short = 'n', default_value = "20")]
+        limit: i64,
+    },
+    Approve {
+        id: i64,
+    },
+    Discard {
+        id: i64,
+    },
+    Edit {
+        id: i64,
+        #[arg(long)]
+        text: Option<String>,
+        #[arg(long = "topic-key")]
+        topic_key: Option<String>,
+        #[arg(long = "type")]
+        memory_type: Option<String>,
+        #[arg(long)]
+        scope: Option<String>,
     },
 }

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -71,8 +71,10 @@ pub fn insert_memory_full(
         if !topic_key.is_empty() {
             let existing_id: Option<i64> = conn
                 .query_row(
-                    "SELECT id FROM memories WHERE project = ?1 AND topic_key = ?2 LIMIT 1",
-                    params![project, topic_key],
+                    "SELECT id FROM memories
+                     WHERE project = ?1 AND topic_key = ?2 AND scope = ?3
+                     LIMIT 1",
+                    params![project, topic_key, scope],
                     |row| row.get(0),
                 )
                 .ok();

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -46,13 +46,13 @@ struct ObservationBatch {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-struct ParsedMemoryCandidate {
-    scope: String,
-    memory_type: String,
-    topic_key: String,
-    text: String,
-    confidence: f64,
-    risk_class: String,
+pub(super) struct ParsedMemoryCandidate {
+    pub(super) scope: String,
+    pub(super) memory_type: String,
+    pub(super) topic_key: String,
+    pub(super) text: String,
+    pub(super) confidence: f64,
+    pub(super) risk_class: String,
 }
 
 pub(crate) async fn process(task: &db::ExtractionTask) -> Result<MemoryCandidateResult> {
@@ -235,7 +235,7 @@ fn persist_candidates(
         summary.candidates += 1;
 
         if review_status == "auto_promoted" {
-            promote_candidate(&tx, task, candidate_id, candidate, &evidence_json)?;
+            promote_task_candidate(&tx, task, candidate_id, candidate, &evidence_json)?;
             summary.promoted += 1;
         } else {
             summary.pending_review += 1;
@@ -279,18 +279,37 @@ fn candidate_exists(
     Ok(existing.is_some())
 }
 
-fn promote_candidate(
+fn promote_task_candidate(
     conn: &Connection,
     task: &db::ExtractionTask,
     candidate_id: i64,
     candidate: &ParsedMemoryCandidate,
     evidence_json: &str,
 ) -> Result<()> {
-    let title = candidate_title(candidate);
-    let memory_id = crate::memory::insert_memory_full(
+    promote_candidate_to_memory(
         conn,
         task.session_id.as_deref(),
         &task.project,
+        candidate_id,
+        candidate,
+        evidence_json,
+    )?;
+    Ok(())
+}
+
+pub(super) fn promote_candidate_to_memory(
+    conn: &Connection,
+    session_id: Option<&str>,
+    project: &str,
+    candidate_id: i64,
+    candidate: &ParsedMemoryCandidate,
+    evidence_json: &str,
+) -> Result<i64> {
+    let title = candidate_title(candidate);
+    let memory_id = crate::memory::insert_memory_full(
+        conn,
+        session_id,
+        project,
         Some(&candidate.topic_key),
         &title,
         &candidate.text,
@@ -305,10 +324,10 @@ fn promote_candidate(
          SET evidence_event_ids = ?1,
              source_candidate_id = ?2,
              confidence = ?3
-         WHERE id = ?4",
+        WHERE id = ?4",
         params![evidence_json, candidate_id, candidate.confidence, memory_id],
     )?;
-    Ok(())
+    Ok(memory_id)
 }
 
 fn should_auto_promote(candidate: &ParsedMemoryCandidate) -> bool {
@@ -397,14 +416,14 @@ fn required_field(content: &str, field: &str) -> Result<String> {
         .with_context(|| format!("malformed memory_candidate output: missing <{field}>"))
 }
 
-fn normalize_scope(raw: &str) -> Result<String> {
+pub(super) fn normalize_scope(raw: &str) -> Result<String> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "global" | "workspace" | "project" => Ok(raw.trim().to_ascii_lowercase()),
         other => bail!("malformed memory_candidate output: invalid scope '{other}'"),
     }
 }
 
-fn normalize_memory_type(raw: &str) -> Result<String> {
+pub(super) fn normalize_memory_type(raw: &str) -> Result<String> {
     let value = raw.trim().to_ascii_lowercase();
     if crate::memory::MEMORY_TYPES.contains(&value.as_str()) && value != "session_activity" {
         Ok(value)
@@ -413,7 +432,7 @@ fn normalize_memory_type(raw: &str) -> Result<String> {
     }
 }
 
-fn normalize_topic_key(raw: &str) -> Result<String> {
+pub(super) fn normalize_topic_key(raw: &str) -> Result<String> {
     let value = crate::memory::slugify_for_topic(raw.trim(), 96);
     if value.is_empty() {
         bail!("malformed memory_candidate output: empty topic_key");
@@ -421,14 +440,14 @@ fn normalize_topic_key(raw: &str) -> Result<String> {
     Ok(value)
 }
 
-fn normalize_risk_class(raw: &str) -> Result<String> {
+pub(super) fn normalize_risk_class(raw: &str) -> Result<String> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "low" | "medium" | "high" => Ok(raw.trim().to_ascii_lowercase()),
         other => bail!("malformed memory_candidate output: invalid risk_class '{other}'"),
     }
 }
 
-fn parse_confidence(raw: &str) -> Result<f64> {
+pub(super) fn parse_confidence(raw: &str) -> Result<f64> {
     let confidence: f64 = raw
         .trim()
         .parse()
@@ -446,6 +465,8 @@ fn find_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
         .windows(needle.len())
         .position(|window| window.eq_ignore_ascii_case(needle))
 }
+
+pub(crate) mod review;
 
 #[cfg(test)]
 mod tests {

--- a/src/memory_candidate/review.rs
+++ b/src/memory_candidate/review.rs
@@ -1,0 +1,494 @@
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::{
+    normalize_memory_type, normalize_scope, normalize_topic_key, promote_candidate_to_memory,
+    ParsedMemoryCandidate,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ReviewCandidate {
+    pub id: i64,
+    pub project: Option<String>,
+    pub scope: String,
+    pub memory_type: String,
+    pub topic_key: String,
+    pub text: String,
+    pub evidence_event_ids: String,
+    pub evidence_preview: Vec<String>,
+    pub confidence: f64,
+    pub risk_class: String,
+    pub created_at_epoch: i64,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct CandidateEdit {
+    pub scope: Option<String>,
+    pub memory_type: Option<String>,
+    pub topic_key: Option<String>,
+    pub text: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CandidateRow {
+    id: i64,
+    project: Option<String>,
+    scope: String,
+    memory_type: String,
+    topic_key: String,
+    text: String,
+    evidence_event_ids: String,
+    confidence: f64,
+    risk_class: String,
+    review_status: String,
+    created_at_epoch: i64,
+}
+
+pub(crate) fn list_pending(
+    conn: &Connection,
+    project: Option<&str>,
+    limit: i64,
+) -> Result<Vec<ReviewCandidate>> {
+    let limit = limit.clamp(1, 200);
+    let rows = if let Some(project) = project {
+        let mut stmt = conn.prepare(
+            "SELECT c.id, p.project_path, c.scope, c.memory_type, c.topic_key,
+                    c.text, c.evidence_event_ids, c.confidence, c.risk_class,
+                    c.review_status, c.created_at_epoch
+             FROM memory_candidates c
+             LEFT JOIN projects p ON p.id = c.project_id
+             WHERE c.review_status = 'pending_review'
+               AND p.project_path = ?1
+             ORDER BY c.created_at_epoch ASC, c.id ASC
+             LIMIT ?2",
+        )?;
+        let rows = stmt
+            .query_map(params![project, limit], CandidateRow::from_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        rows
+    } else {
+        let mut stmt = conn.prepare(
+            "SELECT c.id, p.project_path, c.scope, c.memory_type, c.topic_key,
+                    c.text, c.evidence_event_ids, c.confidence, c.risk_class,
+                    c.review_status, c.created_at_epoch
+             FROM memory_candidates c
+             LEFT JOIN projects p ON p.id = c.project_id
+             WHERE c.review_status = 'pending_review'
+             ORDER BY c.created_at_epoch ASC, c.id ASC
+             LIMIT ?1",
+        )?;
+        let rows = stmt
+            .query_map(params![limit], CandidateRow::from_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        rows
+    };
+
+    rows.into_iter()
+        .map(|row| {
+            let evidence_preview = evidence_preview(conn, &row.evidence_event_ids)?;
+            Ok(ReviewCandidate {
+                id: row.id,
+                project: row.project,
+                scope: row.scope,
+                memory_type: row.memory_type,
+                topic_key: row.topic_key,
+                text: row.text,
+                evidence_event_ids: row.evidence_event_ids,
+                evidence_preview,
+                confidence: row.confidence,
+                risk_class: row.risk_class,
+                created_at_epoch: row.created_at_epoch,
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn approve_candidate(conn: &mut Connection, id: i64) -> Result<Option<i64>> {
+    let Some(row) = load_candidate(conn, id)? else {
+        return Ok(None);
+    };
+    ensure_pending(&row)?;
+    let tx = conn.transaction()?;
+    let memory_id = promote_row(&tx, &row, "approved", None)?;
+    tx.commit()?;
+    Ok(Some(memory_id))
+}
+
+pub(crate) fn discard_candidate(conn: &Connection, id: i64) -> Result<bool> {
+    let now = chrono::Utc::now().timestamp();
+    let updated = conn.execute(
+        "UPDATE memory_candidates
+         SET review_status = 'discarded', updated_at_epoch = ?1
+         WHERE id = ?2 AND review_status = 'pending_review'",
+        params![now, id],
+    )?;
+    Ok(updated > 0)
+}
+
+pub(crate) fn edit_candidate(
+    conn: &mut Connection,
+    id: i64,
+    edit: CandidateEdit,
+) -> Result<Option<i64>> {
+    if edit.scope.is_none()
+        && edit.memory_type.is_none()
+        && edit.topic_key.is_none()
+        && edit.text.is_none()
+    {
+        bail!("edit requires at least one changed field");
+    }
+    let Some(row) = load_candidate(conn, id)? else {
+        return Ok(None);
+    };
+    ensure_pending(&row)?;
+    let edited = row.apply_edit(edit)?;
+    let tx = conn.transaction()?;
+    let memory_id = promote_row(&tx, &row, "edited", Some(&edited))?;
+    tx.commit()?;
+    Ok(Some(memory_id))
+}
+
+impl CandidateRow {
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get(0)?,
+            project: row.get(1)?,
+            scope: row.get(2)?,
+            memory_type: row.get(3)?,
+            topic_key: row.get(4)?,
+            text: row.get(5)?,
+            evidence_event_ids: row.get(6)?,
+            confidence: row.get(7)?,
+            risk_class: row.get(8)?,
+            review_status: row.get(9)?,
+            created_at_epoch: row.get(10)?,
+        })
+    }
+
+    fn as_candidate(&self) -> ParsedMemoryCandidate {
+        ParsedMemoryCandidate {
+            scope: self.scope.clone(),
+            memory_type: self.memory_type.clone(),
+            topic_key: self.topic_key.clone(),
+            text: self.text.clone(),
+            confidence: self.confidence,
+            risk_class: self.risk_class.clone(),
+        }
+    }
+
+    fn apply_edit(&self, edit: CandidateEdit) -> Result<ParsedMemoryCandidate> {
+        let scope = edit
+            .scope
+            .as_deref()
+            .map(normalize_scope)
+            .transpose()?
+            .unwrap_or_else(|| self.scope.clone());
+        let memory_type = edit
+            .memory_type
+            .as_deref()
+            .map(normalize_memory_type)
+            .transpose()?
+            .unwrap_or_else(|| self.memory_type.clone());
+        let topic_key = edit
+            .topic_key
+            .as_deref()
+            .map(normalize_topic_key)
+            .transpose()?
+            .unwrap_or_else(|| self.topic_key.clone());
+        let text = edit
+            .text
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| self.text.clone());
+        Ok(ParsedMemoryCandidate {
+            scope,
+            memory_type,
+            topic_key,
+            text,
+            confidence: self.confidence,
+            risk_class: self.risk_class.clone(),
+        })
+    }
+}
+
+fn load_candidate(conn: &Connection, id: i64) -> Result<Option<CandidateRow>> {
+    conn.query_row(
+        "SELECT c.id, p.project_path, c.scope, c.memory_type, c.topic_key,
+                c.text, c.evidence_event_ids, c.confidence, c.risk_class,
+                c.review_status, c.created_at_epoch
+         FROM memory_candidates c
+         LEFT JOIN projects p ON p.id = c.project_id
+         WHERE c.id = ?1",
+        params![id],
+        CandidateRow::from_row,
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn ensure_pending(row: &CandidateRow) -> Result<()> {
+    if row.review_status != "pending_review" {
+        bail!(
+            "candidate {} is {}, expected pending_review",
+            row.id,
+            row.review_status
+        );
+    }
+    Ok(())
+}
+
+fn promote_row(
+    conn: &Connection,
+    row: &CandidateRow,
+    review_status: &str,
+    edited: Option<&ParsedMemoryCandidate>,
+) -> Result<i64> {
+    let project = row
+        .project
+        .as_deref()
+        .context("candidate is missing project path")?;
+    let candidate = edited.cloned().unwrap_or_else(|| row.as_candidate());
+    let memory_id = promote_candidate_to_memory(
+        conn,
+        None,
+        project,
+        row.id,
+        &candidate,
+        &row.evidence_event_ids,
+    )?;
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "UPDATE memory_candidates
+         SET scope = ?1,
+             memory_type = ?2,
+             topic_key = ?3,
+             text = ?4,
+             review_status = ?5,
+             updated_at_epoch = ?6
+         WHERE id = ?7",
+        params![
+            candidate.scope,
+            candidate.memory_type,
+            candidate.topic_key,
+            candidate.text,
+            review_status,
+            now,
+            row.id
+        ],
+    )?;
+    Ok(memory_id)
+}
+
+fn evidence_preview(conn: &Connection, evidence_json: &str) -> Result<Vec<String>> {
+    let event_ids: Vec<i64> = serde_json::from_str(evidence_json)
+        .with_context(|| "candidate has malformed evidence_event_ids")?;
+    let mut previews = Vec::new();
+    for event_id in event_ids.into_iter().take(3) {
+        let row: Option<(String, Option<String>, String)> = conn
+            .query_row(
+                "SELECT event_type, tool_name, COALESCE(content_text, '')
+                 FROM captured_events WHERE id = ?1",
+                params![event_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()?;
+        if let Some((event_type, tool_name, content)) = row {
+            let tool = tool_name
+                .map(|value| format!(" tool={value}"))
+                .unwrap_or_default();
+            previews.push(format!(
+                "#{} {}{} {}",
+                event_id,
+                event_type,
+                tool,
+                crate::db::truncate_str(&content, 120)
+            ));
+        } else {
+            previews.push(format!("#{event_id} <missing event>"));
+        }
+    }
+    Ok(previews)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use crate::db::{record_captured_event, CaptureEventInput, ExtractionTaskKind};
+
+    use super::*;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db should open");
+        crate::migrate::run_migrations(&conn).expect("migrations should run");
+        conn
+    }
+
+    fn insert_pending_candidate(conn: &mut Connection, topic_key: &str, text: &str) -> Result<i64> {
+        record_captured_event(
+            conn,
+            &CaptureEventInput {
+                host: "codex-cli",
+                session_id: "sess-review",
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Bash"),
+                content: "cargo test passed",
+                task_kind: Some(ExtractionTaskKind::MemoryCandidate),
+            },
+        )?;
+        let task = crate::db::claim_next_extraction_task(conn, "worker-review", 60)?
+            .expect("task should claim");
+        let evidence_json = serde_json::to_string(&vec![task.high_watermark_event_id.unwrap()])?;
+        let now = chrono::Utc::now().timestamp();
+        conn.execute(
+            "INSERT INTO memory_candidates
+             (project_id, scope, memory_type, topic_key, text, evidence_event_ids,
+              confidence, risk_class, review_status, created_at_epoch, updated_at_epoch)
+             VALUES (?1, 'project', 'decision', ?2, ?3, ?4, 0.72, 'medium',
+                     'pending_review', ?5, ?5)",
+            params![task.project_id, topic_key, text, evidence_json, now],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    #[test]
+    fn review_list_includes_evidence_preview() -> Result<()> {
+        let mut conn = setup_conn();
+        let id = insert_pending_candidate(&mut conn, "review-list", "Review this candidate")?;
+
+        let rows = list_pending(&conn, None, 10)?;
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, id);
+        assert_eq!(rows[0].project.as_deref(), Some("/tmp/remem"));
+        assert!(rows[0].evidence_preview[0].contains("tool_result"));
+        Ok(())
+    }
+
+    #[test]
+    fn review_approve_promotes_candidate() -> Result<()> {
+        let mut conn = setup_conn();
+        let id = insert_pending_candidate(&mut conn, "review-approve", "Approve this memory")?;
+
+        let memory_id = approve_candidate(&mut conn, id)?.expect("candidate should approve");
+
+        let status: String = conn.query_row(
+            "SELECT review_status FROM memory_candidates WHERE id = ?1",
+            params![id],
+            |row| row.get(0),
+        )?;
+        let source_candidate_id: i64 = conn.query_row(
+            "SELECT source_candidate_id FROM memories WHERE id = ?1",
+            params![memory_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(status, "approved");
+        assert_eq!(source_candidate_id, id);
+        Ok(())
+    }
+
+    #[test]
+    fn review_discard_marks_candidate_without_deleting_evidence() -> Result<()> {
+        let mut conn = setup_conn();
+        let id = insert_pending_candidate(&mut conn, "review-discard", "Discard this memory")?;
+
+        assert!(discard_candidate(&conn, id)?);
+
+        let (status, evidence): (String, String) = conn.query_row(
+            "SELECT review_status, evidence_event_ids FROM memory_candidates WHERE id = ?1",
+            params![id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(status, "discarded");
+        assert!(evidence.contains('1'));
+        Ok(())
+    }
+
+    #[test]
+    fn review_edit_promotes_edited_candidate() -> Result<()> {
+        let mut conn = setup_conn();
+        let id = insert_pending_candidate(&mut conn, "review-edit", "Original memory")?;
+
+        let memory_id = edit_candidate(
+            &mut conn,
+            id,
+            CandidateEdit {
+                topic_key: Some("edited-topic".to_string()),
+                memory_type: Some("architecture".to_string()),
+                text: Some("Edited architecture memory".to_string()),
+                ..CandidateEdit::default()
+            },
+        )?
+        .expect("candidate should edit");
+
+        let (status, topic_key, memory_type, text): (String, String, String, String) = conn
+            .query_row(
+                "SELECT c.review_status, m.topic_key, m.memory_type, m.content
+                 FROM memory_candidates c
+                 JOIN memories m ON m.id = ?2
+                 WHERE c.id = ?1",
+                params![id, memory_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )?;
+        assert_eq!(status, "edited");
+        assert_eq!(topic_key, "edited-topic");
+        assert_eq!(memory_type, "architecture");
+        assert_eq!(text, "Edited architecture memory");
+        Ok(())
+    }
+
+    #[test]
+    fn review_invalid_ids_are_reported() -> Result<()> {
+        let mut conn = setup_conn();
+
+        assert!(approve_candidate(&mut conn, 999)?.is_none());
+        assert!(!discard_candidate(&conn, 999)?);
+        assert!(edit_candidate(
+            &mut conn,
+            999,
+            CandidateEdit {
+                text: Some("missing".to_string()),
+                ..CandidateEdit::default()
+            },
+        )?
+        .is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn review_approve_updates_duplicate_topic_memory() -> Result<()> {
+        let mut conn = setup_conn();
+        crate::memory::insert_memory_full(
+            &conn,
+            None,
+            "/tmp/remem",
+            Some("review-dup"),
+            "Existing",
+            "Existing memory",
+            "decision",
+            None,
+            None,
+            "project",
+            None,
+        )?;
+        let id = insert_pending_candidate(&mut conn, "review-dup", "Updated memory")?;
+
+        approve_candidate(&mut conn, id)?.expect("candidate should approve");
+
+        let memory_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+        let content: String = conn.query_row(
+            "SELECT content FROM memories WHERE topic_key = 'review-dup'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(memory_count, 1);
+        assert_eq!(content, "Updated memory");
+        Ok(())
+    }
+}

--- a/src/memory_candidate/review.rs
+++ b/src/memory_candidate/review.rs
@@ -327,6 +327,15 @@ mod tests {
     }
 
     fn insert_pending_candidate(conn: &mut Connection, topic_key: &str, text: &str) -> Result<i64> {
+        insert_pending_candidate_with_scope(conn, topic_key, text, "project")
+    }
+
+    fn insert_pending_candidate_with_scope(
+        conn: &mut Connection,
+        topic_key: &str,
+        text: &str,
+        scope: &str,
+    ) -> Result<i64> {
         record_captured_event(
             conn,
             &CaptureEventInput {
@@ -349,9 +358,9 @@ mod tests {
             "INSERT INTO memory_candidates
              (project_id, scope, memory_type, topic_key, text, evidence_event_ids,
               confidence, risk_class, review_status, created_at_epoch, updated_at_epoch)
-             VALUES (?1, 'project', 'decision', ?2, ?3, ?4, 0.72, 'medium',
-                     'pending_review', ?5, ?5)",
-            params![task.project_id, topic_key, text, evidence_json, now],
+             VALUES (?1, ?2, 'decision', ?3, ?4, ?5, 0.72, 'medium',
+                     'pending_review', ?6, ?6)",
+            params![task.project_id, scope, topic_key, text, evidence_json, now],
         )?;
         Ok(conn.last_insert_rowid())
     }
@@ -489,6 +498,54 @@ mod tests {
         )?;
         assert_eq!(memory_count, 1);
         assert_eq!(content, "Updated memory");
+        Ok(())
+    }
+
+    #[test]
+    fn review_approve_preserves_existing_project_memory_for_global_candidate() -> Result<()> {
+        let mut conn = setup_conn();
+        crate::memory::insert_memory_full(
+            &conn,
+            None,
+            "/tmp/remem",
+            Some("review-scope"),
+            "Project",
+            "Project memory",
+            "decision",
+            None,
+            None,
+            "project",
+            None,
+        )?;
+        let id = insert_pending_candidate_with_scope(
+            &mut conn,
+            "review-scope",
+            "Global memory",
+            "global",
+        )?;
+
+        approve_candidate(&mut conn, id)?.expect("candidate should approve");
+
+        let memory_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memories WHERE topic_key = 'review-scope'",
+            [],
+            |row| row.get(0),
+        )?;
+        let project_content: String = conn.query_row(
+            "SELECT content FROM memories
+             WHERE topic_key = 'review-scope' AND scope = 'project'",
+            [],
+            |row| row.get(0),
+        )?;
+        let global_content: String = conn.query_row(
+            "SELECT content FROM memories
+             WHERE topic_key = 'review-scope' AND scope = 'global'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(memory_count, 2);
+        assert_eq!(project_content, "Project memory");
+        assert_eq!(global_content, "Global memory");
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- add `remem review list/approve/discard/edit` commands for pending memory candidates
- preserve candidate evidence while allowing approved and edited candidates to promote into memories through the shared promotion path
- show evidence context in review list output and document the review commands

Fixes #154

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test memory_candidate::review -- --nocapture`
- `cargo test cli_parses_review_edit_options -- --nocapture`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build --release`
