### PR TITLE
Fix memory maintenance regressions

### DIFF
--- a/src/db/schema/import.rs
+++ b/src/db/schema/import.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use rusqlite::{Connection, OpenFlags};
+use std::collections::HashSet;
 use std::path::Path;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -38,11 +39,15 @@ pub fn import_memories(source_path: &Path, schema_conn: &Connection) -> Result<I
             .with_context(|| format!("reopen unencrypted source {}", source_path.display()))?;
     }
 
-    let mut stmt = source.prepare(
-        "SELECT id, project, topic_key, title, content, memory_type, scope, status,
+    let columns = table_columns(&source, "memories")?;
+    let scope_expr = optional_column_or_literal(&columns, "scope", "'project'");
+    let status_expr = optional_column_or_literal(&columns, "status", "'active'");
+    let query = format!(
+        "SELECT id, project, topic_key, title, content, memory_type, {scope_expr}, {status_expr},
                 created_at_epoch, updated_at_epoch
-         FROM memories",
-    )?;
+         FROM memories"
+    );
+    let mut stmt = source.prepare(&query)?;
     let mut rows = stmt.query([])?;
 
     let mut stats = ImportStats::default();
@@ -110,6 +115,24 @@ pub fn import_memories(source_path: &Path, schema_conn: &Connection) -> Result<I
         }
     }
     Ok(stats)
+}
+
+fn table_columns(conn: &Connection, table: &str) -> Result<HashSet<String>> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    let mut columns = HashSet::new();
+    for row in rows {
+        columns.insert(row?);
+    }
+    Ok(columns)
+}
+
+fn optional_column_or_literal(columns: &HashSet<String>, column: &str, literal: &str) -> String {
+    if columns.contains(column) {
+        column.to_string()
+    } else {
+        format!("{literal} AS {column}")
+    }
 }
 
 /// Returns `(project_id, workspace_inserted, project_inserted)`. Looks up
@@ -202,6 +225,28 @@ mod tests {
                 status TEXT NOT NULL DEFAULT 'active',
                 branch TEXT,
                 scope TEXT DEFAULT 'project'
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn create_pre_scope_source_db(path: &Path) -> Connection {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE memories (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT,
+                project TEXT NOT NULL,
+                topic_key TEXT,
+                title TEXT NOT NULL,
+                content TEXT NOT NULL,
+                memory_type TEXT NOT NULL,
+                files TEXT,
+                created_at_epoch INTEGER NOT NULL,
+                updated_at_epoch INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                branch TEXT
             );",
         )
         .unwrap();
@@ -305,6 +350,35 @@ mod tests {
             .query_row("SELECT project_id FROM memories", [], |r| r.get(0))
             .unwrap();
         assert_eq!(project_id, None);
+        cleanup(&source_path);
+        cleanup(&schema_path);
+    }
+
+    #[test]
+    fn pre_scope_source_defaults_imported_memories_to_project_scope() {
+        let source_path = unique_temp_path("source-pre-scope");
+        let schema_path = unique_temp_path("schema-pre-scope");
+        {
+            let source = create_pre_scope_source_db(&source_path);
+            source
+                .execute(
+                    "INSERT INTO memories(project, topic_key, title, content, memory_type,
+                      status, created_at_epoch, updated_at_epoch)
+                     VALUES ('/repo/old', 'legacy-topic', 'legacy title', 'legacy content',
+                      'discovery', 'active', 100, 200)",
+                    [],
+                )
+                .unwrap();
+        }
+
+        let schema_conn = open_at(&schema_path).unwrap();
+        let stats = import_memories(&source_path, &schema_conn).unwrap();
+
+        assert_eq!(stats.memories_imported, 1);
+        let scope: String = schema_conn
+            .query_row("SELECT scope FROM memories", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(scope, "project");
         cleanup(&source_path);
         cleanup(&schema_path);
     }

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -163,7 +163,7 @@ fn enable_codex_hooks(doc: &mut DocumentMut) -> Result<()> {
         .or_insert(Item::Table(Table::new()))
         .as_table_mut()
         .context("features 存在但不是 table，拒绝覆盖")?;
-    features.remove("codex_hooks");
+    features["codex_hooks"] = value(true);
     features["hooks"] = value(true);
     Ok(())
 }
@@ -271,11 +271,11 @@ startup_timeout_sec = 5
         let rendered = doc.to_string();
         assert!(rendered.contains("[features]"), "{rendered}");
         assert!(rendered.contains("hooks = true"), "{rendered}");
-        assert!(!rendered.contains("codex_hooks"), "{rendered}");
+        assert!(rendered.contains("codex_hooks = true"), "{rendered}");
     }
 
     #[test]
-    fn enable_codex_hooks_removes_deprecated_feature_flag() {
+    fn enable_codex_hooks_preserves_legacy_alias_for_old_codex_clients() {
         let mut doc: DocumentMut = r#"[features]
 codex_hooks = true
 "#
@@ -284,7 +284,7 @@ codex_hooks = true
         enable_codex_hooks(&mut doc).unwrap();
         let rendered = doc.to_string();
         assert!(rendered.contains("hooks = true"), "{rendered}");
-        assert!(!rendered.contains("codex_hooks"), "{rendered}");
+        assert!(rendered.contains("codex_hooks = true"), "{rendered}");
     }
 
     #[test]

--- a/src/mcp/server/raw_tools.rs
+++ b/src/mcp/server/raw_tools.rs
@@ -23,9 +23,10 @@ impl MemoryServer {
         crate::log::info(
             "mcp",
             &format!(
-                "search_raw called query={:?} project={:?} role={:?} limit={} offset={}",
+                "search_raw called query={:?} project={:?} branch={:?} role={:?} limit={} offset={}",
                 params.query,
                 params.project,
+                params.branch,
                 params.role,
                 params.limit.unwrap_or(20),
                 params.offset.unwrap_or(0),
@@ -35,6 +36,7 @@ impl MemoryServer {
             let req = raw_archive::RawSearchRequest {
                 query: params.query.clone(),
                 project: params.project.clone(),
+                branch: params.branch.clone(),
                 role: params.role.clone(),
                 limit: params.limit.unwrap_or(20),
                 offset: params.offset.unwrap_or(0),

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -140,6 +140,10 @@ pub(super) struct SearchRawParams {
     pub query: String,
     #[schemars(description = "Project name filter")]
     pub project: Option<String>,
+    #[schemars(
+        description = "Git branch filter. Returns raw rows for this branch plus older rows without branch metadata."
+    )]
+    pub branch: Option<String>,
     #[schemars(description = "Role filter: 'user' or 'assistant' (default: both)")]
     pub role: Option<String>,
     #[schemars(description = "Max results to return (default 20)")]

--- a/src/memory/raw_archive.rs
+++ b/src/memory/raw_archive.rs
@@ -175,6 +175,7 @@ fn extract_message_text(value: &serde_json::Value) -> String {
 pub struct RawSearchRequest {
     pub query: String,
     pub project: Option<String>,
+    pub branch: Option<String>,
     pub role: Option<String>,
     pub limit: i64,
     pub offset: i64,
@@ -201,6 +202,11 @@ pub fn search_raw_messages(conn: &Connection, req: &RawSearchRequest) -> Result<
         sql.push_str(" AND r.project = ?");
         sql.push_str(&(binds.len() + 1).to_string());
         binds.push(Box::new(project.to_string()));
+    }
+    if let Some(branch) = req.branch.as_deref() {
+        let idx = binds.len() + 1;
+        sql.push_str(&format!(" AND (r.branch = ?{idx} OR r.branch IS NULL)"));
+        binds.push(Box::new(branch.to_string()));
     }
     if let Some(role) = req.role.as_deref() {
         sql.push_str(" AND r.role = ?");
@@ -335,6 +341,7 @@ mod tests {
             &RawSearchRequest {
                 query: "RackNerd".to_string(),
                 project: Some("/proj".to_string()),
+                branch: None,
                 role: None,
                 limit: 10,
                 offset: 0,
@@ -343,5 +350,64 @@ mod tests {
         .unwrap();
         assert_eq!(hits.len(), 1);
         assert!(hits[0].content.contains("RackNerd"));
+    }
+
+    #[test]
+    fn search_branch_filter_keeps_matching_and_branchless_raw_messages() {
+        let conn = setup_conn();
+        insert_raw_message(
+            &conn,
+            "s-main",
+            "/proj",
+            ROLE_USER,
+            "shared needle on main",
+            SOURCE_HOOK,
+            Some("main"),
+            None,
+        )
+        .unwrap();
+        insert_raw_message(
+            &conn,
+            "s-feature",
+            "/proj",
+            ROLE_USER,
+            "shared needle on feature",
+            SOURCE_HOOK,
+            Some("feature"),
+            None,
+        )
+        .unwrap();
+        insert_raw_message(
+            &conn,
+            "s-branchless",
+            "/proj",
+            ROLE_USER,
+            "shared needle without branch",
+            SOURCE_HOOK,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let hits = search_raw_messages(
+            &conn,
+            &RawSearchRequest {
+                query: "needle".to_string(),
+                project: Some("/proj".to_string()),
+                branch: Some("main".to_string()),
+                role: None,
+                limit: 10,
+                offset: 0,
+            },
+        )
+        .unwrap();
+        let branches: Vec<Option<String>> = hits.into_iter().map(|hit| hit.branch).collect();
+
+        assert!(branches.contains(&Some("main".to_string())));
+        assert!(branches.contains(&None));
+        assert!(
+            !branches.contains(&Some("feature".to_string())),
+            "{branches:?}"
+        );
     }
 }

--- a/src/memory/service/search.rs
+++ b/src/memory/service/search.rs
@@ -96,6 +96,7 @@ fn maybe_fallback_raw(
     let raw_req = crate::memory::raw_archive::RawSearchRequest {
         query: query.to_string(),
         project: req.project.clone(),
+        branch: req.branch.clone(),
         role: None,
         limit: RAW_FALLBACK_LIMIT,
         offset: 0,
@@ -106,5 +107,71 @@ fn maybe_fallback_raw(
             crate::log::warn("search", &format!("raw archive fallback failed: {}", error));
             vec![]
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::raw_archive::{insert_raw_message, ROLE_USER, SOURCE_HOOK};
+
+    #[test]
+    fn raw_fallback_respects_branch_filter() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::migrate::run_migrations(&conn).unwrap();
+        insert_raw_message(
+            &conn,
+            "s-main",
+            "/repo",
+            ROLE_USER,
+            "fallback needle from main",
+            SOURCE_HOOK,
+            Some("main"),
+            None,
+        )
+        .unwrap();
+        insert_raw_message(
+            &conn,
+            "s-feature",
+            "/repo",
+            ROLE_USER,
+            "fallback needle from feature",
+            SOURCE_HOOK,
+            Some("feature"),
+            None,
+        )
+        .unwrap();
+        insert_raw_message(
+            &conn,
+            "s-branchless",
+            "/repo",
+            ROLE_USER,
+            "fallback needle from branchless history",
+            SOURCE_HOOK,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let result = search_memories(
+            &conn,
+            &SearchRequest {
+                query: Some("needle".to_string()),
+                project: Some("/repo".to_string()),
+                limit: 10,
+                branch: Some("main".to_string()),
+                ..SearchRequest::default()
+            },
+        )
+        .unwrap();
+        let branches: Vec<Option<String>> =
+            result.raw_hits.into_iter().map(|hit| hit.branch).collect();
+
+        assert!(branches.contains(&Some("main".to_string())));
+        assert!(branches.contains(&None));
+        assert!(
+            !branches.contains(&Some("feature".to_string())),
+            "{branches:?}"
+        );
     }
 }

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -408,6 +408,50 @@ fn memory_cols_all_present_after_migration() -> Result<()> {
 }
 
 #[test]
+fn memories_fts_active_filter_ignores_non_active_delete_and_update() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    run_migrations(&conn)?;
+
+    conn.execute(
+        "INSERT INTO memories(id, project, title, content, memory_type, created_at_epoch,
+            updated_at_epoch, status)
+         VALUES (1, 'proj', 'stale title', 'stale body needle', 'discovery', 100, 100, 'stale')",
+        [],
+    )?;
+    conn.execute("DELETE FROM memories WHERE id = 1", [])?;
+
+    conn.execute(
+        "INSERT INTO memories(id, project, title, content, memory_type, created_at_epoch,
+            updated_at_epoch, status)
+         VALUES (2, 'proj', 'promoted title', 'promoted body needle', 'discovery', 100, 100, 'stale')",
+        [],
+    )?;
+    conn.execute(
+        "UPDATE memories SET status = 'active', updated_at_epoch = 200 WHERE id = 2",
+        [],
+    )?;
+    let active_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories_fts WHERE memories_fts MATCH 'promoted'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(active_count, 1);
+
+    conn.execute(
+        "UPDATE memories SET status = 'stale', updated_at_epoch = 300 WHERE id = 2",
+        [],
+    )?;
+    let stale_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories_fts WHERE memories_fts MATCH 'promoted'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(stale_count, 0);
+
+    Ok(())
+}
+
+#[test]
 fn run_migrations_rejects_db_newer_than_binary() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     run_migrations(&conn)?;

--- a/src/migrations/v005_memories_fts_active_filter.sql
+++ b/src/migrations/v005_memories_fts_active_filter.sql
@@ -28,12 +28,12 @@ END;
 
 CREATE TRIGGER memories_ad AFTER DELETE ON memories BEGIN
     INSERT INTO memories_fts(memories_fts, rowid, title, content)
-    VALUES ('delete', old.id, old.title, old.content);
+    SELECT 'delete', old.id, old.title, old.content WHERE old.status = 'active';
 END;
 
 CREATE TRIGGER memories_au AFTER UPDATE ON memories BEGIN
     INSERT INTO memories_fts(memories_fts, rowid, title, content)
-    VALUES ('delete', old.id, old.title, old.content);
+    SELECT 'delete', old.id, old.title, old.content WHERE old.status = 'active';
     INSERT INTO memories_fts(rowid, title, content)
     SELECT new.id, new.title, new.content WHERE new.status = 'active';
 END;


### PR DESCRIPTION
## Summary
- Guard active-only memory FTS deletes so stale/archived rows that are not indexed do not corrupt FTS maintenance.
- Import older backup databases without a `scope` column by defaulting imported rows to project scope.
- Carry branch filters into raw archive fallback/search_raw so branch-scoped searches do not leak other branches.
- Keep both Codex hook feature flags (`hooks` and legacy `codex_hooks`) enabled for pre-0.129 clients.

Fixes #144.
Fixes #145.
Fixes #146.

Addresses the unresolved Codex review thread on #148.

## Validation
- cargo check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

## Review
Manual pre-landing review: no new blocking findings found across SQL/data safety, branch filter contract, old-client compatibility, and test coverage.