### PR TITLE
Add token usage cost reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Added `remem usage` for daily and weekly AI token/cost reporting.
+- Added `ai_usage_events` token breakdown fields for input, output, reasoning,
+  cache creation, cache read, raw input/output, usage source, and pricing source.
+- Added Codex session JSONL token accounting keyed by a per-run remem id.
+- Added historical usage repricing migration for older zero-cost rows.
+
+### Changed
+- Defaulted remem's Codex summarization model to `gpt-5.2`; set
+  `REMEM_CODEX_MODEL=auto` to use the Codex CLI default.
+- Updated model pricing to include current cache/reasoning-aware OpenAI and
+  Anthropic price families.
+- Serialized schema migrations with `BEGIN IMMEDIATE` to avoid concurrent
+  migration races.
+
+### Docs
+- Documented usage reporting, precision levels, pricing overrides, and the
+  `gpt-5.2` Codex default in English/Chinese README and architecture docs.
+
 ## [0.3.8] - 2026-04-03
 
 ### Packaging

--- a/README.md
+++ b/README.md
@@ -151,6 +151,31 @@ python3 eval/local/run_local_eval.py --n 20
 
 Requires `.env` with `OPENAI_API_KEY` (optional `OPENAI_BASE_URL`, `OPENAI_MODEL`).
 
+## Token Usage And Cost Reporting
+
+remem records an AI usage ledger for its own background extraction, summary,
+compression, and promotion calls. The CLI can report daily and weekly token
+usage and estimated cost:
+
+```bash
+remem usage --days 14 --weeks 8
+remem usage --project /path/to/project --days 30 --weeks 12
+```
+
+The report includes calls, input tokens, cache tokens, output tokens, reasoning
+tokens, total tokens, estimated USD cost, and a precision note. Usage rows are
+tagged by source:
+
+- `anthropic_usage`: provider-reported usage from the Anthropic Messages API
+- `codex_log`: token counts parsed from Codex session JSONL logs for the
+  matching remem run id
+- `text_estimate`: fallback estimate from prompt/response text length
+
+Cost is an estimate, not an invoice. Historical rows may be text estimates or
+may have been repriced from older rows that did not store the exact model.
+Codex summarization defaults to `gpt-5.2`; set `REMEM_CODEX_MODEL=auto` to let
+Codex choose its own default, or set any explicit Codex model name.
+
 ## Commands
 
 ```bash
@@ -165,6 +190,7 @@ remem backfill-entities
 remem encrypt
 remem api --port 5567
 remem status
+remem usage --days 14 --weeks 8
 remem pending list-failed
 remem pending retry-failed
 remem pending purge-failed

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -143,6 +143,27 @@ python3 eval/local/run_local_eval.py --n 20
 
 需要项目根目录 `.env` 中配置 `OPENAI_API_KEY`（可选 `OPENAI_BASE_URL`、`OPENAI_MODEL`）。
 
+## Token 使用量与费用统计
+
+remem 会为自己的后台提炼、总结、压缩、promotion 调用写入 AI usage
+账本。CLI 可以查看每日、每周 token 使用量和估算费用：
+
+```bash
+remem usage --days 14 --weeks 8
+remem usage --project /path/to/project --days 30 --weeks 12
+```
+
+报表包含调用次数、input/cache/output/reasoning token、total token、估算
+美元费用，以及统计精度说明。usage row 会标记来源：
+
+- `anthropic_usage`：Anthropic Messages API 返回的 provider usage
+- `codex_log`：用 remem run id 匹配 Codex session JSONL 后解析出的 token count
+- `text_estimate`：拿不到真实 usage 时，用 prompt/response 文本长度估算
+
+费用是估算，不是账单。历史数据可能是文本估算，也可能从旧的无精确模型记录
+重估过。Codex 后台总结默认使用 `gpt-5.2`；如果要让 Codex 自己选择默认模型，
+设置 `REMEM_CODEX_MODEL=auto`，也可以设置成任意明确的 Codex 模型名。
+
 ## 常用命令
 
 ```bash
@@ -157,6 +178,7 @@ remem backfill-entities
 remem encrypt
 remem api --port 5567
 remem status
+remem usage --days 14 --weeks 8
 remem pending list-failed
 remem pending retry-failed
 remem pending purge-failed

--- a/SPEC-benchmark.md
+++ b/SPEC-benchmark.md
@@ -14,9 +14,19 @@
 ```
 tests/benchmark.rs          — 端到端评估测试（#[test]）
 tests/bench_fixtures.rs     — 测试数据生成器（模拟编程会话）
+eval/local/run_local_eval.py — 本地真实记忆 QA 评估
+eval/locomo/run_locomo.py    — LoCoMo 长对话记忆评估
 ```
 
 所有测试使用 in-memory SQLite，不依赖外部 AI 服务。
+
+## Commands
+
+```bash
+cargo test --test benchmark
+python3 eval/local/run_local_eval.py --n 20
+cd eval/locomo && python3 run_locomo.py --remem-url http://127.0.0.1:7899
+```
 
 ## Evaluation Scenarios
 
@@ -41,6 +51,21 @@ Project A 存入 global preference → Project B 查询 → 验证 global scope 
 ### Scenario 7: Summary Parse & Promotion
 输入 AI 生成的 summary XML → parse_summary → promote_summary_to_memories → 验证 decisions/discoveries/preferences 被正确提取为独立记忆。
 
+### Scenario 8: Search Filter By Type
+插入不同 memory type → 按 type 搜索 → 验证过滤语义和排序稳定。
+
+### Scenario 9: Topic Key Dedup
+重复写入相同 `topic_key` → 验证 upsert/dedup 行为。
+
+### Scenario 10: Multi-hop Entity Graph Retrieval
+跨实体关系检索 → 验证 multi-hop expansion 能召回相关记忆。
+
+### Scenario 11: Entity Graph Expansion
+基于实体索引扩展候选 → 验证 2-hop 相关实体能进入结果集。
+
+### Scenario 12: Aggregate Report
+汇总 benchmark 指标 → 验证报告统计口径稳定。
+
 ## Quantitative Metrics
 
 | Metric | Formula | Target |
@@ -53,7 +78,9 @@ Project A 存入 global preference → Project B 查询 → 验证 global scope 
 | Global Visibility | global_mem_visible_in_other_project ? 1 : 0 | = 1.0 |
 | Decay Correctness | newer_ranked_higher ? 1 : 0 | = 1.0 |
 
-## Files Affected
+## Current Automated Coverage
 
-- `tests/benchmark.rs` (new)
-- `tests/bench_fixtures.rs` (new)
+- `tests/benchmark.rs` contains 16 automated benchmark tests.
+- `tests/rate_limit.rs` adds retrieval edge-case integration coverage.
+- `README.md` / `README.zh-CN.md` publish the current LoCoMo and local QA
+  benchmark snapshots.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -249,17 +249,29 @@ Short-lived process model (each hook = independent process) cannot dedup via in-
 ## AI Calls
 
 ```
-              ┌─ ANTHROPIC_API_KEY exists?
-              │
-         Yes ─┤──→ HTTP API direct (2-5s)
-              │         │ fails
-              │         ▼
-         No ──┴──→ claude -p CLI (30-60s)
+                  ┌─ executor = codex-cli?
+                  │
+             Yes ─┤──→ codex exec --model REMEM_CODEX_MODEL (default gpt-5.2)
+                  │         │
+                  │         └── usage from matching Codex session JSONL token_count
+                  │
+             No ──┴─ ANTHROPIC_API_KEY exists?
+                        │
+                   Yes ─┤──→ HTTP API direct (2-5s)
+                        │         │
+                        │         └── usage from Anthropic response.usage
+                        │
+                   No ──┴──→ claude -p CLI (30-60s)
+                                  │
+                                  └── usage fallback = text estimate
 ```
 
 - **Model mapping**: `REMEM_MODEL=haiku` → `claude-haiku-4-5-20251001` (HTTP uses full ID, CLI uses short name)
+- **Codex model**: `REMEM_CODEX_MODEL` defaults to `gpt-5.2`; set `auto` to omit `--model` and use the Codex CLI default
 - **Timeouts**: Single AI call 90s, entire worker 180s
 - **4 prompts**: observation (capture), summary (session summary), compress (long-term compression), promote (summary→memory)
+- **Usage ledger**: `ai_usage_events` stores model, operation, token breakdown, usage source, pricing source, and estimated USD cost
+- **Precision levels**: provider/log usage (`anthropic_usage`, `codex_log`) is preferred; `text_estimate` is kept only as a fallback and marked in reports
 
 ## MCP Server
 
@@ -341,18 +353,56 @@ Project key = `last two path segments + canonical absolute path hash`, balancing
 | `REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT` | `1500` | Preference section character budget |
 | `REMEM_CLAUDE_PATH` | `claude` | Claude CLI path |
 | `REMEM_CODEX_PATH` | `codex` | Codex CLI path |
-| `REMEM_CODEX_MODEL` | - | Optional Codex CLI model override |
+| `REMEM_CODEX_MODEL` | `gpt-5.2` | Codex CLI model. Set `auto` to omit `--model` and use the Codex CLI default |
 | `REMEM_LOG_MAX_BYTES` | `10485760` | Log file size limit (bytes), auto-rotated |
 | `REMEM_SAVE_MEMORY_LOCAL_COPY` | `true` | Enable local Markdown backup for save_memory |
 | `REMEM_SAVE_MEMORY_LOCAL_DIR` | `~/.remem/manual-notes` | Local backup directory |
 | `REMEM_PRICE_INPUT_PER_MTOK` | model default | Override all models input price (USD/M tokens) |
 | `REMEM_PRICE_OUTPUT_PER_MTOK` | model default | Override all models output price (USD/M tokens) |
-| `REMEM_PRICE_HAIKU_INPUT_PER_MTOK` | `0.8` | Haiku input price |
-| `REMEM_PRICE_HAIKU_OUTPUT_PER_MTOK` | `4.0` | Haiku output price |
+| `REMEM_PRICE_REASONING_PER_MTOK` | output price | Override all models reasoning token price |
+| `REMEM_PRICE_CACHE_CREATION_PER_MTOK` | input price | Override all models cache creation price |
+| `REMEM_PRICE_CACHE_READ_PER_MTOK` | input price | Override all models cache read price |
+| `REMEM_PRICE_HAIKU_INPUT_PER_MTOK` | `1.0` | Haiku input price |
+| `REMEM_PRICE_HAIKU_OUTPUT_PER_MTOK` | `5.0` | Haiku output price |
+| `REMEM_PRICE_HAIKU_REASONING_PER_MTOK` | output price | Haiku reasoning token price |
+| `REMEM_PRICE_HAIKU_CACHE_CREATION_PER_MTOK` | `1.25` | Haiku cache creation price |
+| `REMEM_PRICE_HAIKU_CACHE_READ_PER_MTOK` | `0.10` | Haiku cache read price |
 | `REMEM_PRICE_SONNET_INPUT_PER_MTOK` | `3.0` | Sonnet input price |
 | `REMEM_PRICE_SONNET_OUTPUT_PER_MTOK` | `15.0` | Sonnet output price |
+| `REMEM_PRICE_SONNET_REASONING_PER_MTOK` | output price | Sonnet reasoning token price |
+| `REMEM_PRICE_SONNET_CACHE_CREATION_PER_MTOK` | `3.75` | Sonnet cache creation price |
+| `REMEM_PRICE_SONNET_CACHE_READ_PER_MTOK` | `0.30` | Sonnet cache read price |
 | `REMEM_PRICE_OPUS_INPUT_PER_MTOK` | `15.0` | Opus input price |
 | `REMEM_PRICE_OPUS_OUTPUT_PER_MTOK` | `75.0` | Opus output price |
+| `REMEM_PRICE_OPUS_REASONING_PER_MTOK` | output price | Opus reasoning token price |
+| `REMEM_PRICE_OPUS_CACHE_CREATION_PER_MTOK` | `18.75` | Opus cache creation price |
+| `REMEM_PRICE_OPUS_CACHE_READ_PER_MTOK` | `1.50` | Opus cache read price |
+| `REMEM_PRICE_GPT5_CODEX_INPUT_PER_MTOK` | `1.75` | GPT-5.2 / GPT-5.3-Codex input price |
+| `REMEM_PRICE_GPT5_CODEX_OUTPUT_PER_MTOK` | `14.0` | GPT-5.2 / GPT-5.3-Codex output price |
+| `REMEM_PRICE_GPT5_CODEX_REASONING_PER_MTOK` | output price | GPT-5.2 / GPT-5.3-Codex reasoning token price |
+| `REMEM_PRICE_GPT5_CODEX_CACHE_CREATION_PER_MTOK` | `0.0` | GPT-5.2 / GPT-5.3-Codex cache creation price |
+| `REMEM_PRICE_GPT5_CODEX_CACHE_READ_PER_MTOK` | `0.175` | GPT-5.2 / GPT-5.3-Codex cached input price |
+
+OpenAI family price overrides also support the same suffixes for `GPT55`,
+`GPT54`, `GPT54_MINI`, `GPT54_NANO`, `GPT5`, and `CODEX_MINI`.
+
+## Usage Reporting
+
+```bash
+remem usage --days 14 --weeks 8
+remem usage --project /path/to/project --days 30 --weeks 12
+```
+
+The usage report reads `ai_usage_events` and renders:
+
+- Total calls, token breakdown, and estimated cost for the selected weekly window
+- Daily buckets for the selected day window
+- Weekly buckets for the selected week window
+- Precision summary separating provider/log usage from `text_estimate` fallback rows
+
+Cost is intentionally labeled as estimated. Historical rows can be text
+estimates or repriced rows from older schema versions; new Codex rows should use
+`codex_log` when the matching session JSONL token count is available.
 
 ## Data Cleanup
 
@@ -397,7 +447,11 @@ summarize_cooldown (project, last_summarize_epoch, last_message_hash)
 
 -- AI call statistics
 ai_usage_events (created_at_epoch, project, operation, executor, model,
-                 input_tokens, output_tokens, total_tokens, estimated_cost_usd)
+                 input_tokens, output_tokens, reasoning_tokens,
+                 cache_creation_tokens, cache_read_tokens,
+                 raw_input_tokens, raw_output_tokens,
+                 total_tokens, estimated_cost_usd,
+                 usage_source, pricing_source)
 
 -- Full-text indexes
 observations_fts (title, subtitle, narrative, facts, concepts)  -- FTS5 trigram
@@ -408,7 +462,7 @@ memories_fts (title, content)                                    -- FTS5 trigram
 
 - **Short-lived process model**: Each hook call = independent process, zero shared state, <6ms response, never blocks Claude Code
 - **SQLite constraint compensation**: No in-memory Map dedup capability, DB tables (`summarize_cooldown`) simulate rate limiting
-- **HTTP-first AI calls**: HTTP API direct 2-5s vs `claude -p` CLI 30+s, 6-12x performance gap
+- **Executor-specific AI calls**: Anthropic HTTP is preferred when API credentials exist; Codex hosts can use `codex exec` with explicit model control
 - **Stop hook async**: Dispatcher returns in 6ms, `std::process::Command` spawns independent worker
 - **SQLite single-file + WAL**: Zero dependencies, FTS5 full-text search, WAL concurrent read/write
 - **Queue batch processing**: Claude Code PostToolUse only queues (<1ms), Stop processes ≤15 events in one AI call

--- a/eval/locomo/README.md
+++ b/eval/locomo/README.md
@@ -12,15 +12,30 @@ python download_data.py
 remem api --port 7899
 
 # 3. Run benchmark (ingest + retrieve + answer + judge)
-python run_locomo.py --remem-url http://127.0.0.1:7899 --model claude-3-5-haiku-20241022
-
-# 4. Generate scores report
-python score.py --results results/locomo_results.json
+OPENAI_API_KEY=... python run_locomo.py --remem-url http://127.0.0.1:7899 --model gpt-5.4
 ```
 
-## Cost Estimate
+`run_locomo.py` writes both raw QA rows and score summaries under
+`eval/locomo/results/`. Use `--sample-index N` for one conversation and
+`--skip-ingest` when the API database already contains the LoCoMo memories.
 
-- ~1986 QA pairs (excluding category 5 adversarial)
-- Answer generation: ~1986 x ~800 tokens = ~1.6M tokens (~$0.80 with Haiku)
-- LLM judge: ~1986 x ~300 tokens = ~0.6M tokens (~$0.05 with GPT-4o-mini)
-- Total: ~$0.85 per full run
+## Current Snapshot
+
+The checked-in score files cover all 10 LoCoMo conversations after adversarial
+category skipping:
+
+| Metric | Value |
+|---|---:|
+| QA pairs | 1540 |
+| Correct | 965 |
+| Weighted overall | 62.66% |
+| Mean sample accuracy | 63.00% |
+| Model | gpt-5.4 |
+
+This matches the top-level README `v2 (optimized)` LoCoMo benchmark snapshot.
+
+## Cost Note
+
+Cost depends on the selected model, answer/judge token lengths, and whether
+ingest is re-run. Prefer `--sample-index` first when validating code changes,
+then run all 10 conversations once the pipeline is stable.

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod codex_cli;
+mod codex_usage;
 mod config;
 mod http;
 mod pricing;
@@ -14,6 +15,7 @@ use http::call_http;
 use pricing::estimate_tokens;
 use usage::record_usage;
 
+pub(crate) use types::TokenUsage;
 pub use types::UsageContext;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/ai/cli.rs
+++ b/src/ai/cli.rs
@@ -55,5 +55,7 @@ pub(super) async fn call_cli(system: &str, user_message: &str) -> Result<AiCallR
         text,
         executor: "cli",
         model,
+        usage: None,
+        usage_source: None,
     })
 }

--- a/src/ai/codex_cli.rs
+++ b/src/ai/codex_cli.rs
@@ -11,12 +11,18 @@ pub(super) async fn call_codex_cli(system: &str, user_message: &str) -> Result<A
     let codex = get_codex_path();
     let model = get_codex_model();
     let reasoning_effort = get_codex_reasoning_effort();
+    let started_at = std::time::SystemTime::now();
+    let run_id = format!(
+        "remem-usage-{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
     let output_path = std::env::temp_dir().join(format!(
         "remem-codex-summary-{}-{}.txt",
         std::process::id(),
         chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
     ));
-    let prompt = build_prompt(system, user_message);
+    let prompt = build_prompt(system, user_message, &run_id);
     let working_dir = super::stable_working_dir();
 
     let mut command = Command::new(&codex);
@@ -74,10 +80,29 @@ pub(super) async fn call_codex_cli(system: &str, user_message: &str) -> Result<A
         anyhow::bail!("codex CLI returned empty response");
     }
 
+    let codex_usage = match super::codex_usage::collect_codex_usage_for_run(&run_id, started_at) {
+        Ok(usage) => usage,
+        Err(error) => {
+            crate::log::warn("ai", &format!("codex usage parse failed: {}", error));
+            None
+        }
+    };
+    if codex_usage.is_none() {
+        crate::log::warn("ai", "codex usage parse found no matching token_count log");
+    }
+    let usage = codex_usage
+        .as_ref()
+        .map(|run_usage| run_usage.usage.clone());
+    let usage_model = codex_usage.and_then(|run_usage| run_usage.model);
+
     Ok(AiCallResult {
         text,
         executor: "codex-cli",
-        model: model.unwrap_or_else(|| "codex-default".to_string()),
+        model: usage_model
+            .or(model)
+            .unwrap_or_else(|| "codex-default".to_string()),
+        usage,
+        usage_source: Some("codex_log"),
     })
 }
 
@@ -118,13 +143,14 @@ fn build_codex_args(
     args
 }
 
-fn build_prompt(system: &str, user_message: &str) -> String {
+fn build_prompt(system: &str, user_message: &str, run_id: &str) -> String {
     format!(
         "You are running as remem's Codex CLI summarization backend.\n\
          Follow the system instructions exactly and return only the requested output.\n\n\
+         <remem_usage_run_id>{}</remem_usage_run_id>\n\n\
          <system>\n{}\n</system>\n\n\
          <input>\n{}\n</input>\n",
-        system, user_message
+        run_id, system, user_message
     )
 }
 

--- a/src/ai/codex_usage.rs
+++ b/src/ai/codex_usage.rs
@@ -1,0 +1,294 @@
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::ai::types::TokenUsage;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CodexRunUsage {
+    pub usage: TokenUsage,
+    pub model: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct CodexCounters {
+    input_tokens: i64,
+    cached_input_tokens: i64,
+    output_tokens: i64,
+    reasoning_output_tokens: i64,
+    total_tokens: i64,
+}
+
+impl CodexCounters {
+    fn from_value(value: &Value) -> Self {
+        Self {
+            input_tokens: json_i64(value, "input_tokens"),
+            cached_input_tokens: json_i64(value, "cached_input_tokens")
+                .max(json_i64(value, "cache_read_input_tokens")),
+            output_tokens: json_i64(value, "output_tokens"),
+            reasoning_output_tokens: json_i64(value, "reasoning_output_tokens"),
+            total_tokens: json_i64(value, "total_tokens"),
+        }
+    }
+
+    fn subtract(self, previous: Self) -> Self {
+        Self {
+            input_tokens: (self.input_tokens - previous.input_tokens).max(0),
+            cached_input_tokens: (self.cached_input_tokens - previous.cached_input_tokens).max(0),
+            output_tokens: (self.output_tokens - previous.output_tokens).max(0),
+            reasoning_output_tokens: (self.reasoning_output_tokens
+                - previous.reasoning_output_tokens)
+                .max(0),
+            total_tokens: (self.total_tokens - previous.total_tokens).max(0),
+        }
+    }
+
+    fn is_empty(self) -> bool {
+        self.input_tokens == 0
+            && self.cached_input_tokens == 0
+            && self.output_tokens == 0
+            && self.reasoning_output_tokens == 0
+    }
+
+    fn into_token_usage(self) -> TokenUsage {
+        let input_tokens = (self.input_tokens - self.cached_input_tokens).max(0);
+        let output_tokens = (self.output_tokens - self.reasoning_output_tokens).max(0);
+        TokenUsage {
+            input_tokens,
+            output_tokens,
+            reasoning_tokens: self.reasoning_output_tokens,
+            cache_read_tokens: self.cached_input_tokens,
+            raw_input_tokens: self.input_tokens,
+            raw_output_tokens: self.output_tokens,
+            ..TokenUsage::default()
+        }
+    }
+}
+
+pub(super) fn collect_codex_usage_for_run(
+    run_id: &str,
+    started_at: SystemTime,
+) -> Result<Option<CodexRunUsage>> {
+    let Some(sessions_dir) = codex_sessions_dir() else {
+        return Ok(None);
+    };
+    let threshold = started_at
+        .checked_sub(Duration::from_secs(60))
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+
+    let mut files = Vec::new();
+    collect_recent_jsonl_files(&sessions_dir, threshold, &mut files)?;
+
+    let mut aggregate = TokenUsage::default();
+    let mut model = None;
+    let mut matched_any = false;
+    for path in files {
+        let Some(run_usage) = parse_codex_file(&path, run_id)? else {
+            continue;
+        };
+        matched_any = true;
+        aggregate.add(&run_usage.usage);
+        if run_usage.model.is_some() {
+            model = run_usage.model;
+        }
+    }
+
+    if matched_any && !aggregate.is_empty() {
+        Ok(Some(CodexRunUsage {
+            usage: aggregate,
+            model,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+fn codex_sessions_dir() -> Option<PathBuf> {
+    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
+        let path = PathBuf::from(codex_home).join("sessions");
+        if path.is_dir() {
+            return Some(path);
+        }
+    }
+
+    let home = dirs::home_dir()?;
+    let path = home.join(".codex").join("sessions");
+    path.is_dir().then_some(path)
+}
+
+fn collect_recent_jsonl_files(
+    dir: &Path,
+    threshold: SystemTime,
+    out: &mut Vec<PathBuf>,
+) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_recent_jsonl_files(&path, threshold, out)?;
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        if modified >= threshold {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn parse_codex_file(path: &Path, run_id: &str) -> Result<Option<CodexRunUsage>> {
+    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    parse_codex_reader(BufReader::new(file), run_id)
+}
+
+fn parse_codex_reader(reader: impl BufRead, run_id: &str) -> Result<Option<CodexRunUsage>> {
+    let mut saw_run_id = false;
+    let mut previous_total: Option<CodexCounters> = None;
+    let mut current_model: Option<String> = None;
+    let mut usage = TokenUsage::default();
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.contains(run_id) {
+            saw_run_id = true;
+        }
+        if !saw_run_id {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let entry_type = value.get("type").and_then(Value::as_str);
+        let Some(payload) = value.get("payload") else {
+            continue;
+        };
+
+        if entry_type == Some("turn_context") {
+            if let Some(model) = extract_model(payload) {
+                current_model = Some(model);
+            }
+            continue;
+        }
+
+        if entry_type != Some("event_msg")
+            || payload.get("type").and_then(Value::as_str) != Some("token_count")
+        {
+            continue;
+        }
+
+        let Some(info) = payload.get("info") else {
+            continue;
+        };
+        if let Some(model) = extract_model(payload) {
+            current_model = Some(model);
+        }
+
+        let Some(total_value) = info.get("total_token_usage") else {
+            continue;
+        };
+        let total = CodexCounters::from_value(total_value);
+        if previous_total.is_some_and(|previous| total.total_tokens == previous.total_tokens) {
+            continue;
+        }
+
+        let delta = info
+            .get("last_token_usage")
+            .map(CodexCounters::from_value)
+            .filter(|counters| !counters.is_empty())
+            .unwrap_or_else(|| previous_total.map_or(total, |previous| total.subtract(previous)));
+        previous_total = Some(total);
+        if delta.is_empty() {
+            continue;
+        }
+        usage.add(&delta.into_token_usage());
+    }
+
+    if saw_run_id {
+        Ok(Some(CodexRunUsage {
+            usage,
+            model: current_model,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+fn extract_model(payload: &Value) -> Option<String> {
+    let info = payload.get("info");
+    [
+        info.and_then(|value| value.get("model")),
+        info.and_then(|value| value.get("model_name")),
+        info.and_then(|value| value.get("metadata"))
+            .and_then(|metadata| metadata.get("model")),
+        payload.get("model"),
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(Value::as_str)
+    .map(str::trim)
+    .find(|model| !model.is_empty())
+    .map(ToOwned::to_owned)
+}
+
+fn json_i64(value: &Value, key: &str) -> i64 {
+    value.get(key).and_then(Value::as_i64).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::parse_codex_reader;
+
+    #[test]
+    fn parses_last_token_usage_after_run_marker() {
+        let log = r#"
+{"type":"response_item","payload":{"item":{"type":"message","content":[{"text":"run remem-usage-1"}]}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"model":"gpt-5.5","total_token_usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":500,"reasoning_output_tokens":150,"total_tokens":1500},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":500,"reasoning_output_tokens":150,"total_tokens":1500}}}}
+"#;
+        let parsed = parse_codex_reader(Cursor::new(log), "remem-usage-1")
+            .expect("parse should succeed")
+            .expect("run should match");
+        assert_eq!(parsed.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(parsed.usage.input_tokens, 800);
+        assert_eq!(parsed.usage.cache_read_tokens, 200);
+        assert_eq!(parsed.usage.output_tokens, 350);
+        assert_eq!(parsed.usage.reasoning_tokens, 150);
+        assert_eq!(parsed.usage.total_tokens(), 1500);
+    }
+
+    #[test]
+    fn computes_delta_when_last_usage_is_missing() {
+        let log = r#"
+{"type":"response_item","payload":{"item":{"type":"message","content":[{"text":"run remem-usage-2"}]}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"model":"gpt-5.4","total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":150}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"model":"gpt-5.4","total_token_usage":{"input_tokens":400,"cached_input_tokens":100,"output_tokens":150,"reasoning_output_tokens":40,"total_tokens":550}}}}
+"#;
+        let parsed = parse_codex_reader(Cursor::new(log), "remem-usage-2")
+            .expect("parse should succeed")
+            .expect("run should match");
+        assert_eq!(parsed.usage.input_tokens, 300);
+        assert_eq!(parsed.usage.cache_read_tokens, 100);
+        assert_eq!(parsed.usage.output_tokens, 110);
+        assert_eq!(parsed.usage.reasoning_tokens, 40);
+        assert_eq!(parsed.usage.total_tokens(), 550);
+    }
+
+    #[test]
+    fn ignores_files_without_run_marker() {
+        let log = r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":50,"total_tokens":150}}}}"#;
+        let parsed = parse_codex_reader(Cursor::new(log), "missing").expect("parse should succeed");
+        assert!(parsed.is_none());
+    }
+}

--- a/src/ai/config.rs
+++ b/src/ai/config.rs
@@ -1,3 +1,5 @@
+const DEFAULT_CODEX_MODEL: &str = "gpt-5.2";
+
 pub(super) fn get_model_raw() -> String {
     std::env::var("REMEM_MODEL").unwrap_or_else(|_| "haiku".to_string())
 }
@@ -22,9 +24,11 @@ pub(super) fn get_codex_path() -> String {
 }
 
 pub(super) fn get_codex_model() -> Option<String> {
-    std::env::var("REMEM_CODEX_MODEL")
-        .ok()
-        .filter(|model| !model.trim().is_empty())
+    match std::env::var("REMEM_CODEX_MODEL") {
+        Ok(model) if model.trim().eq_ignore_ascii_case("auto") => None,
+        Ok(model) if !model.trim().is_empty() => Some(model),
+        _ => Some(DEFAULT_CODEX_MODEL.to_string()),
+    }
 }
 
 pub(super) fn get_codex_reasoning_effort() -> Option<String> {

--- a/src/ai/http.rs
+++ b/src/ai/http.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 
 use crate::ai::config::{get_model_raw, resolve_model_for_api};
-use crate::ai::types::{AiCallResult, AI_TIMEOUT_SECS};
+use crate::ai::types::{AiCallResult, TokenUsage, AI_TIMEOUT_SECS};
 
 pub(super) async fn call_http(system: &str, user_message: &str) -> Result<AiCallResult> {
     let api_key = std::env::var("ANTHROPIC_API_KEY")
@@ -43,11 +43,14 @@ pub(super) async fn call_http(system: &str, user_message: &str) -> Result<AiCall
 
     let data: serde_json::Value = resp.json().await?;
     let text = extract_text(&data)?;
+    let usage = extract_usage(&data);
 
     Ok(AiCallResult {
         text,
         executor: "http",
         model: model.to_string(),
+        usage,
+        usage_source: Some("anthropic_usage"),
     })
 }
 
@@ -72,9 +75,33 @@ fn extract_text(data: &serde_json::Value) -> Result<String> {
     Ok(text)
 }
 
+fn json_i64(data: &serde_json::Value, key: &str) -> i64 {
+    data.get(key)
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0)
+}
+
+fn extract_usage(data: &serde_json::Value) -> Option<TokenUsage> {
+    let usage = data.get("usage")?;
+    let input_tokens = json_i64(usage, "input_tokens");
+    let output_tokens = json_i64(usage, "output_tokens");
+    let cache_creation_tokens = json_i64(usage, "cache_creation_input_tokens");
+    let cache_read_tokens = json_i64(usage, "cache_read_input_tokens");
+    let token_usage = TokenUsage {
+        input_tokens,
+        output_tokens,
+        cache_creation_tokens,
+        cache_read_tokens,
+        raw_input_tokens: input_tokens + cache_creation_tokens + cache_read_tokens,
+        raw_output_tokens: output_tokens,
+        ..TokenUsage::default()
+    };
+    (!token_usage.is_empty()).then_some(token_usage)
+}
+
 #[cfg(test)]
 mod http_tests {
-    use super::extract_text;
+    use super::{extract_text, extract_usage};
     use serde_json::json;
 
     #[test]
@@ -119,5 +146,24 @@ mod http_tests {
         let data = json!({"content": [{"type": "text", "text": ""}]});
         let err = extract_text(&data).unwrap_err().to_string();
         assert!(err.contains("empty text body"), "got: {err}");
+    }
+
+    #[test]
+    fn extracts_anthropic_usage_breakdown() {
+        let data = json!({
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 40,
+                "cache_creation_input_tokens": 20,
+                "cache_read_input_tokens": 300
+            }
+        });
+        let usage = extract_usage(&data).expect("usage should parse");
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 40);
+        assert_eq!(usage.cache_creation_tokens, 20);
+        assert_eq!(usage.cache_read_tokens, 300);
+        assert_eq!(usage.raw_input_tokens, 420);
+        assert_eq!(usage.total_tokens(), 460);
     }
 }

--- a/src/ai/pricing.rs
+++ b/src/ai/pricing.rs
@@ -2,38 +2,133 @@ fn parse_env_f64(key: &str) -> Option<f64> {
     std::env::var(key).ok()?.trim().parse::<f64>().ok()
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct ModelPricing {
+    input_per_mtok: f64,
+    output_per_mtok: f64,
+    reasoning_per_mtok: f64,
+    cache_creation_per_mtok: f64,
+    cache_read_per_mtok: f64,
+    source: &'static str,
+}
+
+impl ModelPricing {
+    fn new(input: f64, output: f64, cache_creation: f64, cache_read: f64) -> Self {
+        Self {
+            input_per_mtok: input,
+            output_per_mtok: output,
+            reasoning_per_mtok: output,
+            cache_creation_per_mtok: cache_creation,
+            cache_read_per_mtok: cache_read,
+            source: "remem_static",
+        }
+    }
+
+    fn openai(input: f64, output: f64, cache_read: f64) -> Self {
+        Self::new(input, output, 0.0, cache_read)
+    }
+}
+
 pub(super) fn estimate_tokens(text: &str) -> i64 {
     ((text.len() + 3) / 4) as i64
 }
 
+#[cfg(test)]
 pub(super) fn pricing_for_model(model: &str) -> (f64, f64) {
-    if let (Some(input), Some(output)) = (
-        parse_env_f64("REMEM_PRICE_INPUT_PER_MTOK"),
-        parse_env_f64("REMEM_PRICE_OUTPUT_PER_MTOK"),
-    ) {
-        return (input, output);
+    pricing_breakdown_for_model(model)
+        .map(|pricing| (pricing.input_per_mtok, pricing.output_per_mtok))
+        .unwrap_or((0.0, 0.0))
+}
+
+pub(super) fn pricing_breakdown_for_model(model: &str) -> Option<ModelPricing> {
+    if let Some(pricing) = env_pricing() {
+        return Some(pricing);
     }
 
     let model_lower = model.to_lowercase();
-    let (input_default, output_default, prefix) = if model_lower.contains("opus") {
-        (15.0, 75.0, "OPUS")
+    let (default, prefix) = if model_lower.contains("opus-4-7")
+        || model_lower.contains("opus-4.7")
+        || model_lower.contains("opus-4-6")
+        || model_lower.contains("opus-4.6")
+        || model_lower.contains("opus-4-5")
+        || model_lower.contains("opus-4.5")
+    {
+        (ModelPricing::new(5.0, 25.0, 6.25, 0.50), "OPUS")
+    } else if model_lower.contains("opus") {
+        (ModelPricing::new(15.0, 75.0, 18.75, 1.50), "OPUS")
     } else if model_lower.contains("sonnet") {
-        (3.0, 15.0, "SONNET")
+        (ModelPricing::new(3.0, 15.0, 3.75, 0.30), "SONNET")
     } else if model_lower.contains("haiku") {
-        (0.8, 4.0, "HAIKU")
+        (ModelPricing::new(1.0, 5.0, 1.25, 0.10), "HAIKU")
+    } else if model_lower.contains("gpt-5.5") {
+        (ModelPricing::openai(5.0, 30.0, 0.50), "GPT55")
+    } else if model_lower.contains("gpt-5.4-mini") {
+        (ModelPricing::openai(0.75, 4.5, 0.075), "GPT54_MINI")
+    } else if model_lower.contains("gpt-5.4-nano") {
+        (ModelPricing::openai(0.20, 1.25, 0.020), "GPT54_NANO")
+    } else if model_lower.contains("gpt-5.4") {
+        (ModelPricing::openai(2.5, 15.0, 0.25), "GPT54")
+    } else if model_lower.contains("gpt-5.2") || model_lower.contains("gpt-5.3-codex") {
+        (ModelPricing::openai(1.75, 14.0, 0.175), "GPT5_CODEX")
+    } else if model_lower.contains("gpt-5-codex") || model_lower.contains("gpt-5.1-codex") {
+        (ModelPricing::openai(1.25, 10.0, 0.125), "GPT5_CODEX")
+    } else if model_lower.contains("codex-mini") {
+        (ModelPricing::openai(1.5, 6.0, 0.375), "CODEX_MINI")
+    } else if model_lower.contains("codex") || model_lower.contains("gpt-5") {
+        (ModelPricing::openai(1.25, 10.0, 0.125), "GPT5")
+    } else if model_lower.contains("gpt-4") {
+        (ModelPricing::openai(2.5, 10.0, 0.0), "GPT4")
     } else {
-        (0.0, 0.0, "UNKNOWN")
+        return None;
     };
 
-    let input =
-        parse_env_f64(&format!("REMEM_PRICE_{}_INPUT_PER_MTOK", prefix)).unwrap_or(input_default);
-    let output =
-        parse_env_f64(&format!("REMEM_PRICE_{}_OUTPUT_PER_MTOK", prefix)).unwrap_or(output_default);
-    (input, output)
+    Some(apply_family_env(default, prefix))
 }
 
-pub(super) fn estimate_cost_usd(model: &str, input_tokens: i64, output_tokens: i64) -> f64 {
-    let (input_per_mtok, output_per_mtok) = pricing_for_model(model);
-    (input_tokens as f64 / 1_000_000.0) * input_per_mtok
-        + (output_tokens as f64 / 1_000_000.0) * output_per_mtok
+fn env_pricing() -> Option<ModelPricing> {
+    let input = parse_env_f64("REMEM_PRICE_INPUT_PER_MTOK")?;
+    let output = parse_env_f64("REMEM_PRICE_OUTPUT_PER_MTOK")?;
+    Some(ModelPricing {
+        input_per_mtok: input,
+        output_per_mtok: output,
+        reasoning_per_mtok: parse_env_f64("REMEM_PRICE_REASONING_PER_MTOK").unwrap_or(output),
+        cache_creation_per_mtok: parse_env_f64("REMEM_PRICE_CACHE_CREATION_PER_MTOK")
+            .unwrap_or(input),
+        cache_read_per_mtok: parse_env_f64("REMEM_PRICE_CACHE_READ_PER_MTOK").unwrap_or(input),
+        source: "env_override",
+    })
+}
+
+fn apply_family_env(default: ModelPricing, prefix: &str) -> ModelPricing {
+    let input = parse_env_f64(&format!("REMEM_PRICE_{}_INPUT_PER_MTOK", prefix))
+        .unwrap_or(default.input_per_mtok);
+    let output = parse_env_f64(&format!("REMEM_PRICE_{}_OUTPUT_PER_MTOK", prefix))
+        .unwrap_or(default.output_per_mtok);
+    ModelPricing {
+        input_per_mtok: input,
+        output_per_mtok: output,
+        reasoning_per_mtok: parse_env_f64(&format!("REMEM_PRICE_{}_REASONING_PER_MTOK", prefix))
+            .unwrap_or(output),
+        cache_creation_per_mtok: parse_env_f64(&format!(
+            "REMEM_PRICE_{}_CACHE_CREATION_PER_MTOK",
+            prefix
+        ))
+        .unwrap_or(default.cache_creation_per_mtok),
+        cache_read_per_mtok: parse_env_f64(&format!("REMEM_PRICE_{}_CACHE_READ_PER_MTOK", prefix))
+            .unwrap_or(default.cache_read_per_mtok),
+        source: default.source,
+    }
+}
+
+pub(super) fn estimate_cost_usd(model: &str, usage: &crate::ai::TokenUsage) -> (f64, &'static str) {
+    let Some(pricing) = pricing_breakdown_for_model(model) else {
+        return (0.0, "unknown_pricing");
+    };
+
+    let cost = (usage.input_tokens as f64 / 1_000_000.0) * pricing.input_per_mtok
+        + (usage.output_tokens as f64 / 1_000_000.0) * pricing.output_per_mtok
+        + (usage.reasoning_tokens as f64 / 1_000_000.0) * pricing.reasoning_per_mtok
+        + (usage.cache_creation_tokens as f64 / 1_000_000.0) * pricing.cache_creation_per_mtok
+        + (usage.cache_read_tokens as f64 / 1_000_000.0) * pricing.cache_read_per_mtok;
+    (cost, pricing.source)
 }

--- a/src/ai/tests.rs
+++ b/src/ai/tests.rs
@@ -1,7 +1,8 @@
 use std::sync::Mutex;
 
-use super::config::resolve_model_for_api;
+use super::config::{get_codex_model, resolve_model_for_api};
 use super::pricing::{estimate_cost_usd, pricing_for_model};
+use super::TokenUsage;
 use super::{executor_for_operation, stable_working_dir, AiExecutor};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -53,7 +54,32 @@ fn pricing_for_model_uses_model_defaults() {
             ("REMEM_PRICE_HAIKU_OUTPUT_PER_MTOK", None),
         ],
         || {
-            assert_eq!(pricing_for_model("haiku"), (0.8, 4.0));
+            assert_eq!(pricing_for_model("haiku"), (1.0, 5.0));
+        },
+    );
+}
+
+#[test]
+fn codex_model_defaults_to_gpt_52_and_allows_auto() {
+    with_env_vars(&[("REMEM_CODEX_MODEL", None)], || {
+        assert_eq!(get_codex_model().as_deref(), Some("gpt-5.2"));
+    });
+    with_env_vars(&[("REMEM_CODEX_MODEL", Some("auto"))], || {
+        assert_eq!(get_codex_model(), None);
+    });
+}
+
+#[test]
+fn pricing_for_gpt_52_uses_current_flagship_rate() {
+    with_env_vars(
+        &[
+            ("REMEM_PRICE_INPUT_PER_MTOK", None),
+            ("REMEM_PRICE_OUTPUT_PER_MTOK", None),
+            ("REMEM_PRICE_GPT5_CODEX_INPUT_PER_MTOK", None),
+            ("REMEM_PRICE_GPT5_CODEX_OUTPUT_PER_MTOK", None),
+        ],
+        || {
+            assert_eq!(pricing_for_model("gpt-5.2"), (1.75, 14.0));
         },
     );
 }
@@ -79,8 +105,35 @@ fn estimate_cost_usd_combines_input_and_output_prices() {
             ("REMEM_PRICE_OUTPUT_PER_MTOK", Some("8.0")),
         ],
         || {
-            let cost = estimate_cost_usd("any-model", 500_000, 250_000);
+            let usage = TokenUsage::estimated(500_000, 250_000);
+            let (cost, pricing_source) = estimate_cost_usd("any-model", &usage);
+            assert_eq!(pricing_source, "env_override");
             assert!((cost - 3.0).abs() < f64::EPSILON);
+        },
+    );
+}
+
+#[test]
+fn estimate_cost_usd_charges_cache_and_reasoning_separately() {
+    with_env_vars(
+        &[
+            ("REMEM_PRICE_INPUT_PER_MTOK", None),
+            ("REMEM_PRICE_OUTPUT_PER_MTOK", None),
+            ("REMEM_PRICE_REASONING_PER_MTOK", None),
+            ("REMEM_PRICE_CACHE_READ_PER_MTOK", None),
+            ("REMEM_PRICE_CACHE_CREATION_PER_MTOK", None),
+        ],
+        || {
+            let usage = TokenUsage {
+                input_tokens: 1_000_000,
+                output_tokens: 1_000_000,
+                reasoning_tokens: 1_000_000,
+                cache_read_tokens: 1_000_000,
+                ..TokenUsage::default()
+            };
+            let (cost, pricing_source) = estimate_cost_usd("gpt-5.5", &usage);
+            assert_eq!(pricing_source, "remem_static");
+            assert!((cost - 65.5).abs() < f64::EPSILON);
         },
     );
 }

--- a/src/ai/types.rs
+++ b/src/ai/types.rs
@@ -6,8 +6,55 @@ pub struct UsageContext<'a> {
     pub operation: &'a str,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct TokenUsage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub raw_input_tokens: i64,
+    pub raw_output_tokens: i64,
+}
+
+impl TokenUsage {
+    pub fn estimated(input_tokens: i64, output_tokens: i64) -> Self {
+        Self {
+            input_tokens,
+            output_tokens,
+            raw_input_tokens: input_tokens,
+            raw_output_tokens: output_tokens,
+            ..Self::default()
+        }
+    }
+
+    pub fn total_tokens(&self) -> i64 {
+        self.input_tokens
+            + self.output_tokens
+            + self.reasoning_tokens
+            + self.cache_creation_tokens
+            + self.cache_read_tokens
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_tokens() == 0
+    }
+
+    pub fn add(&mut self, other: &Self) {
+        self.input_tokens += other.input_tokens;
+        self.output_tokens += other.output_tokens;
+        self.reasoning_tokens += other.reasoning_tokens;
+        self.cache_creation_tokens += other.cache_creation_tokens;
+        self.cache_read_tokens += other.cache_read_tokens;
+        self.raw_input_tokens += other.raw_input_tokens;
+        self.raw_output_tokens += other.raw_output_tokens;
+    }
+}
+
 pub(super) struct AiCallResult {
     pub text: String,
     pub executor: &'static str,
     pub model: String,
+    pub usage: Option<TokenUsage>,
+    pub usage_source: Option<&'static str>,
 }

--- a/src/ai/usage.rs
+++ b/src/ai/usage.rs
@@ -1,5 +1,5 @@
 use crate::ai::pricing::estimate_cost_usd;
-use crate::ai::types::{AiCallResult, UsageContext};
+use crate::ai::types::{AiCallResult, TokenUsage, UsageContext};
 
 pub(super) fn record_usage(
     ctx: UsageContext<'_>,
@@ -12,7 +12,23 @@ pub(super) fn record_usage(
     } else {
         ctx.operation
     };
-    let cost = estimate_cost_usd(&result.model, input_tokens, output_tokens);
+    let (usage, usage_source) = match &result.usage {
+        Some(usage) => (
+            usage.clone(),
+            result.usage_source.unwrap_or("provider_usage"),
+        ),
+        None => (
+            TokenUsage::estimated(input_tokens, output_tokens),
+            "text_estimate",
+        ),
+    };
+    let (cost, pricing_source) = estimate_cost_usd(&result.model, &usage);
+    if pricing_source == "unknown_pricing" && !usage.is_empty() {
+        crate::log::warn(
+            "ai",
+            &format!("usage cost has unknown pricing for model {}", result.model),
+        );
+    }
     match crate::db::open_db().and_then(|conn| {
         crate::db::record_ai_usage(
             &conn,
@@ -20,8 +36,9 @@ pub(super) fn record_usage(
             operation,
             result.executor,
             Some(&result.model),
-            input_tokens,
-            output_tokens,
+            &usage,
+            usage_source,
+            pricing_source,
             cost,
         )?;
         Ok(())

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -7,6 +7,7 @@ mod preferences;
 mod query;
 mod review;
 mod shared;
+mod usage;
 
 pub(super) use admin::run_admin;
 pub(super) use eval::{run_eval, run_eval_local};
@@ -16,3 +17,4 @@ pub(super) use pending::run_pending;
 pub(super) use preferences::run_preferences;
 pub(super) use query::{run_backfill_entities, run_search, run_show, run_status};
 pub(super) use review::run_review;
+pub(super) use usage::run_usage;

--- a/src/cli/actions/usage.rs
+++ b/src/cli/actions/usage.rs
@@ -1,0 +1,165 @@
+use anyhow::{bail, Result};
+
+use crate::db::{self, AiUsageSourceTotals, AiUsageTotals};
+
+const SECS_PER_DAY: i64 = 86_400;
+const SECS_PER_WEEK: i64 = 7 * SECS_PER_DAY;
+
+pub(in crate::cli) fn run_usage(project: Option<&str>, days: i64, weeks: i64) -> Result<()> {
+    validate_window("days", days)?;
+    validate_window("weeks", weeks)?;
+
+    let conn = db::open_db()?;
+    let now = chrono::Utc::now().timestamp();
+    let daily_since = now.saturating_sub(days.saturating_mul(SECS_PER_DAY));
+    let weekly_since = now.saturating_sub(weeks.saturating_mul(SECS_PER_WEEK));
+    let totals = db::query_ai_usage_totals(&conn, Some(weekly_since), project)?;
+    let source_totals = db::query_ai_usage_source_totals(&conn, Some(weekly_since), project)?;
+    let daily = db::query_daily_ai_usage(&conn, daily_since, project, days)?;
+    let weekly = db::query_weekly_ai_usage(&conn, weekly_since, project, weeks)?;
+
+    println!("Token usage");
+    match project {
+        Some(project) => println!("Project: {}", project),
+        None => println!("Project: all"),
+    }
+    println!();
+    print_totals(&format!("Last {weeks} weeks"), &totals);
+    print_precision(&source_totals);
+    println!();
+    print_daily(days, &daily);
+    println!();
+    print_weekly(weeks, &weekly);
+
+    Ok(())
+}
+
+fn print_precision(rows: &[AiUsageSourceTotals]) {
+    if rows.is_empty() {
+        return;
+    }
+
+    let estimated_calls: i64 = rows
+        .iter()
+        .filter(|row| row.usage_source == "text_estimate")
+        .map(|row| row.calls)
+        .sum();
+    let exact_calls: i64 = rows
+        .iter()
+        .filter(|row| row.usage_source != "text_estimate")
+        .map(|row| row.calls)
+        .sum();
+    let estimated_tokens: i64 = rows
+        .iter()
+        .filter(|row| row.usage_source == "text_estimate")
+        .map(|row| row.total_tokens)
+        .sum();
+
+    println!(
+        "  Usage precision:       {:>12} exact/provider/log calls, {:>12} text-estimate calls",
+        exact_calls, estimated_calls
+    );
+    if estimated_tokens > 0 {
+        println!(
+            "  Precision note:        {:>12} tokens are text estimates, not provider invoice data",
+            estimated_tokens
+        );
+    }
+}
+
+fn validate_window(name: &str, value: i64) -> Result<()> {
+    if value < 1 {
+        bail!("{name} must be at least 1");
+    }
+    Ok(())
+}
+
+fn print_totals(label: &str, totals: &AiUsageTotals) {
+    println!("{label}:");
+    println!("  Calls:                 {:>12}", totals.calls);
+    println!("  Input tokens:          {:>12}", totals.input_tokens);
+    println!(
+        "  Cache creation tokens: {:>12}",
+        totals.cache_creation_tokens
+    );
+    println!("  Cache read tokens:     {:>12}", totals.cache_read_tokens);
+    println!("  Output tokens:         {:>12}", totals.output_tokens);
+    println!("  Reasoning tokens:      {:>12}", totals.reasoning_tokens);
+    println!("  Total tokens:          {:>12}", totals.total_tokens);
+    println!(
+        "  Est. cost:             ${:>11.4}",
+        totals.estimated_cost_usd
+    );
+}
+
+fn print_daily(days: i64, rows: &[db::DailyAiUsage]) {
+    println!("Daily (last {days} days):");
+    if rows.is_empty() {
+        println!("  No usage events");
+        return;
+    }
+    print_header("Day");
+    for row in rows {
+        print_row(
+            &row.day,
+            row.calls,
+            row.input_tokens,
+            row.cache_creation_tokens + row.cache_read_tokens,
+            row.output_tokens,
+            row.reasoning_tokens,
+            row.total_tokens,
+            row.estimated_cost_usd,
+        );
+    }
+}
+
+fn print_weekly(weeks: i64, rows: &[db::WeeklyAiUsage]) {
+    println!("Weekly (last {weeks} weeks):");
+    if rows.is_empty() {
+        println!("  No usage events");
+        return;
+    }
+    print_header("Week");
+    for row in rows {
+        print_row(
+            &row.week,
+            row.calls,
+            row.input_tokens,
+            row.cache_creation_tokens + row.cache_read_tokens,
+            row.output_tokens,
+            row.reasoning_tokens,
+            row.total_tokens,
+            row.estimated_cost_usd,
+        );
+    }
+}
+
+fn print_header(label: &str) {
+    println!(
+        "  {:<12} {:>7} {:>11} {:>11} {:>11} {:>11} {:>12} {:>10}",
+        label, "Calls", "Input", "Cache", "Output", "Reasoning", "Total", "Cost"
+    );
+}
+
+fn print_row(
+    label: &str,
+    calls: i64,
+    input_tokens: i64,
+    cache_tokens: i64,
+    output_tokens: i64,
+    reasoning_tokens: i64,
+    total_tokens: i64,
+    estimated_cost_usd: f64,
+) {
+    println!(
+        "  {:<12} {:>7} {:>11} {:>11} {:>11} {:>11} {:>12} ${:>9.4}",
+        label,
+        calls,
+        input_tokens,
+        cache_tokens,
+        output_tokens,
+        reasoning_tokens,
+        total_tokens,
+        estimated_cost_usd
+    );
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -5,7 +5,7 @@ use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 use super::actions::{
     run_admin, run_backfill_entities, run_cleanup, run_dream, run_encrypt, run_eval,
     run_eval_local, run_import, run_pending, run_preferences, run_review, run_search, run_show,
-    run_status,
+    run_status, run_usage,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands};
@@ -55,6 +55,11 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         Commands::Preferences { action } => run_preferences(action)?,
         Commands::Pending { action } => run_pending(action)?,
         Commands::Review { action } => run_review(action)?,
+        Commands::Usage {
+            project,
+            days,
+            weeks,
+        } => run_usage(project.as_deref(), days, weeks)?,
         Commands::Status => run_status()?,
         Commands::Doctor { json, quiet } => {
             let outcome = doctor::run_doctor(doctor::DoctorOptions { json, quiet })?;

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -54,3 +54,30 @@ fn cli_parses_review_edit_options() {
         _ => panic!("expected review edit command"),
     }
 }
+
+#[test]
+fn cli_parses_usage_options() {
+    let cli = Cli::parse_from([
+        "remem",
+        "usage",
+        "--project",
+        "/tmp/remem",
+        "--days",
+        "30",
+        "--weeks",
+        "12",
+    ]);
+
+    match cli.command {
+        Commands::Usage {
+            project,
+            days,
+            weeks,
+        } => {
+            assert_eq!(project.as_deref(), Some("/tmp/remem"));
+            assert_eq!(days, 30);
+            assert_eq!(weeks, 12);
+        }
+        _ => panic!("expected usage command"),
+    }
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -67,6 +67,17 @@ pub(super) enum Commands {
         #[command(subcommand)]
         action: ReviewAction,
     },
+    Usage {
+        /// Restrict usage totals to one project path.
+        #[arg(long, short)]
+        project: Option<String>,
+        /// Number of daily buckets to show.
+        #[arg(long, default_value = "14")]
+        days: i64,
+        /// Number of weekly buckets to show.
+        #[arg(long, default_value = "8")]
+        weeks: i64,
+    },
     Status,
     Doctor {
         /// Emit a single JSON object with per-check status. Stable shape;

--- a/src/db.rs
+++ b/src/db.rs
@@ -24,5 +24,5 @@ pub use observation::*;
 pub use pending::*;
 pub use query::*;
 pub use summarize::*;
-pub use usage::*;
+pub(crate) use usage::*;
 pub use worker::*;

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -94,7 +94,7 @@ pub struct Job {
     pub max_attempts: i64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AiUsageEvent {
     pub created_at: String,
     pub project: Option<String>,
@@ -103,25 +103,60 @@ pub struct AiUsageEvent {
     pub model: Option<String>,
     pub input_tokens: i64,
     pub output_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub raw_input_tokens: i64,
+    pub raw_output_tokens: i64,
     pub total_tokens: i64,
     pub estimated_cost_usd: f64,
+    pub usage_source: String,
+    pub pricing_source: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DailyAiUsage {
     pub day: String,
     pub calls: i64,
     pub input_tokens: i64,
     pub output_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
     pub total_tokens: i64,
     pub estimated_cost_usd: f64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct WeeklyAiUsage {
+    pub week: String,
+    pub calls: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub estimated_cost_usd: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct AiUsageTotals {
     pub calls: i64,
     pub input_tokens: i64,
     pub output_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub estimated_cost_usd: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AiUsageSourceTotals {
+    pub usage_source: String,
+    pub pricing_source: String,
+    pub calls: i64,
     pub total_tokens: i64,
     pub estimated_cost_usd: f64,
 }

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
+use crate::db::{AiUsageSourceTotals, AiUsageTotals, DailyAiUsage, WeeklyAiUsage};
+
 use super::shared::collect_rows;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -194,6 +196,147 @@ pub fn query_top_projects(conn: &Connection, limit: i64) -> Result<Vec<ProjectCo
         Ok(ProjectCount {
             project: row.get(0)?,
             count: row.get(1)?,
+        })
+    })?;
+    collect_rows(rows)
+}
+
+pub fn query_ai_usage_totals(
+    conn: &Connection,
+    since_epoch: Option<i64>,
+    project: Option<&str>,
+) -> Result<AiUsageTotals> {
+    conn.query_row(
+        "SELECT COUNT(*),
+                COALESCE(SUM(input_tokens), 0),
+                COALESCE(SUM(output_tokens), 0),
+                COALESCE(SUM(reasoning_tokens), 0),
+                COALESCE(SUM(cache_creation_tokens), 0),
+                COALESCE(SUM(cache_read_tokens), 0),
+                COALESCE(SUM(total_tokens), 0),
+                COALESCE(SUM(estimated_cost_usd), 0.0)
+         FROM ai_usage_events
+         WHERE (?1 IS NULL OR created_at_epoch >= ?1)
+           AND (?2 IS NULL OR project = ?2)",
+        params![since_epoch, project],
+        |row| {
+            Ok(AiUsageTotals {
+                calls: row.get(0)?,
+                input_tokens: row.get(1)?,
+                output_tokens: row.get(2)?,
+                reasoning_tokens: row.get(3)?,
+                cache_creation_tokens: row.get(4)?,
+                cache_read_tokens: row.get(5)?,
+                total_tokens: row.get(6)?,
+                estimated_cost_usd: row.get(7)?,
+            })
+        },
+    )
+    .map_err(Into::into)
+}
+
+pub fn query_ai_usage_source_totals(
+    conn: &Connection,
+    since_epoch: Option<i64>,
+    project: Option<&str>,
+) -> Result<Vec<AiUsageSourceTotals>> {
+    let mut stmt = conn.prepare(
+        "SELECT usage_source,
+                pricing_source,
+                COUNT(*),
+                COALESCE(SUM(total_tokens), 0),
+                COALESCE(SUM(estimated_cost_usd), 0.0)
+         FROM ai_usage_events
+         WHERE (?1 IS NULL OR created_at_epoch >= ?1)
+           AND (?2 IS NULL OR project = ?2)
+         GROUP BY usage_source, pricing_source
+         ORDER BY SUM(total_tokens) DESC",
+    )?;
+    let rows = stmt.query_map(params![since_epoch, project], |row| {
+        Ok(AiUsageSourceTotals {
+            usage_source: row.get(0)?,
+            pricing_source: row.get(1)?,
+            calls: row.get(2)?,
+            total_tokens: row.get(3)?,
+            estimated_cost_usd: row.get(4)?,
+        })
+    })?;
+    collect_rows(rows)
+}
+
+pub fn query_daily_ai_usage(
+    conn: &Connection,
+    since_epoch: i64,
+    project: Option<&str>,
+    limit: i64,
+) -> Result<Vec<DailyAiUsage>> {
+    let mut stmt = conn.prepare(
+        "SELECT strftime('%Y-%m-%d', created_at_epoch, 'unixepoch') AS day,
+                COUNT(*),
+                COALESCE(SUM(input_tokens), 0),
+                COALESCE(SUM(output_tokens), 0),
+                COALESCE(SUM(reasoning_tokens), 0),
+                COALESCE(SUM(cache_creation_tokens), 0),
+                COALESCE(SUM(cache_read_tokens), 0),
+                COALESCE(SUM(total_tokens), 0),
+                COALESCE(SUM(estimated_cost_usd), 0.0)
+         FROM ai_usage_events
+         WHERE created_at_epoch >= ?1
+           AND (?2 IS NULL OR project = ?2)
+         GROUP BY day
+         ORDER BY day DESC
+         LIMIT ?3",
+    )?;
+    let rows = stmt.query_map(params![since_epoch, project, limit], |row| {
+        Ok(DailyAiUsage {
+            day: row.get(0)?,
+            calls: row.get(1)?,
+            input_tokens: row.get(2)?,
+            output_tokens: row.get(3)?,
+            reasoning_tokens: row.get(4)?,
+            cache_creation_tokens: row.get(5)?,
+            cache_read_tokens: row.get(6)?,
+            total_tokens: row.get(7)?,
+            estimated_cost_usd: row.get(8)?,
+        })
+    })?;
+    collect_rows(rows)
+}
+
+pub fn query_weekly_ai_usage(
+    conn: &Connection,
+    since_epoch: i64,
+    project: Option<&str>,
+    limit: i64,
+) -> Result<Vec<WeeklyAiUsage>> {
+    let mut stmt = conn.prepare(
+        "SELECT strftime('%Y-W%W', created_at_epoch, 'unixepoch') AS week,
+                COUNT(*),
+                COALESCE(SUM(input_tokens), 0),
+                COALESCE(SUM(output_tokens), 0),
+                COALESCE(SUM(reasoning_tokens), 0),
+                COALESCE(SUM(cache_creation_tokens), 0),
+                COALESCE(SUM(cache_read_tokens), 0),
+                COALESCE(SUM(total_tokens), 0),
+                COALESCE(SUM(estimated_cost_usd), 0.0)
+         FROM ai_usage_events
+         WHERE created_at_epoch >= ?1
+           AND (?2 IS NULL OR project = ?2)
+         GROUP BY week
+         ORDER BY week DESC
+         LIMIT ?3",
+    )?;
+    let rows = stmt.query_map(params![since_epoch, project, limit], |row| {
+        Ok(WeeklyAiUsage {
+            week: row.get(0)?,
+            calls: row.get(1)?,
+            input_tokens: row.get(2)?,
+            output_tokens: row.get(3)?,
+            reasoning_tokens: row.get(4)?,
+            cache_creation_tokens: row.get(5)?,
+            cache_read_tokens: row.get(6)?,
+            total_tokens: row.get(7)?,
+            estimated_cost_usd: row.get(8)?,
         })
     })?;
     collect_rows(rows)

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -1,7 +1,11 @@
 use rusqlite::Connection;
 
 use super::{DailyActivityStats, ProjectCount, SystemStats};
-use crate::db::query::{query_daily_activity_stats, query_system_stats, query_top_projects};
+use crate::db::models::{AiUsageSourceTotals, AiUsageTotals, DailyAiUsage, WeeklyAiUsage};
+use crate::db::query::{
+    query_ai_usage_source_totals, query_ai_usage_totals, query_daily_activity_stats,
+    query_daily_ai_usage, query_system_stats, query_top_projects, query_weekly_ai_usage,
+};
 
 fn setup_stats_schema(conn: &Connection) {
     conn.execute_batch(
@@ -53,6 +57,26 @@ fn setup_stats_schema(conn: &Connection) {
             pid INTEGER,
             started_at_epoch INTEGER NOT NULL,
             updated_at_epoch INTEGER NOT NULL
+        );
+        CREATE TABLE ai_usage_events (
+            id INTEGER PRIMARY KEY,
+            created_at TEXT NOT NULL,
+            created_at_epoch INTEGER NOT NULL,
+            project TEXT,
+            operation TEXT NOT NULL,
+            executor TEXT NOT NULL,
+            model TEXT,
+            input_tokens INTEGER NOT NULL,
+            output_tokens INTEGER NOT NULL,
+            reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            raw_input_tokens INTEGER NOT NULL DEFAULT 0,
+            raw_output_tokens INTEGER NOT NULL DEFAULT 0,
+            total_tokens INTEGER NOT NULL,
+            estimated_cost_usd REAL NOT NULL,
+            usage_source TEXT NOT NULL DEFAULT 'text_estimate',
+            pricing_source TEXT NOT NULL DEFAULT 'remem_static'
         );",
     )
     .expect("schema should be created");
@@ -215,6 +239,141 @@ fn query_system_stats_and_related_views_share_one_definition() {
             ProjectCount {
                 project: "beta".to_string(),
                 count: 1,
+            },
+        ]
+    );
+}
+
+fn insert_usage(
+    conn: &Connection,
+    project: &str,
+    created_at_epoch: i64,
+    input_tokens: i64,
+    output_tokens: i64,
+    reasoning_tokens: i64,
+    cache_read_tokens: i64,
+    estimated_cost_usd: f64,
+) {
+    conn.execute(
+        "INSERT INTO ai_usage_events
+         (created_at, created_at_epoch, project, operation, executor, model,
+          input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, total_tokens,
+          estimated_cost_usd, usage_source, pricing_source)
+         VALUES ('2026-01-01T00:00:00Z', ?1, ?2, 'summary', 'codex-cli', 'codex-default',
+                 ?3, ?4, ?5, ?6, ?7, ?8, 'codex_log', 'remem_static')",
+        rusqlite::params![
+            created_at_epoch,
+            project,
+            input_tokens,
+            output_tokens,
+            reasoning_tokens,
+            cache_read_tokens,
+            input_tokens + output_tokens + reasoning_tokens + cache_read_tokens,
+            estimated_cost_usd
+        ],
+    )
+    .expect("usage insert should succeed");
+}
+
+#[test]
+fn query_ai_usage_groups_daily_and_weekly_token_costs() {
+    let conn = Connection::open_in_memory().expect("in-memory db should open");
+    setup_stats_schema(&conn);
+
+    let jan_05_2026 = 1_767_571_200;
+    let jan_06_2026 = 1_767_657_600;
+    let jan_12_2026 = 1_768_176_000;
+
+    insert_usage(&conn, "alpha", jan_05_2026, 100, 40, 10, 50, 0.001);
+    insert_usage(&conn, "alpha", jan_05_2026 + 60, 200, 60, 20, 80, 0.002);
+    insert_usage(&conn, "alpha", jan_06_2026, 300, 80, 30, 120, 0.003);
+    insert_usage(&conn, "beta", jan_12_2026, 500, 100, 40, 160, 0.005);
+
+    let alpha_totals = query_ai_usage_totals(&conn, Some(jan_05_2026), Some("alpha"))
+        .expect("usage totals should load");
+    assert_eq!(
+        alpha_totals,
+        AiUsageTotals {
+            calls: 3,
+            input_tokens: 600,
+            output_tokens: 180,
+            reasoning_tokens: 60,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 250,
+            total_tokens: 1090,
+            estimated_cost_usd: 0.006,
+        }
+    );
+
+    let alpha_sources = query_ai_usage_source_totals(&conn, Some(jan_05_2026), Some("alpha"))
+        .expect("usage source totals should load");
+    assert_eq!(
+        alpha_sources,
+        vec![AiUsageSourceTotals {
+            usage_source: "codex_log".to_string(),
+            pricing_source: "remem_static".to_string(),
+            calls: 3,
+            total_tokens: 1090,
+            estimated_cost_usd: 0.006,
+        }]
+    );
+
+    let daily = query_daily_ai_usage(&conn, jan_05_2026, Some("alpha"), 14)
+        .expect("daily usage should load");
+    assert_eq!(
+        daily,
+        vec![
+            DailyAiUsage {
+                day: "2026-01-06".to_string(),
+                calls: 1,
+                input_tokens: 300,
+                output_tokens: 80,
+                reasoning_tokens: 30,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 120,
+                total_tokens: 530,
+                estimated_cost_usd: 0.003,
+            },
+            DailyAiUsage {
+                day: "2026-01-05".to_string(),
+                calls: 2,
+                input_tokens: 300,
+                output_tokens: 100,
+                reasoning_tokens: 30,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 130,
+                total_tokens: 560,
+                estimated_cost_usd: 0.003,
+            },
+        ]
+    );
+
+    let weekly =
+        query_weekly_ai_usage(&conn, jan_05_2026, None, 8).expect("weekly usage should load");
+    assert_eq!(
+        weekly,
+        vec![
+            WeeklyAiUsage {
+                week: "2026-W02".to_string(),
+                calls: 1,
+                input_tokens: 500,
+                output_tokens: 100,
+                reasoning_tokens: 40,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 160,
+                total_tokens: 800,
+                estimated_cost_usd: 0.005,
+            },
+            WeeklyAiUsage {
+                week: "2026-W01".to_string(),
+                calls: 3,
+                input_tokens: 600,
+                output_tokens: 180,
+                reasoning_tokens: 60,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 250,
+                total_tokens: 1090,
+                estimated_cost_usd: 0.006,
             },
         ]
     );

--- a/src/db/usage.rs
+++ b/src/db/usage.rs
@@ -1,27 +1,31 @@
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
+use crate::ai::TokenUsage;
+
 /// Record AI usage event to database for cost tracking.
-pub fn record_ai_usage(
+pub(crate) fn record_ai_usage(
     conn: &Connection,
     project: Option<&str>,
     operation: &str,
     executor: &str,
     model: Option<&str>,
-    input_tokens: i64,
-    output_tokens: i64,
+    usage: &TokenUsage,
+    usage_source: &str,
+    pricing_source: &str,
     estimated_cost_usd: f64,
 ) -> Result<()> {
     let now = chrono::Utc::now();
     let created_at = now.to_rfc3339();
     let created_at_epoch = now.timestamp();
-    let total_tokens = input_tokens + output_tokens;
 
     conn.execute(
         "INSERT INTO ai_usage_events \
          (created_at, created_at_epoch, project, operation, executor, model, \
-          input_tokens, output_tokens, total_tokens, estimated_cost_usd) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+          input_tokens, output_tokens, reasoning_tokens, cache_creation_tokens, \
+          cache_read_tokens, raw_input_tokens, raw_output_tokens, total_tokens, \
+          estimated_cost_usd, usage_source, pricing_source) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
         params![
             created_at,
             created_at_epoch,
@@ -29,10 +33,17 @@ pub fn record_ai_usage(
             operation,
             executor,
             model,
-            input_tokens,
-            output_tokens,
-            total_tokens,
-            estimated_cost_usd
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.reasoning_tokens,
+            usage.cache_creation_tokens,
+            usage.cache_read_tokens,
+            usage.raw_input_tokens,
+            usage.raw_output_tokens,
+            usage.total_tokens(),
+            estimated_cost_usd,
+            usage_source,
+            pricing_source
         ],
     )?;
     Ok(())

--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -7,6 +7,29 @@ use super::types::{MIGRATIONS, OLD_BASELINE_VERSION};
 
 pub(crate) fn run_migrations(conn: &Connection) -> Result<()> {
     ensure_migration_table(conn)?;
+
+    conn.execute_batch("BEGIN IMMEDIATE")
+        .context("begin migration transaction")?;
+    let result = run_migrations_locked(conn);
+    match result {
+        Ok(()) => {
+            conn.execute_batch("COMMIT")
+                .context("commit migration transaction")?;
+            Ok(())
+        }
+        Err(error) => {
+            if let Err(rollback_error) = conn.execute_batch("ROLLBACK") {
+                crate::log::warn(
+                    "migrate",
+                    &format!("rollback failed after migration error: {rollback_error}"),
+                );
+            }
+            Err(error)
+        }
+    }
+}
+
+fn run_migrations_locked(conn: &Connection) -> Result<()> {
     transition_from_old_system(conn)?;
 
     let applied = applied_versions(conn)?;

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 
 use super::state::applied_versions;
 use super::{dry_run_pending, run_migrations, MIGRATIONS};
-use crate::db::test_support::ScopedTestDataDir;
+use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path, ScopedTestDataDir};
 
 #[test]
 fn baseline_creates_all_tables() -> Result<()> {
@@ -62,10 +62,10 @@ fn full_migration_on_empty_db() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 21);
+    assert_eq!(user_version, 23);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -115,6 +115,83 @@ fn run_migrations_does_not_downgrade_newer_user_version() -> Result<()> {
 }
 
 #[test]
+fn concurrent_run_migrations_serializes_pending_migrations() -> Result<()> {
+    let path = unique_temp_db_path("migrate-concurrent");
+    {
+        let conn = Connection::open(&path)?;
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+    }
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let mut handles = Vec::new();
+
+    for _ in 0..2 {
+        let path = path.clone();
+        let barrier = std::sync::Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || -> Result<()> {
+            let conn = Connection::open(&path)?;
+            conn.busy_timeout(std::time::Duration::from_secs(5))?;
+            conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+            barrier.wait();
+            run_migrations(&conn)?;
+            Ok(())
+        }));
+    }
+
+    for handle in handles {
+        handle.join().expect("migration thread panicked")?;
+    }
+
+    let conn = Connection::open(&path)?;
+    let applied = applied_versions(&conn)?;
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    cleanup_temp_db_files(&path);
+    Ok(())
+}
+
+#[test]
+fn reprice_migration_backfills_zero_cost_usage_rows() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA foreign_keys=ON;
+         CREATE TABLE _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_epoch INTEGER NOT NULL
+         );",
+    )?;
+
+    for migration in &MIGRATIONS[..10] {
+        conn.execute_batch(migration.sql)?;
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, ?2, 1700000000)",
+            params![migration.version, migration.name],
+        )?;
+    }
+    conn.execute_batch("PRAGMA user_version = 22;")?;
+    conn.execute(
+        "INSERT INTO ai_usage_events
+         (created_at, created_at_epoch, project, operation, executor, model,
+          input_tokens, output_tokens, total_tokens, estimated_cost_usd)
+         VALUES ('2026-01-01T00:00:00Z', 1767225600, 'proj', 'summary',
+                 'codex-cli', 'codex-default', 1000000, 100000, 1100000, 0.0)",
+        [],
+    )?;
+
+    run_migrations(&conn)?;
+
+    let (cost, pricing_source): (f64, String) = conn.query_row(
+        "SELECT estimated_cost_usd, pricing_source FROM ai_usage_events",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert!((cost - 2.25).abs() < f64::EPSILON);
+    assert_eq!(pricing_source, "remem_static_backfill");
+    Ok(())
+}
+
+#[test]
 fn transition_from_old_system_skips_baseline() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     conn.execute_batch("PRAGMA user_version = 13;")?;
@@ -123,7 +200,7 @@ fn transition_from_old_system_skips_baseline() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
     Ok(())
 }
 
@@ -148,10 +225,10 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
 
     // Should have auto-upgraded and marked all v1 migrations as applied.
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 21);
+    assert_eq!(user_version, 23);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -191,7 +268,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 21);
+    assert_eq!(result.current_version, 23);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())
@@ -204,7 +281,7 @@ fn dry_run_pending_reports_pending_for_new_db() -> Result<()> {
     let result = dry_run_pending(&conn)?;
 
     assert_eq!(result.current_version, 0);
-    assert_eq!(result.pending_count, 9);
+    assert_eq!(result.pending_count, 11);
     assert!(result.error.is_none());
     Ok(())
 }
@@ -263,7 +340,7 @@ fn dry_run_pending_reports_backfill_error_for_broken_schema() -> Result<()> {
     let result = dry_run_pending(&conn)?;
     // After broken baseline backfill fails, dry_run reports the still-unapplied
     // migrations (v2+ remain pending in _schema_migrations).
-    assert_eq!(result.pending_count, 8);
+    assert_eq!(result.pending_count, 10);
     let error = result
         .error
         .expect("broken schema should surface in dry-run");

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -50,6 +50,16 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "memory_candidate_promotion",
         sql: include_str!("../migrations/v009_memory_candidate_promotion.sql"),
     },
+    Migration {
+        version: 10,
+        name: "ai_usage_token_breakdown",
+        sql: include_str!("../migrations/v010_ai_usage_token_breakdown.sql"),
+    },
+    Migration {
+        version: 11,
+        name: "reprice_ai_usage_events",
+        sql: include_str!("../migrations/v011_reprice_ai_usage_events.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v010_ai_usage_token_breakdown.sql
+++ b/src/migrations/v010_ai_usage_token_breakdown.sql
@@ -1,0 +1,14 @@
+ALTER TABLE ai_usage_events ADD COLUMN reasoning_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ai_usage_events ADD COLUMN cache_creation_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ai_usage_events ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ai_usage_events ADD COLUMN raw_input_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ai_usage_events ADD COLUMN raw_output_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ai_usage_events ADD COLUMN usage_source TEXT NOT NULL DEFAULT 'text_estimate';
+ALTER TABLE ai_usage_events ADD COLUMN pricing_source TEXT NOT NULL DEFAULT 'remem_static';
+
+UPDATE ai_usage_events
+SET raw_input_tokens = input_tokens,
+    raw_output_tokens = output_tokens
+WHERE raw_input_tokens = 0
+  AND raw_output_tokens = 0
+  AND (input_tokens > 0 OR output_tokens > 0);

--- a/src/migrations/v011_reprice_ai_usage_events.sql
+++ b/src/migrations/v011_reprice_ai_usage_events.sql
@@ -1,0 +1,95 @@
+UPDATE ai_usage_events
+SET estimated_cost_usd = CASE
+        WHEN lower(COALESCE(model, '')) LIKE '%opus-4-7%'
+          OR lower(COALESCE(model, '')) LIKE '%opus-4.7%'
+          OR lower(COALESCE(model, '')) LIKE '%opus-4-6%'
+          OR lower(COALESCE(model, '')) LIKE '%opus-4.6%'
+          OR lower(COALESCE(model, '')) LIKE '%opus-4-5%'
+          OR lower(COALESCE(model, '')) LIKE '%opus-4.5%'
+            THEN (input_tokens * 5.0
+                + output_tokens * 25.0
+                + reasoning_tokens * 25.0
+                + cache_creation_tokens * 6.25
+                + cache_read_tokens * 0.50) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%opus%'
+            THEN (input_tokens * 15.0
+                + output_tokens * 75.0
+                + reasoning_tokens * 75.0
+                + cache_creation_tokens * 18.75
+                + cache_read_tokens * 1.50) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%sonnet%'
+            THEN (input_tokens * 3.0
+                + output_tokens * 15.0
+                + reasoning_tokens * 15.0
+                + cache_creation_tokens * 3.75
+                + cache_read_tokens * 0.30) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%haiku%'
+            THEN (input_tokens * 1.0
+                + output_tokens * 5.0
+                + reasoning_tokens * 5.0
+                + cache_creation_tokens * 1.25
+                + cache_read_tokens * 0.10) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%gpt-5.5%'
+            THEN (input_tokens * 5.0
+                + output_tokens * 30.0
+                + reasoning_tokens * 30.0
+                + cache_read_tokens * 0.50) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%gpt-5.4-mini%'
+            THEN (input_tokens * 0.75
+                + output_tokens * 4.50
+                + reasoning_tokens * 4.50
+                + cache_read_tokens * 0.075) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%gpt-5.4-nano%'
+            THEN (input_tokens * 0.20
+                + output_tokens * 1.25
+                + reasoning_tokens * 1.25
+                + cache_read_tokens * 0.020) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%gpt-5.4%'
+            THEN (input_tokens * 2.50
+                + output_tokens * 15.0
+                + reasoning_tokens * 15.0
+                + cache_read_tokens * 0.25) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%gpt-5.2%'
+          OR lower(COALESCE(model, '')) LIKE '%gpt-5.3-codex%'
+            THEN (input_tokens * 1.75
+                + output_tokens * 14.0
+                + reasoning_tokens * 14.0
+                + cache_read_tokens * 0.175) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%gpt-5-codex%'
+          OR lower(COALESCE(model, '')) LIKE '%gpt-5.1-codex%'
+            THEN (input_tokens * 1.25
+                + output_tokens * 10.0
+                + reasoning_tokens * 10.0
+                + cache_read_tokens * 0.125) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%codex-mini%'
+            THEN (input_tokens * 1.50
+                + output_tokens * 6.0
+                + reasoning_tokens * 6.0
+                + cache_read_tokens * 0.375) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%codex%'
+          OR lower(COALESCE(model, '')) LIKE '%gpt-5%'
+            THEN (input_tokens * 1.25
+                + output_tokens * 10.0
+                + reasoning_tokens * 10.0
+                + cache_read_tokens * 0.125) / 1000000.0
+        WHEN lower(COALESCE(model, '')) LIKE '%gpt-4%'
+            THEN (input_tokens * 2.50
+                + output_tokens * 10.0
+                + reasoning_tokens * 10.0) / 1000000.0
+        ELSE estimated_cost_usd
+    END,
+    pricing_source = CASE
+        WHEN lower(COALESCE(model, '')) LIKE '%opus%'
+          OR lower(COALESCE(model, '')) LIKE '%sonnet%'
+          OR lower(COALESCE(model, '')) LIKE '%haiku%'
+          OR lower(COALESCE(model, '')) LIKE '%gpt-5%'
+          OR lower(COALESCE(model, '')) LIKE '%gpt-4%'
+          OR lower(COALESCE(model, '')) LIKE '%codex%'
+            THEN 'remem_static_backfill'
+        ELSE pricing_source
+    END
+WHERE usage_source = 'text_estimate'
+  AND (
+      estimated_cost_usd = 0.0
+      OR pricing_source IN ('remem_static', 'unknown_pricing')
+  );


### PR DESCRIPTION
## Summary
- add `remem usage` daily/weekly AI token and estimated cost reporting
- record provider/Codex-log token breakdowns with usage and pricing source metadata
- add schema migrations for token breakdown fields and historical repricing
- default remem Codex summarization to `gpt-5.2` and document model/cost controls

## Verification
- `cargo fmt --check && cargo check && cargo test`
- `cargo install --path . --root /Users/lifcc/.local --force`
- `/Users/lifcc/.local/bin/remem usage --days 7 --weeks 4`
- `/Users/lifcc/.local/bin/remem doctor --json` (Codex/DB OK; existing Claude hook/MCP install missing)
