### PR TITLE
docs: prepare v0.4.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,20 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-16
+
 ### Added
 - Added `remem usage` for daily and weekly AI token/cost reporting.
 - Added `ai_usage_events` token breakdown fields for input, output, reasoning,
   cache creation, cache read, raw input/output, usage source, and pricing source.
 - Added Codex session JSONL token accounting keyed by a per-run remem id.
 - Added historical usage repricing migration for older zero-cost rows.
+- Added CLI search parity with the canonical memory service, including
+  `--offset`, `--branch`, `--include-stale`, `--multi-hop`, and `--type` as a
+  `--memory-type` alias.
+- Added raw archive fallback previews and `has_more` guidance to CLI search.
+- Added `--dry-run` previews for `pending retry-failed` and
+  `pending purge-failed`.
 
 ### Changed
 - Defaulted remem's Codex summarization model to `gpt-5.2`; set
@@ -16,10 +24,16 @@
   Anthropic price families.
 - Serialized schema migrations with `BEGIN IMMEDIATE` to avoid concurrent
   migration races.
+- Preserved the context stats footer when context output is truncated and the
+  footer fits within the configured character budget.
+- Propagated branch, memory-type, stale-state, and offset filters through
+  multi-hop search expansion.
 
 ### Docs
 - Documented usage reporting, precision levels, pricing overrides, and the
   `gpt-5.2` Codex default in English/Chinese README and architecture docs.
+- Documented filtered multi-hop CLI search and pending dry-run operations in
+  English and Chinese README files.
 
 ## [0.3.8] - 2026-04-03
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ remem install
 remem uninstall
 remem doctor
 remem search "query"
+remem search "query" --branch main --type decision --multi-hop --offset 10
 remem show <id>
 remem eval
 remem eval-local
@@ -192,8 +193,8 @@ remem api --port 5567
 remem status
 remem usage --days 14 --weeks 8
 remem pending list-failed
-remem pending retry-failed
-remem pending purge-failed
+remem pending retry-failed --dry-run
+remem pending purge-failed --dry-run --older-than-days 7
 remem review list
 remem review approve <id>
 remem review discard <id>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,6 +171,7 @@ remem install
 remem uninstall
 remem doctor
 remem search "query"
+remem search "query" --branch main --type decision --multi-hop --offset 10
 remem show <id>
 remem eval
 remem eval-local
@@ -180,8 +181,8 @@ remem api --port 5567
 remem status
 remem usage --days 14 --weeks 8
 remem pending list-failed
-remem pending retry-failed
-remem pending purge-failed
+remem pending retry-failed --dry-run
+remem pending purge-failed --dry-run --older-than-days 7
 remem review list
 remem review approve <id>
 remem review discard <id>


### PR DESCRIPTION
## Summary

- move current changelog entries under v0.4.0 dated 2026-05-16
- document filtered multi-hop CLI search in English and Chinese README files
- document dry-run pending admin examples in English and Chinese README files

## Validation

- remem --version
- cargo fmt --check
- git diff --check
- cargo check
- cargo clippy -- -D warnings
- cargo test cli_parses_search_type_alias_and_multi_hop_filters -- --nocapture
- cargo test multi_hop_respects_filters_before_expansion_and_offset -- --nocapture
- cargo test
- cargo publish --dry-run

## Data Safety

Docs/release metadata only. Local install replaced ~/.cargo/bin/remem with v0.4.0, but no real remem memory data was changed.