### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-16
+
+### Packaging
+- Bumped the crate and binary version to `0.4.1` for the post-`0.4.0`
+  maintenance release.
+
 ## [0.4.0] - 2026-05-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Persistent memory for Claude Code — single binary, zero subprocesses"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump Cargo.toml and Cargo.lock from 0.4.0 to 0.4.1
- add a 0.4.1 changelog entry for the maintenance release

## Validation

- cargo fmt --check
- git diff --check
- cargo check
- cargo test
- cargo clippy -- -D warnings
- cargo publish --dry-run

## Data Safety

Version metadata only. No real remem memory data changed.