### PR TITLE
Fix exact Codex usage accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-16
+
+### Fixed
+- Fixed Codex usage accounting to parse the current `codex exec --json`
+  `turn.completed.usage` event instead of trying to match a run marker in
+  ephemeral session logs. New Codex-backed rows now record `usage_source =
+  codex_log` with cache and reasoning token breakdowns.
+
+### Docs
+- Updated usage accounting docs to describe the `codex exec --json` source for
+  exact Codex token counts.
+
 ## [0.4.1] - 2026-05-16
 
 ### Packaging

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Persistent memory for Claude Code — single binary, zero subprocesses"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ tokens, total tokens, estimated USD cost, and a precision note. Usage rows are
 tagged by source:
 
 - `anthropic_usage`: provider-reported usage from the Anthropic Messages API
-- `codex_log`: token counts parsed from Codex session JSONL logs for the
-  matching remem run id
+- `codex_log`: exact token counts parsed from the current `codex exec --json`
+  `turn.completed.usage` event
 - `text_estimate`: fallback estimate from prompt/response text length
 
 Cost is an estimate, not an invoice. Historical rows may be text estimates or

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -157,7 +157,8 @@ remem usage --project /path/to/project --days 30 --weeks 12
 美元费用，以及统计精度说明。usage row 会标记来源：
 
 - `anthropic_usage`：Anthropic Messages API 返回的 provider usage
-- `codex_log`：用 remem run id 匹配 Codex session JSONL 后解析出的 token count
+- `codex_log`：从当前 `codex exec --json` 的 `turn.completed.usage`
+  事件解析出的精确 token count
 - `text_estimate`：拿不到真实 usage 时，用 prompt/response 文本长度估算
 
 费用是估算，不是账单。历史数据可能是文本估算，也可能从旧的无精确模型记录

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -253,7 +253,7 @@ Short-lived process model (each hook = independent process) cannot dedup via in-
                   │
              Yes ─┤──→ codex exec --model REMEM_CODEX_MODEL (default gpt-5.2)
                   │         │
-                  │         └── usage from matching Codex session JSONL token_count
+                  │         └── usage from codex exec --json turn.completed.usage
                   │
              No ──┴─ ANTHROPIC_API_KEY exists?
                         │
@@ -402,7 +402,7 @@ The usage report reads `ai_usage_events` and renders:
 
 Cost is intentionally labeled as estimated. Historical rows can be text
 estimates or repriced rows from older schema versions; new Codex rows should use
-`codex_log` when the matching session JSONL token count is available.
+`codex_log` from the current `codex exec --json` event stream.
 
 ## Data Cleanup
 

--- a/src/ai/codex_cli.rs
+++ b/src/ai/codex_cli.rs
@@ -11,18 +11,12 @@ pub(super) async fn call_codex_cli(system: &str, user_message: &str) -> Result<A
     let codex = get_codex_path();
     let model = get_codex_model();
     let reasoning_effort = get_codex_reasoning_effort();
-    let started_at = std::time::SystemTime::now();
-    let run_id = format!(
-        "remem-usage-{}-{}",
-        std::process::id(),
-        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
-    );
     let output_path = std::env::temp_dir().join(format!(
         "remem-codex-summary-{}-{}.txt",
         std::process::id(),
         chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
     ));
-    let prompt = build_prompt(system, user_message, &run_id);
+    let prompt = build_prompt(system, user_message);
     let working_dir = super::stable_working_dir();
 
     let mut command = Command::new(&codex);
@@ -35,7 +29,7 @@ pub(super) async fn call_codex_cli(system: &str, user_message: &str) -> Result<A
         .current_dir(&working_dir)
         .env("REMEM_DISABLE_HOOKS", "1")
         .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
 
@@ -80,15 +74,16 @@ pub(super) async fn call_codex_cli(system: &str, user_message: &str) -> Result<A
         anyhow::bail!("codex CLI returned empty response");
     }
 
-    let codex_usage = match super::codex_usage::collect_codex_usage_for_run(&run_id, started_at) {
-        Ok(usage) => usage,
-        Err(error) => {
-            crate::log::warn("ai", &format!("codex usage parse failed: {}", error));
-            None
-        }
-    };
+    let codex_usage =
+        match super::codex_usage::parse_codex_json_events(&output.stdout, model.clone()) {
+            Ok(usage) => usage,
+            Err(error) => {
+                crate::log::warn("ai", &format!("codex usage parse failed: {}", error));
+                None
+            }
+        };
     if codex_usage.is_none() {
-        crate::log::warn("ai", "codex usage parse found no matching token_count log");
+        crate::log::warn("ai", "codex JSON usage parse found no turn.completed usage");
     }
     let usage = codex_usage
         .as_ref()
@@ -121,6 +116,7 @@ fn build_codex_args(
         "--skip-git-repo-check",
         "--sandbox",
         "read-only",
+        "--json",
         "--output-last-message",
     ]
     .into_iter()
@@ -143,14 +139,13 @@ fn build_codex_args(
     args
 }
 
-fn build_prompt(system: &str, user_message: &str, run_id: &str) -> String {
+fn build_prompt(system: &str, user_message: &str) -> String {
     format!(
         "You are running as remem's Codex CLI summarization backend.\n\
          Follow the system instructions exactly and return only the requested output.\n\n\
-         <remem_usage_run_id>{}</remem_usage_run_id>\n\n\
          <system>\n{}\n</system>\n\n\
          <input>\n{}\n</input>\n",
-        run_id, system, user_message
+        system, user_message
     )
 }
 
@@ -173,6 +168,7 @@ mod tests {
             .collect();
 
         assert_eq!(&rendered[..3], ["--ask-for-approval", "never", "exec"]);
+        assert!(rendered.iter().any(|arg| arg == "--json"), "{rendered:?}");
         assert!(
             rendered
                 .windows(2)

--- a/src/ai/codex_usage.rs
+++ b/src/ai/codex_usage.rs
@@ -1,9 +1,6 @@
-use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde_json::Value;
 
 use crate::ai::types::TokenUsage;
@@ -20,7 +17,6 @@ struct CodexCounters {
     cached_input_tokens: i64,
     output_tokens: i64,
     reasoning_output_tokens: i64,
-    total_tokens: i64,
 }
 
 impl CodexCounters {
@@ -31,19 +27,6 @@ impl CodexCounters {
                 .max(json_i64(value, "cache_read_input_tokens")),
             output_tokens: json_i64(value, "output_tokens"),
             reasoning_output_tokens: json_i64(value, "reasoning_output_tokens"),
-            total_tokens: json_i64(value, "total_tokens"),
-        }
-    }
-
-    fn subtract(self, previous: Self) -> Self {
-        Self {
-            input_tokens: (self.input_tokens - previous.input_tokens).max(0),
-            cached_input_tokens: (self.cached_input_tokens - previous.cached_input_tokens).max(0),
-            output_tokens: (self.output_tokens - previous.output_tokens).max(0),
-            reasoning_output_tokens: (self.reasoning_output_tokens
-                - previous.reasoning_output_tokens)
-                .max(0),
-            total_tokens: (self.total_tokens - previous.total_tokens).max(0),
         }
     }
 
@@ -69,176 +52,36 @@ impl CodexCounters {
     }
 }
 
-pub(super) fn collect_codex_usage_for_run(
-    run_id: &str,
-    started_at: SystemTime,
+pub(super) fn parse_codex_json_events(
+    events: &[u8],
+    model: Option<String>,
 ) -> Result<Option<CodexRunUsage>> {
-    let Some(sessions_dir) = codex_sessions_dir() else {
-        return Ok(None);
-    };
-    let threshold = started_at
-        .checked_sub(Duration::from_secs(60))
-        .unwrap_or(SystemTime::UNIX_EPOCH);
-
-    let mut files = Vec::new();
-    collect_recent_jsonl_files(&sessions_dir, threshold, &mut files)?;
-
-    let mut aggregate = TokenUsage::default();
-    let mut model = None;
-    let mut matched_any = false;
-    for path in files {
-        let Some(run_usage) = parse_codex_file(&path, run_id)? else {
-            continue;
-        };
-        matched_any = true;
-        aggregate.add(&run_usage.usage);
-        if run_usage.model.is_some() {
-            model = run_usage.model;
-        }
-    }
-
-    if matched_any && !aggregate.is_empty() {
-        Ok(Some(CodexRunUsage {
-            usage: aggregate,
-            model,
-        }))
-    } else {
-        Ok(None)
-    }
-}
-
-fn codex_sessions_dir() -> Option<PathBuf> {
-    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
-        let path = PathBuf::from(codex_home).join("sessions");
-        if path.is_dir() {
-            return Some(path);
-        }
-    }
-
-    let home = dirs::home_dir()?;
-    let path = home.join(".codex").join("sessions");
-    path.is_dir().then_some(path)
-}
-
-fn collect_recent_jsonl_files(
-    dir: &Path,
-    threshold: SystemTime,
-    out: &mut Vec<PathBuf>,
-) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_recent_jsonl_files(&path, threshold, out)?;
-            continue;
-        }
-        if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
-            continue;
-        }
-        let modified = entry
-            .metadata()
-            .and_then(|metadata| metadata.modified())
-            .unwrap_or(SystemTime::UNIX_EPOCH);
-        if modified >= threshold {
-            out.push(path);
-        }
-    }
-    Ok(())
-}
-
-fn parse_codex_file(path: &Path, run_id: &str) -> Result<Option<CodexRunUsage>> {
-    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
-    parse_codex_reader(BufReader::new(file), run_id)
-}
-
-fn parse_codex_reader(reader: impl BufRead, run_id: &str) -> Result<Option<CodexRunUsage>> {
-    let mut saw_run_id = false;
-    let mut previous_total: Option<CodexCounters> = None;
-    let mut current_model: Option<String> = None;
     let mut usage = TokenUsage::default();
+    let reader = BufReader::new(events);
 
     for line in reader.lines() {
         let line = line?;
-        if line.contains(run_id) {
-            saw_run_id = true;
-        }
-        if !saw_run_id {
-            continue;
-        }
-
         let Ok(value) = serde_json::from_str::<Value>(&line) else {
             continue;
         };
-        let entry_type = value.get("type").and_then(Value::as_str);
-        let Some(payload) = value.get("payload") else {
+        if value.get("type").and_then(Value::as_str) != Some("turn.completed") {
+            continue;
+        }
+        let Some(raw_usage) = value.get("usage") else {
             continue;
         };
-
-        if entry_type == Some("turn_context") {
-            if let Some(model) = extract_model(payload) {
-                current_model = Some(model);
-            }
+        let counters = CodexCounters::from_value(raw_usage);
+        if counters.is_empty() {
             continue;
         }
-
-        if entry_type != Some("event_msg")
-            || payload.get("type").and_then(Value::as_str) != Some("token_count")
-        {
-            continue;
-        }
-
-        let Some(info) = payload.get("info") else {
-            continue;
-        };
-        if let Some(model) = extract_model(payload) {
-            current_model = Some(model);
-        }
-
-        let Some(total_value) = info.get("total_token_usage") else {
-            continue;
-        };
-        let total = CodexCounters::from_value(total_value);
-        if previous_total.is_some_and(|previous| total.total_tokens == previous.total_tokens) {
-            continue;
-        }
-
-        let delta = info
-            .get("last_token_usage")
-            .map(CodexCounters::from_value)
-            .filter(|counters| !counters.is_empty())
-            .unwrap_or_else(|| previous_total.map_or(total, |previous| total.subtract(previous)));
-        previous_total = Some(total);
-        if delta.is_empty() {
-            continue;
-        }
-        usage.add(&delta.into_token_usage());
+        usage.add(&counters.into_token_usage());
     }
 
-    if saw_run_id {
-        Ok(Some(CodexRunUsage {
-            usage,
-            model: current_model,
-        }))
-    } else {
+    if usage.is_empty() {
         Ok(None)
+    } else {
+        Ok(Some(CodexRunUsage { usage, model }))
     }
-}
-
-fn extract_model(payload: &Value) -> Option<String> {
-    let info = payload.get("info");
-    [
-        info.and_then(|value| value.get("model")),
-        info.and_then(|value| value.get("model_name")),
-        info.and_then(|value| value.get("metadata"))
-            .and_then(|metadata| metadata.get("model")),
-        payload.get("model"),
-    ]
-    .into_iter()
-    .flatten()
-    .filter_map(Value::as_str)
-    .map(str::trim)
-    .find(|model| !model.is_empty())
-    .map(ToOwned::to_owned)
 }
 
 fn json_i64(value: &Value, key: &str) -> i64 {
@@ -247,48 +90,53 @@ fn json_i64(value: &Value, key: &str) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
+    use anyhow::{Context, Result};
 
-    use super::parse_codex_reader;
+    use super::parse_codex_json_events;
 
     #[test]
-    fn parses_last_token_usage_after_run_marker() {
+    fn parses_codex_exec_json_turn_completed_usage() -> Result<()> {
         let log = r#"
-{"type":"response_item","payload":{"item":{"type":"message","content":[{"text":"run remem-usage-1"}]}}}
-{"type":"event_msg","payload":{"type":"token_count","info":{"model":"gpt-5.5","total_token_usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":500,"reasoning_output_tokens":150,"total_tokens":1500},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":500,"reasoning_output_tokens":150,"total_tokens":1500}}}}
+{"type":"thread.started","thread_id":"019e2f80-913f-7452-97ed-6340c56b2bd4"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"OK"}}
+{"type":"turn.completed","usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":500,"reasoning_output_tokens":150}}
 "#;
-        let parsed = parse_codex_reader(Cursor::new(log), "remem-usage-1")
-            .expect("parse should succeed")
-            .expect("run should match");
-        assert_eq!(parsed.model.as_deref(), Some("gpt-5.5"));
+        let parsed = parse_codex_json_events(log.as_bytes(), Some("gpt-5.2".to_string()))
+            .and_then(|usage| usage.context("usage should parse"))?;
+        assert_eq!(parsed.model.as_deref(), Some("gpt-5.2"));
         assert_eq!(parsed.usage.input_tokens, 800);
         assert_eq!(parsed.usage.cache_read_tokens, 200);
         assert_eq!(parsed.usage.output_tokens, 350);
         assert_eq!(parsed.usage.reasoning_tokens, 150);
         assert_eq!(parsed.usage.total_tokens(), 1500);
+        Ok(())
     }
 
     #[test]
-    fn computes_delta_when_last_usage_is_missing() {
+    fn parses_multiple_codex_exec_json_turns() -> Result<()> {
         let log = r#"
-{"type":"response_item","payload":{"item":{"type":"message","content":[{"text":"run remem-usage-2"}]}}}
-{"type":"event_msg","payload":{"type":"token_count","info":{"model":"gpt-5.4","total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":150}}}}
-{"type":"event_msg","payload":{"type":"token_count","info":{"model":"gpt-5.4","total_token_usage":{"input_tokens":400,"cached_input_tokens":100,"output_tokens":150,"reasoning_output_tokens":40,"total_tokens":550}}}}
+{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":20,"reasoning_output_tokens":5}}
+{"type":"turn.completed","usage":{"input_tokens":50,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0}}
 "#;
-        let parsed = parse_codex_reader(Cursor::new(log), "remem-usage-2")
-            .expect("parse should succeed")
-            .expect("run should match");
-        assert_eq!(parsed.usage.input_tokens, 300);
-        assert_eq!(parsed.usage.cache_read_tokens, 100);
-        assert_eq!(parsed.usage.output_tokens, 110);
-        assert_eq!(parsed.usage.reasoning_tokens, 40);
-        assert_eq!(parsed.usage.total_tokens(), 550);
+        let parsed = parse_codex_json_events(log.as_bytes(), None)
+            .and_then(|usage| usage.context("usage should parse"))?;
+        assert_eq!(parsed.usage.input_tokens, 70);
+        assert_eq!(parsed.usage.cache_read_tokens, 80);
+        assert_eq!(parsed.usage.output_tokens, 25);
+        assert_eq!(parsed.usage.reasoning_tokens, 5);
+        assert_eq!(parsed.usage.total_tokens(), 180);
+        Ok(())
     }
 
     #[test]
-    fn ignores_files_without_run_marker() {
-        let log = r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":50,"total_tokens":150}}}}"#;
-        let parsed = parse_codex_reader(Cursor::new(log), "missing").expect("parse should succeed");
+    fn returns_none_without_turn_completed_usage() -> Result<()> {
+        let log = r#"
+{"type":"thread.started","thread_id":"019e2f80-913f-7452-97ed-6340c56b2bd4"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"OK"}}
+"#;
+        let parsed = parse_codex_json_events(log.as_bytes(), Some("gpt-5.2".to_string()))?;
         assert!(parsed.is_none());
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Parse Codex usage from the current `codex exec --json` `turn.completed.usage` stream instead of ephemeral session logs.
- Preserve exact cache/reasoning token breakdowns in `codex_log` rows.
- Bump remem to `0.4.2` and update usage accounting docs/changelog.

## Root cause
`codex exec --ephemeral` does not persist the per-run marker in Codex session JSONL, so the old session-log matcher fell back to text estimates.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo test`
- `/Users/lifcc/.local/bin/remem --version` -> `remem 0.4.2`
- `/Users/lifcc/.local/bin/remem usage --days 1 --weeks 1`