### PR TITLE
ci: publish crate during release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,12 @@ jobs:
         with:
           generate_release_notes: true
           files: artifacts/**/*.tar.gz
+
+  publish-crate:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish crate
+        run: cargo publish --locked --token "${{ secrets.CRATES_IO_TOKEN }}"


### PR DESCRIPTION
## Summary

- add a release workflow job that publishes remem-ai to crates.io after GitHub release assets are created
- use the repository Actions secret CRATES_IO_TOKEN instead of storing a token in shell config

## Validation

- ruby YAML parse for .github/workflows/release.yml
- git diff --check

## Security

The token is stored as an encrypted GitHub Actions secret. It is not committed and not written to shell startup files.