### PR TITLE
Keep global memories out of startup context

### DIFF
--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -84,17 +84,15 @@ fn load_project_memories(
     }
 
     let project_query = project.rsplit('/').next().unwrap_or(project);
-    if let Ok(searched) = crate::retrieval::search::search(
+    if let Ok(searched) = memory::search_project_memories_excluding_types(
         conn,
-        Some(project_query),
-        Some(project),
-        None,
+        project,
+        project_query,
+        excluded_types,
         BASENAME_SEARCH_LIMIT,
-        0,
-        false,
     ) {
         for memory in searched {
-            if is_project_scoped_context_memory(&memory, project) && seen_ids.insert(memory.id) {
+            if seen_ids.insert(memory.id) {
                 memories.push(memory);
             }
         }
@@ -108,10 +106,6 @@ fn load_project_memories(
     );
     sort_memories_by_branch(&mut selected, current_branch);
     selected
-}
-
-fn is_project_scoped_context_memory(memory: &Memory, project: &str) -> bool {
-    memory.project == project && memory.scope != "global"
 }
 
 fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -70,7 +70,7 @@ fn load_project_memories(
         .section(SectionKind::MemoryIndex)
         .map(|section| section.exclude_types.as_slice())
         .unwrap_or(&[]);
-    let recent = memory::get_recent_memories_excluding_types(
+    let recent = memory::get_recent_project_memories_excluding_types(
         conn,
         project,
         excluded_types,
@@ -94,7 +94,7 @@ fn load_project_memories(
         false,
     ) {
         for memory in searched {
-            if seen_ids.insert(memory.id) {
+            if is_project_scoped_context_memory(&memory, project) && seen_ids.insert(memory.id) {
                 memories.push(memory);
             }
         }
@@ -108,6 +108,10 @@ fn load_project_memories(
     );
     sort_memories_by_branch(&mut selected, current_branch);
     selected
+}
+
+fn is_project_scoped_context_memory(memory: &Memory, project: &str) -> bool {
+    memory.project == project && memory.scope != "global"
 }
 
 fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -400,23 +400,25 @@ fn load_context_data_excludes_global_non_preferences_from_basename_search() {
         "This fills the tiny recent candidate limit.",
         now,
     );
-    insert_global_memory(
-        &conn,
-        3,
-        "manual",
-        Some("global-remem-memory"),
-        "bugfix",
-        "Global remem bugfix",
-        "A global result matching the basename query should not enter context.",
-        now + 1,
-    );
+    for idx in 0..25 {
+        insert_global_memory(
+            &conn,
+            idx + 3,
+            "manual",
+            Some(&format!("global-remem-memory-{idx}")),
+            "bugfix",
+            &format!("Global remem bugfix {idx}"),
+            "A global result matching the basename query should not enter context.",
+            now + 1 + idx,
+        );
+    }
 
     let loaded = load_context_data_with_policy(&conn, project, None, &policy);
 
     assert!(!loaded
         .memories
         .iter()
-        .any(|memory| memory.title == "Global remem bugfix"));
+        .any(|memory| memory.title.starts_with("Global remem bugfix")));
     assert!(loaded
         .memories
         .iter()

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -4,7 +4,7 @@ use rusqlite::Connection;
 use super::super::policy::{ContextLimits, ContextPolicy};
 use super::super::query::{load_context_data, load_context_data_with_policy};
 use super::super::render::{enforce_total_char_limit, enforce_total_char_limit_preserving_footer};
-use super::{insert_memory, insert_memory_with_branch};
+use super::{insert_global_memory, insert_memory, insert_memory_with_branch};
 
 #[test]
 fn load_context_data_dedupes_generated_topic_keys_by_workstream_context() {
@@ -324,6 +324,103 @@ fn load_context_data_excludes_preferences_before_candidate_limit() {
         .memories
         .iter()
         .any(|memory| memory.title == "Keep core memories visible"));
+}
+
+#[test]
+fn load_context_data_excludes_global_non_preferences_from_main_memory_pool() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_global_memory(
+        &conn,
+        1,
+        "manual",
+        Some("mihomo-proxy-group-duplicate-name"),
+        "bugfix",
+        "Mihomo proxy group duplicate name",
+        "This global bugfix should not appear in project SessionStart Core or Index.",
+        now,
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("context-project-only-memory"),
+        "decision",
+        "Keep context memory project scoped",
+        "SessionStart should load project-local non-preference memories.",
+        now - 1,
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+
+    assert!(!loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Mihomo proxy group duplicate name"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Keep context memory project scoped"));
+}
+
+#[test]
+fn load_context_data_excludes_global_non_preferences_from_basename_search() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+    let limits = ContextLimits {
+        candidate_fetch_limit: 1,
+        memory_index_limit: 10,
+        core_item_limit: 3,
+        ..ContextLimits::default()
+    };
+    let policy = ContextPolicy::from_limits(limits);
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("older-local-memory"),
+        "decision",
+        "Older local remem decision",
+        "A project-local decision should still appear through basename search.",
+        now - 10,
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("newer-local-memory"),
+        "decision",
+        "Newer local context decision",
+        "This fills the tiny recent candidate limit.",
+        now,
+    );
+    insert_global_memory(
+        &conn,
+        3,
+        "manual",
+        Some("global-remem-memory"),
+        "bugfix",
+        "Global remem bugfix",
+        "A global result matching the basename query should not enter context.",
+        now + 1,
+    );
+
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy);
+
+    assert!(!loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Global remem bugfix"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Older local remem decision"));
 }
 
 #[test]

--- a/src/context/tests/mod.rs
+++ b/src/context/tests/mod.rs
@@ -102,6 +102,34 @@ pub(super) fn insert_memory_with_branch(
     .unwrap();
 }
 
+pub(super) fn insert_global_memory(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    topic_key: Option<&str>,
+    memory_type: &str,
+    title: &str,
+    content: &str,
+    updated_at_epoch: i64,
+) {
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope)
+         VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?7, 'active', NULL, 'global')",
+        params![
+            id,
+            project,
+            topic_key,
+            title,
+            content,
+            memory_type,
+            updated_at_epoch
+        ],
+    )
+    .unwrap();
+}
+
 pub(super) fn insert_session_summary(
     conn: &Connection,
     project: &str,

--- a/src/memory/store/read.rs
+++ b/src/memory/store/read.rs
@@ -91,6 +91,59 @@ pub fn get_recent_project_memories_excluding_types(
     crate::db::query::collect_rows(rows)
 }
 
+pub fn search_project_memories_excluding_types(
+    conn: &Connection,
+    project: &str,
+    query: &str,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<Memory>> {
+    if query.trim().is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    conditions.push(format!("project = ?{idx}"));
+    params.push(Box::new(project.to_string()));
+    idx += 1;
+    conditions.push("COALESCE(scope, 'project') != 'global'".to_string());
+    conditions.push("status = 'active'".to_string());
+
+    let like_pattern = format!("%{query}%");
+    conditions.push(format!("(title LIKE ?{idx} OR content LIKE ?{idx})"));
+    params.push(Box::new(like_pattern));
+    idx += 1;
+
+    if !excluded_types.is_empty() {
+        let placeholders: Vec<String> = excluded_types
+            .iter()
+            .map(|memory_type| {
+                let placeholder = format!("?{idx}");
+                params.push(Box::new((*memory_type).to_string()));
+                idx += 1;
+                placeholder
+            })
+            .collect();
+        conditions.push(format!("memory_type NOT IN ({})", placeholders.join(", ")));
+    }
+
+    params.push(Box::new(limit));
+    let sql = format!(
+        "SELECT {} FROM memories \
+         WHERE {} \
+         ORDER BY updated_at_epoch DESC LIMIT ?{}",
+        MEMORY_COLS,
+        conditions.join(" AND "),
+        idx,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), map_memory_row)?;
+    crate::db::query::collect_rows(rows)
+}
+
 pub fn get_memories_by_type(
     conn: &Connection,
     project: &str,

--- a/src/memory/store/read.rs
+++ b/src/memory/store/read.rs
@@ -48,6 +48,49 @@ pub fn get_recent_memories_excluding_types(
     crate::db::query::collect_rows(rows)
 }
 
+pub fn get_recent_project_memories_excluding_types(
+    conn: &Connection,
+    project: &str,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<Memory>> {
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    conditions.push(format!("project = ?{idx}"));
+    params.push(Box::new(project.to_string()));
+    idx += 1;
+    conditions.push("COALESCE(scope, 'project') != 'global'".to_string());
+    conditions.push("status = 'active'".to_string());
+
+    if !excluded_types.is_empty() {
+        let placeholders: Vec<String> = excluded_types
+            .iter()
+            .map(|memory_type| {
+                let placeholder = format!("?{idx}");
+                params.push(Box::new((*memory_type).to_string()));
+                idx += 1;
+                placeholder
+            })
+            .collect();
+        conditions.push(format!("memory_type NOT IN ({})", placeholders.join(", ")));
+    }
+
+    params.push(Box::new(limit));
+    let sql = format!(
+        "SELECT {} FROM memories \
+         WHERE {} \
+         ORDER BY updated_at_epoch DESC LIMIT ?{}",
+        MEMORY_COLS,
+        conditions.join(" AND "),
+        idx,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), map_memory_row)?;
+    crate::db::query::collect_rows(rows)
+}
+
 pub fn get_memories_by_type(
     conn: &Connection,
     project: &str,


### PR DESCRIPTION
## Summary
- restrict SessionStart main memory loading to project-scoped non-preference memories
- keep existing search/list global overlay behavior intact outside startup context
- add regression coverage for recent-memory and basename-search global leakage paths

Closes #174

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/remem --host codex-cli`
  - verified prior leaked global bugfix `#53972 Mihomo...` no longer appears in Core/Index
