### PR TITLE
Fix SessionStart global memory leakage

### DIFF
--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -84,10 +84,10 @@ fn load_project_memories(
     }
 
     let project_query = project.rsplit('/').next().unwrap_or(project);
-    if let Ok(searched) = crate::retrieval::search::search(
+    if let Ok(searched) = crate::retrieval::search::search_project_scoped_query(
         conn,
-        Some(project_query),
-        Some(project),
+        project_query,
+        project,
         None,
         BASENAME_SEARCH_LIMIT,
         0,

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -70,7 +70,7 @@ fn load_project_memories(
         .section(SectionKind::MemoryIndex)
         .map(|section| section.exclude_types.as_slice())
         .unwrap_or(&[]);
-    let recent = memory::get_recent_memories_excluding_types(
+    let recent = memory::get_recent_project_memories_excluding_types(
         conn,
         project,
         excluded_types,
@@ -94,7 +94,7 @@ fn load_project_memories(
         false,
     ) {
         for memory in searched {
-            if seen_ids.insert(memory.id) {
+            if is_project_scoped_memory(&memory, project) && seen_ids.insert(memory.id) {
                 memories.push(memory);
             }
         }
@@ -108,6 +108,10 @@ fn load_project_memories(
     );
     sort_memories_by_branch(&mut selected, current_branch);
     selected
+}
+
+fn is_project_scoped_memory(memory: &Memory, project: &str) -> bool {
+    memory.project == project && memory.scope == "project"
 }
 
 fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -438,6 +438,65 @@ fn load_context_data_filters_global_non_preferences_from_basename_search() {
 }
 
 #[test]
+fn load_context_data_filters_basename_search_scope_before_result_limit() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+    let limits = ContextLimits {
+        candidate_fetch_limit: 1,
+        ..ContextLimits::default()
+    };
+    let policy = ContextPolicy::from_limits(limits);
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("recent-project-filler"),
+        "decision",
+        "Recent project filler",
+        "A recent project memory keeps the direct candidate window full",
+        now,
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("old-remem-local-decision"),
+        "decision",
+        "remem local startup decision",
+        "Project-local remem context must survive global basename floods",
+        now - 10_000,
+    );
+
+    for idx in 0..30 {
+        insert_memory_with_scope(
+            &conn,
+            100 + idx,
+            "manual",
+            Some(&format!("global-remem-bugfix-{idx}")),
+            "bugfix",
+            &format!("remem unrelated global bugfix {idx}"),
+            "A global remem memory from another project",
+            now - idx,
+            "global",
+        );
+    }
+
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy);
+
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "remem local startup decision"));
+    assert!(!loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title.contains("unrelated global bugfix")));
+}
+
+#[test]
 fn enforce_total_char_limit_truncates_rendered_output() {
     let mut output = format!("{}{}", "# [/tmp/demo] context\n", "x".repeat(500));
 

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -4,7 +4,7 @@ use rusqlite::Connection;
 use super::super::policy::{ContextLimits, ContextPolicy};
 use super::super::query::{load_context_data, load_context_data_with_policy};
 use super::super::render::{enforce_total_char_limit, enforce_total_char_limit_preserving_footer};
-use super::{insert_memory, insert_memory_with_branch};
+use super::{insert_memory, insert_memory_with_branch, insert_memory_with_scope};
 
 #[test]
 fn load_context_data_dedupes_generated_topic_keys_by_workstream_context() {
@@ -324,6 +324,117 @@ fn load_context_data_excludes_preferences_before_candidate_limit() {
         .memories
         .iter()
         .any(|memory| memory.title == "Keep core memories visible"));
+}
+
+#[test]
+fn load_context_data_fetches_project_memories_without_global_candidate_flood() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+    let limits = ContextLimits {
+        candidate_fetch_limit: 3,
+        ..ContextLimits::default()
+    };
+    let policy = ContextPolicy::from_limits(limits);
+
+    for idx in 0..10 {
+        insert_memory_with_scope(
+            &conn,
+            idx + 1,
+            "manual",
+            Some(&format!("global-bugfix-{idx}")),
+            "bugfix",
+            &format!("Unrelated global bugfix {idx}"),
+            "A global operational fix from another project",
+            now - idx,
+            "global",
+        );
+    }
+    insert_memory(
+        &conn,
+        100,
+        project,
+        Some("local-bugfix"),
+        "bugfix",
+        "Project-local bugfix",
+        "Keep remem SessionStart project context visible",
+        now - 1_000,
+    );
+    insert_memory(
+        &conn,
+        101,
+        project,
+        Some("local-decision"),
+        "decision",
+        "Project-local decision",
+        "Use project-only passive SessionStart memories",
+        now - 1_001,
+    );
+
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy);
+
+    assert!(loaded
+        .memories
+        .iter()
+        .all(|memory| memory.project == project && memory.scope == "project"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Project-local bugfix"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Project-local decision"));
+    assert!(!loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title.contains("Unrelated global bugfix")));
+}
+
+#[test]
+fn load_context_data_filters_global_non_preferences_from_basename_search() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory_with_scope(
+        &conn,
+        1,
+        "manual",
+        Some("global-remem-bugfix"),
+        "bugfix",
+        "remem global duplicate-name bugfix",
+        "A global memory mentioning remem should not enter passive startup context",
+        now,
+        "global",
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("local-remem-decision"),
+        "decision",
+        "remem local startup decision",
+        "Project-local memories still participate in SessionStart",
+        now - 1,
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "remem local startup decision"));
+    assert!(!loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "remem global duplicate-name bugfix"));
+    assert!(loaded
+        .memories
+        .iter()
+        .all(|memory| memory.scope == "project"));
 }
 
 #[test]

--- a/src/context/tests/mod.rs
+++ b/src/context/tests/mod.rs
@@ -83,11 +83,63 @@ pub(super) fn insert_memory_with_branch(
     updated_at_epoch: i64,
     branch: Option<&str>,
 ) {
+    insert_memory_with_branch_and_scope(
+        conn,
+        id,
+        project,
+        topic_key,
+        memory_type,
+        title,
+        content,
+        updated_at_epoch,
+        branch,
+        "project",
+    );
+}
+
+pub(super) fn insert_memory_with_scope(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    topic_key: Option<&str>,
+    memory_type: &str,
+    title: &str,
+    content: &str,
+    updated_at_epoch: i64,
+    scope: &str,
+) {
+    insert_memory_with_branch_and_scope(
+        conn,
+        id,
+        project,
+        topic_key,
+        memory_type,
+        title,
+        content,
+        updated_at_epoch,
+        None,
+        scope,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_memory_with_branch_and_scope(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    topic_key: Option<&str>,
+    memory_type: &str,
+    title: &str,
+    content: &str,
+    updated_at_epoch: i64,
+    branch: Option<&str>,
+    scope: &str,
+) {
     conn.execute(
         "INSERT INTO memories
          (id, session_id, project, topic_key, title, content, memory_type, files,
           created_at_epoch, updated_at_epoch, status, branch, scope)
-         VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?7, 'active', ?8, 'project')",
+         VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?7, 'active', ?8, ?9)",
         params![
             id,
             project,
@@ -96,7 +148,8 @@ pub(super) fn insert_memory_with_branch(
             content,
             memory_type,
             updated_at_epoch,
-            branch
+            branch,
+            scope
         ],
     )
     .unwrap();

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -10,7 +10,8 @@ pub mod types;
 
 pub use crate::retrieval::memory_search::{
     search_memories_fts, search_memories_fts_filtered, search_memories_like,
-    search_memories_like_filtered,
+    search_memories_like_filtered, search_project_memories_fts_filtered,
+    search_project_memories_like_filtered,
 };
 pub use promote::{promote_summary_to_memories, slugify_for_topic};
 

--- a/src/memory/store/read.rs
+++ b/src/memory/store/read.rs
@@ -14,10 +14,36 @@ pub fn get_recent_memories_excluding_types(
     excluded_types: &[&str],
     limit: i64,
 ) -> Result<Vec<Memory>> {
+    get_recent_memories_excluding_types_with_scope(conn, project, excluded_types, limit, true)
+}
+
+pub fn get_recent_project_memories_excluding_types(
+    conn: &Connection,
+    project: &str,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<Memory>> {
+    get_recent_memories_excluding_types_with_scope(conn, project, excluded_types, limit, false)
+}
+
+fn get_recent_memories_excluding_types_with_scope(
+    conn: &Connection,
+    project: &str,
+    excluded_types: &[&str],
+    limit: i64,
+    include_global: bool,
+) -> Result<Vec<Memory>> {
     let mut conditions = Vec::new();
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
     let mut idx = 1;
-    idx = push_project_filter_required("project", project, idx, &mut conditions, &mut params);
+    if include_global {
+        idx = push_project_filter_required("project", project, idx, &mut conditions, &mut params);
+    } else {
+        conditions.push(format!("project = ?{idx}"));
+        params.push(Box::new(project.to_string()));
+        idx += 1;
+        conditions.push("COALESCE(scope, 'project') = 'project'".to_string());
+    }
     conditions.push("status = 'active'".to_string());
 
     if !excluded_types.is_empty() {

--- a/src/retrieval/entity.rs
+++ b/src/retrieval/entity.rs
@@ -8,4 +8,6 @@ mod tests;
 pub use extract::extract_entities;
 pub use graph::{expand_via_entity_graph, expand_via_entity_graph_filtered};
 pub use link::link_entities;
-pub use search::{search_by_entity, search_by_entity_filtered};
+pub use search::{
+    search_by_entity, search_by_entity_filtered, search_project_memories_by_entity_filtered,
+};

--- a/src/retrieval/entity/search.rs
+++ b/src/retrieval/entity/search.rs
@@ -2,4 +2,6 @@ mod lookup;
 mod runner;
 mod sql;
 
-pub use runner::{search_by_entity, search_by_entity_filtered};
+pub use runner::{
+    search_by_entity, search_by_entity_filtered, search_project_memories_by_entity_filtered,
+};

--- a/src/retrieval/entity/search/lookup.rs
+++ b/src/retrieval/entity/search/lookup.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
+use crate::retrieval::memory_search::ProjectScopeFilter;
+
 use super::sql::{branch_filter_sql, project_filter_sql, status_filter_sql};
 
 pub(super) fn search_by_query_words(
@@ -11,6 +13,29 @@ pub(super) fn search_by_query_words(
     branch: Option<&str>,
     limit: i64,
     include_inactive: bool,
+) -> Result<Vec<i64>> {
+    search_by_query_words_with_scope(
+        conn,
+        query,
+        project,
+        memory_type,
+        branch,
+        limit,
+        include_inactive,
+        ProjectScopeFilter::IncludeGlobal,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn search_by_query_words_with_scope(
+    conn: &Connection,
+    query: &str,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    branch: Option<&str>,
+    limit: i64,
+    include_inactive: bool,
+    scope_filter: ProjectScopeFilter,
 ) -> Result<Vec<i64>> {
     let mut ids = Vec::new();
     for word in query.split_whitespace() {
@@ -27,6 +52,7 @@ pub(super) fn search_by_query_words(
             branch,
             limit,
             include_inactive,
+            scope_filter,
         )?;
         for id in matches {
             if !ids.contains(&id) {
@@ -46,6 +72,7 @@ pub(super) fn query_memory_ids(
     branch: Option<&str>,
     limit: i64,
     include_inactive: bool,
+    scope_filter: ProjectScopeFilter,
 ) -> Result<Vec<i64>> {
     let mut conditions = vec![
         entity_condition,
@@ -54,7 +81,7 @@ pub(super) fn query_memory_ids(
     let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = vec![first_param];
     let mut idx = 2;
     if let Some(project) = project {
-        conditions.push(project_filter_sql(idx));
+        conditions.push(project_filter_sql(idx, scope_filter));
         params_vec.push(Box::new(project.to_string()));
         idx += 1;
     }

--- a/src/retrieval/entity/search/runner.rs
+++ b/src/retrieval/entity/search/runner.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
+use crate::retrieval::memory_search::ProjectScopeFilter;
+
 use super::super::extract::extract_entities;
-use super::lookup::{query_memory_ids, search_by_query_words};
+use super::lookup::{query_memory_ids, search_by_query_words, search_by_query_words_with_scope};
 
 pub fn search_by_entity(
     conn: &Connection,
@@ -22,17 +24,73 @@ pub fn search_by_entity_filtered(
     limit: i64,
     include_inactive: bool,
 ) -> Result<Vec<i64>> {
+    search_by_entity_filtered_with_scope(
+        conn,
+        query,
+        project,
+        memory_type,
+        branch,
+        limit,
+        include_inactive,
+        ProjectScopeFilter::IncludeGlobal,
+    )
+}
+
+pub fn search_project_memories_by_entity_filtered(
+    conn: &Connection,
+    query: &str,
+    project: &str,
+    memory_type: Option<&str>,
+    branch: Option<&str>,
+    limit: i64,
+    include_inactive: bool,
+) -> Result<Vec<i64>> {
+    search_by_entity_filtered_with_scope(
+        conn,
+        query,
+        Some(project),
+        memory_type,
+        branch,
+        limit,
+        include_inactive,
+        ProjectScopeFilter::ProjectOnly,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn search_by_entity_filtered_with_scope(
+    conn: &Connection,
+    query: &str,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    branch: Option<&str>,
+    limit: i64,
+    include_inactive: bool,
+    scope_filter: ProjectScopeFilter,
+) -> Result<Vec<i64>> {
     let query_entities = extract_entities(query, "");
     if query_entities.is_empty() {
-        return search_by_query_words(
-            conn,
-            query,
-            project,
-            memory_type,
-            branch,
-            limit,
-            include_inactive,
-        );
+        return match scope_filter {
+            ProjectScopeFilter::IncludeGlobal => search_by_query_words(
+                conn,
+                query,
+                project,
+                memory_type,
+                branch,
+                limit,
+                include_inactive,
+            ),
+            ProjectScopeFilter::ProjectOnly => search_by_query_words_with_scope(
+                conn,
+                query,
+                project,
+                memory_type,
+                branch,
+                limit,
+                include_inactive,
+                scope_filter,
+            ),
+        };
     }
 
     let mut all_ids = Vec::new();
@@ -46,6 +104,7 @@ pub fn search_by_entity_filtered(
             branch,
             limit,
             include_inactive,
+            scope_filter,
         )?;
         for id in ids {
             if !all_ids.contains(&id) {

--- a/src/retrieval/entity/search/sql.rs
+++ b/src/retrieval/entity/search/sql.rs
@@ -1,5 +1,7 @@
-pub(super) fn project_filter_sql(param_idx: usize) -> String {
-    crate::retrieval::memory_search::project_or_global_clause("m.project", param_idx)
+use crate::retrieval::memory_search::{project_visibility_clause, ProjectScopeFilter};
+
+pub(super) fn project_filter_sql(param_idx: usize, scope_filter: ProjectScopeFilter) -> String {
+    project_visibility_clause("m.project", "m.scope", param_idx, scope_filter)
 }
 
 pub(super) fn branch_filter_sql(param_idx: usize) -> String {

--- a/src/retrieval/memory_search.rs
+++ b/src/retrieval/memory_search.rs
@@ -4,6 +4,13 @@ mod like;
 #[cfg(test)]
 mod tests;
 
-pub use filters::{project_or_global_clause, push_project_filter, push_project_filter_required};
-pub use fts::{search_memories_fts, search_memories_fts_filtered};
-pub use like::{search_memories_like, search_memories_like_filtered};
+pub use filters::{
+    project_or_global_clause, project_visibility_clause, push_project_filter,
+    push_project_filter_required, push_project_filter_with_scope, ProjectScopeFilter,
+};
+pub use fts::{
+    search_memories_fts, search_memories_fts_filtered, search_project_memories_fts_filtered,
+};
+pub use like::{
+    search_memories_like, search_memories_like_filtered, search_project_memories_like_filtered,
+};

--- a/src/retrieval/memory_search/filters.rs
+++ b/src/retrieval/memory_search/filters.rs
@@ -1,3 +1,9 @@
+#[derive(Clone, Copy)]
+pub enum ProjectScopeFilter {
+    IncludeGlobal,
+    ProjectOnly,
+}
+
 /// Push memory project visibility filter into SQL conditions.
 /// When a project is provided, memory queries use project + global overlay.
 /// Returns the next parameter index.
@@ -10,6 +16,28 @@ pub fn push_project_filter(
 ) -> usize {
     if let Some(project) = project {
         conditions.push(project_or_global_clause(column, idx));
+        params.push(Box::new(project.to_string()));
+        idx += 1;
+    }
+    idx
+}
+
+pub fn push_project_filter_with_scope(
+    project_column: &str,
+    scope_column: &str,
+    project: Option<&str>,
+    mut idx: usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+    scope_filter: ProjectScopeFilter,
+) -> usize {
+    if let Some(project) = project {
+        conditions.push(project_visibility_clause(
+            project_column,
+            scope_column,
+            idx,
+            scope_filter,
+        ));
         params.push(Box::new(project.to_string()));
         idx += 1;
     }
@@ -31,6 +59,22 @@ pub fn push_project_filter_required(
 
 pub fn project_or_global_clause(column: &str, param_idx: usize) -> String {
     format!("({column} = ?{param_idx} OR scope = 'global')")
+}
+
+pub fn project_visibility_clause(
+    project_column: &str,
+    scope_column: &str,
+    param_idx: usize,
+    scope_filter: ProjectScopeFilter,
+) -> String {
+    match scope_filter {
+        ProjectScopeFilter::IncludeGlobal => project_or_global_clause(project_column, param_idx),
+        ProjectScopeFilter::ProjectOnly => {
+            format!(
+                "({project_column} = ?{param_idx} AND COALESCE({scope_column}, 'project') = 'project')"
+            )
+        }
+    }
 }
 
 pub(super) fn push_branch_filter(

--- a/src/retrieval/memory_search/fts.rs
+++ b/src/retrieval/memory_search/fts.rs
@@ -3,7 +3,9 @@ use rusqlite::Connection;
 
 use crate::db;
 use crate::memory::{map_memory_row_pub, Memory};
-use crate::retrieval::memory_search::filters::{push_branch_filter, push_project_filter};
+use crate::retrieval::memory_search::filters::{
+    push_branch_filter, push_project_filter_with_scope, ProjectScopeFilter,
+};
 
 /// FTS5 trigram search on memories.
 pub fn search_memories_fts(
@@ -36,6 +38,54 @@ pub fn search_memories_fts_filtered(
     include_inactive: bool,
     branch: Option<&str>,
 ) -> Result<Vec<Memory>> {
+    search_memories_fts_filtered_with_scope(
+        conn,
+        query,
+        project,
+        memory_type,
+        limit,
+        offset,
+        include_inactive,
+        branch,
+        ProjectScopeFilter::IncludeGlobal,
+    )
+}
+
+pub fn search_project_memories_fts_filtered(
+    conn: &Connection,
+    query: &str,
+    project: &str,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_inactive: bool,
+    branch: Option<&str>,
+) -> Result<Vec<Memory>> {
+    search_memories_fts_filtered_with_scope(
+        conn,
+        query,
+        Some(project),
+        memory_type,
+        limit,
+        offset,
+        include_inactive,
+        branch,
+        ProjectScopeFilter::ProjectOnly,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn search_memories_fts_filtered_with_scope(
+    conn: &Connection,
+    query: &str,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_inactive: bool,
+    branch: Option<&str>,
+    scope_filter: ProjectScopeFilter,
+) -> Result<Vec<Memory>> {
     let mut conditions = vec!["memories_fts MATCH ?1".to_string()];
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(query.to_string())];
 
@@ -44,12 +94,14 @@ pub fn search_memories_fts_filtered(
         conditions.push("m.status = 'active'".to_string());
     }
 
-    idx = push_project_filter(
+    idx = push_project_filter_with_scope(
         "m.project",
+        "m.scope",
         project,
         idx,
         &mut conditions,
         &mut param_values,
+        scope_filter,
     );
     idx = push_branch_filter("m.branch", branch, idx, &mut conditions, &mut param_values);
     if let Some(memory_type) = memory_type {

--- a/src/retrieval/memory_search/like.rs
+++ b/src/retrieval/memory_search/like.rs
@@ -3,7 +3,9 @@ use rusqlite::Connection;
 
 use crate::db;
 use crate::memory::{map_memory_row_pub, Memory};
-use crate::retrieval::memory_search::filters::{push_branch_filter, push_project_filter};
+use crate::retrieval::memory_search::filters::{
+    push_branch_filter, push_project_filter_with_scope, ProjectScopeFilter,
+};
 
 /// LIKE fallback for short tokens.
 pub fn search_memories_like(
@@ -36,6 +38,54 @@ pub fn search_memories_like_filtered(
     include_inactive: bool,
     branch: Option<&str>,
 ) -> Result<Vec<Memory>> {
+    search_memories_like_filtered_with_scope(
+        conn,
+        tokens,
+        project,
+        memory_type,
+        limit,
+        offset,
+        include_inactive,
+        branch,
+        ProjectScopeFilter::IncludeGlobal,
+    )
+}
+
+pub fn search_project_memories_like_filtered(
+    conn: &Connection,
+    tokens: &[&str],
+    project: &str,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_inactive: bool,
+    branch: Option<&str>,
+) -> Result<Vec<Memory>> {
+    search_memories_like_filtered_with_scope(
+        conn,
+        tokens,
+        Some(project),
+        memory_type,
+        limit,
+        offset,
+        include_inactive,
+        branch,
+        ProjectScopeFilter::ProjectOnly,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn search_memories_like_filtered_with_scope(
+    conn: &Connection,
+    tokens: &[&str],
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_inactive: bool,
+    branch: Option<&str>,
+    scope_filter: ProjectScopeFilter,
+) -> Result<Vec<Memory>> {
     if tokens.is_empty() {
         return Ok(vec![]);
     }
@@ -60,12 +110,14 @@ pub fn search_memories_like_filtered(
         idx += 1;
     }
 
-    idx = push_project_filter(
+    idx = push_project_filter_with_scope(
         "m.project",
+        "m.scope",
         project,
         idx,
         &mut conditions,
         &mut param_values,
+        scope_filter,
     );
     idx = push_branch_filter("m.branch", branch, idx, &mut conditions, &mut param_values);
     if let Some(memory_type) = memory_type {

--- a/src/retrieval/search.rs
+++ b/src/retrieval/search.rs
@@ -2,5 +2,5 @@ mod common;
 mod memory;
 mod observation;
 
-pub use memory::{search, search_with_branch};
+pub use memory::{search, search_project_scoped_query, search_with_branch};
 pub use observation::search_observations;

--- a/src/retrieval/search/memory.rs
+++ b/src/retrieval/search/memory.rs
@@ -2,4 +2,4 @@ mod listing;
 mod runner;
 mod text;
 
-pub use runner::{search, search_with_branch};
+pub use runner::{search, search_project_scoped_query, search_with_branch};

--- a/src/retrieval/search/memory/runner.rs
+++ b/src/retrieval/search/memory/runner.rs
@@ -4,7 +4,7 @@ use rusqlite::Connection;
 use crate::memory::Memory;
 
 use super::listing::search_without_query;
-use super::text::search_with_query;
+use super::text::{search_project_scoped_with_query, search_with_query};
 
 pub fn search(
     conn: &Connection,
@@ -58,4 +58,29 @@ pub fn search_with_branch(
             branch,
         ),
     }
+}
+
+pub fn search_project_scoped_query(
+    conn: &Connection,
+    query_text: &str,
+    project: &str,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_stale: bool,
+) -> Result<Vec<Memory>> {
+    if query_text.is_empty() {
+        return Ok(vec![]);
+    }
+
+    search_project_scoped_with_query(
+        conn,
+        query_text,
+        project,
+        memory_type,
+        limit,
+        offset,
+        include_stale,
+        None,
+    )
 }

--- a/src/retrieval/search/memory/text.rs
+++ b/src/retrieval/search/memory/text.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use rusqlite::Connection;
 
 use crate::memory::{self, Memory};
+use crate::retrieval::memory_search::ProjectScopeFilter;
 
 use super::super::common::{paginate_memories, rrf_fuse, sanitize_fts_query};
 
@@ -29,6 +30,60 @@ pub(super) fn search_with_query(
     include_stale: bool,
     branch: Option<&str>,
 ) -> Result<Vec<Memory>> {
+    search_with_query_scope(
+        conn,
+        query_text,
+        project,
+        memory_type,
+        limit,
+        offset,
+        include_stale,
+        branch,
+        ProjectScopeFilter::IncludeGlobal,
+    )
+}
+
+pub(super) fn search_project_scoped_with_query(
+    conn: &Connection,
+    query_text: &str,
+    project: &str,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_stale: bool,
+    branch: Option<&str>,
+) -> Result<Vec<Memory>> {
+    search_with_query_scope(
+        conn,
+        query_text,
+        Some(project),
+        memory_type,
+        limit,
+        offset,
+        include_stale,
+        branch,
+        ProjectScopeFilter::ProjectOnly,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn search_with_query_scope(
+    conn: &Connection,
+    query_text: &str,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_stale: bool,
+    branch: Option<&str>,
+    scope_filter: ProjectScopeFilter,
+) -> Result<Vec<Memory>> {
+    let project_scoped_name = match scope_filter {
+        ProjectScopeFilter::IncludeGlobal => "",
+        ProjectScopeFilter::ProjectOnly => {
+            project.ok_or_else(|| anyhow!("project-scoped search requires a project"))?
+        }
+    };
     let page_target = (limit.max(1) + offset.max(0) + 1).max(2);
     let fetch = page_target * 3;
     let expanded = crate::retrieval::query_expand::expand_query(query_text);
@@ -45,57 +100,109 @@ pub(super) fn search_with_query(
 
     if !long_tokens.is_empty() {
         let safe_query = sanitize_fts_query(&long_tokens.join(" "));
-        let fts = memory::search_memories_fts_filtered(
+        let fts = match scope_filter {
+            ProjectScopeFilter::IncludeGlobal => memory::search_memories_fts_filtered(
+                conn,
+                &safe_query,
+                project,
+                memory_type,
+                fetch,
+                0,
+                include_stale,
+                branch,
+            )?,
+            ProjectScopeFilter::ProjectOnly => memory::search_project_memories_fts_filtered(
+                conn,
+                &safe_query,
+                project_scoped_name,
+                memory_type,
+                fetch,
+                0,
+                include_stale,
+                branch,
+            )?,
+        };
+        channels.push(fts.iter().map(|memory| memory.id).collect());
+    }
+
+    let entity_ids = match scope_filter {
+        ProjectScopeFilter::IncludeGlobal => crate::retrieval::entity::search_by_entity_filtered(
             conn,
-            &safe_query,
+            query_text,
+            project,
+            memory_type,
+            branch,
+            fetch,
+            include_stale,
+        )?,
+        ProjectScopeFilter::ProjectOnly => {
+            crate::retrieval::entity::search_project_memories_by_entity_filtered(
+                conn,
+                query_text,
+                project_scoped_name,
+                memory_type,
+                branch,
+                fetch,
+                include_stale,
+            )?
+        }
+    };
+    if !entity_ids.is_empty() {
+        channels.push(entity_ids);
+    }
+
+    if let Some(temporal_constraint) = crate::retrieval::temporal::extract_temporal(query_text) {
+        let temporal_ids = match scope_filter {
+            ProjectScopeFilter::IncludeGlobal => {
+                crate::retrieval::temporal::search_by_time_filtered(
+                    conn,
+                    &temporal_constraint,
+                    project,
+                    memory_type,
+                    branch,
+                    fetch,
+                    include_stale,
+                )?
+            }
+            ProjectScopeFilter::ProjectOnly => {
+                crate::retrieval::temporal::search_by_time_project_scoped(
+                    conn,
+                    &temporal_constraint,
+                    project_scoped_name,
+                    memory_type,
+                    branch,
+                    fetch,
+                    include_stale,
+                )?
+            }
+        };
+        if !temporal_ids.is_empty() {
+            channels.push(temporal_ids);
+        }
+    }
+
+    let like = match scope_filter {
+        ProjectScopeFilter::IncludeGlobal => memory::search_memories_like_filtered(
+            conn,
+            &core_refs,
             project,
             memory_type,
             fetch,
             0,
             include_stale,
             branch,
-        )?;
-        channels.push(fts.iter().map(|memory| memory.id).collect());
-    }
-
-    let entity_ids = crate::retrieval::entity::search_by_entity_filtered(
-        conn,
-        query_text,
-        project,
-        memory_type,
-        branch,
-        fetch,
-        include_stale,
-    )?;
-    if !entity_ids.is_empty() {
-        channels.push(entity_ids);
-    }
-
-    if let Some(temporal_constraint) = crate::retrieval::temporal::extract_temporal(query_text) {
-        let temporal_ids = crate::retrieval::temporal::search_by_time_filtered(
+        )?,
+        ProjectScopeFilter::ProjectOnly => memory::search_project_memories_like_filtered(
             conn,
-            &temporal_constraint,
-            project,
+            &core_refs,
+            project_scoped_name,
             memory_type,
-            branch,
             fetch,
+            0,
             include_stale,
-        )?;
-        if !temporal_ids.is_empty() {
-            channels.push(temporal_ids);
-        }
-    }
-
-    let like = memory::search_memories_like_filtered(
-        conn,
-        &core_refs,
-        project,
-        memory_type,
-        fetch,
-        0,
-        include_stale,
-        branch,
-    )?;
+            branch,
+        )?,
+    };
     if !like.is_empty() {
         channels.push(like.iter().map(|memory| memory.id).collect());
     }

--- a/src/retrieval/temporal.rs
+++ b/src/retrieval/temporal.rs
@@ -5,5 +5,5 @@ mod tests;
 mod types;
 
 pub use parse::extract_temporal;
-pub use search::{search_by_time, search_by_time_filtered};
+pub use search::{search_by_time, search_by_time_filtered, search_by_time_project_scoped};
 pub use types::TemporalConstraint;

--- a/src/retrieval/temporal/search.rs
+++ b/src/retrieval/temporal/search.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use rusqlite::{types::ToSql, Connection};
 
+use crate::retrieval::memory_search::{project_visibility_clause, ProjectScopeFilter};
+
 use crate::retrieval::temporal::types::TemporalConstraint;
 
 /// Search memories within a time range, sorted by recency.
@@ -22,6 +24,50 @@ pub fn search_by_time_filtered(
     limit: i64,
     include_inactive: bool,
 ) -> Result<Vec<i64>> {
+    search_by_time_filtered_with_scope(
+        conn,
+        constraint,
+        project,
+        memory_type,
+        branch,
+        limit,
+        include_inactive,
+        ProjectScopeFilter::IncludeGlobal,
+    )
+}
+
+pub fn search_by_time_project_scoped(
+    conn: &Connection,
+    constraint: &TemporalConstraint,
+    project: &str,
+    memory_type: Option<&str>,
+    branch: Option<&str>,
+    limit: i64,
+    include_inactive: bool,
+) -> Result<Vec<i64>> {
+    search_by_time_filtered_with_scope(
+        conn,
+        constraint,
+        Some(project),
+        memory_type,
+        branch,
+        limit,
+        include_inactive,
+        ProjectScopeFilter::ProjectOnly,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn search_by_time_filtered_with_scope(
+    conn: &Connection,
+    constraint: &TemporalConstraint,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    branch: Option<&str>,
+    limit: i64,
+    include_inactive: bool,
+    scope_filter: ProjectScopeFilter,
+) -> Result<Vec<i64>> {
     let mut ids = Vec::new();
     let mut conditions = vec!["updated_at_epoch BETWEEN ?1 AND ?2".to_string()];
     let mut params_vec: Vec<Box<dyn ToSql>> = vec![
@@ -34,8 +80,11 @@ pub fn search_by_time_filtered(
         conditions.push("status = 'active'".to_string());
     }
     if let Some(project) = project {
-        conditions.push(crate::retrieval::memory_search::project_or_global_clause(
-            "project", idx,
+        conditions.push(project_visibility_clause(
+            "project",
+            "scope",
+            idx,
+            scope_filter,
         ));
         params_vec.push(Box::new(project.to_string()));
         idx += 1;


### PR DESCRIPTION
Fixes #174.

## Summary
- Add a project-only recent-memory helper for SessionStart Core/Index candidates.
- Keep explicit search behavior using the existing project+global overlay, while filtering SessionStart basename backfill to project-scoped rows.
- Add regressions for global bugfix floods, basename-search global leakage, and project-local bugfix/decision retention.

## Validation
- cargo fmt --check
- cargo check
- cargo clippy -- -D warnings
- cargo test
- cargo run -- context --cwd /Users/lifcc/Desktop/code/AI/tools/remem --host codex-cli
- cargo run -- context --cwd /Users/apple/Desktop/code/AI/tool/remem --host codex-cli
- rg no-match checks for #53972/Mihomo in generated context output
