### PR TITLE
Harden SessionStart context diagnostics

### DIFF
--- a/docs/sessionstart-context-smoke.md
+++ b/docs/sessionstart-context-smoke.md
@@ -1,0 +1,17 @@
+# SessionStart Context Smoke Matrix
+
+Use these read-only commands after context compiler changes:
+
+```bash
+REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/remem
+REMEM_CONTEXT_HOST=claude-code cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/remem
+REMEM_CONTEXT_DEBUG=1 REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/remem
+```
+
+Expected checks:
+
+- Normal output has no `## Debug Trace` section.
+- Footer includes host, branch, per-section chars, approximate tokens, and truncation status.
+- Project preferences render by default; global preferences require `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT`.
+- Long session requests are truncated inside the Sessions section.
+- Total truncation keeps the truncation marker and stats footer when both fit.

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -17,12 +17,13 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             session_id,
             host,
             color,
+            debug,
         } => {
             if remem_hooks_disabled() {
                 return Ok(());
             }
             let cwd = resolve_cwd_arg(cwd);
-            context::generate_context(&cwd, session_id.as_deref(), color, host.as_deref())?;
+            context::generate_context(&cwd, session_id.as_deref(), color, host.as_deref(), debug)?;
         }
         Commands::SessionInit => {
             if remem_hooks_disabled() {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -123,3 +123,27 @@ fn cli_parses_usage_options() {
         _ => panic!("expected usage command"),
     }
 }
+
+#[test]
+fn cli_parses_context_debug_option() {
+    let cli = Cli::parse_from([
+        "remem",
+        "context",
+        "--cwd",
+        "/tmp/remem",
+        "--host",
+        "codex-cli",
+        "--debug",
+    ]);
+
+    match cli.command {
+        Commands::Context {
+            cwd, host, debug, ..
+        } => {
+            assert_eq!(cwd.as_deref(), Some("/tmp/remem"));
+            assert_eq!(host.as_deref(), Some("codex-cli"));
+            assert!(debug);
+        }
+        _ => panic!("expected context command"),
+    }
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -25,6 +25,8 @@ pub(super) enum Commands {
         host: Option<String>,
         #[arg(long)]
         color: bool,
+        #[arg(long)]
+        debug: bool,
     },
     SessionInit,
     Observe,

--- a/src/context/format.rs
+++ b/src/context/format.rs
@@ -31,3 +31,22 @@ pub(super) fn format_epoch_time(epoch: i64) -> String {
         .map(|dt| dt.format("%-I:%M%P").to_string())
         .unwrap_or_default()
 }
+
+pub(super) fn char_len(value: &str) -> usize {
+    value.chars().count()
+}
+
+pub(super) fn truncate_chars_with_ellipsis(value: &str, max_chars: usize) -> String {
+    if char_len(value) <= max_chars {
+        return value.to_string();
+    }
+    if max_chars == 0 {
+        return String::new();
+    }
+    if max_chars <= 3 {
+        return value.chars().take(max_chars).collect();
+    }
+    let mut truncated: String = value.chars().take(max_chars - 3).collect();
+    truncated.push_str("...");
+    truncated
+}

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -3,12 +3,12 @@ use anyhow::Result;
 use crate::db;
 use crate::db::project_from_cwd;
 
-use super::format::format_header_datetime;
+use super::format::{char_len, format_header_datetime, truncate_chars_with_ellipsis};
 use super::host::{resolve_host_kind, resolve_profile};
 use super::policy::{ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
-    render_core_memory_with_limits, render_empty_state, render_memory_index_with_limits,
+    render_core_memory_with_limits, render_empty_state, render_memory_index_with_limits_excluding,
     render_recent_sessions_with_limit, render_workstreams_with_limits,
 };
 use super::types::ContextRequest;
@@ -18,6 +18,7 @@ pub fn generate_context(
     session_id: Option<&str>,
     use_colors: bool,
     host_arg: Option<&str>,
+    debug: bool,
 ) -> Result<()> {
     let timer = crate::log::Timer::start("context", &format!("cwd={}", cwd));
     let project = project_from_cwd(cwd);
@@ -25,6 +26,7 @@ pub fn generate_context(
     let host = resolve_host_kind(host_arg);
     let profile = resolve_profile(host);
     let policy = profile.default_policy();
+    let debug = debug || context_debug_enabled();
     let request = ContextRequest {
         cwd: cwd.to_string(),
         project: project.clone(),
@@ -54,16 +56,19 @@ pub fn generate_context(
         request.current_branch.as_deref(),
         &policy,
     );
-    let (preference_output, preference_count) =
+    let (preference_output, preference_summary) =
         match render_preferences_to_buffer(&conn, &project, cwd, &policy) {
             Ok(rendered) => rendered,
             Err(error) => {
                 crate::log::warn("context", &format!("render_preferences failed: {}", error));
-                (String::new(), 0)
+                (
+                    String::new(),
+                    crate::memory::preference::PreferenceRenderSummary::default(),
+                )
             }
         };
 
-    if preference_count == 0
+    if preference_summary.rendered == 0
         && loaded.memories.is_empty()
         && loaded.summaries.is_empty()
         && loaded.workstreams.is_empty()
@@ -81,40 +86,87 @@ pub fn generate_context(
     output.push_str(profile.retrieval_hints().line);
     output.push_str("\n\n");
 
+    let mut stats = ContextRenderStats {
+        host: request.host.as_env_value().to_string(),
+        branch: request.current_branch.clone(),
+        total_char_limit: policy.limits.total_char_limit,
+        memories_loaded: loaded.memories.len(),
+        project_preferences: preference_summary.project_rendered,
+        global_preferences: preference_summary.global_rendered,
+        ..ContextRenderStats::default()
+    };
+
+    let before = char_len(&output);
     output.push_str(&preference_output);
+    stats.preferences = SectionRenderStats {
+        count: preference_summary.rendered,
+        chars: char_len(&output).saturating_sub(before),
+    };
 
     let mut core_count = 0;
     let mut index_count = 0;
     if !loaded.memories.is_empty() {
         let render_limits = section_render_limits(&policy);
-        core_count = render_core_memory_with_limits(&mut output, &loaded.memories, &render_limits);
-        index_count =
-            render_memory_index_with_limits(&mut output, &loaded.memories, &render_limits);
+        let before = char_len(&output);
+        let core_summary =
+            render_core_memory_with_limits(&mut output, &loaded.memories, &render_limits);
+        core_count = core_summary.count;
+        stats.core_ids = core_summary.ids.clone();
+        stats.core = SectionRenderStats {
+            count: core_count,
+            chars: char_len(&output).saturating_sub(before),
+        };
+        let before = char_len(&output);
+        let core_ids = core_summary.ids.into_iter().collect();
+        index_count = render_memory_index_with_limits_excluding(
+            &mut output,
+            &loaded.memories,
+            &render_limits,
+            &core_ids,
+        );
+        stats.index = SectionRenderStats {
+            count: index_count,
+            chars: char_len(&output).saturating_sub(before),
+        };
     }
     if !loaded.workstreams.is_empty() {
-        render_workstreams_with_limits(
+        let before = char_len(&output);
+        let workstream_count = render_workstreams_with_limits(
             &mut output,
             &loaded.workstreams,
             policy.section_item_limit(SectionKind::Workstreams, 5),
             policy.section_char_limit(SectionKind::Workstreams, 1_200),
         );
+        stats.workstreams = SectionRenderStats {
+            count: workstream_count,
+            chars: char_len(&output).saturating_sub(before),
+        };
     }
     if !loaded.summaries.is_empty() {
-        render_recent_sessions_with_limit(
+        let before = char_len(&output);
+        let session_count = render_recent_sessions_with_limit(
             &mut output,
             &loaded.summaries,
             policy.section_char_limit(SectionKind::Sessions, 2_200),
         );
+        stats.sessions = SectionRenderStats {
+            count: session_count,
+            chars: char_len(&output).saturating_sub(before),
+        };
     }
 
-    let stats_footer = format!(
-        "{} context memories loaded. {} core memories. {} indexed memories. {} preferences. {} sessions.\n",
-        loaded.memories.len(),
-        core_count,
-        index_count,
-        preference_count,
-        loaded.summaries.len()
-    );
+    if debug {
+        output.push_str(&build_context_debug_trace(
+            &request, &policy, &loaded, &stats,
+        ));
+    }
+
+    stats.output_chars = char_len(&output);
+    let mut stats_footer = build_context_stats_footer(&stats);
+    stats.output_chars += char_len(&stats_footer);
+    stats.truncated = stats.total_char_limit > 0 && stats.output_chars > stats.total_char_limit;
+    stats_footer = build_context_stats_footer(&stats);
+    stats.output_chars = char_len(&output) + char_len(&stats_footer);
     output.push_str(&stats_footer);
     enforce_total_char_limit_preserving_footer(
         &mut output,
@@ -138,7 +190,7 @@ pub fn generate_context(
         loaded.memories.len(),
         core_count,
         index_count,
-        preference_count,
+        preference_summary.rendered,
         loaded.summaries.len(),
         loaded.workstreams.len(),
     ));
@@ -161,10 +213,10 @@ fn render_preferences_to_buffer(
     project: &str,
     cwd: &str,
     policy: &ContextPolicy,
-) -> Result<(String, usize)> {
+) -> Result<(String, crate::memory::preference::PreferenceRenderSummary)> {
     let mut output = String::new();
     let limits = &policy.limits;
-    let count = crate::memory::preference::render_preferences_with_limits(
+    let summary = crate::memory::preference::render_preferences_with_limits_detailed(
         &mut output,
         conn,
         project,
@@ -173,7 +225,145 @@ fn render_preferences_to_buffer(
         limits.preference_global_limit,
         limits.preference_char_limit,
     )?;
-    Ok((output, count))
+    Ok((output, summary))
+}
+
+#[derive(Debug, Clone, Default)]
+pub(in crate::context) struct SectionRenderStats {
+    pub count: usize,
+    pub chars: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(in crate::context) struct ContextRenderStats {
+    pub host: String,
+    pub branch: Option<String>,
+    pub total_char_limit: usize,
+    pub memories_loaded: usize,
+    pub core: SectionRenderStats,
+    pub index: SectionRenderStats,
+    pub preferences: SectionRenderStats,
+    pub project_preferences: usize,
+    pub global_preferences: usize,
+    pub sessions: SectionRenderStats,
+    pub workstreams: SectionRenderStats,
+    pub core_ids: Vec<i64>,
+    pub output_chars: usize,
+    pub truncated: bool,
+}
+
+pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats) -> String {
+    let branch = stats.branch.as_deref().unwrap_or("-");
+    let estimated_tokens = estimate_tokens(stats.output_chars);
+    format!(
+        "{} context memories loaded. {} core ({} chars). {} indexed ({} chars). {} preferences (project:{} global:{}, {} chars). {} sessions ({} chars). host={} branch={} total={} chars/~{} tokens limit={} truncated={}\n",
+        stats.memories_loaded,
+        stats.core.count,
+        stats.core.chars,
+        stats.index.count,
+        stats.index.chars,
+        stats.preferences.count,
+        stats.project_preferences,
+        stats.global_preferences,
+        stats.preferences.chars,
+        stats.sessions.count,
+        stats.sessions.chars,
+        stats.host,
+        branch,
+        stats.output_chars,
+        estimated_tokens,
+        stats.total_char_limit,
+        if stats.truncated { "yes" } else { "no" },
+    )
+}
+
+fn build_context_debug_trace(
+    request: &ContextRequest,
+    policy: &ContextPolicy,
+    loaded: &super::types::LoadedContext,
+    stats: &ContextRenderStats,
+) -> String {
+    let mut trace = String::from("## Debug Trace\n");
+    trace.push_str(&format!(
+        "- request host={} project={} cwd={} branch={} session={}\n",
+        request.host.as_env_value(),
+        request.project,
+        request.cwd,
+        request.current_branch.as_deref().unwrap_or("-"),
+        request.session_id.as_deref().unwrap_or("-")
+    ));
+    trace.push_str(&format!(
+        "- limits total={} core_items={} core_chars={} index_items={} index_chars={} sessions={} preferences(project={}, global={}, chars={})\n",
+        policy.limits.total_char_limit,
+        policy.limits.core_item_limit,
+        policy.limits.core_char_limit,
+        policy.limits.memory_index_limit,
+        policy.limits.memory_index_char_limit,
+        policy.limits.session_limit,
+        policy.limits.preference_project_limit,
+        policy.limits.preference_global_limit,
+        policy.limits.preference_char_limit
+    ));
+    trace.push_str(&format!(
+        "- rendered core={} index={} preferences={} sessions={} workstreams={}\n",
+        stats.core.count,
+        stats.index.count,
+        stats.preferences.count,
+        stats.sessions.count,
+        stats.workstreams.count
+    ));
+    trace.push_str(&format!(
+        "- preferences project_rendered={} global_rendered={} reason=scope_limits_then_claude_md_dedup\n",
+        stats.project_preferences, stats.global_preferences
+    ));
+    for (rank, memory) in loaded.memories.iter().take(30).enumerate() {
+        let target = if stats.core_ids.contains(&memory.id) {
+            "core"
+        } else {
+            "index_candidate"
+        };
+        trace.push_str(&format!(
+            "- memory rank={} id={} type={} scope={} branch={} topic={} target={} reason=loaded_after_scope_branch_dedupe title={}\n",
+            rank + 1,
+            memory.id,
+            memory.memory_type,
+            memory.scope,
+            memory.branch.as_deref().unwrap_or("-"),
+            memory.topic_key.as_deref().unwrap_or("-"),
+            target,
+            truncate_chars_with_ellipsis(&memory.title, 120)
+        ));
+    }
+    if loaded.memories.len() > 30 {
+        trace.push_str(&format!(
+            "- memory trace truncated: {} additional candidates omitted\n",
+            loaded.memories.len() - 30
+        ));
+    }
+    for (rank, summary) in loaded
+        .summaries
+        .iter()
+        .take(policy.limits.session_limit)
+        .enumerate()
+    {
+        trace.push_str(&format!(
+            "- session rank={} reason=recent_after_cluster_filter request={}\n",
+            rank + 1,
+            truncate_chars_with_ellipsis(&summary.request, 120)
+        ));
+    }
+    trace.push('\n');
+    trace
+}
+
+fn context_debug_enabled() -> bool {
+    std::env::var("REMEM_CONTEXT_DEBUG")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+fn estimate_tokens(chars: usize) -> usize {
+    (chars + 3) / 4
 }
 
 #[cfg(test)]

--- a/src/context/sections.rs
+++ b/src/context/sections.rs
@@ -10,7 +10,9 @@ pub(super) use core::render_core_memory_with_limits;
 pub(super) use empty::render_empty_state;
 #[cfg(test)]
 pub(super) use index::render_memory_index;
+#[cfg(test)]
 pub(super) use index::render_memory_index_with_limits;
+pub(super) use index::render_memory_index_with_limits_excluding;
 #[cfg(test)]
 pub(super) use sessions::render_recent_sessions;
 pub(super) use sessions::render_recent_sessions_with_limit;

--- a/src/context/sections/core.rs
+++ b/src/context/sections/core.rs
@@ -1,13 +1,19 @@
 use crate::memory::Memory;
 use std::collections::HashMap;
 
-use super::super::format::format_epoch_short;
+use super::super::format::{char_len, format_epoch_short, truncate_chars_with_ellipsis};
 use super::super::memory_traits::is_memory_self_diagnostic;
 use super::super::policy::ContextLimits;
 
 const PREVIEW_LEN: usize = 200;
 const MAX_PRIMARY_ITEMS_PER_TYPE: usize = 2;
 const MIN_ADDITIONAL_CORE_SCORE: f64 = 1.3;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(in crate::context) struct CoreRenderSummary {
+    pub count: usize,
+    pub ids: Vec<i64>,
+}
 
 #[cfg(test)]
 pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Memory]) {
@@ -18,15 +24,15 @@ pub(in crate::context) fn render_core_memory_with_limits(
     output: &mut String,
     memories: &[Memory],
     limits: &ContextLimits,
-) -> usize {
+) -> CoreRenderSummary {
     if limits.core_item_limit == 0 || limits.core_char_limit == 0 {
-        return 0;
+        return CoreRenderSummary::default();
     }
     let header = "## Core\n";
     let trailer_chars = 1;
-    let header_chars = header.chars().count();
+    let header_chars = char_len(header);
     if header_chars + trailer_chars >= limits.core_char_limit {
-        return 0;
+        return CoreRenderSummary::default();
     }
 
     let now = chrono::Utc::now().timestamp();
@@ -91,11 +97,15 @@ pub(in crate::context) fn render_core_memory_with_limits(
     }
 
     if selected.is_empty() {
-        return 0;
+        return CoreRenderSummary::default();
     }
 
     output.push_str(header);
     let selected_count = selected.len();
+    let selected_ids = selected
+        .iter()
+        .map(|(memory, _)| memory.id)
+        .collect::<Vec<_>>();
     for (memory, preview) in selected {
         let date = format_epoch_short(memory.updated_at_epoch);
         output.push_str(&format!(
@@ -106,7 +116,10 @@ pub(in crate::context) fn render_core_memory_with_limits(
         output.push('\n');
     }
     output.push('\n');
-    selected_count
+    CoreRenderSummary {
+        count: selected_count,
+        ids: selected_ids,
+    }
 }
 
 fn push_selected_memory<'a>(
@@ -122,36 +135,21 @@ fn push_selected_memory<'a>(
         memory.memory_type,
         format_epoch_short(memory.updated_at_epoch)
     );
-    let fixed_chars = header.chars().count() + 1;
+    let fixed_chars = char_len(&header) + 1;
     if *total_chars + fixed_chars >= max_chars {
         return false;
     }
 
     let remaining_chars = max_chars - *total_chars - fixed_chars;
     let preview_limit = remaining_chars.min(PREVIEW_LEN);
-    let preview = truncate_to_chars(&memory.text, preview_limit);
+    let preview = truncate_chars_with_ellipsis(&memory.text, preview_limit);
     if preview.is_empty() {
         return false;
     }
-    let item_len = preview.chars().count() + fixed_chars;
+    let item_len = char_len(&preview) + fixed_chars;
     selected.push((memory, preview));
     *total_chars += item_len;
     true
-}
-
-fn truncate_to_chars(value: &str, max_chars: usize) -> String {
-    if max_chars == 0 {
-        return String::new();
-    }
-    if value.chars().count() <= max_chars {
-        return value.to_string();
-    }
-    if max_chars <= 3 {
-        return value.chars().take(max_chars).collect();
-    }
-    let mut truncated: String = value.chars().take(max_chars - 3).collect();
-    truncated.push_str("...");
-    truncated
 }
 
 fn is_core_memory_type(memory_type: &str) -> bool {

--- a/src/context/sections/index.rs
+++ b/src/context/sections/index.rs
@@ -1,8 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::memory::Memory;
 
-use super::super::format::{format_epoch_short, type_label};
+use super::super::format::{
+    char_len, format_epoch_short, truncate_chars_with_ellipsis, type_label,
+};
 use super::super::policy::ContextLimits;
 
 #[cfg(test)]
@@ -10,10 +12,21 @@ pub(in crate::context) fn render_memory_index(output: &mut String, memories: &[M
     render_memory_index_with_limits(output, memories, &ContextLimits::default())
 }
 
+#[cfg(test)]
 pub(in crate::context) fn render_memory_index_with_limits(
     output: &mut String,
     memories: &[Memory],
     limits: &ContextLimits,
+) -> usize {
+    let excluded_ids = HashSet::new();
+    render_memory_index_with_limits_excluding(output, memories, limits, &excluded_ids)
+}
+
+pub(in crate::context) fn render_memory_index_with_limits_excluding(
+    output: &mut String,
+    memories: &[Memory],
+    limits: &ContextLimits,
+    excluded_ids: &HashSet<i64>,
 ) -> usize {
     if limits.memory_index_limit == 0 || limits.memory_index_char_limit == 0 {
         return 0;
@@ -23,6 +36,7 @@ pub(in crate::context) fn render_memory_index_with_limits(
     for memory in memories
         .iter()
         .filter(|memory| memory.memory_type != "preference")
+        .filter(|memory| !excluded_ids.contains(&memory.id))
         .take(limits.memory_index_limit)
     {
         by_type
@@ -119,7 +133,7 @@ fn push_memory_index_line(
             if remaining == 0 {
                 break;
             }
-            let truncated = truncate_to_chars(&item, remaining);
+            let truncated = truncate_chars_with_ellipsis(&item, remaining);
             if truncated.is_empty() {
                 break;
             }
@@ -145,20 +159,4 @@ fn push_memory_index_line(
     output.push_str(&line);
     *total_chars += line_chars;
     rendered
-}
-
-fn char_len(value: &str) -> usize {
-    value.chars().count()
-}
-
-fn truncate_to_chars(value: &str, max_chars: usize) -> String {
-    if value.chars().count() <= max_chars {
-        return value.to_string();
-    }
-    if max_chars <= 3 {
-        return value.chars().take(max_chars).collect();
-    }
-    let mut truncated: String = value.chars().take(max_chars - 3).collect();
-    truncated.push_str("...");
-    truncated
 }

--- a/src/context/sections/sessions.rs
+++ b/src/context/sections/sessions.rs
@@ -1,5 +1,10 @@
-use super::super::format::{format_epoch_short, format_epoch_time};
+use super::super::format::{
+    char_len, format_epoch_short, format_epoch_time, truncate_chars_with_ellipsis,
+};
 use super::super::types::SessionSummaryBrief;
+
+const REQUEST_PREVIEW_CHARS: usize = 160;
+const COMPLETED_PREVIEW_CHARS: usize = 120;
 
 #[cfg(test)]
 pub(in crate::context) fn render_recent_sessions(
@@ -13,15 +18,15 @@ pub(in crate::context) fn render_recent_sessions_with_limit(
     output: &mut String,
     summaries: &[SessionSummaryBrief],
     char_limit: usize,
-) {
+) -> usize {
     if char_limit == 0 {
-        return;
+        return 0;
     }
     let header = "## Sessions\n";
-    let header_chars = header.chars().count();
+    let header_chars = char_len(header);
     let trailer_chars = 1;
     if header_chars + trailer_chars >= char_limit {
-        return;
+        return 0;
     }
 
     let mut section = String::from(header);
@@ -36,11 +41,9 @@ pub(in crate::context) fn render_recent_sessions_with_limit(
             .and_then(|completed| completed.lines().find(|line| !line.trim().is_empty()))
             .map(format_completed_line)
             .unwrap_or_default();
-        let line = format!(
-            "- **{}** {} {}{}\n",
-            date, time, summary.request, completed_part
-        );
-        let line_chars = line.chars().count();
+        let request = truncate_chars_with_ellipsis(&summary.request, REQUEST_PREVIEW_CHARS);
+        let line = format!("- **{}** {} {}{}\n", date, time, request, completed_part);
+        let line_chars = char_len(&line);
         if total_chars + line_chars > char_limit {
             break;
         }
@@ -49,16 +52,17 @@ pub(in crate::context) fn render_recent_sessions_with_limit(
         rendered += 1;
     }
     if rendered == 0 {
-        return;
+        return 0;
     }
     section.push('\n');
     output.push_str(&section);
+    rendered
 }
 
 fn format_completed_line(line: &str) -> String {
-    let truncated: String = line.chars().take(120).collect();
-    if line.len() > 120 {
-        format!(" => {}...", truncated)
+    let truncated = truncate_chars_with_ellipsis(line, COMPLETED_PREVIEW_CHARS);
+    if char_len(line) > COMPLETED_PREVIEW_CHARS {
+        format!(" => {}", truncated)
     } else {
         format!(" => {}", truncated)
     }

--- a/src/context/sections/sessions.rs
+++ b/src/context/sections/sessions.rs
@@ -61,9 +61,5 @@ pub(in crate::context) fn render_recent_sessions_with_limit(
 
 fn format_completed_line(line: &str) -> String {
     let truncated = truncate_chars_with_ellipsis(line, COMPLETED_PREVIEW_CHARS);
-    if char_len(line) > COMPLETED_PREVIEW_CHARS {
-        format!(" => {}", truncated)
-    } else {
-        format!(" => {}", truncated)
-    }
+    format!(" => {}", truncated)
 }

--- a/src/context/sections/workstreams.rs
+++ b/src/context/sections/workstreams.rs
@@ -1,5 +1,7 @@
 use crate::workstream::WorkStream;
 
+use super::super::format::char_len;
+
 #[cfg(test)]
 pub(in crate::context) fn render_workstreams(output: &mut String, workstreams: &[WorkStream]) {
     render_workstreams_with_limits(output, workstreams, usize::MAX, usize::MAX);
@@ -10,16 +12,16 @@ pub(in crate::context) fn render_workstreams_with_limits(
     workstreams: &[WorkStream],
     item_limit: usize,
     char_limit: usize,
-) {
+) -> usize {
     if item_limit == 0 || char_limit == 0 {
-        return;
+        return 0;
     }
 
     let header = "## WorkStreams\n";
-    let header_chars = header.chars().count();
+    let header_chars = char_len(header);
     let trailer_chars = 1;
     if header_chars + trailer_chars >= char_limit {
-        return;
+        return 0;
     }
 
     let mut section = String::from(header);
@@ -28,7 +30,7 @@ pub(in crate::context) fn render_workstreams_with_limits(
 
     for workstream in workstreams.iter().take(item_limit) {
         let line = format_workstream_line(workstream);
-        let line_chars = line.chars().count();
+        let line_chars = char_len(&line);
         if total_chars + line_chars > char_limit {
             break;
         }
@@ -38,11 +40,12 @@ pub(in crate::context) fn render_workstreams_with_limits(
     }
 
     if rendered == 0 {
-        return;
+        return 0;
     }
 
     section.push('\n');
     output.push_str(&section);
+    rendered
 }
 
 fn format_workstream_line(workstream: &WorkStream) -> String {

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -1,10 +1,12 @@
 use crate::workstream::{WorkStream, WorkStreamStatus};
 
 use super::super::policy::ContextLimits;
+use super::super::render::{build_context_stats_footer, ContextRenderStats, SectionRenderStats};
 use super::super::sections::{
     render_core_memory, render_core_memory_with_limits, render_memory_index,
-    render_memory_index_with_limits, render_recent_sessions, render_recent_sessions_with_limit,
-    render_workstreams, render_workstreams_with_limits,
+    render_memory_index_with_limits, render_memory_index_with_limits_excluding,
+    render_recent_sessions, render_recent_sessions_with_limit, render_workstreams,
+    render_workstreams_with_limits,
 };
 use super::super::types::SessionSummaryBrief;
 use super::{sample_memory, sample_memory_with_epoch, sample_workstream};
@@ -24,6 +26,23 @@ fn render_recent_sessions_truncates_completed_line() {
     assert!(output.contains("=> "));
     assert!(output.contains("..."));
     assert!(!output.contains("ignored"));
+}
+
+#[test]
+fn render_recent_sessions_truncates_request_text() {
+    let mut output = String::new();
+    let long_request = format!("Investigate SessionStart budget {}", "x".repeat(300));
+    let summaries = vec![SessionSummaryBrief {
+        request: long_request.clone(),
+        completed: Some("done".to_string()),
+        created_at_epoch: 1_710_000_000,
+    }];
+
+    render_recent_sessions(&mut output, &summaries);
+
+    assert!(output.contains("Investigate SessionStart budget"));
+    assert!(output.contains("..."));
+    assert!(!output.contains(&long_request));
 }
 
 #[test]
@@ -119,6 +138,37 @@ fn render_memory_index_truncates_first_item_to_char_limit() {
     assert!(body.chars().count() <= limits.memory_index_char_limit);
     assert!(output.contains("..."));
     assert!(!output.contains(long_title));
+}
+
+#[test]
+fn render_memory_index_can_skip_core_selected_ids() {
+    let mut core_output = String::new();
+    let now = chrono::Utc::now().timestamp();
+    let memories = vec![
+        sample_memory_with_epoch(1, "bugfix", "Core bugfix", now),
+        sample_memory_with_epoch(2, "decision", "Index decision", now),
+    ];
+    let core_summary = render_core_memory_with_limits(
+        &mut core_output,
+        &memories,
+        &ContextLimits {
+            core_item_limit: 1,
+            ..ContextLimits::default()
+        },
+    );
+    let excluded_ids = core_summary.ids.into_iter().collect();
+
+    let mut index_output = String::new();
+    let rendered = render_memory_index_with_limits_excluding(
+        &mut index_output,
+        &memories,
+        &ContextLimits::default(),
+        &excluded_ids,
+    );
+
+    assert_eq!(rendered, 1);
+    assert!(!index_output.contains("Core bugfix"));
+    assert!(index_output.contains("Index decision"));
 }
 
 #[test]
@@ -261,4 +311,47 @@ fn render_core_memory_keeps_stale_decision_out_when_recent_context_is_available(
     render_core_memory(&mut output, &memories);
 
     assert!(!output.contains("Stale landing page decision"));
+}
+
+#[test]
+fn context_stats_footer_reports_budget_scope_and_truncation() {
+    let footer = build_context_stats_footer(&ContextRenderStats {
+        host: "codex-cli".to_string(),
+        branch: Some("fix/context".to_string()),
+        total_char_limit: 12_000,
+        memories_loaded: 7,
+        core: SectionRenderStats {
+            count: 2,
+            chars: 430,
+        },
+        index: SectionRenderStats {
+            count: 5,
+            chars: 800,
+        },
+        preferences: SectionRenderStats {
+            count: 3,
+            chars: 240,
+        },
+        project_preferences: 2,
+        global_preferences: 1,
+        sessions: SectionRenderStats {
+            count: 4,
+            chars: 620,
+        },
+        workstreams: SectionRenderStats {
+            count: 1,
+            chars: 80,
+        },
+        core_ids: vec![1, 2],
+        output_chars: 3_200,
+        truncated: true,
+    });
+
+    assert!(footer.contains("7 context memories loaded"));
+    assert!(footer.contains("2 core (430 chars)"));
+    assert!(footer.contains("3 preferences (project:2 global:1"));
+    assert!(footer.contains("host=codex-cli"));
+    assert!(footer.contains("branch=fix/context"));
+    assert!(footer.contains("total=3200 chars/~800 tokens"));
+    assert!(footer.contains("truncated=yes"));
 }

--- a/src/memory/preference.rs
+++ b/src/memory/preference.rs
@@ -6,4 +6,7 @@ mod tests;
 
 pub use command::{add_preference, list_preferences, remove_preference};
 pub use query::{query_global_preferences, query_project_preferences};
-pub use render::{dedup_with_claude_md, render_preferences, render_preferences_with_limits};
+pub use render::{
+    dedup_with_claude_md, render_preferences, render_preferences_with_limits,
+    render_preferences_with_limits_detailed, PreferenceRenderSummary,
+};

--- a/src/memory/preference/render.rs
+++ b/src/memory/preference/render.rs
@@ -5,6 +5,19 @@ use crate::memory::Memory;
 
 use super::{query_global_preferences, query_project_preferences};
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PreferenceRenderSummary {
+    pub rendered: usize,
+    pub project_rendered: usize,
+    pub global_rendered: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreferenceSource {
+    Project,
+    Global,
+}
+
 pub fn dedup_with_claude_md(prefs: &[Memory], cwd: &str) -> Vec<usize> {
     let claude_md_path = std::path::Path::new(cwd).join("CLAUDE.md");
     let claude_md_content = std::fs::read_to_string(&claude_md_path).unwrap_or_default();
@@ -43,52 +56,85 @@ pub fn render_preferences_with_limits(
     global_limit: usize,
     char_limit: usize,
 ) -> Result<usize> {
+    render_preferences_with_limits_detailed(
+        output,
+        conn,
+        project,
+        cwd,
+        project_limit,
+        global_limit,
+        char_limit,
+    )
+    .map(|summary| summary.rendered)
+}
+
+pub fn render_preferences_with_limits_detailed(
+    output: &mut String,
+    conn: &Connection,
+    project: &str,
+    cwd: &str,
+    project_limit: usize,
+    global_limit: usize,
+    char_limit: usize,
+) -> Result<PreferenceRenderSummary> {
     let project_prefs = query_project_preferences(conn, project, project_limit)?;
     let global_prefs = query_global_preferences(conn, global_limit).unwrap_or_default();
 
-    let mut all_prefs = project_prefs;
+    let mut all_prefs: Vec<(Memory, PreferenceSource)> = project_prefs
+        .into_iter()
+        .map(|memory| (memory, PreferenceSource::Project))
+        .collect();
     let project_topics: std::collections::HashSet<String> = all_prefs
         .iter()
-        .filter_map(|memory| memory.topic_key.clone())
+        .filter_map(|(memory, _)| memory.topic_key.clone())
         .collect();
     for global_pref in global_prefs {
         if let Some(ref topic_key) = global_pref.topic_key {
             if !project_topics.contains(topic_key) {
-                all_prefs.push(global_pref);
+                all_prefs.push((global_pref, PreferenceSource::Global));
             }
         }
     }
 
     if all_prefs.is_empty() {
-        return Ok(0);
+        return Ok(PreferenceRenderSummary::default());
     }
 
-    let keep_indices = dedup_with_claude_md(&all_prefs, cwd);
+    let memories = all_prefs
+        .iter()
+        .map(|(memory, _)| memory.clone())
+        .collect::<Vec<_>>();
+    let keep_indices = dedup_with_claude_md(&memories, cwd);
     if keep_indices.is_empty() {
-        return Ok(0);
+        return Ok(PreferenceRenderSummary::default());
     }
 
     output.push_str("## Your Preferences (always apply these)\n");
-    let mut total_chars = 0;
-    let mut rendered = 0usize;
+    let mut total_chars = 0usize;
+    let mut summary = PreferenceRenderSummary::default();
 
     for &idx in &keep_indices {
-        let pref = &all_prefs[idx];
+        let (pref, source) = &all_prefs[idx];
         let text = pref.text.trim();
         let preview: String = text.chars().take(120).collect();
-        let line = if preview.len() < text.len() {
-            format!("- {}\n", preview)
+        let line = if preview.chars().count() < text.chars().count() {
+            format!("- {}...\n", preview)
         } else {
             format!("- {}\n", text)
         };
-        if total_chars + line.len() > char_limit && total_chars > 0 {
+        let line_chars = line.chars().count();
+        if total_chars + line_chars > char_limit && total_chars > 0 {
             break;
         }
         output.push_str(&line);
-        total_chars += line.len();
-        rendered += 1;
+        total_chars += line_chars;
+        summary.rendered += 1;
+        match source {
+            PreferenceSource::Project => summary.project_rendered += 1,
+            PreferenceSource::Global => summary.global_rendered += 1,
+        }
     }
     output.push('\n');
 
-    Ok(rendered)
+    Ok(summary)
 }

--- a/src/memory/preference/tests.rs
+++ b/src/memory/preference/tests.rs
@@ -6,6 +6,7 @@ use crate::memory::{self, Memory};
 use super::{
     add_preference, dedup_with_claude_md, query_global_preferences, query_project_preferences,
     remove_preference, render_preferences, render_preferences_with_limits,
+    render_preferences_with_limits_detailed,
 };
 
 fn setup_test_db() -> Connection {
@@ -182,6 +183,52 @@ fn test_render_preferences_global_limit_explicitly_opted_in() -> Result<()> {
 
     assert_eq!(rendered, 1);
     assert!(output.contains("AtlasCloud"));
+    Ok(())
+}
+
+#[test]
+fn test_render_preferences_reports_project_global_split() -> Result<()> {
+    let conn = setup_test_db();
+    memory::insert_memory(
+        &conn,
+        None,
+        "test/proj",
+        Some("local-pref"),
+        "Preference: Local workflow",
+        "Use the local project workflow",
+        "preference",
+        None,
+    )?;
+    memory::insert_memory_full(
+        &conn,
+        None,
+        "other/proj",
+        Some("global-pref"),
+        "Preference: Global reviews",
+        "Review global release notes",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+
+    let mut output = String::new();
+    let summary = render_preferences_with_limits_detailed(
+        &mut output,
+        &conn,
+        "test/proj",
+        "/nonexistent",
+        20,
+        1,
+        1500,
+    )?;
+
+    assert_eq!(summary.rendered, 2);
+    assert_eq!(summary.project_rendered, 1);
+    assert_eq!(summary.global_rendered, 1);
+    assert!(output.contains("local project workflow"));
+    assert!(output.contains("global release notes"));
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #173.

## Summary
- add opt-in SessionStart explainability with `remem context --debug` and `REMEM_CONTEXT_DEBUG=1`
- replace the coarse context footer with compact per-section char/token budget stats, host, branch, preference split, and truncation state
- truncate long session requests locally and keep Core-selected memories out of the Index to reduce duplicate startup context
- add regression coverage for debug CLI parsing, footer scope/budget stats, Core/Index duplication, request truncation, and project/global preference counts
- document a read-only SessionStart smoke matrix for Codex and Claude Code host modes

## Validation
- cargo fmt --check
- cargo check
- cargo test
- REMEM_CONTEXT_HOST=codex-cli REMEM_CONTEXT_TOTAL_CHAR_LIMIT=3000 cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/remem
- REMEM_CONTEXT_DEBUG=1 REMEM_CONTEXT_HOST=codex-cli REMEM_CONTEXT_TOTAL_CHAR_LIMIT=8000 cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/remem
