### PR TITLE
Add golden query eval metrics

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,69 @@
+# Golden Query Eval
+
+`remem eval` runs a deterministic retrieval-quality check against a versioned JSON fixture.
+
+```bash
+remem eval --dataset eval/golden.json -k 5
+```
+
+The command reports per-query status plus overall and per-category metrics:
+
+- `H@k`: at least one expected memory or evidence ref appears in the top `k`.
+- `MRR@10`: reciprocal rank of the first expected hit in the top 10.
+- `P@k`: relevant top-`k` results divided by returned top-`k` results.
+- `R@k`: expected evidence refs matched by top-`k` results.
+- `nDCG@10`: binary ranking quality against the expected evidence count.
+- `evidence@k`: expected evidence refs matched by top-`k` results.
+- `Abstention`: no-answer / false-premise queries where returning no curated result is the desired behavior.
+
+## Schema
+
+Top-level fields:
+
+- `version`: schema version string.
+- `description`: human-readable dataset note.
+- `queries`: array of query cases.
+
+Query fields:
+
+- `id`: stable case id.
+- `query`: user-facing search query.
+- `category`: bucket for per-category reporting, for example `single_session`, `multi_session`, `temporal`, `knowledge_update`, `project_scope`, `procedure`, or `abstention`.
+- `project`: optional project filter.
+- `branch`: optional branch filter.
+- `memory_type`: optional memory type filter.
+- `evidence_refs`: stable expected evidence references. Prefer this for new cases.
+- `relevant_ids`: legacy memory-id list. Still accepted, but less stable than evidence refs.
+- `expect_abstain`: true when no curated memory should be returned.
+- `false_premise`: true for adversarial queries based on a false premise. This also counts as abstention.
+- `notes`: optional maintenance note.
+
+Evidence ref fields are conjunctive: every populated field must match the returned memory.
+
+- `memory_id`: legacy exact memory id.
+- `topic_key`: stable topic key.
+- `project`: expected project.
+- `branch`: expected branch.
+- `memory_type`: expected memory type.
+- `scope`: expected memory scope.
+- `title_contains`: case-insensitive title substring.
+- `text_contains`: case-insensitive memory text substring.
+
+Example:
+
+```json
+{
+  "id": "procedure-pr-review",
+  "query": "PR review merge workflow",
+  "category": "procedure",
+  "project": "tools/remem",
+  "branch": "main",
+  "evidence_refs": [
+    {
+      "topic_key": "pr-review-merge-workflow",
+      "memory_type": "procedure",
+      "text_contains": "@codex review"
+    }
+  ]
+}
+```

--- a/eval/golden.json
+++ b/eval/golden.json
@@ -1,246 +1,89 @@
 {
-  "version": "1.1",
-  "description": "Golden dataset for remem search quality evaluation. Relevance: 3=highly relevant, 2=partially relevant, 1=marginally relevant, 0=irrelevant.",
+  "version": "1.2",
+  "description": "Golden dataset for remem search quality evaluation. Uses stable evidence_refs where possible; relevant_ids remain supported only for legacy datasets.",
   "queries": [
     {
-      "id": "q01",
-      "query": "FTS5 搜索",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [20, 19, 965, 966, 1068, 22],
-      "notes": "Should find FTS5-related decisions and discoveries. 965/966/1068 are newer sessions discussing FTS5 search quality."
-    },
-    {
-      "id": "q02",
-      "query": "数据库加密",
-      "category": "exact",
-      "project": "tools/remem",
-      "relevant_ids": [940, 941],
-      "notes": "Should find SQLCipher encryption decisions"
-    },
-    {
-      "id": "q03",
-      "query": "POST 端点挂起",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [929, 930],
-      "notes": "Should find Harness POST /tasks hang diagnosis"
-    },
-    {
-      "id": "q04",
-      "query": "竞品分析",
-      "category": "exact",
-      "project": "tools/remem",
-      "relevant_ids": [914, 915, 20, 19],
-      "notes": "Should find competitive analysis for remem"
-    },
-    {
-      "id": "q05",
-      "query": "错误处理 unwrap",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [93, 94, 95, 96],
-      "notes": "Should find unwrap error handling fix sessions"
-    },
-    {
-      "id": "q06",
-      "query": "偏好系统",
-      "category": "exact",
-      "project": "tools/remem",
-      "relevant_ids": [700, 701, 912, 913, 662],
-      "notes": "Should find preference system implementation decisions"
-    },
-    {
-      "id": "q07",
-      "query": "Harness 任务失败",
-      "category": "fuzzy",
-      "project": "tools/harness",
-      "relevant_ids": [878, 929, 930, 955, 956, 791],
-      "notes": "Should find Harness task failure diagnosis across sessions. 955/956 are newer task failure sessions."
-    },
-    {
-      "id": "q08",
-      "query": "记忆质量",
-      "category": "fuzzy",
-      "project": null,
-      "relevant_ids": [748, 914, 915, 936, 946, 948, 912, 663],
-      "notes": "Should find memories about memory quality preferences and strategy. Multiple sessions discuss quality-first principle."
-    },
-    {
-      "id": "q09",
-      "query": "ToolAdapter trait",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [],
-      "notes": "ToolAdapter does not appear in any memory content. Original IDs were incorrectly assigned."
-    },
-    {
-      "id": "q10",
-      "query": "REST API",
-      "category": "exact",
-      "project": "tools/remem",
-      "relevant_ids": [940, 941],
-      "notes": "Should find REST API implementation decisions"
-    },
-    {
-      "id": "q11",
-      "query": "跨项目记忆共享",
-      "category": "fuzzy",
-      "project": null,
-      "relevant_ids": [700, 701, 912, 913, 668, 669, 914],
-      "notes": "Should find global scope and cross-project sharing decisions. 668/669 discuss cross-project sync, 914 discusses quality strategy."
-    },
-    {
-      "id": "q12",
-      "query": "om-generator 架构",
-      "category": "exact",
-      "project": "mutil-om/om-generator",
-      "relevant_ids": [187, 723],
-      "notes": "Should find OM Generator architecture. ID 12 has project='om-generator' (no prefix), so doesn't match filter. 187 and 723 are correct project matches."
-    },
-    {
-      "id": "q13",
-      "query": "视频生成",
-      "category": "fuzzy",
-      "project": null,
-      "relevant_ids": [],
-      "notes": "Broad query about video generation across projects"
-    },
-    {
-      "id": "q14",
-      "query": "自动提升 memory",
-      "category": "exact",
-      "project": "tools/remem",
-      "relevant_ids": [700, 701, 912, 1009],
-      "notes": "Should find auto-promote summary to memories feature. 700/701 contain auto-promote design. 912 discusses memory quality strategy."
-    },
-    {
-      "id": "q15",
-      "query": "worker 超时",
-      "category": "fuzzy",
-      "project": null,
-      "relevant_ids": [],
-      "notes": "Should find worker timeout/retry related decisions if any"
-    },
-    {
-      "id": "q16",
-      "query": "trigram tokenizer",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [20, 95, 96],
-      "notes": "Should find trigram tokenizer decisions for CJK"
-    },
-    {
-      "id": "q17",
-      "query": "uv 环境管理",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [8],
-      "notes": "Should find uv contribution/migration work"
-    },
-    {
-      "id": "q18",
-      "query": "抖音视频发布",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [845, 11, 581, 577, 844, 856, 262, 340],
-      "notes": "Should find Douyin video publishing decisions. Multiple sessions cover douyin video publishing workflow."
-    },
-    {
-      "id": "q19",
-      "query": "Claude Code hook 机制",
-      "category": "fuzzy",
-      "project": null,
-      "relevant_ids": [416, 417, 20, 18],
-      "notes": "Should find hook system design decisions. 416/417 directly discuss Claude Code hooks vs subagent. Removed project filter since hook discussions span projects."
-    },
-    {
-      "id": "q20",
-      "query": "context compression",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [],
-      "notes": "No memories specifically discuss context compression implementation. Removed incorrect IDs and project filter."
-    },
-    {
-      "id": "q21",
-      "query": "上次修了什么 bug",
-      "category": "temporal",
-      "project": null,
-      "relevant_ids": [],
-      "notes": "Temporal query - should find recent bugfix memories"
-    },
-    {
-      "id": "q22",
-      "query": "Reddit 自动回复",
-      "category": "exact",
-      "project": "life/x",
-      "relevant_ids": [666],
-      "notes": "Should find Reddit auto-reply system decisions"
-    },
-    {
-      "id": "q23",
-      "query": "MCP server 实现",
-      "category": "fuzzy",
-      "project": "tools/remem",
-      "relevant_ids": [18, 913],
-      "notes": "Should find MCP server implementation details. 18 is MCP ecosystem survey, 913 discusses MCP integration."
-    },
-    {
-      "id": "q24",
-      "query": "Engram 对比",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [19, 20, 914, 915],
-      "notes": "Should find Engram competitive comparison"
-    },
-    {
-      "id": "q25",
-      "query": "数据库迁移到 MongoDB",
-      "category": "adversarial",
-      "project": null,
-      "relevant_ids": [],
-      "notes": "Adversarial: we never discussed MongoDB migration, should return empty or irrelevant"
-    },
-    {
-      "id": "q26",
-      "query": "性能优化 benchmark",
-      "category": "fuzzy",
-      "project": null,
-      "relevant_ids": [80, 936, 937],
-      "notes": "Should find benchmark and performance related work. 80 is Seedance benchmark, 936/937 discuss quality optimization."
-    },
-    {
-      "id": "q27",
-      "query": "X Twitter 发帖",
-      "category": "exact",
-      "project": "life/x",
-      "relevant_ids": [666, 54, 55, 470, 495],
-      "notes": "Should find X/Twitter posting automation decisions. Multiple sessions discuss X posting."
-    },
-    {
-      "id": "q28",
+      "id": "project-scope-quality-first",
       "query": "质量优先成本",
-      "category": "exact",
-      "project": null,
-      "relevant_ids": [748, 912, 936, 946, 948, 688, 728],
-      "notes": "Should find quality-over-cost preference. Multiple memories express this principle."
-    },
-    {
-      "id": "q29",
-      "query": "VibeGuard 规则",
-      "category": "fuzzy",
-      "project": null,
-      "relevant_ids": [16, 733, 107, 1084],
-      "notes": "Should find VibeGuard rule-related decisions. 16 is VibeGuard Learn, 733 is VibeGuard packaging, 1084 is guard message format."
-    },
-    {
-      "id": "q30",
-      "query": "session summary 格式",
-      "category": "exact",
+      "category": "project_scope",
       "project": "tools/remem",
-      "relevant_ids": [18, 1009],
-      "notes": "Should find summary format/structure decisions. 18 discusses MCP tools including summary format. 1009 discusses title/content format."
+      "evidence_refs": [
+        {
+          "topic_key": "auto-decision-remem-0-2-0-产品化：完成-phase-1a-2（偏好-文档），启动评估-agent-架构",
+          "project": "tools/remem",
+          "memory_type": "decision",
+          "text_contains": "记忆质量是否提升"
+        }
+      ],
+      "notes": "Project-scoped query should find remem quality-over-cost decision via topic_key and text evidence."
+    },
+    {
+      "id": "temporal-recent-project-leak",
+      "query": "最近 project leak eval-local",
+      "category": "temporal",
+      "project": "/Users/lifcc/Desktop/code/AI/tool/remem",
+      "evidence_refs": [
+        {
+          "topic_key": "discovery-fed2bd98cfb44f74",
+          "memory_type": "discovery",
+          "text_contains": "project leak"
+        }
+      ],
+      "notes": "Temporal query should find the recent eval-local project leak metric-artifact discovery."
+    },
+    {
+      "id": "knowledge-update-codex-usage",
+      "query": "Codex exact usage accounting",
+      "category": "knowledge_update",
+      "project": "/Users/lifcc/Desktop/code/AI/tool/remem",
+      "branch": "codex/exact-usage-accounting",
+      "evidence_refs": [
+        {
+          "topic_key": "codex-exec-json-usage-accounting",
+          "branch": "codex/exact-usage-accounting",
+          "memory_type": "bugfix",
+          "text_contains": "turn.completed.usage"
+        }
+      ],
+      "notes": "Branch-scoped update/conflict style query should find the corrected Codex usage accounting bugfix."
+    },
+    {
+      "id": "procedure-separate-prs",
+      "query": "roadmap follow-ups separate PRs",
+      "category": "procedure",
+      "project": "/Users/lifcc/Desktop/code/AI/tool/remem",
+      "evidence_refs": [
+        {
+          "topic_key": "decision-d011b868bc6122fe",
+          "memory_type": "decision",
+          "text_contains": "separate PRs"
+        }
+      ],
+      "notes": "Procedural workflow query should retrieve the decision to implement roadmap issues as separate PRs."
+    },
+    {
+      "id": "preference-non-vector-first",
+      "query": "non-vector first deterministic ordering",
+      "category": "preference",
+      "project": "/Users/lifcc/Desktop/code/AI/tool/remem",
+      "evidence_refs": [
+        {
+          "topic_key": "decision-54f7031e8d49adca",
+          "memory_type": "decision",
+          "text_contains": "non-vector first"
+        }
+      ],
+      "notes": "Preference-like decision query should retrieve the current non-vector-first constraint."
+    },
+    {
+      "id": "abstain-false-premise-mongodb",
+      "query": "remem 已经迁移到 MongoDB 的 schema 怎么设计",
+      "category": "abstention",
+      "project": "/Users/lifcc/Desktop/code/AI/tool/remem",
+      "evidence_refs": [],
+      "expect_abstain": true,
+      "false_premise": true,
+      "notes": "False-premise query should ideally return no curated memory; failures expose abstention weakness."
     }
   ]
 }

--- a/src/cli/actions/eval.rs
+++ b/src/cli/actions/eval.rs
@@ -1,20 +1,6 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use crate::db;
-
-#[derive(serde::Deserialize)]
-struct GoldenDataset {
-    queries: Vec<GoldenQuery>,
-}
-
-#[derive(serde::Deserialize)]
-struct GoldenQuery {
-    id: String,
-    query: String,
-    category: String,
-    project: Option<String>,
-    relevant_ids: Vec<i64>,
-}
 
 pub(in crate::cli) fn run_eval_local() -> Result<()> {
     let conn = db::open_db()?;
@@ -24,88 +10,8 @@ pub(in crate::cli) fn run_eval_local() -> Result<()> {
 }
 
 pub(in crate::cli) fn run_eval(dataset_path: &str, k: usize) -> Result<()> {
-    let content = std::fs::read_to_string(dataset_path)
-        .map_err(|error| anyhow!("cannot read {}: {}", dataset_path, error))?;
-    let dataset: GoldenDataset = serde_json::from_str(&content)?;
     let conn = db::open_db()?;
-
-    let mut total_rr = 0.0;
-    let mut total_p = 0.0;
-    let mut total_r = 0.0;
-    let mut total_hit = 0.0;
-    let mut evaluated = 0usize;
-
-    println!("remem eval — {} queries, k={}\n", dataset.queries.len(), k);
-
-    for query in &dataset.queries {
-        let results = crate::retrieval::search::search(
-            &conn,
-            Some(&query.query),
-            query.project.as_deref(),
-            None,
-            k as i64,
-            0,
-            false,
-        )?;
-        let result_ids: Vec<i64> = results.iter().map(|memory| memory.id).collect();
-
-        let rr = crate::eval::metrics::reciprocal_rank(&result_ids, &query.relevant_ids);
-        let precision = crate::eval::metrics::precision_at_k(&result_ids, &query.relevant_ids, k);
-        let recall = crate::eval::metrics::recall_at_k(&result_ids, &query.relevant_ids, k);
-        let hit = crate::eval::metrics::hit_at_k(&result_ids, &query.relevant_ids, k);
-        let status = eval_status(query, &results, hit);
-
-        println!(
-            "  [{}] {:>4} | P@{}={:.2} R@{}={:.2} RR={:.2} | {} | {}",
-            query.id, status, k, precision, k, recall, rr, query.category, query.query
-        );
-
-        if !query.relevant_ids.is_empty() {
-            total_rr += rr;
-            total_p += precision;
-            total_r += recall;
-            total_hit += hit;
-            evaluated += 1;
-        }
-    }
-
-    print_aggregate_metrics(k, evaluated, total_rr, total_p, total_r, total_hit);
+    let report = crate::eval::golden::run_dataset_path(&conn, dataset_path, k)?;
+    print!("{}", report);
     Ok(())
-}
-
-fn eval_status(query: &GoldenQuery, results: &[crate::memory::Memory], hit: f64) -> &'static str {
-    if query.relevant_ids.is_empty() {
-        if results.is_empty() {
-            "PASS"
-        } else {
-            "---"
-        }
-    } else if hit > 0.0 {
-        "HIT"
-    } else {
-        "MISS"
-    }
-}
-
-fn print_aggregate_metrics(
-    k: usize,
-    evaluated: usize,
-    total_rr: f64,
-    total_p: f64,
-    total_r: f64,
-    total_hit: f64,
-) {
-    if evaluated == 0 {
-        return;
-    }
-
-    let n = evaluated as f64;
-    println!(
-        "\n--- Aggregate ({} queries with ground truth) ---",
-        evaluated
-    );
-    println!("  MRR:          {:.3}", total_rr / n);
-    println!("  Precision@{}:  {:.3}", k, total_p / n);
-    println!("  Recall@{}:     {:.3}", k, total_r / n);
-    println!("  Hit Rate@{}:   {:.3}", k, total_hit / n);
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,2 +1,3 @@
+pub mod golden;
 pub mod local;
 pub mod metrics;

--- a/src/eval/golden.rs
+++ b/src/eval/golden.rs
@@ -1,0 +1,11 @@
+mod display;
+mod run;
+#[cfg(test)]
+mod tests;
+mod types;
+
+pub use run::{evaluate_dataset, load_dataset, run_dataset_path};
+pub use types::{
+    EvidenceRef, GoldenDataset, GoldenEvalReport, GoldenQuery, MetricAverages, QueryEvaluation,
+    QueryMetrics, QueryStatus,
+};

--- a/src/eval/golden/display.rs
+++ b/src/eval/golden/display.rs
@@ -1,0 +1,116 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use super::types::{GoldenEvalReport, MetricAverages};
+
+impl Display for GoldenEvalReport {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        writeln!(
+            f,
+            "remem eval — {} queries, k={}, rank_k={}",
+            self.total_queries, self.k, self.rank_k
+        )?;
+        if let Some(version) = self.version.as_deref() {
+            writeln!(f, "schema: {version}")?;
+        }
+        if let Some(description) = self.description.as_deref() {
+            writeln!(f, "{description}")?;
+        }
+        writeln!(f)?;
+
+        for query in &self.queries {
+            if let Some(metrics) = query.metrics.as_ref() {
+                writeln!(
+                    f,
+                    "  [{}] {:>4} | H@{}={:.2} MRR@10={:.2} P@{}={:.2} R@{}={:.2} nDCG@10={:.2} evidence@{}={:.2} | {} | {}",
+                    query.id,
+                    query.status.label(),
+                    self.k,
+                    metrics.hit_at_k,
+                    metrics.mrr_at_10,
+                    self.k,
+                    metrics.precision_at_k,
+                    self.k,
+                    metrics.recall_at_k,
+                    metrics.ndcg_at_10,
+                    self.k,
+                    metrics.evidence_recall_at_k,
+                    query.category,
+                    query.query
+                )?;
+            } else {
+                writeln!(
+                    f,
+                    "  [{}] {:>4} | results={} expected_refs={} matched_refs={} | {} | {}",
+                    query.id,
+                    query.status.label(),
+                    query.result_count,
+                    query.expected_refs,
+                    query.matched_refs,
+                    query.category,
+                    query.query
+                )?;
+            }
+        }
+
+        writeln!(f)?;
+        writeln!(
+            f,
+            "--- Overall ({} scored, {} abstention, {} skipped) ---",
+            self.scored_queries, self.abstention_queries, self.skipped_queries
+        )?;
+        if let Some(metrics) = self.overall.as_ref() {
+            write_metrics(f, "all", metrics, self.k)?;
+        }
+        if self.abstention_queries > 0 {
+            writeln!(
+                f,
+                "  Abstention: {}/{}",
+                self.abstention_passed, self.abstention_queries
+            )?;
+        }
+
+        if !self.by_category.is_empty() {
+            writeln!(f)?;
+            writeln!(f, "--- By Category ---")?;
+            for (category, evaluation) in &self.by_category {
+                if let Some(metrics) = evaluation.metrics.as_ref() {
+                    write_metrics(f, category, metrics, self.k)?;
+                } else {
+                    writeln!(
+                        f,
+                        "  {}: scored=0 abstention={}/{} total={}",
+                        category,
+                        evaluation.abstention_passed,
+                        evaluation.abstention_queries,
+                        evaluation.total_queries
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn write_metrics(
+    f: &mut Formatter<'_>,
+    label: &str,
+    metrics: &MetricAverages,
+    k: usize,
+) -> FmtResult {
+    writeln!(
+        f,
+        "  {}: n={} H@{}={:.3} MRR@10={:.3} P@{}={:.3} R@{}={:.3} nDCG@10={:.3} evidence@{}={:.3}",
+        label,
+        metrics.count,
+        k,
+        metrics.hit_at_k,
+        metrics.mrr_at_10,
+        k,
+        metrics.precision_at_k,
+        k,
+        metrics.recall_at_k,
+        metrics.ndcg_at_10,
+        k,
+        metrics.evidence_recall_at_k
+    )
+}

--- a/src/eval/golden/run.rs
+++ b/src/eval/golden/run.rs
@@ -1,0 +1,294 @@
+use std::collections::{BTreeMap, HashSet};
+
+use anyhow::{anyhow, Context, Result};
+use rusqlite::Connection;
+
+use super::types::{
+    CategoryEvaluation, EvidenceRef, GoldenDataset, GoldenEvalReport, GoldenQuery, MetricSums,
+    QueryEvaluation, QueryMetrics, QueryStatus,
+};
+
+const RANK_K: usize = 10;
+
+#[derive(Default)]
+struct CategoryAccumulator {
+    total_queries: usize,
+    abstention_queries: usize,
+    abstention_passed: usize,
+    metrics: MetricSums,
+}
+
+pub fn load_dataset(dataset_path: &str) -> Result<GoldenDataset> {
+    let content = std::fs::read_to_string(dataset_path)
+        .with_context(|| format!("read golden eval dataset {dataset_path}"))?;
+    let dataset: GoldenDataset = serde_json::from_str(&content)
+        .with_context(|| format!("parse golden eval dataset {dataset_path}"))?;
+    validate_dataset(&dataset)?;
+    Ok(dataset)
+}
+
+pub fn run_dataset_path(
+    conn: &Connection,
+    dataset_path: &str,
+    k: usize,
+) -> Result<GoldenEvalReport> {
+    let dataset = load_dataset(dataset_path)?;
+    evaluate_dataset(conn, &dataset, k)
+}
+
+pub fn evaluate_dataset(
+    conn: &Connection,
+    dataset: &GoldenDataset,
+    k: usize,
+) -> Result<GoldenEvalReport> {
+    validate_dataset(dataset)?;
+    let k = k.max(1);
+    let fetch_limit = k.max(RANK_K) as i64;
+    let mut query_reports = Vec::with_capacity(dataset.queries.len());
+    let mut overall_sums = MetricSums::default();
+    let mut categories = BTreeMap::<String, CategoryAccumulator>::new();
+    let mut skipped_queries = 0usize;
+    let mut abstention_queries = 0usize;
+    let mut abstention_passed = 0usize;
+
+    for query in &dataset.queries {
+        let results = crate::retrieval::search::search_with_branch(
+            conn,
+            Some(&query.query),
+            query.project.as_deref(),
+            query.memory_type.as_deref(),
+            fetch_limit,
+            0,
+            false,
+            query.branch.as_deref(),
+        )?;
+        let evaluation = evaluate_query(query, &results, k);
+        let category = categories.entry(query.category.clone()).or_default();
+        category.total_queries += 1;
+
+        if query.expects_abstention() {
+            abstention_queries += 1;
+            category.abstention_queries += 1;
+            if evaluation.status == QueryStatus::Pass {
+                abstention_passed += 1;
+                category.abstention_passed += 1;
+            }
+        } else if let Some(metrics) = evaluation.metrics.as_ref() {
+            overall_sums.add(metrics);
+            category.metrics.add(metrics);
+        } else {
+            skipped_queries += 1;
+        }
+
+        query_reports.push(evaluation);
+    }
+
+    Ok(GoldenEvalReport {
+        version: dataset.version.clone(),
+        description: dataset.description.clone(),
+        k,
+        rank_k: RANK_K,
+        total_queries: dataset.queries.len(),
+        scored_queries: overall_sums.averages().map_or(0, |metrics| metrics.count),
+        skipped_queries,
+        abstention_queries,
+        abstention_passed,
+        overall: overall_sums.averages(),
+        by_category: categories
+            .into_iter()
+            .map(|(name, category)| {
+                (
+                    name,
+                    CategoryEvaluation {
+                        total_queries: category.total_queries,
+                        scored_queries: category.metrics.averages().map_or(0, |m| m.count),
+                        abstention_queries: category.abstention_queries,
+                        abstention_passed: category.abstention_passed,
+                        metrics: category.metrics.averages(),
+                    },
+                )
+            })
+            .collect(),
+        queries: query_reports,
+    })
+}
+
+fn validate_dataset(dataset: &GoldenDataset) -> Result<()> {
+    if dataset.queries.is_empty() {
+        return Err(anyhow!(
+            "golden eval dataset must contain at least one query"
+        ));
+    }
+    let mut seen_ids = HashSet::new();
+    for query in &dataset.queries {
+        if query.id.trim().is_empty() {
+            return Err(anyhow!("golden eval query id must not be empty"));
+        }
+        if !seen_ids.insert(query.id.as_str()) {
+            return Err(anyhow!("duplicate golden eval query id {}", query.id));
+        }
+        if query.query.trim().is_empty() {
+            return Err(anyhow!(
+                "golden eval query {} text must not be empty",
+                query.id
+            ));
+        }
+        if query.category.trim().is_empty() {
+            return Err(anyhow!(
+                "golden eval query {} category must not be empty",
+                query.id
+            ));
+        }
+        for evidence_ref in &query.evidence_refs {
+            if !evidence_ref.has_match_criteria() {
+                return Err(anyhow!(
+                    "golden eval query {} contains an empty evidence ref",
+                    query.id
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn evaluate_query(
+    query: &GoldenQuery,
+    results: &[crate::memory::Memory],
+    k: usize,
+) -> QueryEvaluation {
+    let expected_refs = query.expected_refs();
+    if query.expects_abstention() {
+        return QueryEvaluation {
+            id: query.id.clone(),
+            query: query.query.clone(),
+            category: query.category.clone(),
+            status: if results.is_empty() {
+                QueryStatus::Pass
+            } else {
+                QueryStatus::Fail
+            },
+            result_count: results.len(),
+            matched_refs: 0,
+            expected_refs: expected_refs.len(),
+            metrics: None,
+        };
+    }
+
+    if expected_refs.is_empty() {
+        return QueryEvaluation {
+            id: query.id.clone(),
+            query: query.query.clone(),
+            category: query.category.clone(),
+            status: QueryStatus::Skip,
+            result_count: results.len(),
+            matched_refs: 0,
+            expected_refs: 0,
+            metrics: None,
+        };
+    }
+
+    let metrics = score_results(results, &expected_refs, k);
+    let matched_refs = matched_ref_indexes(results, &expected_refs, k).len();
+    let status = if metrics.hit_at_k > 0.0 {
+        QueryStatus::Hit
+    } else {
+        QueryStatus::Miss
+    };
+    QueryEvaluation {
+        id: query.id.clone(),
+        query: query.query.clone(),
+        category: query.category.clone(),
+        status,
+        result_count: results.len(),
+        matched_refs,
+        expected_refs: expected_refs.len(),
+        metrics: Some(metrics),
+    }
+}
+
+fn score_results(
+    results: &[crate::memory::Memory],
+    expected_refs: &[EvidenceRef],
+    k: usize,
+) -> QueryMetrics {
+    let top_k = k.min(results.len());
+    let top_rank_k = RANK_K.min(results.len());
+    let relevance_at_k: Vec<bool> = results
+        .iter()
+        .take(top_k)
+        .map(|memory| {
+            expected_refs
+                .iter()
+                .any(|evidence_ref| evidence_ref.matches(memory))
+        })
+        .collect();
+    let relevance_at_rank_k: Vec<bool> = results
+        .iter()
+        .take(top_rank_k)
+        .map(|memory| {
+            expected_refs
+                .iter()
+                .any(|evidence_ref| evidence_ref.matches(memory))
+        })
+        .collect();
+    let matched_refs = matched_ref_indexes(results, expected_refs, k).len();
+    let relevant_hits = relevance_at_k
+        .iter()
+        .filter(|is_relevant| **is_relevant)
+        .count();
+    let precision_denominator = top_k.max(1);
+
+    QueryMetrics {
+        hit_at_k: if relevant_hits > 0 { 1.0 } else { 0.0 },
+        mrr_at_10: reciprocal_rank_from_relevance(&relevance_at_rank_k),
+        precision_at_k: relevant_hits as f64 / precision_denominator as f64,
+        recall_at_k: matched_refs as f64 / expected_refs.len() as f64,
+        ndcg_at_10: binary_ndcg_at_k(&relevance_at_rank_k, expected_refs.len(), RANK_K),
+        evidence_recall_at_k: matched_refs as f64 / expected_refs.len() as f64,
+    }
+}
+
+fn matched_ref_indexes(
+    results: &[crate::memory::Memory],
+    expected_refs: &[EvidenceRef],
+    k: usize,
+) -> HashSet<usize> {
+    let mut matched = HashSet::new();
+    for memory in results.iter().take(k) {
+        for (index, evidence_ref) in expected_refs.iter().enumerate() {
+            if evidence_ref.matches(memory) {
+                matched.insert(index);
+            }
+        }
+    }
+    matched
+}
+
+fn reciprocal_rank_from_relevance(relevance: &[bool]) -> f64 {
+    relevance
+        .iter()
+        .position(|is_relevant| *is_relevant)
+        .map_or(0.0, |index| 1.0 / (index as f64 + 1.0))
+}
+
+fn binary_ndcg_at_k(relevance: &[bool], expected_count: usize, k: usize) -> f64 {
+    if k == 0 || expected_count == 0 {
+        return 0.0;
+    }
+    let dcg: f64 = relevance
+        .iter()
+        .take(k)
+        .enumerate()
+        .filter(|(_, is_relevant)| **is_relevant)
+        .map(|(index, _)| 1.0 / (index as f64 + 2.0).log2())
+        .sum();
+    let ideal_hits = expected_count.min(k);
+    let idcg: f64 = (0..ideal_hits)
+        .map(|index| 1.0 / (index as f64 + 2.0).log2())
+        .sum();
+    if idcg == 0.0 {
+        0.0
+    } else {
+        dcg / idcg
+    }
+}

--- a/src/eval/golden/tests.rs
+++ b/src/eval/golden/tests.rs
@@ -1,0 +1,292 @@
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+
+use super::{evaluate_dataset, EvidenceRef, GoldenDataset, GoldenQuery, QueryStatus};
+
+fn setup_conn() -> Result<Connection> {
+    let conn = Connection::open_in_memory()?;
+    crate::memory::tests_helper::setup_memory_schema(&conn);
+    Ok(conn)
+}
+
+struct TestMemory<'a> {
+    id: i64,
+    project: &'a str,
+    topic_key: &'a str,
+    title: &'a str,
+    content: &'a str,
+    memory_type: &'a str,
+    branch: Option<&'a str>,
+    status: &'a str,
+    updated_at_epoch: i64,
+}
+
+fn insert_memory(conn: &Connection, memory: &TestMemory<'_>) -> Result<()> {
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?9, ?10, ?11, 'project')",
+        params![
+            memory.id,
+            format!("session-{}", memory.id),
+            memory.project,
+            memory.topic_key,
+            memory.title,
+            memory.content,
+            memory.memory_type,
+            memory.updated_at_epoch,
+            memory.updated_at_epoch,
+            memory.status,
+            memory.branch,
+        ],
+    )?;
+    Ok(())
+}
+
+fn query(
+    id: &str,
+    text: &str,
+    category: &str,
+    project: Option<&str>,
+    branch: Option<&str>,
+    evidence_ref: EvidenceRef,
+) -> GoldenQuery {
+    GoldenQuery {
+        id: id.to_string(),
+        query: text.to_string(),
+        category: category.to_string(),
+        project: project.map(str::to_string),
+        branch: branch.map(str::to_string),
+        memory_type: None,
+        relevant_ids: vec![],
+        evidence_refs: vec![evidence_ref],
+        expect_abstain: false,
+        false_premise: false,
+        notes: None,
+    }
+}
+
+#[test]
+fn golden_eval_scores_core_categories_and_abstention() -> Result<()> {
+    let conn = setup_conn()?;
+    let now = chrono::Utc::now().timestamp();
+    for memory in [
+        TestMemory {
+            id: 1,
+            project: "/repo-a",
+            topic_key: "repo-a-project-scope",
+            title: "SQLite project scoped fix",
+            content: "SQLite WAL timeout fix belongs to repo A.",
+            memory_type: "bugfix",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now - 100,
+        },
+        TestMemory {
+            id: 2,
+            project: "/repo-b",
+            topic_key: "repo-b-project-scope",
+            title: "SQLite project scoped fix",
+            content: "SQLite WAL timeout fix belongs to repo B.",
+            memory_type: "bugfix",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now - 90,
+        },
+        TestMemory {
+            id: 3,
+            project: "/repo-a",
+            topic_key: "recent-temporal-fix",
+            title: "Recent deploy fix",
+            content: "recent deploy fix for worker heartbeat",
+            memory_type: "bugfix",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now - 3_600,
+        },
+        TestMemory {
+            id: 4,
+            project: "/repo-a",
+            topic_key: "port-old",
+            title: "Old port decision",
+            content: "Use old port 1234 for local API.",
+            memory_type: "decision",
+            branch: Some("main"),
+            status: "archived",
+            updated_at_epoch: now - 200,
+        },
+        TestMemory {
+            id: 5,
+            project: "/repo-a",
+            topic_key: "port-current",
+            title: "Current port decision",
+            content: "Use corrected port 5567 for local API.",
+            memory_type: "decision",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now - 50,
+        },
+        TestMemory {
+            id: 6,
+            project: "/repo-a",
+            topic_key: "procedure-pr-review",
+            title: "PR review procedure",
+            content: "Run tests, post @codex review, fix feedback, then merge.",
+            memory_type: "procedure",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now - 40,
+        },
+        TestMemory {
+            id: 7,
+            project: "/repo-a",
+            topic_key: "branch-main",
+            title: "Branch scoped note",
+            content: "branch scoped needle belongs to main.",
+            memory_type: "discovery",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now - 30,
+        },
+        TestMemory {
+            id: 8,
+            project: "/repo-a",
+            topic_key: "branch-feature",
+            title: "Branch scoped note",
+            content: "branch scoped needle belongs to feature.",
+            memory_type: "discovery",
+            branch: Some("feature"),
+            status: "active",
+            updated_at_epoch: now - 20,
+        },
+    ] {
+        insert_memory(&conn, &memory)?;
+    }
+
+    let dataset = GoldenDataset {
+        version: Some("1.2-test".to_string()),
+        description: Some("test fixture".to_string()),
+        queries: vec![
+            query(
+                "project",
+                "SQLite WAL timeout",
+                "project_scope",
+                Some("/repo-a"),
+                Some("main"),
+                EvidenceRef {
+                    topic_key: Some("repo-a-project-scope".to_string()),
+                    project: Some("/repo-a".to_string()),
+                    branch: Some("main".to_string()),
+                    ..EvidenceRef::default()
+                },
+            ),
+            query(
+                "temporal",
+                "recent deploy fix",
+                "temporal",
+                Some("/repo-a"),
+                Some("main"),
+                EvidenceRef {
+                    topic_key: Some("recent-temporal-fix".to_string()),
+                    ..EvidenceRef::default()
+                },
+            ),
+            query(
+                "update",
+                "corrected port 5567",
+                "knowledge_update",
+                Some("/repo-a"),
+                Some("main"),
+                EvidenceRef {
+                    topic_key: Some("port-current".to_string()),
+                    text_contains: Some("5567".to_string()),
+                    ..EvidenceRef::default()
+                },
+            ),
+            query(
+                "procedure",
+                "PR review procedure",
+                "procedure",
+                Some("/repo-a"),
+                Some("main"),
+                EvidenceRef {
+                    memory_type: Some("procedure".to_string()),
+                    text_contains: Some("@codex review".to_string()),
+                    ..EvidenceRef::default()
+                },
+            ),
+            query(
+                "branch",
+                "branch scoped needle",
+                "project_scope",
+                Some("/repo-a"),
+                Some("main"),
+                EvidenceRef {
+                    topic_key: Some("branch-main".to_string()),
+                    branch: Some("main".to_string()),
+                    ..EvidenceRef::default()
+                },
+            ),
+            GoldenQuery {
+                id: "abstain".to_string(),
+                query: "MongoDB migration nonexistent".to_string(),
+                category: "abstention".to_string(),
+                project: Some("/repo-a".to_string()),
+                branch: Some("main".to_string()),
+                memory_type: None,
+                relevant_ids: vec![],
+                evidence_refs: vec![],
+                expect_abstain: true,
+                false_premise: true,
+                notes: None,
+            },
+        ],
+    };
+
+    let report = evaluate_dataset(&conn, &dataset, 5)?;
+
+    assert_eq!(report.scored_queries, 5);
+    assert_eq!(report.abstention_queries, 1);
+    assert_eq!(report.abstention_passed, 1);
+    let overall = report.overall.as_ref().context("missing overall metrics")?;
+    assert_eq!(overall.hit_at_k, 1.0);
+    let project_scope = report
+        .by_category
+        .get("project_scope")
+        .context("missing project_scope category")?;
+    let project_scope_metrics = project_scope
+        .metrics
+        .as_ref()
+        .context("missing project_scope metrics")?;
+    assert_eq!(project_scope_metrics.count, 2);
+    assert_eq!(
+        report.queries.last().map(|query| query.status),
+        Some(QueryStatus::Pass)
+    );
+    Ok(())
+}
+
+#[test]
+fn golden_eval_rejects_empty_evidence_refs() -> Result<()> {
+    let conn = setup_conn()?;
+    let dataset = GoldenDataset {
+        version: Some("1.2-test".to_string()),
+        description: None,
+        queries: vec![query(
+            "bad",
+            "bad query",
+            "bad",
+            None,
+            None,
+            EvidenceRef::default(),
+        )],
+    };
+
+    let Err(error) = evaluate_dataset(&conn, &dataset, 5) else {
+        panic!("empty evidence ref should fail validation");
+    };
+
+    assert!(error.to_string().contains("empty evidence ref"));
+    Ok(())
+}

--- a/src/eval/golden/types.rs
+++ b/src/eval/golden/types.rs
@@ -1,0 +1,241 @@
+use std::collections::BTreeMap;
+
+use crate::memory::Memory;
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct GoldenDataset {
+    pub version: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub queries: Vec<GoldenQuery>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct GoldenQuery {
+    pub id: String,
+    pub query: String,
+    pub category: String,
+    pub project: Option<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub memory_type: Option<String>,
+    #[serde(default)]
+    pub relevant_ids: Vec<i64>,
+    #[serde(default, alias = "expected_refs")]
+    pub evidence_refs: Vec<EvidenceRef>,
+    #[serde(default)]
+    pub expect_abstain: bool,
+    #[serde(default)]
+    pub false_premise: bool,
+    pub notes: Option<String>,
+}
+
+impl GoldenQuery {
+    pub fn expects_abstention(&self) -> bool {
+        self.expect_abstain || self.false_premise
+    }
+
+    pub fn expected_refs(&self) -> Vec<EvidenceRef> {
+        let mut refs = self.evidence_refs.clone();
+        refs.extend(self.relevant_ids.iter().map(|id| EvidenceRef {
+            memory_id: Some(*id),
+            ..EvidenceRef::default()
+        }));
+        refs
+    }
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct EvidenceRef {
+    pub memory_id: Option<i64>,
+    pub topic_key: Option<String>,
+    pub project: Option<String>,
+    pub branch: Option<String>,
+    pub memory_type: Option<String>,
+    pub scope: Option<String>,
+    pub title_contains: Option<String>,
+    pub text_contains: Option<String>,
+}
+
+impl EvidenceRef {
+    pub fn has_match_criteria(&self) -> bool {
+        self.memory_id.is_some()
+            || self.topic_key.is_some()
+            || self.project.is_some()
+            || self.branch.is_some()
+            || self.memory_type.is_some()
+            || self.scope.is_some()
+            || self.title_contains.is_some()
+            || self.text_contains.is_some()
+    }
+
+    pub fn matches(&self, memory: &Memory) -> bool {
+        if !self.has_match_criteria() {
+            return false;
+        }
+        if let Some(memory_id) = self.memory_id {
+            if memory.id != memory_id {
+                return false;
+            }
+        }
+        if let Some(project) = self.project.as_deref() {
+            if !crate::project_id::project_matches(Some(&memory.project), project) {
+                return false;
+            }
+        }
+        if let Some(branch) = self.branch.as_deref() {
+            if memory.branch.as_deref() != Some(branch) {
+                return false;
+            }
+        }
+        if let Some(topic_key) = self.topic_key.as_deref() {
+            if memory.topic_key.as_deref() != Some(topic_key) {
+                return false;
+            }
+        }
+        if let Some(memory_type) = self.memory_type.as_deref() {
+            if memory.memory_type != memory_type {
+                return false;
+            }
+        }
+        if let Some(scope) = self.scope.as_deref() {
+            if memory.scope != scope {
+                return false;
+            }
+        }
+        if let Some(needle) = self.title_contains.as_deref() {
+            if !contains_case_insensitive(&memory.title, needle) {
+                return false;
+            }
+        }
+        if let Some(needle) = self.text_contains.as_deref() {
+            if !contains_case_insensitive(&memory.text, needle) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+fn contains_case_insensitive(haystack: &str, needle: &str) -> bool {
+    haystack.to_lowercase().contains(&needle.to_lowercase())
+}
+
+#[derive(Debug, Clone)]
+pub struct GoldenEvalReport {
+    pub version: Option<String>,
+    pub description: Option<String>,
+    pub k: usize,
+    pub rank_k: usize,
+    pub total_queries: usize,
+    pub scored_queries: usize,
+    pub skipped_queries: usize,
+    pub abstention_queries: usize,
+    pub abstention_passed: usize,
+    pub overall: Option<MetricAverages>,
+    pub by_category: BTreeMap<String, CategoryEvaluation>,
+    pub queries: Vec<QueryEvaluation>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CategoryEvaluation {
+    pub total_queries: usize,
+    pub scored_queries: usize,
+    pub abstention_queries: usize,
+    pub abstention_passed: usize,
+    pub metrics: Option<MetricAverages>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryEvaluation {
+    pub id: String,
+    pub query: String,
+    pub category: String,
+    pub status: QueryStatus,
+    pub result_count: usize,
+    pub matched_refs: usize,
+    pub expected_refs: usize,
+    pub metrics: Option<QueryMetrics>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryStatus {
+    Hit,
+    Miss,
+    Pass,
+    Fail,
+    Skip,
+}
+
+impl QueryStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            QueryStatus::Hit => "HIT",
+            QueryStatus::Miss => "MISS",
+            QueryStatus::Pass => "PASS",
+            QueryStatus::Fail => "FAIL",
+            QueryStatus::Skip => "SKIP",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct QueryMetrics {
+    pub hit_at_k: f64,
+    pub mrr_at_10: f64,
+    pub precision_at_k: f64,
+    pub recall_at_k: f64,
+    pub ndcg_at_10: f64,
+    pub evidence_recall_at_k: f64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MetricAverages {
+    pub count: usize,
+    pub hit_at_k: f64,
+    pub mrr_at_10: f64,
+    pub precision_at_k: f64,
+    pub recall_at_k: f64,
+    pub ndcg_at_10: f64,
+    pub evidence_recall_at_k: f64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct MetricSums {
+    count: usize,
+    hit_at_k: f64,
+    mrr_at_10: f64,
+    precision_at_k: f64,
+    recall_at_k: f64,
+    ndcg_at_10: f64,
+    evidence_recall_at_k: f64,
+}
+
+impl MetricSums {
+    pub(super) fn add(&mut self, metrics: &QueryMetrics) {
+        self.count += 1;
+        self.hit_at_k += metrics.hit_at_k;
+        self.mrr_at_10 += metrics.mrr_at_10;
+        self.precision_at_k += metrics.precision_at_k;
+        self.recall_at_k += metrics.recall_at_k;
+        self.ndcg_at_10 += metrics.ndcg_at_10;
+        self.evidence_recall_at_k += metrics.evidence_recall_at_k;
+    }
+
+    pub(super) fn averages(&self) -> Option<MetricAverages> {
+        if self.count == 0 {
+            return None;
+        }
+        let n = self.count as f64;
+        Some(MetricAverages {
+            count: self.count,
+            hit_at_k: self.hit_at_k / n,
+            mrr_at_10: self.mrr_at_10 / n,
+            precision_at_k: self.precision_at_k / n,
+            recall_at_k: self.recall_at_k / n,
+            ndcg_at_10: self.ndcg_at_10 / n,
+            evidence_recall_at_k: self.evidence_recall_at_k / n,
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- move `remem eval` golden-query logic out of the CLI action into `src/eval/golden/`
- add schema v1.2 support for stable `evidence_refs`, branch/memory_type filters, abstention, and false-premise cases
- report overall and per-category `H@k`, `MRR@10`, `P@k`, `R@k`, `nDCG@10`, and `evidence@k`
- replace the stale legacy-id default fixture with stable current evidence refs and document the schema in `eval/README.md`

Closes #183.

## Verification
- `cargo test eval::golden --lib --quiet` -> 2 passed
- `cargo run --quiet -- eval --dataset eval/golden.json -k 5` -> 5/5 scored cases HIT, abstention baseline 0/1
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test` -> 492 lib tests, 16 benchmark tests, 21 rate_limit tests passed
- `cargo run --quiet -- eval-local` -> overall 4.9/5.0, project_filter 0 true leaks / 95 hits

## Notes
The default fixture intentionally leaves one false-premise abstention case failing because current retrieval still returns curated memories for that query. That gives the next search-quality PR a visible baseline instead of hiding the weakness.