### PR TITLE
Add search explain output

### DIFF
--- a/src/api/handlers/search.rs
+++ b/src/api/handlers/search.rs
@@ -27,6 +27,7 @@ pub(in crate::api) fn search_request_from_params(params: SearchParams) -> servic
             .unwrap_or_else(service::default_include_stale),
         branch: params.branch,
         multi_hop: params.multi_hop.unwrap_or(false),
+        explain: false,
     }
 }
 

--- a/src/cli/actions/import.rs
+++ b/src/cli/actions/import.rs
@@ -260,6 +260,7 @@ mod tests {
                 include_stale: false,
                 branch: None,
                 multi_hop: false,
+                explain: false,
             },
         )
         .unwrap();

--- a/src/cli/actions/query/search.rs
+++ b/src/cli/actions/query/search.rs
@@ -7,6 +7,7 @@ use crate::{
         service::{MultiHopMeta, SearchRequest, SearchResultSet},
         Memory,
     },
+    retrieval::search::SearchExplain,
 };
 
 pub(in crate::cli) fn run_search(
@@ -18,6 +19,7 @@ pub(in crate::cli) fn run_search(
     branch: Option<&str>,
     include_stale: bool,
     multi_hop: bool,
+    explain: bool,
 ) -> Result<()> {
     let conn = db::open_db()?;
     let request = build_search_request(
@@ -29,6 +31,7 @@ pub(in crate::cli) fn run_search(
         branch,
         include_stale,
         multi_hop,
+        explain,
     );
     let results = crate::memory::service::search_memories(&conn, &request)?;
     print!("{}", render_search_results(&results, offset, limit.max(1)));
@@ -44,6 +47,7 @@ pub(super) fn build_search_request(
     branch: Option<&str>,
     include_stale: bool,
     multi_hop: bool,
+    explain: bool,
 ) -> SearchRequest {
     SearchRequest {
         query: Some(query.to_string()),
@@ -54,6 +58,7 @@ pub(super) fn build_search_request(
         include_stale,
         branch: branch.map(str::to_string),
         multi_hop,
+        explain,
     }
 }
 
@@ -92,6 +97,13 @@ pub(super) fn render_search_results(results: &SearchResultSet, offset: i64, limi
         for raw in &results.raw_hits {
             output.push_str(&format_raw_hit_line(raw));
         }
+    }
+    if let Some(explain) = results.explain.as_ref() {
+        if !output.ends_with('\n') {
+            output.push('\n');
+        }
+        output.push('\n');
+        output.push_str(&render_search_explain(explain));
     }
 
     output
@@ -143,6 +155,75 @@ fn format_raw_hit_line(raw: &RawMessage) -> String {
         output.push_str(&format!(" | {}", preview));
     }
     output.push('\n');
+    output
+}
+
+fn render_search_explain(explain: &SearchExplain) -> String {
+    let mut output = String::new();
+    output.push_str("Search explain:\n");
+    output.push_str(&format!("  query: {:?}\n", explain.query));
+    output.push_str(&format!(
+        "  filters: project={:?} branch={:?} type={:?} include_stale={}\n",
+        explain.project, explain.branch, explain.memory_type, explain.include_stale
+    ));
+    output.push_str(&format!(
+        "  pagination: limit={} offset={} fetch_limit={} has_more={}\n",
+        explain.limit, explain.offset, explain.fetch_limit, explain.has_more
+    ));
+    output.push_str(&format!(
+        "  expanded_terms: [{}]\n",
+        explain.expanded_terms.join(", ")
+    ));
+    output.push_str(&format!(
+        "  core_terms: [{}]\n",
+        explain.core_terms.join(", ")
+    ));
+    output.push_str(&format!("  fts_query: {:?}\n", explain.fts_query));
+    output.push_str(&format!("  temporal_range: {:?}\n", explain.temporal_range));
+    output.push_str(&format!("  rrf_k: {:.1}\n", explain.rrf_k));
+    output.push_str("  channels:\n");
+    for channel in &explain.channels {
+        output.push_str(&format!(
+            "    {}: {}\n",
+            channel.name,
+            channel
+                .hits
+                .iter()
+                .map(|hit| format!("{}#{}", hit.memory_id, hit.rank))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    output.push_str("  results:\n");
+    for result in &explain.results {
+        output.push_str(&format!(
+            "    [{}] rank={} score={:.6} visibility={} scope={} project={}\n",
+            result.memory_id,
+            result.final_rank,
+            result.final_score,
+            result.visibility,
+            result.scope,
+            result.project
+        ));
+        if !result.contributions.is_empty() {
+            output.push_str(&format!(
+                "      contributions: {}\n",
+                result
+                    .contributions
+                    .iter()
+                    .map(|contribution| format!(
+                        "{}#{}={:.6}",
+                        contribution.channel, contribution.rank, contribution.score
+                    ))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
+    output.push_str(&format!(
+        "  raw_fallback_count: {}\n",
+        explain.raw_fallback_count
+    ));
     output
 }
 

--- a/src/cli/actions/query/tests.rs
+++ b/src/cli/actions/query/tests.rs
@@ -3,6 +3,7 @@ use crate::memory::{
     service::{MultiHopMeta, SearchResultSet},
     Memory,
 };
+use crate::retrieval::search::{ChannelContribution, SearchExplain, SearchExplainResult};
 
 use super::{
     search::{build_search_request, preview_raw_text, preview_text, render_search_results},
@@ -41,6 +42,46 @@ fn sample_raw() -> RawMessage {
     }
 }
 
+fn sample_explain() -> SearchExplain {
+    SearchExplain {
+        query: "needle".to_string(),
+        project: Some("proj".to_string()),
+        memory_type: Some("decision".to_string()),
+        branch: Some("main".to_string()),
+        include_stale: false,
+        limit: 10,
+        offset: 0,
+        fetch_limit: 33,
+        expanded_terms: vec!["needle".to_string()],
+        core_terms: vec!["needle".to_string()],
+        fts_query: Some("\"needle\"".to_string()),
+        temporal_range: None,
+        rrf_k: 60.0,
+        channels: vec![crate::retrieval::search::SearchExplainChannel {
+            name: "fts".to_string(),
+            hits: vec![crate::retrieval::search::ChannelHit {
+                memory_id: 1,
+                rank: 1,
+            }],
+        }],
+        results: vec![SearchExplainResult {
+            memory_id: 1,
+            final_rank: 1,
+            final_score: 0.016393,
+            project: "proj".to_string(),
+            scope: "project".to_string(),
+            visibility: "project-local".to_string(),
+            contributions: vec![ChannelContribution {
+                channel: "fts".to_string(),
+                rank: 1,
+                score: 0.016393,
+            }],
+        }],
+        has_more: false,
+        raw_fallback_count: 0,
+    }
+}
+
 #[test]
 fn cli_query_preview_uses_first_line_and_truncates() {
     let memory = sample_memory();
@@ -66,6 +107,7 @@ fn cli_search_request_carries_service_search_options() {
         Some("feature"),
         true,
         true,
+        true,
     );
 
     assert_eq!(request.query.as_deref(), Some("needle"));
@@ -76,6 +118,7 @@ fn cli_search_request_carries_service_search_options() {
     assert_eq!(request.branch.as_deref(), Some("feature"));
     assert!(request.include_stale);
     assert!(request.multi_hop);
+    assert!(request.explain);
 }
 
 #[test]
@@ -87,6 +130,7 @@ fn cli_search_render_shows_multi_hop_has_more_and_raw_fallback() {
             entities_discovered: vec!["Graphiti".to_string(), "Mem0".to_string()],
         }),
         has_more: true,
+        explain: None,
         raw_hits: vec![sample_raw()],
     };
 
@@ -105,6 +149,7 @@ fn cli_search_render_uses_raw_fallback_when_curated_is_empty() {
         memories: vec![],
         multi_hop: None,
         has_more: false,
+        explain: None,
         raw_hits: vec![sample_raw()],
     };
 
@@ -113,6 +158,26 @@ fn cli_search_render_uses_raw_fallback_when_curated_is_empty() {
     assert!(output.contains("No curated memories found."));
     assert!(output.contains("Raw archive fallback:"));
     assert!(!output.contains("No results found."));
+}
+
+#[test]
+fn cli_search_render_includes_explain_without_memory_content_dump() {
+    let result = SearchResultSet {
+        memories: vec![sample_memory()],
+        multi_hop: None,
+        has_more: false,
+        explain: Some(sample_explain()),
+        raw_hits: vec![],
+    };
+
+    let output = render_search_results(&result, 0, 10);
+
+    assert!(output.contains("Search explain:"));
+    assert!(output.contains("channels:"));
+    assert!(output.contains("fts: 1#1"));
+    assert!(output.contains("visibility=project-local"));
+    assert!(output.contains("contributions: fts#1=0.016393"));
+    assert!(!output.contains("second line"));
 }
 
 #[test]

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -78,6 +78,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             branch,
             include_stale,
             multi_hop,
+            explain,
         } => run_search(
             &query,
             project.as_deref(),
@@ -87,6 +88,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             branch.as_deref(),
             include_stale,
             multi_hop,
+            explain,
         )?,
         Commands::Show { id } => run_show(id)?,
         Commands::Eval { dataset, k } => run_eval(&dataset, k)?,

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -83,6 +83,7 @@ fn cli_parses_search_type_alias_and_multi_hop_filters() {
             branch,
             include_stale,
             multi_hop,
+            explain,
         } => {
             assert_eq!(query, "Melanie rollout");
             assert_eq!(project.as_deref(), Some("personal"));
@@ -92,6 +93,7 @@ fn cli_parses_search_type_alias_and_multi_hop_filters() {
             assert_eq!(branch.as_deref(), Some("main"));
             assert!(include_stale);
             assert!(multi_hop);
+            assert!(!explain);
         }
         _ => panic!("expected search command"),
     }

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -107,6 +107,8 @@ pub(super) enum Commands {
         include_stale: bool,
         #[arg(long)]
         multi_hop: bool,
+        #[arg(long)]
+        explain: bool,
     },
     Show {
         id: i64,

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -43,6 +43,7 @@ impl MemoryServer {
                     .unwrap_or_else(service::default_include_stale),
                 branch: params.branch.clone(),
                 multi_hop: requested_multi_hop,
+                explain: false,
             };
             let search_set = service::search_memories(conn, &req).map_err(|e| {
                 crate::log::warn("mcp", &format!("search failed: {}", e));
@@ -54,6 +55,7 @@ impl MemoryServer {
                 memories,
                 multi_hop,
                 has_more,
+                explain: _,
                 raw_hits,
             } = search_set;
 

--- a/src/memory/service/search.rs
+++ b/src/memory/service/search.rs
@@ -17,23 +17,45 @@ pub fn search_memories(conn: &Connection, req: &SearchRequest) -> Result<SearchR
         return multi_hop_search(conn, query, req.project.as_deref(), limit, req);
     }
 
-    let mut memories = crate::retrieval::search::search_with_branch(
-        conn,
-        query,
-        req.project.as_deref(),
-        req.memory_type.as_deref(),
-        limit + 1,
-        req.offset.max(0),
-        req.include_stale,
-        req.branch.as_deref(),
-    )?;
+    let (mut memories, mut explain) = if req.explain {
+        crate::retrieval::search::search_with_branch_explain(
+            conn,
+            query,
+            req.project.as_deref(),
+            req.memory_type.as_deref(),
+            limit + 1,
+            req.offset.max(0),
+            req.include_stale,
+            req.branch.as_deref(),
+        )?
+    } else {
+        (
+            crate::retrieval::search::search_with_branch(
+                conn,
+                query,
+                req.project.as_deref(),
+                req.memory_type.as_deref(),
+                limit + 1,
+                req.offset.max(0),
+                req.include_stale,
+                req.branch.as_deref(),
+            )?,
+            None,
+        )
+    };
     let has_more = memories.len() as i64 > limit;
     memories.truncate(limit as usize);
     let raw_hits = maybe_fallback_raw(conn, req, memories.len());
+    if let Some(explain) = explain.as_mut() {
+        let result_ids: Vec<i64> = memories.iter().map(|memory| memory.id).collect();
+        explain.retain_result_ids(&result_ids, has_more, limit);
+        explain.set_raw_fallback_count(raw_hits.len());
+    }
     Ok(SearchResultSet {
         memories,
         multi_hop: None,
         has_more,
+        explain,
         raw_hits,
     })
 }
@@ -66,6 +88,7 @@ fn multi_hop_search(
                 entities_discovered: result.entities_discovered,
             }),
             has_more,
+            explain: None,
             raw_hits,
         })
     } else {
@@ -76,6 +99,7 @@ fn multi_hop_search(
                 entities_discovered: vec![],
             }),
             has_more: false,
+            explain: None,
             raw_hits: vec![],
         })
     }

--- a/src/memory/service/types.rs
+++ b/src/memory/service/types.rs
@@ -8,6 +8,7 @@ pub struct SearchRequest {
     pub include_stale: bool,
     pub branch: Option<String>,
     pub multi_hop: bool,
+    pub explain: bool,
 }
 
 /// Canonical default for `include_stale` across every adapter (MCP, REST, CLI).
@@ -29,6 +30,7 @@ pub struct SearchResultSet {
     pub memories: Vec<crate::memory::Memory>,
     pub multi_hop: Option<MultiHopMeta>,
     pub has_more: bool,
+    pub explain: Option<crate::retrieval::search::SearchExplain>,
     /// Raw archive hits attached as fallback when curated memories are sparse.
     pub raw_hits: Vec<crate::memory::raw_archive::RawMessage>,
 }

--- a/src/retrieval/search.rs
+++ b/src/retrieval/search.rs
@@ -2,5 +2,8 @@ mod common;
 mod memory;
 mod observation;
 
-pub use memory::{search, search_with_branch};
+pub use memory::{
+    search, search_with_branch, search_with_branch_explain, ChannelContribution, ChannelHit,
+    SearchExplain, SearchExplainChannel, SearchExplainResult,
+};
 pub use observation::search_observations;

--- a/src/retrieval/search/memory.rs
+++ b/src/retrieval/search/memory.rs
@@ -1,5 +1,11 @@
+mod explain;
 mod listing;
 mod runner;
+#[cfg(test)]
+mod tests;
 mod text;
 
-pub use runner::{search, search_with_branch};
+pub use explain::{
+    ChannelContribution, ChannelHit, SearchExplain, SearchExplainChannel, SearchExplainResult,
+};
+pub use runner::{search, search_with_branch, search_with_branch_explain};

--- a/src/retrieval/search/memory/explain.rs
+++ b/src/retrieval/search/memory/explain.rs
@@ -1,0 +1,66 @@
+#[derive(Debug, Clone)]
+pub struct SearchExplain {
+    pub query: String,
+    pub project: Option<String>,
+    pub memory_type: Option<String>,
+    pub branch: Option<String>,
+    pub include_stale: bool,
+    pub limit: i64,
+    pub offset: i64,
+    pub fetch_limit: i64,
+    pub expanded_terms: Vec<String>,
+    pub core_terms: Vec<String>,
+    pub fts_query: Option<String>,
+    pub temporal_range: Option<(i64, i64)>,
+    pub rrf_k: f64,
+    pub channels: Vec<SearchExplainChannel>,
+    pub results: Vec<SearchExplainResult>,
+    pub has_more: bool,
+    pub raw_fallback_count: usize,
+}
+
+impl SearchExplain {
+    pub fn retain_result_ids(&mut self, result_ids: &[i64], has_more: bool, visible_limit: i64) {
+        self.has_more = has_more;
+        self.limit = visible_limit;
+        self.results
+            .retain(|result| result_ids.contains(&result.memory_id));
+        for (index, result) in self.results.iter_mut().enumerate() {
+            result.final_rank = index + 1;
+        }
+    }
+
+    pub fn set_raw_fallback_count(&mut self, count: usize) {
+        self.raw_fallback_count = count;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchExplainChannel {
+    pub name: String,
+    pub hits: Vec<ChannelHit>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChannelHit {
+    pub memory_id: i64,
+    pub rank: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchExplainResult {
+    pub memory_id: i64,
+    pub final_rank: usize,
+    pub final_score: f64,
+    pub project: String,
+    pub scope: String,
+    pub visibility: String,
+    pub contributions: Vec<ChannelContribution>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChannelContribution {
+    pub channel: String,
+    pub rank: usize,
+    pub score: f64,
+}

--- a/src/retrieval/search/memory/runner.rs
+++ b/src/retrieval/search/memory/runner.rs
@@ -4,7 +4,8 @@ use rusqlite::Connection;
 use crate::memory::Memory;
 
 use super::listing::search_without_query;
-use super::text::search_with_query;
+use super::text::{search_with_query, search_with_query_explain};
+use super::SearchExplain;
 
 pub fn search(
     conn: &Connection,
@@ -57,5 +58,42 @@ pub fn search_with_branch(
             include_stale,
             branch,
         ),
+    }
+}
+
+pub fn search_with_branch_explain(
+    conn: &Connection,
+    query: Option<&str>,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_stale: bool,
+    branch: Option<&str>,
+) -> Result<(Vec<Memory>, Option<SearchExplain>)> {
+    match query {
+        Some(query_text) if !query_text.is_empty() => search_with_query_explain(
+            conn,
+            query_text,
+            project,
+            memory_type,
+            limit,
+            offset,
+            include_stale,
+            branch,
+        )
+        .map(|result| (result.memories, Some(result.explain))),
+        _ => Ok((
+            search_without_query(
+                conn,
+                project,
+                memory_type,
+                limit,
+                offset,
+                include_stale,
+                branch,
+            )?,
+            None,
+        )),
     }
 }

--- a/src/retrieval/search/memory/tests.rs
+++ b/src/retrieval/search/memory/tests.rs
@@ -1,0 +1,122 @@
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+
+use super::search_with_branch_explain;
+
+fn setup_explain_conn() -> Result<Connection> {
+    let conn = Connection::open_in_memory()?;
+    crate::memory::tests_helper::setup_memory_schema(&conn);
+    Ok(conn)
+}
+
+struct ExplainMemory<'a> {
+    id: i64,
+    project: &'a str,
+    title: &'a str,
+    content: &'a str,
+    scope: &'a str,
+    updated_at_epoch: i64,
+}
+
+fn insert_explain_memory(conn: &Connection, memory: &ExplainMemory<'_>) -> Result<()> {
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope)
+         VALUES (?1, ?2, ?3, NULL, ?4, ?5, 'decision', NULL, ?6, ?6, 'active', NULL, ?7)",
+        params![
+            memory.id,
+            format!("session-{}", memory.id),
+            memory.project,
+            memory.title,
+            memory.content,
+            memory.updated_at_epoch,
+            memory.scope,
+        ],
+    )?;
+    Ok(())
+}
+
+#[test]
+fn search_explain_reports_channels_scores_and_visibility() -> Result<()> {
+    let conn = setup_explain_conn()?;
+    let now = chrono::Utc::now().timestamp();
+    insert_explain_memory(
+        &conn,
+        &ExplainMemory {
+            id: 1,
+            project: "/repo",
+            title: "Recently SQLite project fix",
+            content: "recently SQLite project migration fix",
+            scope: "project",
+            updated_at_epoch: now - 100,
+        },
+    )?;
+    insert_explain_memory(
+        &conn,
+        &ExplainMemory {
+            id: 2,
+            project: "/elsewhere",
+            title: "Recently SQLite global preference",
+            content: "recently SQLite global preference",
+            scope: "global",
+            updated_at_epoch: now - 90,
+        },
+    )?;
+    insert_explain_memory(
+        &conn,
+        &ExplainMemory {
+            id: 3,
+            project: "/repo",
+            title: "Recently unrelated note",
+            content: "recently unrelated note",
+            scope: "project",
+            updated_at_epoch: now - 80,
+        },
+    )?;
+    crate::retrieval::entity::link_entities(&conn, 1, &["SQLite".to_string()])?;
+    crate::retrieval::entity::link_entities(&conn, 2, &["SQLite".to_string()])?;
+
+    let (memories, explain) = search_with_branch_explain(
+        &conn,
+        Some("recently SQLite"),
+        Some("/repo"),
+        None,
+        5,
+        0,
+        false,
+        None,
+    )?;
+    let explain = explain.context("query explain should be present")?;
+
+    assert!(!memories.is_empty());
+    for expected in ["fts", "entity", "temporal", "like_fallback"] {
+        assert!(
+            explain
+                .channels
+                .iter()
+                .any(|channel| channel.name == expected),
+            "{expected} channel missing from {:#?}",
+            explain.channels
+        );
+    }
+    assert_eq!(explain.rrf_k, 60.0);
+    assert!(explain
+        .fts_query
+        .as_deref()
+        .unwrap_or("")
+        .contains("SQLite"));
+    assert!(explain.temporal_range.is_some());
+    assert!(explain
+        .results
+        .iter()
+        .any(|result| result.visibility == "global-overlay"));
+    assert!(explain.results.iter().all(|result| {
+        !result.contributions.is_empty()
+            && result
+                .contributions
+                .iter()
+                .all(|contribution| contribution.score > 0.0)
+    }));
+    Ok(())
+}

--- a/src/retrieval/search/memory/text.rs
+++ b/src/retrieval/search/memory/text.rs
@@ -6,6 +6,30 @@ use rusqlite::Connection;
 use crate::memory::{self, Memory};
 
 use super::super::common::{paginate_memories, rrf_fuse, sanitize_fts_query};
+use super::{
+    ChannelContribution, ChannelHit, SearchExplain, SearchExplainChannel, SearchExplainResult,
+};
+
+const RRF_K: f64 = 60.0;
+
+pub(super) struct QuerySearchWithExplain {
+    pub memories: Vec<Memory>,
+    pub explain: SearchExplain,
+}
+
+struct QuerySearchPlan {
+    expanded_terms: Vec<String>,
+    core_terms: Vec<String>,
+    fts_query: Option<String>,
+    temporal_range: Option<(i64, i64)>,
+    fetch_limit: i64,
+    channels: Vec<NamedChannel>,
+}
+
+struct NamedChannel {
+    name: &'static str,
+    ids: Vec<i64>,
+}
 
 fn load_ordered_memories(conn: &Connection, ids: &[i64]) -> Result<Vec<Memory>> {
     let loaded = memory::get_memories_by_ids(conn, ids, None)?;
@@ -29,6 +53,115 @@ pub(super) fn search_with_query(
     include_stale: bool,
     branch: Option<&str>,
 ) -> Result<Vec<Memory>> {
+    let plan = build_query_search_plan(
+        conn,
+        query_text,
+        project,
+        memory_type,
+        limit,
+        offset,
+        include_stale,
+        branch,
+    )?;
+    if plan.channels.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let channel_ids: Vec<Vec<i64>> = plan
+        .channels
+        .iter()
+        .map(|channel| channel.ids.clone())
+        .collect();
+    let final_ids: Vec<i64> = rrf_fuse(&channel_ids, RRF_K)
+        .iter()
+        .map(|(id, _)| *id)
+        .collect();
+    let ordered = load_ordered_memories(conn, &final_ids)?;
+    Ok(paginate_memories(ordered, limit, offset))
+}
+
+pub(super) fn search_with_query_explain(
+    conn: &Connection,
+    query_text: &str,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_stale: bool,
+    branch: Option<&str>,
+) -> Result<QuerySearchWithExplain> {
+    let plan = build_query_search_plan(
+        conn,
+        query_text,
+        project,
+        memory_type,
+        limit,
+        offset,
+        include_stale,
+        branch,
+    )?;
+    if plan.channels.is_empty() {
+        return Ok(QuerySearchWithExplain {
+            memories: vec![],
+            explain: SearchExplain {
+                query: query_text.to_string(),
+                project: project.map(str::to_string),
+                memory_type: memory_type.map(str::to_string),
+                branch: branch.map(str::to_string),
+                include_stale,
+                limit,
+                offset,
+                fetch_limit: plan.fetch_limit,
+                expanded_terms: plan.expanded_terms,
+                core_terms: plan.core_terms,
+                fts_query: plan.fts_query,
+                temporal_range: plan.temporal_range,
+                rrf_k: RRF_K,
+                channels: vec![],
+                results: vec![],
+                has_more: false,
+                raw_fallback_count: 0,
+            },
+        });
+    }
+
+    let channel_ids: Vec<Vec<i64>> = plan
+        .channels
+        .iter()
+        .map(|channel| channel.ids.clone())
+        .collect();
+    let fused = rrf_fuse(&channel_ids, RRF_K);
+    let final_ids: Vec<i64> = fused.iter().map(|(id, _)| *id).collect();
+    let ordered = load_ordered_memories(conn, &final_ids)?;
+    let paged = paginate_memories(ordered, limit, offset);
+    let explain = build_explain(
+        query_text,
+        project,
+        memory_type,
+        limit,
+        offset,
+        include_stale,
+        branch,
+        &plan,
+        &fused,
+        &paged,
+    );
+    Ok(QuerySearchWithExplain {
+        memories: paged,
+        explain,
+    })
+}
+
+fn build_query_search_plan(
+    conn: &Connection,
+    query_text: &str,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_stale: bool,
+    branch: Option<&str>,
+) -> Result<QuerySearchPlan> {
     let page_target = (limit.max(1) + offset.max(0) + 1).max(2);
     let fetch = page_target * 3;
     let expanded = crate::retrieval::query_expand::expand_query(query_text);
@@ -41,10 +174,13 @@ pub(super) fn search_with_query(
 
     let core_tokens = crate::retrieval::query_expand::core_tokens(query_text);
     let core_refs: Vec<&str> = core_tokens.iter().map(|token| token.as_str()).collect();
-    let mut channels: Vec<Vec<i64>> = Vec::new();
+    let mut channels: Vec<NamedChannel> = Vec::new();
+    let mut fts_query = None;
+    let mut temporal_range = None;
 
     if !long_tokens.is_empty() {
         let safe_query = sanitize_fts_query(&long_tokens.join(" "));
+        fts_query = Some(safe_query.clone());
         let fts = memory::search_memories_fts_filtered(
             conn,
             &safe_query,
@@ -55,7 +191,10 @@ pub(super) fn search_with_query(
             include_stale,
             branch,
         )?;
-        channels.push(fts.iter().map(|memory| memory.id).collect());
+        let ids: Vec<i64> = fts.iter().map(|memory| memory.id).collect();
+        if !ids.is_empty() {
+            channels.push(NamedChannel { name: "fts", ids });
+        }
     }
 
     let entity_ids = crate::retrieval::entity::search_by_entity_filtered(
@@ -68,10 +207,17 @@ pub(super) fn search_with_query(
         include_stale,
     )?;
     if !entity_ids.is_empty() {
-        channels.push(entity_ids);
+        channels.push(NamedChannel {
+            name: "entity",
+            ids: entity_ids,
+        });
     }
 
     if let Some(temporal_constraint) = crate::retrieval::temporal::extract_temporal(query_text) {
+        temporal_range = Some((
+            temporal_constraint.start_epoch,
+            temporal_constraint.end_epoch,
+        ));
         let temporal_ids = crate::retrieval::temporal::search_by_time_filtered(
             conn,
             &temporal_constraint,
@@ -82,7 +228,10 @@ pub(super) fn search_with_query(
             include_stale,
         )?;
         if !temporal_ids.is_empty() {
-            channels.push(temporal_ids);
+            channels.push(NamedChannel {
+                name: "temporal",
+                ids: temporal_ids,
+            });
         }
     }
 
@@ -97,17 +246,112 @@ pub(super) fn search_with_query(
         branch,
     )?;
     if !like.is_empty() {
-        channels.push(like.iter().map(|memory| memory.id).collect());
+        channels.push(NamedChannel {
+            name: "like_fallback",
+            ids: like.iter().map(|memory| memory.id).collect(),
+        });
     }
 
-    if channels.is_empty() {
-        return Ok(vec![]);
-    }
+    Ok(QuerySearchPlan {
+        expanded_terms: expanded,
+        core_terms: core_tokens,
+        fts_query,
+        temporal_range,
+        fetch_limit: fetch,
+        channels,
+    })
+}
 
-    let final_ids: Vec<i64> = rrf_fuse(&channels, 60.0)
+#[allow(clippy::too_many_arguments)]
+fn build_explain(
+    query_text: &str,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_stale: bool,
+    branch: Option<&str>,
+    plan: &QuerySearchPlan,
+    fused: &[(i64, f64)],
+    paged: &[Memory],
+) -> SearchExplain {
+    let channels = plan
+        .channels
         .iter()
-        .map(|(id, _)| *id)
+        .map(|channel| SearchExplainChannel {
+            name: channel.name.to_string(),
+            hits: channel
+                .ids
+                .iter()
+                .enumerate()
+                .map(|(index, id)| ChannelHit {
+                    memory_id: *id,
+                    rank: index + 1,
+                })
+                .collect(),
+        })
         .collect();
-    let ordered = load_ordered_memories(conn, &final_ids)?;
-    Ok(paginate_memories(ordered, limit, offset))
+    let id_to_score: HashMap<i64, f64> = fused.iter().copied().collect();
+    let results = paged
+        .iter()
+        .enumerate()
+        .map(|(index, memory)| SearchExplainResult {
+            memory_id: memory.id,
+            final_rank: index + 1,
+            final_score: id_to_score.get(&memory.id).copied().unwrap_or_default(),
+            project: memory.project.clone(),
+            scope: memory.scope.clone(),
+            visibility: visibility_label(memory, project).to_string(),
+            contributions: contributions_for(memory.id, &plan.channels),
+        })
+        .collect();
+    SearchExplain {
+        query: query_text.to_string(),
+        project: project.map(str::to_string),
+        memory_type: memory_type.map(str::to_string),
+        branch: branch.map(str::to_string),
+        include_stale,
+        limit,
+        offset,
+        fetch_limit: plan.fetch_limit,
+        expanded_terms: plan.expanded_terms.clone(),
+        core_terms: plan.core_terms.clone(),
+        fts_query: plan.fts_query.clone(),
+        temporal_range: plan.temporal_range,
+        rrf_k: RRF_K,
+        channels,
+        results,
+        has_more: false,
+        raw_fallback_count: 0,
+    }
+}
+
+fn contributions_for(memory_id: i64, channels: &[NamedChannel]) -> Vec<ChannelContribution> {
+    channels
+        .iter()
+        .filter_map(|channel| {
+            channel
+                .ids
+                .iter()
+                .position(|id| *id == memory_id)
+                .map(|index| ChannelContribution {
+                    channel: channel.name.to_string(),
+                    rank: index + 1,
+                    score: 1.0 / (RRF_K + index as f64 + 1.0),
+                })
+        })
+        .collect()
+}
+
+fn visibility_label(memory: &Memory, requested_project: Option<&str>) -> &'static str {
+    if memory.scope == "global" {
+        "global-overlay"
+    } else if requested_project
+        .map(|project| crate::project_id::project_matches(Some(&memory.project), project))
+        .unwrap_or(false)
+    {
+        "project-local"
+    } else {
+        "unscoped"
+    }
 }


### PR DESCRIPTION
## Summary
- add optional `--explain` search output with structured retrieval channels, query plan data, visibility/scope, and RRF contributions
- expose explain data through the service result shape while keeping API/MCP/default search behavior unchanged
- cover FTS, entity, temporal, global overlay, fallback, and no-raw-content explain rendering paths

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo run --quiet -- eval --dataset eval/golden.json -k 5`
- `cargo run --quiet -- eval-local`
- `cargo run --quiet -- search "最近 project leak eval-local" --project /Users/lifcc/Desktop/code/AI/tool/remem --limit 2 --explain`

Closes #181