### PR TITLE
Add memory lifecycle operations

### DIFF
--- a/docs/memory-lifecycle.md
+++ b/docs/memory-lifecycle.md
@@ -1,0 +1,80 @@
+# Memory Lifecycle
+
+remem memory is not append-only. Durable facts move through explicit lifecycle
+operations so corrected facts can replace stale facts without losing audit
+history.
+
+## Operation Model
+
+| Operation | When to use | Storage effect |
+|---|---|---|
+| `add` | New durable fact with enough evidence. | Insert an active memory. |
+| `update` | A new fact corrects or replaces older facts. | Insert the replacement memory and mark superseded ids `stale`. |
+| `invalidate` | Existing memories are known to be wrong or obsolete. | Mark the listed memories `stale`; do not delete their rows. |
+| `noop` | Evidence is already represented or not durable. | Record an explicit no-op outcome; write no memory. |
+| `defer` | Evidence is ambiguous, contradictory, or incomplete. | Leave durable memory unchanged and requeue/review the extraction task. |
+
+`delete` is intentionally not a normal memory operation. Unless a future
+privacy or retention feature requires hard deletion, invalidation should be a
+soft state transition to preserve provenance and debugging history.
+
+## State Semantics
+
+`active` memories are the current facts used by default retrieval. `stale`
+memories remain in the database as historical evidence but should not rank as
+current facts unless a caller explicitly asks to include stale entries.
+
+Candidate review state is separate from memory state:
+
+| Candidate state | Meaning |
+|---|---|
+| `auto_promoted` | Low-risk candidate was promoted to an active memory. |
+| `pending_review` | Candidate needs manual review before becoming durable memory. |
+| `discarded` | Candidate was rejected after review. |
+| `defer` outcome | No candidate row is created; the extraction task keeps the reason in `last_error` and retries later. |
+
+## Provenance Rules
+
+Every promoted memory should keep enough provenance to explain why it exists:
+
+- source session and project context
+- evidence event ids
+- source candidate id when promotion came from candidate extraction
+- confidence for extracted candidates
+- branch and file metadata when available
+
+Superseded memories keep their original content and provenance. The replacement
+memory points forward through normal fields such as `topic_key`, while the old
+rows are preserved by `status='stale'`.
+
+## Retrieval Rules
+
+Default search excludes stale memories, so corrected facts outrank obsolete
+facts by visibility rather than only by score tuning. Historical/debug flows can
+set `include_stale=true` or query ids directly when they need to inspect the old
+facts.
+
+FTS maintenance follows the same rule: active memories are searchable as current
+facts, while stale rows are removed from the active FTS index by the existing
+status triggers.
+
+## Failure Handling
+
+Ambiguous extraction is not the same as "no candidates." Extractors should use:
+
+- `<no_candidates reason="..."/>` when the evidence is clear but not durable.
+- `<defer reason="..."/>` when the evidence is ambiguous, contradictory, or not
+  safe to decide automatically.
+
+Worker handling maps `defer` to the extraction task retry/review path. This
+keeps uncertain facts out of durable memory and avoids silent drops.
+
+## Metrics To Track
+
+The lifecycle should remain observable as more automation is added:
+
+- write count by operation: add, update, invalidate, noop, defer
+- stale/superseded count by project
+- defer age and retry count
+- candidate promotion rate versus pending review rate
+- conflict/update tests in the evaluation suite

--- a/src/dream/apply.rs
+++ b/src/dream/apply.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, Result};
-use rusqlite::{params, Connection};
+use anyhow::Result;
+use rusqlite::Connection;
 
 use super::merge::MergeResult;
 
@@ -21,33 +21,12 @@ pub(super) fn apply(conn: &mut Connection, project: &str, result: &MergeResult) 
         None,
     )?;
 
-    // Deduplicate before processing: a hallucinated duplicate id from the LLM
-    // would otherwise re-fire the `memories_au` trigger on the second pass,
-    // and the trigger's 'delete' against an already-removed FTS row can
-    // surface as `database disk image is malformed` and abort the
-    // transaction. `filter_superseded_ids` already drops out-of-cluster ids
-    // but does not deduplicate.
-    let mut seen = std::collections::HashSet::with_capacity(result.superseded_ids.len());
-    let unique_ids: Vec<i64> = result
-        .superseded_ids
-        .iter()
-        .copied()
-        .filter(|id| *id != merged_id && seen.insert(*id))
-        .collect();
-
-    for id in &unique_ids {
-        let updated = tx.execute(
-            "UPDATE memories SET status = 'stale' WHERE id = ?1 AND project = ?2",
-            params![id, project],
-        )?;
-        if updated != 1 {
-            return Err(anyhow!(
-                "failed to mark superseded memory stale: id={} project={}",
-                id,
-                project
-            ));
-        }
-    }
+    crate::memory::lifecycle::soft_supersede(
+        &tx,
+        project,
+        &result.superseded_ids,
+        Some(merged_id),
+    )?;
 
     tx.commit()?;
     Ok(())
@@ -58,7 +37,7 @@ mod tests {
     use super::*;
     use crate::memory::insert_memory;
     use crate::memory::tests_helper::setup_memory_schema;
-    use rusqlite::Connection;
+    use rusqlite::{params, Connection};
 
     fn setup() -> (Connection, String) {
         let conn = Connection::open_in_memory().expect("in-memory db");

--- a/src/extraction_worker.rs
+++ b/src/extraction_worker.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use tokio::time::Duration;
 
 use crate::db;
+use crate::memory_candidate::MemoryCandidateResult;
 
 enum ExtractionTaskOutcome {
     Deferred(String),
@@ -98,8 +99,12 @@ async fn process_extraction_task(task: &db::ExtractionTask) -> Result<Extraction
             Ok(ExtractionTaskOutcome::Done)
         }
         db::ExtractionTaskKind::MemoryCandidate => {
-            crate::memory_candidate::process(task).await?;
-            Ok(ExtractionTaskOutcome::Done)
+            match crate::memory_candidate::process(task).await? {
+                MemoryCandidateResult::Deferred { reason } => {
+                    Ok(ExtractionTaskOutcome::Deferred(reason))
+                }
+                _ => Ok(ExtractionTaskOutcome::Done),
+            }
         }
         _ => Ok(ExtractionTaskOutcome::Deferred(format!(
             "extraction task kind '{}' is not implemented",

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,6 +1,7 @@
 pub mod dedup;
 pub mod events;
 pub mod format;
+pub mod lifecycle;
 pub mod preference;
 pub mod promote;
 pub mod raw_archive;

--- a/src/memory/format.rs
+++ b/src/memory/format.rs
@@ -8,5 +8,6 @@ mod types;
 pub use crate::db::models::OBSERVATION_TYPES;
 pub use escape::{xml_escape_attr, xml_escape_text};
 pub use extract::extract_field;
+pub(crate) use parse::find_ascii_ci;
 pub use parse::parse_observations;
 pub use types::ParsedObservation;

--- a/src/memory/format/parse.rs
+++ b/src/memory/format/parse.rs
@@ -2,7 +2,7 @@ use super::{extract_field, ParsedObservation, OBSERVATION_TYPES};
 
 /// Find `needle` in `haystack` using ASCII case-insensitive comparison.
 /// Returns the byte offset of the first match, or `None`.
-fn find_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
+pub(crate) fn find_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
     let needle = needle.as_bytes();
     haystack
         .as_bytes()

--- a/src/memory/lifecycle.rs
+++ b/src/memory/lifecycle.rs
@@ -1,0 +1,275 @@
+use anyhow::{anyhow, Result};
+use rusqlite::{params, Connection};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryLifecycleOp {
+    Add,
+    Update,
+    Invalidate,
+    Noop,
+    Defer,
+}
+
+impl MemoryLifecycleOp {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Add => "add",
+            Self::Update => "update",
+            Self::Invalidate => "invalidate",
+            Self::Noop => "noop",
+            Self::Defer => "defer",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LifecycleOutcome {
+    pub op: MemoryLifecycleOp,
+    pub memory_id: Option<i64>,
+    pub superseded: usize,
+    pub noop: bool,
+    pub deferred: bool,
+    pub reason: Option<String>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn apply_add(
+    conn: &Connection,
+    session_id: Option<&str>,
+    project: &str,
+    topic_key: Option<&str>,
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    files: Option<&str>,
+    branch: Option<&str>,
+    scope: &str,
+) -> Result<LifecycleOutcome> {
+    let memory_id = crate::memory::insert_memory_full(
+        conn,
+        session_id,
+        project,
+        topic_key,
+        title,
+        content,
+        memory_type,
+        files,
+        branch,
+        scope,
+        None,
+    )?;
+    Ok(LifecycleOutcome {
+        op: MemoryLifecycleOp::Add,
+        memory_id: Some(memory_id),
+        superseded: 0,
+        noop: false,
+        deferred: false,
+        reason: None,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn apply_update(
+    conn: &Connection,
+    session_id: Option<&str>,
+    project: &str,
+    topic_key: &str,
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    files: Option<&str>,
+    branch: Option<&str>,
+    scope: &str,
+    superseded_ids: &[i64],
+) -> Result<LifecycleOutcome> {
+    let memory_id = crate::memory::insert_memory_full(
+        conn,
+        session_id,
+        project,
+        Some(topic_key),
+        title,
+        content,
+        memory_type,
+        files,
+        branch,
+        scope,
+        None,
+    )?;
+    let superseded = soft_supersede(conn, project, superseded_ids, Some(memory_id))?;
+    Ok(LifecycleOutcome {
+        op: MemoryLifecycleOp::Update,
+        memory_id: Some(memory_id),
+        superseded,
+        noop: false,
+        deferred: false,
+        reason: None,
+    })
+}
+
+pub fn apply_invalidate(
+    conn: &Connection,
+    project: &str,
+    memory_ids: &[i64],
+    reason: Option<&str>,
+) -> Result<LifecycleOutcome> {
+    let superseded = soft_supersede(conn, project, memory_ids, None)?;
+    Ok(LifecycleOutcome {
+        op: MemoryLifecycleOp::Invalidate,
+        memory_id: None,
+        superseded,
+        noop: false,
+        deferred: false,
+        reason: reason.map(str::to_string),
+    })
+}
+
+pub fn noop(reason: impl Into<String>) -> LifecycleOutcome {
+    LifecycleOutcome {
+        op: MemoryLifecycleOp::Noop,
+        memory_id: None,
+        superseded: 0,
+        noop: true,
+        deferred: false,
+        reason: Some(reason.into()),
+    }
+}
+
+pub fn defer(reason: impl Into<String>) -> LifecycleOutcome {
+    LifecycleOutcome {
+        op: MemoryLifecycleOp::Defer,
+        memory_id: None,
+        superseded: 0,
+        noop: false,
+        deferred: true,
+        reason: Some(reason.into()),
+    }
+}
+
+pub fn soft_supersede(
+    conn: &Connection,
+    project: &str,
+    memory_ids: &[i64],
+    replacement_id: Option<i64>,
+) -> Result<usize> {
+    let mut seen = std::collections::HashSet::with_capacity(memory_ids.len());
+    let mut changed = 0usize;
+    for id in memory_ids
+        .iter()
+        .copied()
+        .filter(|id| Some(*id) != replacement_id && seen.insert(*id))
+    {
+        let updated = conn.execute(
+            "UPDATE memories SET status = 'stale' WHERE id = ?1 AND project = ?2",
+            params![id, project],
+        )?;
+        if updated != 1 {
+            return Err(anyhow!(
+                "failed to mark superseded memory stale: id={} project={}",
+                id,
+                project
+            ));
+        }
+        changed += updated;
+    }
+    Ok(changed)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::memory::insert_memory;
+    use crate::memory::tests_helper::setup_memory_schema;
+    use crate::retrieval::search::search_with_branch;
+
+    #[test]
+    fn update_preserves_superseded_memory_but_default_search_returns_current_fact() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup_memory_schema(&conn);
+        let project = "test-lifecycle";
+        let old_id = insert_memory(
+            &conn,
+            Some("s1"),
+            project,
+            Some("deploy-target"),
+            "Deploy target",
+            "Deploy target is staging.",
+            "decision",
+            None,
+        )?;
+
+        let outcome = apply_update(
+            &conn,
+            Some("s2"),
+            project,
+            "deploy-target-current",
+            "Deploy target corrected",
+            "Deploy target is production.",
+            "decision",
+            None,
+            None,
+            "project",
+            &[old_id],
+        )?;
+
+        assert_eq!(outcome.op, MemoryLifecycleOp::Update);
+        assert_eq!(outcome.superseded, 1);
+        let old_status: String = conn.query_row(
+            "SELECT status FROM memories WHERE id = ?1",
+            [old_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(old_status, "stale");
+
+        let results = search_with_branch(
+            &conn,
+            Some("deploy target"),
+            Some(project),
+            None,
+            10,
+            0,
+            false,
+            None,
+        )?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].text, "Deploy target is production.");
+        Ok(())
+    }
+
+    #[test]
+    fn invalidate_marks_memory_stale_without_deleting_it() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup_memory_schema(&conn);
+        let project = "test-lifecycle";
+        let id = insert_memory(
+            &conn,
+            Some("s1"),
+            project,
+            Some("old-fact"),
+            "Old fact",
+            "This fact is no longer valid.",
+            "discovery",
+            None,
+        )?;
+
+        let outcome = apply_invalidate(&conn, project, &[id], Some("contradicted"))?;
+        assert_eq!(outcome.op, MemoryLifecycleOp::Invalidate);
+        assert_eq!(outcome.superseded, 1);
+
+        let (status, content): (String, String) = conn.query_row(
+            "SELECT status, content FROM memories WHERE id = ?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(status, "stale");
+        assert_eq!(content, "This fact is no longer valid.");
+        Ok(())
+    }
+
+    #[test]
+    fn noop_and_defer_are_explicit_outcomes() {
+        assert!(noop("duplicate").noop);
+        assert!(defer("ambiguous conflict").deferred);
+    }
+}

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -5,7 +5,13 @@ use anyhow::{bail, Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::db;
-use crate::memory::format::{extract_field, xml_escape_attr, xml_escape_text};
+use crate::memory::format::{xml_escape_attr, xml_escape_text};
+
+mod parse;
+pub(crate) mod review;
+
+use parse::{normalize_memory_type, normalize_scope, normalize_topic_key};
+use parse::{parse_defer_reason, parse_memory_candidates};
 
 const MEMORY_CANDIDATE_SYSTEM: &str = "\
 Generate durable memory candidates from extracted observations.
@@ -14,6 +20,7 @@ Each block must include <scope>, <type>, <topic_key>, <risk_class>, <confidence>
 Use scope=project unless the observation is explicitly a stable user preference.
 Use risk_class=low only for factual project-scoped information that can be promoted without review.
 If there is no durable memory candidate, return exactly <no_candidates reason=\"...\"/>.
+If evidence is ambiguous or contradictory, return exactly <defer reason=\"...\"/> so it can be retried or reviewed.
 Use only provided observations and evidence; do not invent files, outcomes, decisions, or facts.";
 
 const AUTO_PROMOTE_MIN_CONFIDENCE: f64 = 0.80;
@@ -38,6 +45,9 @@ const AUTO_PROMOTE_UNSAFE_MARKERS: &[&str] = &[
 pub(crate) enum MemoryCandidateResult {
     EmptyRange,
     NoCandidates,
+    Deferred {
+        reason: String,
+    },
     Written {
         candidates: usize,
         promoted: usize,
@@ -108,6 +118,9 @@ where
     let response = generate(prompt).await?;
     let candidates = parse_memory_candidates(&response)?;
     if candidates.is_empty() {
+        if let Some(reason) = parse_defer_reason(&response) {
+            return Ok(MemoryCandidateResult::Deferred { reason });
+        }
         if response.contains("<no_candidates") {
             return Ok(MemoryCandidateResult::NoCandidates);
         }
@@ -423,99 +436,6 @@ fn build_candidate_prompt(task: &db::ExtractionTask, batch: &ObservationBatch) -
     prompt
 }
 
-fn parse_memory_candidates(text: &str) -> Result<Vec<ParsedMemoryCandidate>> {
-    let mut candidates = Vec::new();
-    let mut pos = 0;
-    while let Some(tag_start_rel) = find_ascii_ci(&text[pos..], "<memory_candidate") {
-        let tag_start = pos + tag_start_rel;
-        let Some(open_end_rel) = text[tag_start..].find('>') else {
-            bail!("malformed memory_candidate output: unterminated opening tag");
-        };
-        let content_start = tag_start + open_end_rel + 1;
-        let Some(close_rel) = find_ascii_ci(&text[content_start..], "</memory_candidate>") else {
-            bail!("malformed memory_candidate output: missing closing tag");
-        };
-        let content_end = content_start + close_rel;
-        candidates.push(parse_candidate_content(&text[content_start..content_end])?);
-        pos = content_end + "</memory_candidate>".len();
-    }
-    Ok(candidates)
-}
-
-fn parse_candidate_content(content: &str) -> Result<ParsedMemoryCandidate> {
-    let scope = normalize_scope(required_field(content, "scope")?.as_str())?;
-    let memory_type = normalize_memory_type(required_field(content, "type")?.as_str())?;
-    let topic_key = normalize_topic_key(required_field(content, "topic_key")?.as_str())?;
-    let risk_class = normalize_risk_class(required_field(content, "risk_class")?.as_str())?;
-    let confidence = parse_confidence(required_field(content, "confidence")?.as_str())?;
-    let text = required_field(content, "text")?;
-    Ok(ParsedMemoryCandidate {
-        scope,
-        memory_type,
-        topic_key,
-        text,
-        confidence,
-        risk_class,
-    })
-}
-
-fn required_field(content: &str, field: &str) -> Result<String> {
-    extract_field(content, field)
-        .with_context(|| format!("malformed memory_candidate output: missing <{field}>"))
-}
-
-pub(super) fn normalize_scope(raw: &str) -> Result<String> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "global" | "workspace" | "project" => Ok(raw.trim().to_ascii_lowercase()),
-        other => bail!("malformed memory_candidate output: invalid scope '{other}'"),
-    }
-}
-
-pub(super) fn normalize_memory_type(raw: &str) -> Result<String> {
-    let value = raw.trim().to_ascii_lowercase();
-    if crate::memory::MEMORY_TYPES.contains(&value.as_str()) && value != "session_activity" {
-        Ok(value)
-    } else {
-        bail!("malformed memory_candidate output: invalid memory type '{value}'")
-    }
-}
-
-pub(super) fn normalize_topic_key(raw: &str) -> Result<String> {
-    let value = crate::memory::slugify_for_topic(raw.trim(), 96);
-    if value.is_empty() {
-        bail!("malformed memory_candidate output: empty topic_key");
-    }
-    Ok(value)
-}
-
-pub(super) fn normalize_risk_class(raw: &str) -> Result<String> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "low" | "medium" | "high" => Ok(raw.trim().to_ascii_lowercase()),
-        other => bail!("malformed memory_candidate output: invalid risk_class '{other}'"),
-    }
-}
-
-pub(super) fn parse_confidence(raw: &str) -> Result<f64> {
-    let confidence: f64 = raw
-        .trim()
-        .parse()
-        .with_context(|| "malformed memory_candidate output: invalid confidence")?;
-    if !(0.0..=1.0).contains(&confidence) {
-        bail!("malformed memory_candidate output: confidence out of range");
-    }
-    Ok(confidence)
-}
-
-fn find_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
-    let needle = needle.as_bytes();
-    haystack
-        .as_bytes()
-        .windows(needle.len())
-        .position(|window| window.eq_ignore_ascii_case(needle))
-}
-
-pub(crate) mod review;
-
 #[cfg(test)]
 mod tests {
     use rusqlite::params;
@@ -777,6 +697,34 @@ mod tests {
         .await?;
 
         assert_eq!(result, MemoryCandidateResult::NoCandidates);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn memory_candidate_defer_output_is_explicit() -> Result<()> {
+        let mut conn = setup_conn();
+        let task = setup_task(&mut conn, "sess-candidate-defer")?;
+        insert_source_observation(&conn, &task, "Deploy target is staging or production.")?;
+
+        let result = process_with_generator(&mut conn, &task, |_prompt| async {
+            Ok("<defer reason=\"ambiguous conflict\"/>".to_string())
+        })
+        .await?;
+
+        assert_eq!(
+            result,
+            MemoryCandidateResult::Deferred {
+                reason: "ambiguous conflict".to_string()
+            }
+        );
+        let candidate_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+                row.get(0)
+            })?;
+        let memory_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+        assert_eq!(candidate_count, 0);
+        assert_eq!(memory_count, 0);
         Ok(())
     }
 

--- a/src/memory_candidate/parse.rs
+++ b/src/memory_candidate/parse.rs
@@ -1,0 +1,122 @@
+use anyhow::{bail, Context, Result};
+
+use super::ParsedMemoryCandidate;
+use crate::memory::format::{extract_field, find_ascii_ci};
+
+pub(super) fn parse_memory_candidates(text: &str) -> Result<Vec<ParsedMemoryCandidate>> {
+    let mut candidates = Vec::new();
+    let mut pos = 0;
+    while let Some(tag_start_rel) = find_ascii_ci(&text[pos..], "<memory_candidate") {
+        let tag_start = pos + tag_start_rel;
+        let Some(open_end_rel) = text[tag_start..].find('>') else {
+            bail!("malformed memory_candidate output: unterminated opening tag");
+        };
+        let content_start = tag_start + open_end_rel + 1;
+        let Some(close_rel) = find_ascii_ci(&text[content_start..], "</memory_candidate>") else {
+            bail!("malformed memory_candidate output: missing closing tag");
+        };
+        let content_end = content_start + close_rel;
+        candidates.push(parse_candidate_content(&text[content_start..content_end])?);
+        pos = content_end + "</memory_candidate>".len();
+    }
+    Ok(candidates)
+}
+
+pub(super) fn parse_defer_reason(text: &str) -> Option<String> {
+    let tag_start = find_ascii_ci(text, "<defer")?;
+    let open_end = text[tag_start..].find('>')?;
+    let opening = &text[tag_start..tag_start + open_end + 1];
+    extract_attr(opening, "reason")
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty())
+        .map(str::to_string)
+}
+
+fn parse_candidate_content(content: &str) -> Result<ParsedMemoryCandidate> {
+    let scope = normalize_scope(required_field(content, "scope")?.as_str())?;
+    let memory_type = normalize_memory_type(required_field(content, "type")?.as_str())?;
+    let topic_key = normalize_topic_key(required_field(content, "topic_key")?.as_str())?;
+    let risk_class = normalize_risk_class(required_field(content, "risk_class")?.as_str())?;
+    let confidence = parse_confidence(required_field(content, "confidence")?.as_str())?;
+    let text = required_field(content, "text")?;
+    Ok(ParsedMemoryCandidate {
+        scope,
+        memory_type,
+        topic_key,
+        text,
+        confidence,
+        risk_class,
+    })
+}
+
+fn required_field(content: &str, field: &str) -> Result<String> {
+    extract_field(content, field)
+        .with_context(|| format!("malformed memory_candidate output: missing <{field}>"))
+}
+
+pub(super) fn normalize_scope(raw: &str) -> Result<String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "global" | "workspace" | "project" => Ok(raw.trim().to_ascii_lowercase()),
+        other => bail!("malformed memory_candidate output: invalid scope '{other}'"),
+    }
+}
+
+pub(super) fn normalize_memory_type(raw: &str) -> Result<String> {
+    let value = raw.trim().to_ascii_lowercase();
+    if crate::memory::MEMORY_TYPES.contains(&value.as_str()) && value != "session_activity" {
+        Ok(value)
+    } else {
+        bail!("malformed memory_candidate output: invalid memory type '{value}'")
+    }
+}
+
+pub(super) fn normalize_topic_key(raw: &str) -> Result<String> {
+    let value = crate::memory::slugify_for_topic(raw.trim(), 96);
+    if value.is_empty() {
+        bail!("malformed memory_candidate output: empty topic_key");
+    }
+    Ok(value)
+}
+
+fn normalize_risk_class(raw: &str) -> Result<String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "low" | "medium" | "high" => Ok(raw.trim().to_ascii_lowercase()),
+        other => bail!("malformed memory_candidate output: invalid risk_class '{other}'"),
+    }
+}
+
+fn parse_confidence(raw: &str) -> Result<f64> {
+    let confidence: f64 = raw
+        .trim()
+        .parse()
+        .with_context(|| "malformed memory_candidate output: invalid confidence")?;
+    if !(0.0..=1.0).contains(&confidence) {
+        bail!("malformed memory_candidate output: confidence out of range");
+    }
+    Ok(confidence)
+}
+
+fn extract_attr<'a>(tag: &'a str, attr: &str) -> Option<&'a str> {
+    let needle = format!("{attr}=\"");
+    let value_start = tag.find(&needle)? + needle.len();
+    let value_end = tag[value_start..].find('"')?;
+    Some(&tag[value_start..value_start + value_end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_defer_reason_from_self_closing_tag() {
+        assert_eq!(
+            parse_defer_reason("<defer reason=\"ambiguous conflict\"/>"),
+            Some("ambiguous conflict".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_defer_without_reason() {
+        assert_eq!(parse_defer_reason("<defer/>"), None);
+    }
+}


### PR DESCRIPTION
Closes #184.

## Summary
- Add explicit memory lifecycle operations for add, update, invalidate, noop, and defer.
- Preserve superseded memories as stale and reuse the shared soft-supersede path from dream apply.
- Make ambiguous memory-candidate extraction return explicit defer outcomes and map them to the worker retry/review path.
- Document lifecycle semantics in docs/memory-lifecycle.md.

## Validation
- cargo fmt --check
- cargo check
- cargo clippy -- -D warnings
- cargo test
- cargo run --quiet -- eval --dataset eval/golden.json -k 5
- REMEM_DATA_DIR=/tmp/remem-eval-184.0182h6 cargo run --quiet -- eval-local