### PR TITLE
Add temporal memory facts

### DIFF
--- a/docs/temporal-facts.md
+++ b/docs/temporal-facts.md
@@ -1,0 +1,58 @@
+# Temporal Facts
+
+remem uses a lightweight SQLite fact layer for time-sensitive relationships.
+This layer is deliberately relational: it adds queryable edges without adopting
+a graph database or vector index.
+
+## Schema
+
+Migration `v013_memory_temporal_facts` creates `memory_facts`:
+
+| Column | Meaning |
+|---|---|
+| `project` | Project path/scope used by existing memory retrieval. |
+| `subject` | Stable local subject key, such as `deploy-target`, `PR #190`, or a file path. |
+| `predicate` | One fixed coding relation: `fixed_by`, `verified_by`, `supersedes`, `blocked_by`, `uses_file`, `uses_command`, `affects_project`. |
+| `object` | Relation target, stored as text so it can point to commands, files, issues, PRs, or memory ids. |
+| `valid_from_epoch` / `valid_to_epoch` | Validity interval for the fact. `valid_to_epoch` is exclusive. |
+| `learned_at_epoch` | When remem learned the fact; separate from validity time. |
+| `source_memory_id` | Optional link to the durable memory that produced the fact. |
+| `source_observation_id` | Optional link to the observation that produced the fact. |
+| `source_event_ids` | JSON array of raw `captured_events` ids. |
+| `confidence` | Extractor/reviewer confidence, constrained to `0.0..=1.0`. |
+| `supersedes_fact_id` | Optional pointer to the fact this one replaced. |
+| `status` | `active` for current facts, `stale` after soft supersession. |
+
+## Query Path
+
+Current-fact queries filter by project, optional subject, optional predicate,
+`status='active'`, and the current validity interval. Historical queries use
+`list_facts_as_of(project, as_of_epoch, ...)` and include stale rows when their
+validity interval covered the requested time.
+
+This split is intentional:
+
+- default retrieval should not surface obsolete facts as current truth
+- historical/debug flows can still answer "what was true at the time?"
+- superseded facts remain auditable through source ids and validity windows
+
+## Supersession
+
+Inserting a fact with `supersedes_fact_id` performs one transaction:
+
+1. verify the superseded fact exists in the same project
+2. mark the old fact `stale`
+3. set the old `valid_to_epoch` to the replacement's `valid_from_epoch`, or to
+   `learned_at_epoch` when validity is unknown
+4. insert the replacement as `active`
+
+The old fact is preserved rather than deleted. This mirrors the memory lifecycle
+rule that invalidation is a soft state transition unless a future privacy or
+retention feature explicitly requires hard deletion.
+
+## Design Boundary
+
+This model is the first step toward temporal relationship memory. It does not
+try to solve entity merging, PageRank, community summaries, graph traversal, or
+LLM extraction in this PR. Those can build on the table once the write and query
+semantics are proven.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,5 +1,6 @@
 pub mod dedup;
 pub mod events;
+pub mod facts;
 pub mod format;
 pub mod lifecycle;
 pub mod preference;

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -1,0 +1,266 @@
+use anyhow::{bail, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FactPredicate {
+    FixedBy,
+    VerifiedBy,
+    Supersedes,
+    BlockedBy,
+    UsesFile,
+    UsesCommand,
+    AffectsProject,
+}
+
+impl FactPredicate {
+    pub fn db_value(self) -> &'static str {
+        match self {
+            Self::FixedBy => "fixed_by",
+            Self::VerifiedBy => "verified_by",
+            Self::Supersedes => "supersedes",
+            Self::BlockedBy => "blocked_by",
+            Self::UsesFile => "uses_file",
+            Self::UsesCommand => "uses_command",
+            Self::AffectsProject => "affects_project",
+        }
+    }
+
+    fn parse_db(raw: &str) -> Option<Self> {
+        match raw {
+            "fixed_by" => Some(Self::FixedBy),
+            "verified_by" => Some(Self::VerifiedBy),
+            "supersedes" => Some(Self::Supersedes),
+            "blocked_by" => Some(Self::BlockedBy),
+            "uses_file" => Some(Self::UsesFile),
+            "uses_command" => Some(Self::UsesCommand),
+            "affects_project" => Some(Self::AffectsProject),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TemporalFactInput<'a> {
+    pub project: &'a str,
+    pub subject: &'a str,
+    pub predicate: FactPredicate,
+    pub object: &'a str,
+    pub valid_from_epoch: Option<i64>,
+    pub valid_to_epoch: Option<i64>,
+    pub learned_at_epoch: Option<i64>,
+    pub source_memory_id: Option<i64>,
+    pub source_observation_id: Option<i64>,
+    pub source_event_ids: &'a [i64],
+    pub confidence: f64,
+    pub supersedes_fact_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemporalFact {
+    pub id: i64,
+    pub project: String,
+    pub subject: String,
+    pub predicate: FactPredicate,
+    pub object: String,
+    pub valid_from_epoch: Option<i64>,
+    pub valid_to_epoch: Option<i64>,
+    pub learned_at_epoch: i64,
+    pub source_memory_id: Option<i64>,
+    pub source_observation_id: Option<i64>,
+    pub source_event_ids: Vec<i64>,
+    pub confidence: f64,
+    pub supersedes_fact_id: Option<i64>,
+    pub status: String,
+}
+
+pub fn insert_temporal_fact(conn: &mut Connection, input: &TemporalFactInput<'_>) -> Result<i64> {
+    validate_input(input)?;
+    let now = chrono::Utc::now().timestamp();
+    let learned_at = input.learned_at_epoch.unwrap_or(now);
+    let superseded_at = input.valid_from_epoch.unwrap_or(learned_at);
+    let source_event_ids = serde_json::to_string(input.source_event_ids)?;
+
+    let tx = conn.transaction()?;
+    if let Some(old_id) = input.supersedes_fact_id {
+        let old_project: Option<String> = tx
+            .query_row(
+                "SELECT project FROM memory_facts WHERE id = ?1",
+                [old_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        match old_project {
+            Some(project) if project == input.project => {}
+            Some(project) => bail!(
+                "cannot supersede fact {old_id} from project '{project}' with project '{}'",
+                input.project
+            ),
+            None => bail!("cannot supersede missing memory fact {old_id}"),
+        }
+        tx.execute(
+            "UPDATE memory_facts
+             SET status = 'stale',
+                 valid_to_epoch = CASE
+                     WHEN valid_to_epoch IS NULL OR valid_to_epoch > ?1 THEN ?1
+                     ELSE valid_to_epoch
+                 END,
+                 updated_at_epoch = ?2
+             WHERE id = ?3",
+            params![superseded_at, now, old_id],
+        )?;
+    }
+
+    tx.execute(
+        "INSERT INTO memory_facts
+         (project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
+          learned_at_epoch, source_memory_id, source_observation_id, source_event_ids,
+          confidence, supersedes_fact_id, status, created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 'active', ?13, ?13)",
+        params![
+            input.project,
+            input.subject,
+            input.predicate.db_value(),
+            input.object,
+            input.valid_from_epoch,
+            input.valid_to_epoch,
+            learned_at,
+            input.source_memory_id,
+            input.source_observation_id,
+            source_event_ids,
+            input.confidence,
+            input.supersedes_fact_id,
+            now
+        ],
+    )?;
+    let id = tx.last_insert_rowid();
+    tx.commit()?;
+    Ok(id)
+}
+
+pub fn list_current_facts(
+    conn: &Connection,
+    project: &str,
+    subject: Option<&str>,
+    predicate: Option<FactPredicate>,
+) -> Result<Vec<TemporalFact>> {
+    let now = chrono::Utc::now().timestamp();
+    query_facts(conn, project, subject, predicate, Some(now), true)
+}
+
+pub fn list_facts_as_of(
+    conn: &Connection,
+    project: &str,
+    as_of_epoch: i64,
+    subject: Option<&str>,
+    predicate: Option<FactPredicate>,
+) -> Result<Vec<TemporalFact>> {
+    query_facts(conn, project, subject, predicate, Some(as_of_epoch), false)
+}
+
+fn query_facts(
+    conn: &Connection,
+    project: &str,
+    subject: Option<&str>,
+    predicate: Option<FactPredicate>,
+    as_of_epoch: Option<i64>,
+    active_only: bool,
+) -> Result<Vec<TemporalFact>> {
+    let mut conditions = vec!["project = ?1".to_string()];
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(project.to_string())];
+    let mut idx = 2;
+    if let Some(subject) = subject {
+        conditions.push(format!("subject = ?{idx}"));
+        params.push(Box::new(subject.to_string()));
+        idx += 1;
+    }
+    if let Some(predicate) = predicate {
+        conditions.push(format!("predicate = ?{idx}"));
+        params.push(Box::new(predicate.db_value().to_string()));
+        idx += 1;
+    }
+    if let Some(as_of_epoch) = as_of_epoch {
+        conditions.push(format!(
+            "(valid_from_epoch IS NULL OR valid_from_epoch <= ?{idx})"
+        ));
+        conditions.push(format!(
+            "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx})"
+        ));
+        params.push(Box::new(as_of_epoch));
+    }
+    if active_only {
+        conditions.push("status = 'active'".to_string());
+    }
+
+    let sql = format!(
+        "SELECT id, project, subject, predicate, object, valid_from_epoch,
+                valid_to_epoch, learned_at_epoch, source_memory_id,
+                source_observation_id, source_event_ids, confidence,
+                supersedes_fact_id, status
+         FROM memory_facts
+         WHERE {}
+         ORDER BY learned_at_epoch DESC, id DESC",
+        conditions.join(" AND ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), map_fact_row)?;
+    crate::db::query::collect_rows(rows)
+}
+
+fn validate_input(input: &TemporalFactInput<'_>) -> Result<()> {
+    if input.project.trim().is_empty() {
+        bail!("memory fact project is required");
+    }
+    if input.subject.trim().is_empty() {
+        bail!("memory fact subject is required");
+    }
+    if input.object.trim().is_empty() {
+        bail!("memory fact object is required");
+    }
+    if !(0.0..=1.0).contains(&input.confidence) {
+        bail!("memory fact confidence out of range");
+    }
+    if let (Some(valid_from), Some(valid_to)) = (input.valid_from_epoch, input.valid_to_epoch) {
+        if valid_to < valid_from {
+            bail!("memory fact valid_to_epoch cannot be before valid_from_epoch");
+        }
+    }
+    Ok(())
+}
+
+fn map_fact_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TemporalFact> {
+    let predicate_raw: String = row.get(3)?;
+    let source_event_json: String = row.get(10)?;
+    let source_event_ids = serde_json::from_str(&source_event_json).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(10, rusqlite::types::Type::Text, Box::new(err))
+    })?;
+    let predicate = FactPredicate::parse_db(&predicate_raw).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unknown memory fact predicate: {predicate_raw}"),
+            )),
+        )
+    })?;
+    Ok(TemporalFact {
+        id: row.get(0)?,
+        project: row.get(1)?,
+        subject: row.get(2)?,
+        predicate,
+        object: row.get(4)?,
+        valid_from_epoch: row.get(5)?,
+        valid_to_epoch: row.get(6)?,
+        learned_at_epoch: row.get(7)?,
+        source_memory_id: row.get(8)?,
+        source_observation_id: row.get(9)?,
+        source_event_ids,
+        confidence: row.get(11)?,
+        supersedes_fact_id: row.get(12)?,
+        status: row.get(13)?,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/memory/facts/tests.rs
+++ b/src/memory/facts/tests.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+fn setup_fact_conn() -> Result<Connection> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+    crate::migrate::run_migrations(&conn)?;
+    Ok(conn)
+}
+
+fn input<'a>(project: &'a str, object: &'a str, valid_from_epoch: i64) -> TemporalFactInput<'a> {
+    TemporalFactInput {
+        project,
+        subject: "deploy-target",
+        predicate: FactPredicate::AffectsProject,
+        object,
+        valid_from_epoch: Some(valid_from_epoch),
+        valid_to_epoch: None,
+        learned_at_epoch: Some(valid_from_epoch),
+        source_memory_id: None,
+        source_observation_id: None,
+        source_event_ids: &[],
+        confidence: 0.9,
+        supersedes_fact_id: None,
+    }
+}
+
+#[test]
+fn supersession_preserves_historical_fact_but_hides_it_from_current() -> Result<()> {
+    let mut conn = setup_fact_conn()?;
+    let project = "test-temporal";
+    let old_id = insert_temporal_fact(&mut conn, &input(project, "staging", 100))?;
+    let mut replacement = input(project, "production", 200);
+    replacement.supersedes_fact_id = Some(old_id);
+    let new_id = insert_temporal_fact(&mut conn, &replacement)?;
+
+    let current = list_current_facts(
+        &conn,
+        project,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert_eq!(
+        current.iter().map(|fact| fact.id).collect::<Vec<_>>(),
+        vec![new_id]
+    );
+    assert_eq!(current[0].object, "production");
+
+    let old: TemporalFact = conn.query_row(
+        "SELECT id, project, subject, predicate, object, valid_from_epoch,
+                valid_to_epoch, learned_at_epoch, source_memory_id,
+                source_observation_id, source_event_ids, confidence,
+                supersedes_fact_id, status
+         FROM memory_facts WHERE id = ?1",
+        [old_id],
+        map_fact_row,
+    )?;
+    assert_eq!(old.status, "stale");
+    assert_eq!(old.valid_to_epoch, Some(200));
+
+    let before = list_facts_as_of(
+        &conn,
+        project,
+        150,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert_eq!(before[0].object, "staging");
+
+    let after = list_facts_as_of(
+        &conn,
+        project,
+        250,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert_eq!(after[0].object, "production");
+    Ok(())
+}
+
+#[test]
+fn provenance_links_to_source_memory_and_events() -> Result<()> {
+    let mut conn = setup_fact_conn()?;
+    let memory_id = crate::memory::insert_memory(
+        &conn,
+        Some("session-a"),
+        "test-provenance",
+        Some("verification-command"),
+        "Verification command",
+        "The deploy fix was verified with cargo test.",
+        "bugfix",
+        None,
+    )?;
+    let observation_id = crate::db::insert_observation(
+        &conn,
+        "session-a",
+        "test-provenance",
+        "bugfix",
+        Some("Deploy fix"),
+        None,
+        Some("The deploy fix was verified with cargo test."),
+        None,
+        None,
+        None,
+        None,
+        Some(1),
+        0,
+    )?;
+    let input = TemporalFactInput {
+        project: "test-provenance",
+        subject: "deploy-fix",
+        predicate: FactPredicate::VerifiedBy,
+        object: "cargo test",
+        valid_from_epoch: Some(300),
+        valid_to_epoch: None,
+        learned_at_epoch: Some(320),
+        source_memory_id: Some(memory_id),
+        source_observation_id: Some(observation_id),
+        source_event_ids: &[11, 12],
+        confidence: 0.95,
+        supersedes_fact_id: None,
+    };
+    let id = insert_temporal_fact(&mut conn, &input)?;
+
+    let facts = list_current_facts(
+        &conn,
+        "test-provenance",
+        Some("deploy-fix"),
+        Some(FactPredicate::VerifiedBy),
+    )?;
+    assert_eq!(facts.len(), 1);
+    assert_eq!(facts[0].id, id);
+    assert_eq!(facts[0].source_memory_id, Some(memory_id));
+    assert_eq!(facts[0].source_observation_id, Some(observation_id));
+    assert_eq!(facts[0].source_event_ids, vec![11, 12]);
+    assert_eq!(facts[0].confidence, 0.95);
+    Ok(())
+}
+
+#[test]
+fn rejects_invalid_validity_window() -> Result<()> {
+    let mut conn = setup_fact_conn()?;
+    let mut input = input("test-invalid", "production", 500);
+    input.valid_to_epoch = Some(400);
+    let err = insert_temporal_fact(&mut conn, &input).expect_err("invalid time must fail");
+    assert!(err.to_string().contains("valid_to_epoch"));
+    Ok(())
+}

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -62,10 +62,10 @@ fn full_migration_on_empty_db() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 24);
+    assert_eq!(user_version, 25);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -87,6 +87,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "captured_events",
         "extraction_tasks",
         "memory_candidates",
+        "memory_facts",
         "rule_candidates",
     ] {
         let exists: bool = conn
@@ -206,7 +207,7 @@ fn concurrent_run_migrations_serializes_pending_migrations() -> Result<()> {
 
     let conn = Connection::open(&path)?;
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
     cleanup_temp_db_files(&path);
     Ok(())
 }
@@ -263,7 +264,7 @@ fn transition_from_old_system_skips_baseline() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
     Ok(())
 }
 
@@ -288,10 +289,10 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
 
     // Should have auto-upgraded and marked all v1 migrations as applied.
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 24);
+    assert_eq!(user_version, 25);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -331,7 +332,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 24);
+    assert_eq!(result.current_version, 25);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())
@@ -344,7 +345,7 @@ fn dry_run_pending_reports_pending_for_new_db() -> Result<()> {
     let result = dry_run_pending(&conn)?;
 
     assert_eq!(result.current_version, 0);
-    assert_eq!(result.pending_count, 12);
+    assert_eq!(result.pending_count, 13);
     assert!(result.error.is_none());
     Ok(())
 }
@@ -403,7 +404,7 @@ fn dry_run_pending_reports_backfill_error_for_broken_schema() -> Result<()> {
     let result = dry_run_pending(&conn)?;
     // After broken baseline backfill fails, dry_run reports the still-unapplied
     // migrations (v2+ remain pending in _schema_migrations).
-    assert_eq!(result.pending_count, 11);
+    assert_eq!(result.pending_count, 12);
     let error = result
         .error
         .expect("broken schema should surface in dry-run");

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -65,6 +65,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "memory_search_context",
         sql: include_str!("../migrations/v012_memory_search_context.sql"),
     },
+    Migration {
+        version: 13,
+        name: "memory_temporal_facts",
+        sql: include_str!("../migrations/v013_memory_temporal_facts.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v013_memory_temporal_facts.sql
+++ b/src/migrations/v013_memory_temporal_facts.sql
@@ -1,0 +1,54 @@
+-- v013_memory_temporal_facts: SQLite-native temporal facts with provenance.
+--
+-- This is intentionally a small relational layer, not a graph database. Facts
+-- carry subject/predicate/object, validity time, learned time, provenance links,
+-- confidence, and soft supersession.
+
+CREATE TABLE IF NOT EXISTS memory_facts (
+    id INTEGER PRIMARY KEY,
+    project TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    predicate TEXT NOT NULL CHECK (
+        predicate IN (
+            'fixed_by',
+            'verified_by',
+            'supersedes',
+            'blocked_by',
+            'uses_file',
+            'uses_command',
+            'affects_project'
+        )
+    ),
+    object TEXT NOT NULL,
+    valid_from_epoch INTEGER,
+    valid_to_epoch INTEGER,
+    learned_at_epoch INTEGER NOT NULL,
+    source_memory_id INTEGER REFERENCES memories(id) ON DELETE SET NULL,
+    source_observation_id INTEGER REFERENCES observations(id) ON DELETE SET NULL,
+    source_event_ids TEXT NOT NULL DEFAULT '[]',
+    confidence REAL NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    supersedes_fact_id INTEGER REFERENCES memory_facts(id) ON DELETE SET NULL,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'stale')),
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    CHECK (
+        valid_to_epoch IS NULL
+        OR valid_from_epoch IS NULL
+        OR valid_to_epoch >= valid_from_epoch
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_facts_current
+    ON memory_facts(project, subject, predicate, status, valid_to_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_memory_facts_as_of
+    ON memory_facts(project, subject, predicate, valid_from_epoch, valid_to_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_memory_facts_source_memory
+    ON memory_facts(source_memory_id);
+
+CREATE INDEX IF NOT EXISTS idx_memory_facts_source_observation
+    ON memory_facts(source_observation_id);
+
+CREATE INDEX IF NOT EXISTS idx_memory_facts_supersedes
+    ON memory_facts(supersedes_fact_id);


### PR DESCRIPTION
Closes #185.

## Summary
- Add v013 `memory_facts` migration for SQLite-native temporal facts with fixed coding predicates.
- Add `memory::facts` APIs for inserting, current queries, as-of queries, provenance, and soft supersession.
- Document schema, query path, supersession behavior, and design boundaries in docs/temporal-facts.md.
- Update migration version expectations to schema user_version 25.

## Validation
- cargo test memory::facts --lib
- cargo test migrate:: --lib
- cargo fmt --check
- cargo check
- cargo clippy -- -D warnings
- cargo test
- REMEM_DATA_DIR=/tmp/remem-eval-185.kaslvr cargo run --quiet -- eval --dataset eval/golden.json -k 5
- REMEM_DATA_DIR=/tmp/remem-eval-185.kaslvr cargo run --quiet -- eval-local