### PR TITLE
Preserve procedure verification history across windows

### DIFF
--- a/src/db/schema/migrate.rs
+++ b/src/db/schema/migrate.rs
@@ -65,6 +65,7 @@ mod tests {
             "observations",
             "memory_candidates",
             "memories",
+            "procedure_verifications",
             "rule_candidates",
             "worker_heartbeats",
         ] {
@@ -90,6 +91,7 @@ mod tests {
             "idx_extraction_tasks_claim",
             "idx_extraction_tasks_lease",
             "idx_memories_topic_unique",
+            "idx_procedure_verifications_lookup",
         ] {
             assert!(index_exists(&conn, idx), "index {} missing", idx);
         }

--- a/src/memory/procedure.rs
+++ b/src/memory/procedure.rs
@@ -225,10 +225,9 @@ fn load_verified_procedure_traces(
          WHERE e.host_id = ?1
            AND e.project_id = ?2
            AND e.session_row_id = ?3
-           AND e.id > ?4
-           AND e.id <= ?5
+           AND e.id <= ?4
            AND e.tool_name = 'Bash'
-           AND e.created_at_epoch >= ?6
+           AND e.created_at_epoch >= ?5
          ORDER BY e.created_at_epoch ASC, e.id ASC",
     )?;
     let rows = stmt.query_map(
@@ -236,7 +235,6 @@ fn load_verified_procedure_traces(
             task.host_id,
             task.project_id,
             session_row_id,
-            cursor,
             high_watermark,
             earliest
         ],
@@ -618,6 +616,92 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(procedure_count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn production_task_accumulates_verified_runs_across_windows() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        crate::migrate::run_migrations(&conn)?;
+        let command = "cargo test";
+
+        crate::db::record_captured_event(
+            &conn,
+            &crate::db::CaptureEventInput {
+                host: "codex-cli",
+                session_id: "sess-procedure-windowed",
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Bash"),
+                content: &serde_json::json!({
+                    "event_type": "bash",
+                    "exit_code": 0,
+                    "tool_input": { "command": command },
+                    "files": "[\"src/lib.rs\"]",
+                    "git_branch": "main"
+                })
+                .to_string(),
+                task_kind: Some(crate::db::ExtractionTaskKind::ObservationExtract),
+            },
+        )?;
+        let first_task = crate::db::claim_next_extraction_task(&mut conn, "worker-a", 60)?
+            .ok_or_else(|| anyhow::anyhow!("first task should be claimed"))?;
+        assert_eq!(
+            promote_verified_procedures_for_task(
+                &conn,
+                &first_task,
+                &ProcedurePromotionPolicy::default(),
+            )?,
+            0
+        );
+        crate::db::mark_extraction_task_done(
+            &conn,
+            first_task.id,
+            "worker-a",
+            first_task.high_watermark_event_id,
+        )?;
+
+        crate::db::record_captured_event(
+            &conn,
+            &crate::db::CaptureEventInput {
+                host: "codex-cli",
+                session_id: "sess-procedure-windowed",
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Bash"),
+                content: &serde_json::json!({
+                    "event_type": "bash",
+                    "exit_code": 0,
+                    "tool_input": { "command": command },
+                    "files": "[\"src/lib.rs\"]",
+                    "git_branch": "main"
+                })
+                .to_string(),
+                task_kind: Some(crate::db::ExtractionTaskKind::ObservationExtract),
+            },
+        )?;
+        let second_task = crate::db::claim_next_extraction_task(&mut conn, "worker-b", 60)?
+            .ok_or_else(|| anyhow::anyhow!("second task should be claimed"))?;
+
+        assert_eq!(
+            promote_verified_procedures_for_task(
+                &conn,
+                &second_task,
+                &ProcedurePromotionPolicy::default(),
+            )?,
+            1
+        );
+        let evidence: String = conn.query_row(
+            "SELECT evidence_event_ids FROM memories WHERE memory_type = 'procedure'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(serde_json::from_str::<Vec<i64>>(&evidence)?.len(), 2);
         Ok(())
     }
 }

--- a/src/memory/procedure/incremental_tests.rs
+++ b/src/memory/procedure/incremental_tests.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+use rusqlite::Connection;
+
+use super::{promote_verified_procedures_for_task, ProcedurePromotionPolicy};
+
+fn record_bash_event(conn: &Connection, session_id: &str, seq: i64) -> Result<i64> {
+    let outcome = crate::db::record_captured_event(
+        conn,
+        &crate::db::CaptureEventInput {
+            host: "codex-cli",
+            session_id,
+            project: "/tmp/remem",
+            cwd: None,
+            event_type: "tool_result",
+            role: None,
+            tool_name: Some("Bash"),
+            content: &serde_json::json!({
+                "seq": seq,
+                "event_type": "bash",
+                "exit_code": 0,
+                "tool_input": { "command": "cargo test" },
+                "files": "[\"src/lib.rs\"]",
+                "git_branch": "main"
+            })
+            .to_string(),
+            task_kind: None,
+        },
+    )?;
+    Ok(outcome.event_row_id)
+}
+
+#[test]
+fn production_task_does_not_rescan_unstored_prior_bash_events() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+    crate::migrate::run_migrations(&conn)?;
+    let session_id = "sess-procedure-incremental";
+
+    record_bash_event(&conn, session_id, 1)?;
+    let old_high_watermark = record_bash_event(&conn, session_id, 2)?;
+    let current_event_id = record_bash_event(&conn, session_id, 3)?;
+
+    let (host_id, workspace_id, project_id, session_row_id): (i64, i64, i64, i64) = conn
+        .query_row(
+            "SELECT host_id, workspace_id, project_id, session_row_id
+             FROM captured_events
+             WHERE id = ?1",
+            [current_event_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+    let task = crate::db::ExtractionTask {
+        id: 1,
+        task_kind: crate::db::ExtractionTaskKind::ObservationExtract,
+        host_id,
+        workspace_id,
+        project_id,
+        session_row_id: Some(session_row_id),
+        host: "codex-cli".to_string(),
+        project: "/tmp/remem".to_string(),
+        session_id: Some(session_id.to_string()),
+        priority: crate::db::ExtractionTaskKind::ObservationExtract.priority(),
+        cursor_event_id: Some(old_high_watermark),
+        high_watermark_event_id: Some(current_event_id),
+        attempts: 0,
+    };
+
+    let promoted =
+        promote_verified_procedures_for_task(&conn, &task, &ProcedurePromotionPolicy::default())?;
+
+    assert_eq!(promoted, 0);
+    let trace_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM procedure_verifications", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(trace_count, 1);
+    let procedure_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories WHERE memory_type = 'procedure'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(procedure_count, 0);
+    Ok(())
+}

--- a/src/memory/procedure/mod.rs
+++ b/src/memory/procedure/mod.rs
@@ -2,7 +2,11 @@ use std::collections::BTreeMap;
 
 use anyhow::Result;
 use rusqlite::{params, Connection, OptionalExtension};
-use serde_json::Value;
+
+mod trace_store;
+
+#[cfg(test)]
+mod incremental_tests;
 
 const DEFAULT_MIN_VERIFIED_RUNS: usize = 2;
 const DEFAULT_MAX_VERIFICATION_AGE_SECS: i64 = 14 * 24 * 60 * 60;
@@ -160,7 +164,7 @@ pub(crate) fn promote_verified_procedures_for_task(
     policy: &ProcedurePromotionPolicy,
 ) -> Result<usize> {
     let now_epoch = chrono::Utc::now().timestamp();
-    let traces = load_verified_procedure_traces(conn, task, policy, now_epoch)?;
+    let traces = trace_store::load_verified_procedure_traces(conn, task, policy, now_epoch)?;
     let mut groups: BTreeMap<(String, Option<String>, String, String), Vec<ProcedureTrace>> =
         BTreeMap::new();
     for trace in traces {
@@ -187,149 +191,6 @@ pub(crate) fn promote_verified_procedures_for_task(
         }
     }
     Ok(promoted)
-}
-
-fn load_verified_procedure_traces(
-    conn: &Connection,
-    task: &crate::db::ExtractionTask,
-    policy: &ProcedurePromotionPolicy,
-    now_epoch: i64,
-) -> Result<Vec<ProcedureTrace>> {
-    let Some(session_row_id) = task.session_row_id else {
-        return Ok(Vec::new());
-    };
-    let Some(high_watermark) = task.high_watermark_event_id else {
-        return Ok(Vec::new());
-    };
-    let cursor = task.cursor_event_id.unwrap_or(0);
-    if high_watermark <= cursor {
-        return Ok(Vec::new());
-    }
-
-    let earliest = now_epoch.saturating_sub(policy.max_verification_age_secs);
-    let mut stmt = conn.prepare(
-        "SELECT e.id,
-                p.project_path,
-                COALESCE(
-                    CASE
-                        WHEN b.content_encoding = 'plain' THEN CAST(b.content_bytes AS TEXT)
-                        ELSE NULL
-                    END,
-                    e.content_text,
-                    ''
-                ) AS content,
-                e.created_at_epoch
-         FROM captured_events e
-         JOIN projects p ON p.id = e.project_id
-         LEFT JOIN event_blobs b ON b.id = e.content_blob_id
-         WHERE e.host_id = ?1
-           AND e.project_id = ?2
-           AND e.session_row_id = ?3
-           AND e.id <= ?4
-           AND e.tool_name = 'Bash'
-           AND e.created_at_epoch >= ?5
-         ORDER BY e.created_at_epoch ASC, e.id ASC",
-    )?;
-    let rows = stmt.query_map(
-        params![
-            task.host_id,
-            task.project_id,
-            session_row_id,
-            high_watermark,
-            earliest
-        ],
-        |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, i64>(3)?,
-            ))
-        },
-    )?;
-
-    let mut traces = Vec::new();
-    for row in rows {
-        let (event_id, project, content, created_at_epoch) = row?;
-        if let Some(trace) = parse_procedure_trace(event_id, project, &content, created_at_epoch) {
-            traces.push(trace);
-        }
-    }
-    Ok(traces)
-}
-
-fn parse_procedure_trace(
-    event_id: i64,
-    project: String,
-    content: &str,
-    verified_at_epoch: i64,
-) -> Option<ProcedureTrace> {
-    let value: Value = serde_json::from_str(content).ok()?;
-    if value.get("event_type")?.as_str()? != "bash" {
-        return None;
-    }
-    if value.get("exit_code")?.as_i64()? != 0 {
-        return None;
-    }
-    let command = value
-        .get("tool_input")?
-        .get("command")?
-        .as_str()?
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
-    if command.is_empty() {
-        return None;
-    }
-    Some(ProcedureTrace {
-        project,
-        branch: parse_event_branch(&value),
-        workflow_key: workflow_key_for_command(&command),
-        command,
-        files_touched: parse_event_files(&value),
-        succeeded: true,
-        verified_at_epoch,
-        source_event_id: Some(event_id),
-    })
-}
-
-fn parse_event_branch(value: &Value) -> Option<String> {
-    value
-        .get("git_branch")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|branch| !branch.is_empty())
-        .map(str::to_string)
-}
-
-fn parse_event_files(value: &Value) -> Vec<String> {
-    let Some(files) = value.get("files") else {
-        return Vec::new();
-    };
-    let mut parsed = match files {
-        Value::Array(items) => items
-            .iter()
-            .filter_map(|item| item.as_str().map(str::to_string))
-            .collect::<Vec<_>>(),
-        Value::String(raw) => match serde_json::from_str::<Vec<String>>(raw) {
-            Ok(files) => files,
-            Err(error) => {
-                crate::log::warn(
-                    "procedure",
-                    &format!("ignored malformed procedure event files JSON: {error}"),
-                );
-                Vec::new()
-            }
-        },
-        _ => Vec::new(),
-    };
-    parsed.sort();
-    parsed.dedup();
-    parsed
-}
-
-fn workflow_key_for_command(command: &str) -> String {
-    crate::memory::slugify_for_topic(command, 64)
 }
 
 fn procedure_topic_key(trace: &ProcedureTrace) -> String {

--- a/src/memory/procedure/trace_store.rs
+++ b/src/memory/procedure/trace_store.rs
@@ -1,0 +1,312 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+use serde_json::Value;
+
+use super::{ProcedurePromotionPolicy, ProcedureTrace};
+
+pub(super) fn load_verified_procedure_traces(
+    conn: &Connection,
+    task: &crate::db::ExtractionTask,
+    policy: &ProcedurePromotionPolicy,
+    now_epoch: i64,
+) -> Result<Vec<ProcedureTrace>> {
+    let Some(session_row_id) = task.session_row_id else {
+        return Ok(Vec::new());
+    };
+    let Some(high_watermark) = task.high_watermark_event_id else {
+        return Ok(Vec::new());
+    };
+    let cursor = task.cursor_event_id.unwrap_or(0);
+    if high_watermark <= cursor {
+        return Ok(Vec::new());
+    }
+
+    let earliest = now_epoch.saturating_sub(policy.max_verification_age_secs);
+    let new_traces =
+        load_current_window_traces(conn, task, session_row_id, cursor, high_watermark, earliest)?;
+    if new_traces.is_empty() {
+        return Ok(Vec::new());
+    }
+    persist_verifications(conn, task, session_row_id, &new_traces, now_epoch)?;
+    load_trace_history(
+        conn,
+        task,
+        session_row_id,
+        high_watermark,
+        earliest,
+        &new_traces,
+    )
+}
+
+fn load_current_window_traces(
+    conn: &Connection,
+    task: &crate::db::ExtractionTask,
+    session_row_id: i64,
+    cursor: i64,
+    high_watermark: i64,
+    earliest: i64,
+) -> Result<Vec<ProcedureTrace>> {
+    let mut stmt = conn.prepare(
+        "SELECT e.id,
+                p.project_path,
+                COALESCE(
+                    CASE
+                        WHEN b.content_encoding = 'plain' THEN CAST(b.content_bytes AS TEXT)
+                        ELSE NULL
+                    END,
+                    e.content_text,
+                    ''
+                ) AS content,
+                e.created_at_epoch
+         FROM captured_events e
+         JOIN projects p ON p.id = e.project_id
+         LEFT JOIN event_blobs b ON b.id = e.content_blob_id
+         WHERE e.host_id = ?1
+           AND e.project_id = ?2
+           AND e.session_row_id = ?3
+           AND e.id > ?4
+           AND e.id <= ?5
+           AND e.tool_name = 'Bash'
+           AND e.created_at_epoch >= ?6
+         ORDER BY e.created_at_epoch ASC, e.id ASC",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            task.host_id,
+            task.project_id,
+            session_row_id,
+            cursor,
+            high_watermark,
+            earliest
+        ],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        },
+    )?;
+
+    let mut traces = Vec::new();
+    for row in rows {
+        let (event_id, project, content, created_at_epoch) = row?;
+        if let Some(trace) = parse_procedure_trace(event_id, project, &content, created_at_epoch) {
+            traces.push(trace);
+        }
+    }
+    Ok(traces)
+}
+
+fn persist_verifications(
+    conn: &Connection,
+    task: &crate::db::ExtractionTask,
+    session_row_id: i64,
+    traces: &[ProcedureTrace],
+    now_epoch: i64,
+) -> Result<()> {
+    for trace in traces {
+        let source_event_id = trace
+            .source_event_id
+            .context("procedure trace missing source event id")?;
+        let files_json = serde_json::to_string(&trace.files_touched)?;
+        conn.execute(
+            "INSERT INTO procedure_verifications
+             (host_id, project_id, session_row_id, branch, workflow_key, command,
+              files_touched, source_event_id, verified_at_epoch, created_at_epoch, updated_at_epoch)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10)
+             ON CONFLICT(host_id, project_id, session_row_id, source_event_id)
+             DO UPDATE SET
+                 branch = excluded.branch,
+                 workflow_key = excluded.workflow_key,
+                 command = excluded.command,
+                 files_touched = excluded.files_touched,
+                 verified_at_epoch = excluded.verified_at_epoch,
+                 updated_at_epoch = excluded.updated_at_epoch",
+            params![
+                task.host_id,
+                task.project_id,
+                session_row_id,
+                trace.branch.as_deref(),
+                trace.workflow_key.as_str(),
+                trace.command.as_str(),
+                files_json,
+                source_event_id,
+                trace.verified_at_epoch,
+                now_epoch
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn load_trace_history(
+    conn: &Connection,
+    task: &crate::db::ExtractionTask,
+    session_row_id: i64,
+    high_watermark: i64,
+    earliest: i64,
+    new_traces: &[ProcedureTrace],
+) -> Result<Vec<ProcedureTrace>> {
+    let mut groups: BTreeMap<(Option<String>, String, String), ()> = BTreeMap::new();
+    for trace in new_traces {
+        groups.insert(
+            (
+                trace.branch.clone(),
+                trace.workflow_key.clone(),
+                trace.command.clone(),
+            ),
+            (),
+        );
+    }
+
+    let mut traces = Vec::new();
+    let mut stmt = conn.prepare(
+        "SELECT p.project_path,
+                v.branch,
+                v.workflow_key,
+                v.command,
+                v.files_touched,
+                v.source_event_id,
+                v.verified_at_epoch
+         FROM procedure_verifications v
+         JOIN projects p ON p.id = v.project_id
+         WHERE v.host_id = ?1
+           AND v.project_id = ?2
+           AND v.session_row_id = ?3
+           AND ((v.branch IS NULL AND ?4 IS NULL) OR v.branch = ?4)
+           AND v.workflow_key = ?5
+           AND v.command = ?6
+           AND v.source_event_id <= ?7
+           AND v.verified_at_epoch >= ?8
+         ORDER BY v.verified_at_epoch ASC, v.source_event_id ASC",
+    )?;
+    for (branch, workflow_key, command) in groups.into_keys() {
+        let rows = stmt.query_map(
+            params![
+                task.host_id,
+                task.project_id,
+                session_row_id,
+                branch.as_deref(),
+                workflow_key.as_str(),
+                command.as_str(),
+                high_watermark,
+                earliest
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, i64>(6)?,
+                ))
+            },
+        )?;
+        for row in rows {
+            let (
+                project,
+                branch,
+                workflow_key,
+                command,
+                files_touched_json,
+                source_event_id,
+                verified_at_epoch,
+            ) = row?;
+            let files_touched = serde_json::from_str::<Vec<String>>(&files_touched_json)
+                .with_context(|| {
+                    format!("procedure verification {source_event_id} has malformed files_touched")
+                })?;
+            traces.push(ProcedureTrace {
+                project,
+                branch,
+                workflow_key,
+                command,
+                files_touched,
+                succeeded: true,
+                verified_at_epoch,
+                source_event_id: Some(source_event_id),
+            });
+        }
+    }
+    Ok(traces)
+}
+
+fn parse_procedure_trace(
+    event_id: i64,
+    project: String,
+    content: &str,
+    verified_at_epoch: i64,
+) -> Option<ProcedureTrace> {
+    let value: Value = serde_json::from_str(content).ok()?;
+    if value.get("event_type")?.as_str()? != "bash" {
+        return None;
+    }
+    if value.get("exit_code")?.as_i64()? != 0 {
+        return None;
+    }
+    let command = value
+        .get("tool_input")?
+        .get("command")?
+        .as_str()?
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if command.is_empty() {
+        return None;
+    }
+    Some(ProcedureTrace {
+        project,
+        branch: parse_event_branch(&value),
+        workflow_key: workflow_key_for_command(&command),
+        command,
+        files_touched: parse_event_files(&value),
+        succeeded: true,
+        verified_at_epoch,
+        source_event_id: Some(event_id),
+    })
+}
+
+fn parse_event_branch(value: &Value) -> Option<String> {
+    value
+        .get("git_branch")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|branch| !branch.is_empty())
+        .map(str::to_string)
+}
+
+fn parse_event_files(value: &Value) -> Vec<String> {
+    let Some(files) = value.get("files") else {
+        return Vec::new();
+    };
+    let mut parsed = match files {
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| item.as_str().map(str::to_string))
+            .collect::<Vec<_>>(),
+        Value::String(raw) => match serde_json::from_str::<Vec<String>>(raw) {
+            Ok(files) => files,
+            Err(error) => {
+                crate::log::warn(
+                    "procedure",
+                    &format!("ignored malformed procedure event files JSON: {error}"),
+                );
+                Vec::new()
+            }
+        },
+        _ => Vec::new(),
+    };
+    parsed.sort();
+    parsed.dedup();
+    parsed
+}
+
+fn workflow_key_for_command(command: &str) -> String {
+    crate::memory::slugify_for_topic(command, 64)
+}

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -62,10 +62,10 @@ fn full_migration_on_empty_db() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 25);
+    assert_eq!(user_version, 26);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -88,6 +88,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "extraction_tasks",
         "memory_candidates",
         "memory_facts",
+        "procedure_verifications",
         "rule_candidates",
     ] {
         let exists: bool = conn
@@ -207,7 +208,13 @@ fn concurrent_run_migrations_serializes_pending_migrations() -> Result<()> {
 
     let conn = Connection::open(&path)?;
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    assert_eq!(
+        applied,
+        MIGRATIONS
+            .iter()
+            .map(|migration| migration.version)
+            .collect::<Vec<_>>()
+    );
     cleanup_temp_db_files(&path);
     Ok(())
 }
@@ -264,7 +271,13 @@ fn transition_from_old_system_skips_baseline() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    assert_eq!(
+        applied,
+        MIGRATIONS
+            .iter()
+            .map(|migration| migration.version)
+            .collect::<Vec<_>>()
+    );
     Ok(())
 }
 
@@ -289,10 +302,16 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
 
     // Should have auto-upgraded and marked all v1 migrations as applied.
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    assert_eq!(
+        applied,
+        MIGRATIONS
+            .iter()
+            .map(|migration| migration.version)
+            .collect::<Vec<_>>()
+    );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 25);
+    assert_eq!(user_version, 26);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -332,7 +351,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 25);
+    assert_eq!(result.current_version, 26);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())
@@ -345,7 +364,7 @@ fn dry_run_pending_reports_pending_for_new_db() -> Result<()> {
     let result = dry_run_pending(&conn)?;
 
     assert_eq!(result.current_version, 0);
-    assert_eq!(result.pending_count, 13);
+    assert_eq!(result.pending_count, MIGRATIONS.len());
     assert!(result.error.is_none());
     Ok(())
 }
@@ -404,7 +423,7 @@ fn dry_run_pending_reports_backfill_error_for_broken_schema() -> Result<()> {
     let result = dry_run_pending(&conn)?;
     // After broken baseline backfill fails, dry_run reports the still-unapplied
     // migrations (v2+ remain pending in _schema_migrations).
-    assert_eq!(result.pending_count, 12);
+    assert_eq!(result.pending_count, MIGRATIONS.len() - 1);
     let error = result
         .error
         .expect("broken schema should surface in dry-run");

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -70,6 +70,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "memory_temporal_facts",
         sql: include_str!("../migrations/v013_memory_temporal_facts.sql"),
     },
+    Migration {
+        version: 14,
+        name: "procedure_verifications",
+        sql: include_str!("../migrations/v014_procedure_verifications.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/schema_001_baseline.sql
+++ b/src/migrations/schema_001_baseline.sql
@@ -160,6 +160,22 @@ CREATE TABLE IF NOT EXISTS memories (
     updated_at_epoch INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS procedure_verifications (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+    branch TEXT,
+    workflow_key TEXT NOT NULL,
+    command TEXT NOT NULL,
+    files_touched TEXT NOT NULL,
+    source_event_id INTEGER NOT NULL REFERENCES captured_events(id),
+    verified_at_epoch INTEGER NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    UNIQUE(host_id, project_id, session_row_id, source_event_id)
+);
+
 CREATE TABLE IF NOT EXISTS rule_candidates (
     id INTEGER PRIMARY KEY,
     workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
@@ -219,6 +235,11 @@ CREATE INDEX IF NOT EXISTS idx_memories_project_status
 -- index, since SQLite UNIQUE table constraints reject expressions.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_topic_unique
     ON memories(scope, COALESCE(project_id, 0), topic_key);
+
+CREATE INDEX IF NOT EXISTS idx_procedure_verifications_lookup
+    ON procedure_verifications(host_id, project_id, session_row_id, workflow_key, command, branch, verified_at_epoch);
+CREATE INDEX IF NOT EXISTS idx_procedure_verifications_source
+    ON procedure_verifications(source_event_id);
 
 CREATE INDEX IF NOT EXISTS idx_rule_candidates_review
     ON rule_candidates(workspace_id, review_status);

--- a/src/migrations/v014_procedure_verifications.sql
+++ b/src/migrations/v014_procedure_verifications.sql
@@ -1,0 +1,22 @@
+-- v014_procedure_verifications: persist verified procedure traces incrementally.
+
+CREATE TABLE IF NOT EXISTS procedure_verifications (
+    id INTEGER PRIMARY KEY,
+    host_id INTEGER NOT NULL REFERENCES hosts(id),
+    project_id INTEGER NOT NULL REFERENCES projects(id),
+    session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+    branch TEXT,
+    workflow_key TEXT NOT NULL,
+    command TEXT NOT NULL,
+    files_touched TEXT NOT NULL,
+    source_event_id INTEGER NOT NULL REFERENCES captured_events(id),
+    verified_at_epoch INTEGER NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    UNIQUE(host_id, project_id, session_row_id, source_event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_procedure_verifications_lookup
+    ON procedure_verifications(host_id, project_id, session_row_id, workflow_key, command, branch, verified_at_epoch);
+CREATE INDEX IF NOT EXISTS idx_procedure_verifications_source
+    ON procedure_verifications(source_event_id);


### PR DESCRIPTION
Fixes #197.

Summary:
- Keep procedure promotion bounded to the task session and high-watermark event.
- Persist verified procedure traces incrementally in `procedure_verifications`, so one successful run per extraction window can satisfy `min_verified_runs` without rescanning all old Bash events.
- Split procedure trace loading into a focused submodule to keep `procedure/mod.rs` below the file-size guard.
- Add regression coverage for cross-window accumulation and for avoiding broad scans of unstored prior Bash events.

Verification:
- cargo fmt --check
- git diff --check
- cargo check
- cargo test
- cargo clippy -- -D warnings