### PR TITLE
Drop Codex hooks legacy alias

### DIFF
--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -163,7 +163,7 @@ fn enable_codex_hooks(doc: &mut DocumentMut) -> Result<()> {
         .or_insert(Item::Table(Table::new()))
         .as_table_mut()
         .context("features 存在但不是 table，拒绝覆盖")?;
-    features["codex_hooks"] = value(true);
+    features.remove("codex_hooks");
     features["hooks"] = value(true);
     Ok(())
 }
@@ -271,11 +271,11 @@ startup_timeout_sec = 5
         let rendered = doc.to_string();
         assert!(rendered.contains("[features]"), "{rendered}");
         assert!(rendered.contains("hooks = true"), "{rendered}");
-        assert!(rendered.contains("codex_hooks = true"), "{rendered}");
+        assert!(!rendered.contains("codex_hooks"), "{rendered}");
     }
 
     #[test]
-    fn enable_codex_hooks_preserves_legacy_alias_for_old_codex_clients() {
+    fn enable_codex_hooks_removes_legacy_alias() {
         let mut doc: DocumentMut = r#"[features]
 codex_hooks = true
 "#
@@ -284,7 +284,7 @@ codex_hooks = true
         enable_codex_hooks(&mut doc).unwrap();
         let rendered = doc.to_string();
         assert!(rendered.contains("hooks = true"), "{rendered}");
-        assert!(rendered.contains("codex_hooks = true"), "{rendered}");
+        assert!(!rendered.contains("codex_hooks"), "{rendered}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove the legacy `codex_hooks` feature alias when enabling Codex hooks
- keep the stable `hooks = true` flag as the only Codex hook feature flag
- update installer tests to assert `codex_hooks` is removed

Fixes #201

## Verification
- cargo fmt --check
- cargo test install::hosts::codex --lib
- cargo check
- cargo test
- cargo clippy -- -D warnings
- git diff --check