### PR TITLE
fix(install): preserve codex legacy hook flag

### DIFF
--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -163,7 +163,7 @@ fn enable_codex_hooks(doc: &mut DocumentMut) -> Result<()> {
         .or_insert(Item::Table(Table::new()))
         .as_table_mut()
         .context("features 存在但不是 table，拒绝覆盖")?;
-    features.remove("codex_hooks");
+    features["codex_hooks"] = value(true);
     features["hooks"] = value(true);
     Ok(())
 }
@@ -271,11 +271,11 @@ startup_timeout_sec = 5
         let rendered = doc.to_string();
         assert!(rendered.contains("[features]"), "{rendered}");
         assert!(rendered.contains("hooks = true"), "{rendered}");
-        assert!(!rendered.contains("codex_hooks"), "{rendered}");
+        assert!(rendered.contains("codex_hooks = true"), "{rendered}");
     }
 
     #[test]
-    fn enable_codex_hooks_removes_legacy_alias() {
+    fn enable_codex_hooks_preserves_legacy_alias_for_old_codex_clients() {
         let mut doc: DocumentMut = r#"[features]
 codex_hooks = true
 "#
@@ -284,7 +284,7 @@ codex_hooks = true
         enable_codex_hooks(&mut doc).unwrap();
         let rendered = doc.to_string();
         assert!(rendered.contains("hooks = true"), "{rendered}");
-        assert!(!rendered.contains("codex_hooks"), "{rendered}");
+        assert!(rendered.contains("codex_hooks = true"), "{rendered}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- write both `features.codex_hooks` and `features.hooks` in Codex config until the minimum Codex version is enforced
- keep compatibility with old Codex clients that still read the legacy alias
- update regression coverage for preserving the legacy flag

## Verification
- `cargo fmt --check`
- `cargo test install::hosts::codex::tests --lib`
- `git diff --check`
- `cargo check`
- `cargo test`