### PR TITLE
fix: address remem P1 review followups

### DIFF
--- a/src/eval/golden/run.rs
+++ b/src/eval/golden/run.rs
@@ -243,7 +243,7 @@ fn score_results(
         mrr_at_10: reciprocal_rank_from_relevance(&relevance_at_rank_k),
         precision_at_k: relevant_hits as f64 / precision_denominator as f64,
         recall_at_k: matched_refs as f64 / expected_refs.len() as f64,
-        ndcg_at_10: binary_ndcg_at_k(&relevance_at_rank_k, expected_refs.len(), RANK_K),
+        ndcg_at_10: ndcg_at_k(results, expected_refs, RANK_K),
         evidence_recall_at_k: matched_refs as f64 / expected_refs.len() as f64,
     }
 }
@@ -271,18 +271,30 @@ fn reciprocal_rank_from_relevance(relevance: &[bool]) -> f64 {
         .map_or(0.0, |index| 1.0 / (index as f64 + 1.0))
 }
 
-fn binary_ndcg_at_k(relevance: &[bool], expected_count: usize, k: usize) -> f64 {
-    if k == 0 || expected_count == 0 {
+fn ndcg_at_k(results: &[crate::memory::Memory], expected_refs: &[EvidenceRef], k: usize) -> f64 {
+    if k == 0 || expected_refs.is_empty() {
         return 0.0;
     }
-    let dcg: f64 = relevance
+
+    let mut matched_refs = HashSet::new();
+    let dcg: f64 = results
         .iter()
         .take(k)
         .enumerate()
-        .filter(|(_, is_relevant)| **is_relevant)
-        .map(|(index, _)| 1.0 / (index as f64 + 2.0).log2())
+        .filter_map(|(rank, memory)| {
+            let ref_index =
+                expected_refs
+                    .iter()
+                    .enumerate()
+                    .find_map(|(index, evidence_ref)| {
+                        (!matched_refs.contains(&index) && evidence_ref.matches(memory))
+                            .then_some(index)
+                    })?;
+            matched_refs.insert(ref_index);
+            Some(1.0 / (rank as f64 + 2.0).log2())
+        })
         .sum();
-    let ideal_hits = expected_count.min(k);
+    let ideal_hits = expected_refs.len().min(k);
     let idcg: f64 = (0..ideal_hits)
         .map(|index| 1.0 / (index as f64 + 2.0).log2())
         .sum();

--- a/src/eval/golden/run.rs
+++ b/src/eval/golden/run.rs
@@ -276,24 +276,18 @@ fn ndcg_at_k(results: &[crate::memory::Memory], expected_refs: &[EvidenceRef], k
         return 0.0;
     }
 
-    let mut matched_refs = HashSet::new();
-    let dcg: f64 = results
+    let matches_by_rank: Vec<Vec<usize>> = results
         .iter()
         .take(k)
-        .enumerate()
-        .filter_map(|(rank, memory)| {
-            let ref_index =
-                expected_refs
-                    .iter()
-                    .enumerate()
-                    .find_map(|(index, evidence_ref)| {
-                        (!matched_refs.contains(&index) && evidence_ref.matches(memory))
-                            .then_some(index)
-                    })?;
-            matched_refs.insert(ref_index);
-            Some(1.0 / (rank as f64 + 2.0).log2())
+        .map(|memory| {
+            expected_refs
+                .iter()
+                .enumerate()
+                .filter_map(|(index, evidence_ref)| evidence_ref.matches(memory).then_some(index))
+                .collect()
         })
-        .sum();
+        .collect();
+    let dcg = best_dcg_for_matchable_ranks(&matches_by_rank);
     let ideal_hits = expected_refs.len().min(k);
     let idcg: f64 = (0..ideal_hits)
         .map(|index| 1.0 / (index as f64 + 2.0).log2())
@@ -303,4 +297,60 @@ fn ndcg_at_k(results: &[crate::memory::Memory], expected_refs: &[EvidenceRef], k
     } else {
         dcg / idcg
     }
+}
+
+fn best_dcg_for_matchable_ranks(matches_by_rank: &[Vec<usize>]) -> f64 {
+    let mut best = 0.0;
+    for mask in 1usize..(1usize << matches_by_rank.len()) {
+        let dcg: f64 = (0..matches_by_rank.len())
+            .filter(|rank| (mask & (1usize << rank)) != 0)
+            .map(|rank| 1.0 / (rank as f64 + 2.0).log2())
+            .sum();
+        if dcg > best && can_assign_unique_refs(matches_by_rank, mask) {
+            best = dcg;
+        }
+    }
+    best
+}
+
+fn can_assign_unique_refs(matches_by_rank: &[Vec<usize>], mask: usize) -> bool {
+    let mut selected_ranks: Vec<usize> = (0..matches_by_rank.len())
+        .filter(|rank| (mask & (1usize << rank)) != 0)
+        .collect();
+    if selected_ranks
+        .iter()
+        .any(|rank| matches_by_rank[*rank].is_empty())
+    {
+        return false;
+    }
+    selected_ranks.sort_by_key(|rank| matches_by_rank[*rank].len());
+
+    let mut assigned_refs = HashSet::new();
+    assign_rank_ref(0, &selected_ranks, matches_by_rank, &mut assigned_refs)
+}
+
+fn assign_rank_ref(
+    selected_index: usize,
+    selected_ranks: &[usize],
+    matches_by_rank: &[Vec<usize>],
+    assigned_refs: &mut HashSet<usize>,
+) -> bool {
+    let Some(rank) = selected_ranks.get(selected_index).copied() else {
+        return true;
+    };
+
+    for ref_index in &matches_by_rank[rank] {
+        if assigned_refs.insert(*ref_index) {
+            if assign_rank_ref(
+                selected_index + 1,
+                selected_ranks,
+                matches_by_rank,
+                assigned_refs,
+            ) {
+                return true;
+            }
+            assigned_refs.remove(ref_index);
+        }
+    }
+    false
 }

--- a/src/eval/golden/tests.rs
+++ b/src/eval/golden/tests.rs
@@ -290,3 +290,61 @@ fn golden_eval_rejects_empty_evidence_refs() -> Result<()> {
     assert!(error.to_string().contains("empty evidence ref"));
     Ok(())
 }
+
+#[test]
+fn golden_eval_ndcg_counts_each_expected_ref_once() -> Result<()> {
+    let conn = setup_conn()?;
+    let now = chrono::Utc::now().timestamp();
+    for memory in [
+        TestMemory {
+            id: 1,
+            project: "/repo-a",
+            topic_key: "dup-a",
+            title: "Duplicate eval needle",
+            content: "duplicate ndcg needle from one memory",
+            memory_type: "bugfix",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now,
+        },
+        TestMemory {
+            id: 2,
+            project: "/repo-a",
+            topic_key: "dup-b",
+            title: "Duplicate eval needle",
+            content: "duplicate ndcg needle from another memory",
+            memory_type: "bugfix",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now - 1,
+        },
+    ] {
+        insert_memory(&conn, &memory)?;
+    }
+
+    let dataset = GoldenDataset {
+        version: Some("1.2-test".to_string()),
+        description: None,
+        queries: vec![query(
+            "dup",
+            "duplicate ndcg needle",
+            "dedupe",
+            Some("/repo-a"),
+            Some("main"),
+            EvidenceRef {
+                text_contains: Some("duplicate ndcg needle".to_string()),
+                ..EvidenceRef::default()
+            },
+        )],
+    };
+
+    let report = evaluate_dataset(&conn, &dataset, 10)?;
+    let metrics = report.queries[0]
+        .metrics
+        .as_ref()
+        .context("missing query metrics")?;
+    assert_eq!(report.queries[0].matched_refs, 1);
+    assert!(metrics.ndcg_at_10 <= 1.0, "{metrics:?}");
+    assert_eq!(metrics.ndcg_at_10, 1.0);
+    Ok(())
+}

--- a/src/eval/golden/tests.rs
+++ b/src/eval/golden/tests.rs
@@ -348,3 +348,71 @@ fn golden_eval_ndcg_counts_each_expected_ref_once() -> Result<()> {
     assert_eq!(metrics.ndcg_at_10, 1.0);
     Ok(())
 }
+
+#[test]
+fn golden_eval_ndcg_uses_best_assignment_for_overlapping_refs() -> Result<()> {
+    let conn = setup_conn()?;
+    let now = chrono::Utc::now().timestamp();
+    for memory in [
+        TestMemory {
+            id: 1,
+            project: "/repo-a",
+            topic_key: "specific-overlap",
+            title: "Overlapping assignment needle",
+            content: "overlapping assignment shared unique specific memory",
+            memory_type: "bugfix",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now,
+        },
+        TestMemory {
+            id: 2,
+            project: "/repo-a",
+            topic_key: "broad-only",
+            title: "Overlapping assignment needle",
+            content: "overlapping assignment shared broad memory",
+            memory_type: "bugfix",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now - 1,
+        },
+    ] {
+        insert_memory(&conn, &memory)?;
+    }
+
+    let dataset = GoldenDataset {
+        version: Some("1.2-test".to_string()),
+        description: None,
+        queries: vec![GoldenQuery {
+            id: "overlap".to_string(),
+            query: "overlapping assignment shared".to_string(),
+            category: "dedupe".to_string(),
+            project: Some("/repo-a".to_string()),
+            branch: Some("main".to_string()),
+            memory_type: None,
+            relevant_ids: vec![],
+            evidence_refs: vec![
+                EvidenceRef {
+                    text_contains: Some("overlapping assignment shared".to_string()),
+                    ..EvidenceRef::default()
+                },
+                EvidenceRef {
+                    topic_key: Some("specific-overlap".to_string()),
+                    ..EvidenceRef::default()
+                },
+            ],
+            expect_abstain: false,
+            false_premise: false,
+            notes: None,
+        }],
+    };
+
+    let report = evaluate_dataset(&conn, &dataset, 10)?;
+    let metrics = report.queries[0]
+        .metrics
+        .as_ref()
+        .context("missing query metrics")?;
+    assert_eq!(report.queries[0].matched_refs, 2);
+    assert_eq!(metrics.ndcg_at_10, 1.0);
+    Ok(())
+}

--- a/src/extraction_worker.rs
+++ b/src/extraction_worker.rs
@@ -116,11 +116,11 @@ fn memory_candidate_task_outcome(result: MemoryCandidateResult) -> ExtractionTas
             crate::log::warn(
                 "worker",
                 &format!(
-                    "memory candidate extraction deferred by model and will not be retried automatically: {}",
+                    "memory candidate extraction deferred by model: {}",
                     crate::db::truncate_str(&reason, 300)
                 ),
             );
-            ExtractionTaskOutcome::Done
+            ExtractionTaskOutcome::Deferred(reason)
         }
         _ => ExtractionTaskOutcome::Done,
     }
@@ -142,11 +142,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn memory_candidate_defer_is_terminal_for_worker_retry_loop() {
+    fn memory_candidate_defer_preserves_range_for_reprocessing() {
         let outcome = memory_candidate_task_outcome(MemoryCandidateResult::Deferred {
             reason: "ambiguous conflict".to_string(),
         });
 
-        assert_eq!(outcome, ExtractionTaskOutcome::Done);
+        assert_eq!(
+            outcome,
+            ExtractionTaskOutcome::Deferred("ambiguous conflict".to_string())
+        );
     }
 }

--- a/src/extraction_worker.rs
+++ b/src/extraction_worker.rs
@@ -4,6 +4,7 @@ use tokio::time::Duration;
 use crate::db;
 use crate::memory_candidate::MemoryCandidateResult;
 
+#[derive(Debug, PartialEq, Eq)]
 enum ExtractionTaskOutcome {
     Deferred(String),
     Done,
@@ -99,17 +100,29 @@ async fn process_extraction_task(task: &db::ExtractionTask) -> Result<Extraction
             Ok(ExtractionTaskOutcome::Done)
         }
         db::ExtractionTaskKind::MemoryCandidate => {
-            match crate::memory_candidate::process(task).await? {
-                MemoryCandidateResult::Deferred { reason } => {
-                    Ok(ExtractionTaskOutcome::Deferred(reason))
-                }
-                _ => Ok(ExtractionTaskOutcome::Done),
-            }
+            let result = crate::memory_candidate::process(task).await?;
+            Ok(memory_candidate_task_outcome(result))
         }
         _ => Ok(ExtractionTaskOutcome::Deferred(format!(
             "extraction task kind '{}' is not implemented",
             task.task_kind.as_str()
         ))),
+    }
+}
+
+fn memory_candidate_task_outcome(result: MemoryCandidateResult) -> ExtractionTaskOutcome {
+    match result {
+        MemoryCandidateResult::Deferred { reason } => {
+            crate::log::warn(
+                "worker",
+                &format!(
+                    "memory candidate extraction deferred by model and will not be retried automatically: {}",
+                    crate::db::truncate_str(&reason, 300)
+                ),
+            );
+            ExtractionTaskOutcome::Done
+        }
+        _ => ExtractionTaskOutcome::Done,
     }
 }
 
@@ -121,5 +134,19 @@ fn retry_backoff_secs(attempt: i64) -> i64 {
         3 => 120,
         4 => 300,
         _ => 900,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_candidate_defer_is_terminal_for_worker_retry_loop() {
+        let outcome = memory_candidate_task_outcome(MemoryCandidateResult::Deferred {
+            reason: "ambiguous conflict".to_string(),
+        });
+
+        assert_eq!(outcome, ExtractionTaskOutcome::Done);
     }
 }

--- a/src/memory/search_context.rs
+++ b/src/memory/search_context.rs
@@ -2,6 +2,7 @@ use rusqlite::Connection;
 
 const MAX_HINT_CHARS: usize = 180;
 const MAX_CONTEXT_CHARS: usize = 4000;
+const REBUILD_BATCH_SIZE: i64 = 500;
 
 pub fn build_search_context(
     memory_type: &str,
@@ -37,37 +38,63 @@ pub fn build_search_context(
 }
 
 pub fn rebuild_all(conn: &Connection) -> anyhow::Result<usize> {
-    let rows = {
-        let mut stmt = conn.prepare(
-            "SELECT id, topic_key, content, memory_type, files
-             FROM memories",
-        )?;
-        let mapped = stmt.query_map([], |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, Option<String>>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, Option<String>>(4)?,
-            ))
-        })?;
-        mapped.collect::<Result<Vec<_>, _>>()?
-    };
-
     let mut changed = 0usize;
-    for (id, topic_key, content, memory_type, files) in rows {
-        let search_context = build_search_context(
-            &memory_type,
-            topic_key.as_deref(),
-            &content,
-            files.as_deref(),
-        );
-        changed += conn.execute(
-            "UPDATE memories SET search_context = ?1 WHERE id = ?2",
-            rusqlite::params![search_context, id],
-        )?;
+    let mut last_id = 0i64;
+
+    loop {
+        let rows = load_rebuild_batch(conn, last_id, REBUILD_BATCH_SIZE)?;
+        let Some(next_last_id) = rows.last().map(|row| row.id) else {
+            break;
+        };
+
+        for row in rows {
+            let search_context = build_search_context(
+                &row.memory_type,
+                row.topic_key.as_deref(),
+                &row.content,
+                row.files.as_deref(),
+            );
+            changed += conn.execute(
+                "UPDATE memories SET search_context = ?1 WHERE id = ?2",
+                rusqlite::params![search_context, row.id],
+            )?;
+        }
+        last_id = next_last_id;
     }
+
     Ok(changed)
+}
+
+struct RebuildRow {
+    id: i64,
+    topic_key: Option<String>,
+    content: String,
+    memory_type: String,
+    files: Option<String>,
+}
+
+fn load_rebuild_batch(
+    conn: &Connection,
+    last_id: i64,
+    batch_size: i64,
+) -> anyhow::Result<Vec<RebuildRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, topic_key, content, memory_type, files
+         FROM memories
+         WHERE id > ?1
+         ORDER BY id
+         LIMIT ?2",
+    )?;
+    let mapped = stmt.query_map(rusqlite::params![last_id, batch_size], |row| {
+        Ok(RebuildRow {
+            id: row.get(0)?,
+            topic_key: row.get(1)?,
+            content: row.get(2)?,
+            memory_type: row.get(3)?,
+            files: row.get(4)?,
+        })
+    })?;
+    mapped.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
 
 fn non_empty(value: &str) -> Option<&str> {
@@ -231,7 +258,7 @@ fn truncate_context(value: &str) -> String {
 mod tests {
     use rusqlite::Connection;
 
-    use super::{build_search_context, rebuild_all};
+    use super::{build_search_context, rebuild_all, REBUILD_BATCH_SIZE};
 
     #[test]
     fn search_context_includes_rebuildable_structured_hints() {
@@ -278,6 +305,36 @@ mod tests {
         assert!(context.contains("search context rebuild"));
         assert!(context.contains("src/memory/search_context.rs"));
         assert!(context.contains("commands: cargo test"));
+        Ok(())
+    }
+
+    #[test]
+    fn rebuild_all_processes_multiple_batches() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        crate::memory::types::tests_helper::setup_memory_schema(&conn);
+
+        let total = REBUILD_BATCH_SIZE + 3;
+        for id in 1..=total {
+            conn.execute(
+                "INSERT INTO memories
+                 (id, session_id, project, topic_key, title, content, memory_type, files,
+                  created_at_epoch, updated_at_epoch, status, branch, scope)
+                 VALUES (?1, NULL, 'proj', ?2, 'Title',
+                         'Issue: miss. Resolved by adding context. Verified with `cargo test`.',
+                         'bugfix', '[\"src/memory/search_context.rs\"]',
+                         100, 100, 'active', NULL, 'project')",
+                rusqlite::params![id, format!("search-context-rebuild-{id}")],
+            )?;
+        }
+
+        let changed = rebuild_all(&conn)?;
+        assert_eq!(changed, total as usize);
+        let populated: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memories WHERE search_context IS NOT NULL AND search_context != ''",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(populated, total);
         Ok(())
     }
 }

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -24,7 +24,7 @@ If evidence is ambiguous or contradictory, return exactly <defer reason=\"...\"/
 Use only provided observations and evidence; do not invent files, outcomes, decisions, or facts.";
 
 const AUTO_PROMOTE_MIN_CONFIDENCE: f64 = 0.80;
-const AUTO_PROMOTE_MIN_OBSERVATION_CONFIDENCE: f64 = 0.80;
+const AUTO_PROMOTE_MIN_OBSERVATION_CONFIDENCE: f64 = 0.75;
 const AUTO_PROMOTE_TYPES: &[&str] = &["architecture", "bugfix", "decision", "discovery"];
 const AUTO_PROMOTE_UNSAFE_MARKERS: &[&str] = &[
     "api key",
@@ -474,6 +474,15 @@ mod tests {
         task: &db::ExtractionTask,
         text: &str,
     ) -> Result<()> {
+        insert_source_observation_with_confidence(conn, task, text, 0.91)
+    }
+
+    fn insert_source_observation_with_confidence(
+        conn: &Connection,
+        task: &db::ExtractionTask,
+        text: &str,
+        confidence: f64,
+    ) -> Result<()> {
         let obs_id = db::insert_observation_with_branch(
             conn,
             "capture-observation-test",
@@ -500,17 +509,50 @@ mod tests {
                  observation_type = 'decision',
                  text = ?4,
                  evidence_event_ids = ?5,
-                 confidence = 0.91
-             WHERE id = ?6",
+                 confidence = ?6
+             WHERE id = ?7",
             params![
                 task.host_id,
                 task.project_id,
                 task.session_row_id,
                 text,
                 serde_json::to_string(&vec![event_id])?,
+                confidence,
                 obs_id
             ],
         )?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn memory_candidate_auto_promotes_default_confidence_observation() -> Result<()> {
+        let mut conn = setup_conn();
+        let task = setup_task(&mut conn, "sess-candidate-default-confidence")?;
+        insert_source_observation_with_confidence(
+            &conn,
+            &task,
+            "Use the worker loop to process extraction tasks after observation extraction.",
+            0.75,
+        )?;
+
+        let result = process_with_generator(&mut conn, &task, |_prompt| async {
+            Ok(low_risk_candidate_xml())
+        })
+        .await?;
+
+        assert_eq!(
+            result,
+            MemoryCandidateResult::Written {
+                candidates: 1,
+                promoted: 1,
+                pending_review: 0
+            }
+        );
+        let review_status: String =
+            conn.query_row("SELECT review_status FROM memory_candidates", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(review_status, "auto_promoted");
         Ok(())
     }
 

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -158,7 +158,14 @@ impl DryRunTempPath {
                 .context("system time before unix epoch")?
                 .as_nanos();
             let path = temp_dir.join(format!("remem-dry-run-{}-{nonce}-{counter}", process::id()));
-            match OpenOptions::new().write(true).create_new(true).open(&path) {
+            let mut options = OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            match options.open(&path) {
                 Ok(_) => return Ok(Self { path }),
                 Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
                 Err(error) => {
@@ -211,6 +218,17 @@ fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
 mod tests {
     use super::*;
     use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
+
+    #[cfg(unix)]
+    #[test]
+    fn dry_run_temp_path_uses_owner_only_permissions() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_path = DryRunTempPath::create()?;
+        let mode = fs::metadata(temp_path.path())?.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        Ok(())
+    }
 
     #[test]
     fn dry_run_temp_path_uses_on_disk_database_and_cleans_up() -> Result<()> {

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -1,6 +1,13 @@
-use anyhow::{ensure, Result};
+use anyhow::{bail, ensure, Context, Result};
 use rusqlite::{backup::Backup, Connection};
-use std::time::Duration;
+use std::{
+    fs::{self, OpenOptions},
+    io::ErrorKind,
+    path::{Path, PathBuf},
+    process,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use super::run::run_post_migration_hook;
 use super::state::{applied_versions, has_migration_table};
@@ -14,7 +21,26 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
     let applied = infer_applied_versions(real_conn, raw_current_version)?;
     let current_version = logical_current_version(raw_current_version, &applied);
 
-    let mut test_conn = Connection::open_in_memory()?;
+    let temp_path = match DryRunTempPath::create() {
+        Ok(temp_path) => temp_path,
+        Err(error) => {
+            return Ok(DryRunResult {
+                current_version,
+                pending_count: applied_pending_count(&applied),
+                error: Some(format!("database clone: {}", error)),
+            });
+        }
+    };
+    let mut test_conn = match Connection::open(temp_path.path()) {
+        Ok(conn) => conn,
+        Err(error) => {
+            return Ok(DryRunResult {
+                current_version,
+                pending_count: applied_pending_count(&applied),
+                error: Some(format!("database clone: {}", error)),
+            });
+        }
+    };
     if let Err(error) = clone_database(real_conn, &mut test_conn) {
         return Ok(DryRunResult {
             current_version,
@@ -114,4 +140,117 @@ fn clone_database(src: &Connection, dst: &mut Connection) -> Result<()> {
     let backup = Backup::new(src, dst)?;
     backup.run_to_completion(100, Duration::from_millis(1), None)?;
     Ok(())
+}
+
+struct DryRunTempPath {
+    path: PathBuf,
+}
+
+impl DryRunTempPath {
+    fn create() -> Result<Self> {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let temp_dir = std::env::temp_dir();
+        for _ in 0..32 {
+            let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .context("system time before unix epoch")?
+                .as_nanos();
+            let path = temp_dir.join(format!("remem-dry-run-{}-{nonce}-{counter}", process::id()));
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(_) => return Ok(Self { path }),
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("create dry-run database {}", path.display()));
+                }
+            }
+        }
+
+        bail!("create unique dry-run database path")
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for DryRunTempPath {
+    fn drop(&mut self) {
+        cleanup_sqlite_files(&self.path);
+    }
+}
+
+fn cleanup_sqlite_files(path: &Path) {
+    remove_sqlite_file(path);
+    remove_sqlite_file(&sqlite_sidecar_path(path, "-wal"));
+    remove_sqlite_file(&sqlite_sidecar_path(path, "-shm"));
+    remove_sqlite_file(&sqlite_sidecar_path(path, "-journal"));
+}
+
+fn remove_sqlite_file(path: &Path) {
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => eprintln!(
+            "failed to remove dry-run database file {}: {}",
+            path.display(),
+            error
+        ),
+    }
+}
+
+fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut sidecar = path.as_os_str().to_os_string();
+    sidecar.push(suffix);
+    PathBuf::from(sidecar)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path};
+
+    #[test]
+    fn dry_run_temp_path_uses_on_disk_database_and_cleans_up() -> Result<()> {
+        let source_path = unique_temp_db_path("dry-run-source");
+        let dry_run_path;
+        {
+            let source = Connection::open(&source_path)?;
+            source.execute_batch(
+                "PRAGMA page_size = 8192;
+                 CREATE TABLE items (id INTEGER PRIMARY KEY);
+                 INSERT INTO items DEFAULT VALUES;",
+            )?;
+
+            let temp_path = DryRunTempPath::create()?;
+            dry_run_path = temp_path.path().to_path_buf();
+            {
+                let mut dst = Connection::open(temp_path.path())?;
+                clone_database(&source, &mut dst)?;
+
+                let count: i64 =
+                    dst.query_row("SELECT COUNT(*) FROM items", [], |row| row.get(0))?;
+                assert_eq!(count, 1);
+
+                let page_size: i64 = dst.query_row("PRAGMA page_size", [], |row| row.get(0))?;
+                assert_eq!(page_size, 8192);
+            }
+
+            assert!(
+                dry_run_path.exists(),
+                "dry-run clone should use a temporary on-disk database file"
+            );
+        }
+        assert!(
+            !dry_run_path.exists(),
+            "temporary dry-run database should be removed after use"
+        );
+        assert!(!sqlite_sidecar_path(&dry_run_path, "-wal").exists());
+        assert!(!sqlite_sidecar_path(&dry_run_path, "-shm").exists());
+
+        cleanup_temp_db_files(&source_path);
+        Ok(())
+    }
 }

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use rusqlite::{backup::Backup, Connection};
 use std::time::Duration;
 
@@ -108,6 +108,9 @@ fn logical_current_version(raw_current_version: i64, applied: &[i64]) -> i64 {
 }
 
 fn clone_database(src: &Connection, dst: &mut Connection) -> Result<()> {
+    let page_size: i64 = src.query_row("PRAGMA page_size", [], |row| row.get(0))?;
+    ensure!(page_size > 0, "source database page_size must be positive");
+    dst.execute_batch(&format!("PRAGMA page_size = {page_size}"))?;
     let backup = Backup::new(src, dst)?;
     backup.run_to_completion(100, Duration::from_millis(1), None)?;
     Ok(())

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
+use super::run::run_post_migration_hook;
 use super::state::{applied_versions, has_migration_table};
 use super::transition::backfill_to_baseline;
 use super::types::{DryRunResult, Migration, MIGRATIONS, OLD_BASELINE_VERSION};
@@ -50,6 +51,16 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
                 pending_count: pending.len(),
                 error: Some(format!(
                     "v{:03}_{}: {}",
+                    migration.version, migration.name, error
+                )),
+            });
+        }
+        if let Err(error) = run_post_migration_hook(&test_conn, migration.version, migration.name) {
+            return Ok(DryRunResult {
+                current_version,
+                pending_count: pending.len(),
+                error: Some(format!(
+                    "v{:03}_{} post-migration hook: {}",
                     migration.version, migration.name, error
                 )),
             });

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use rusqlite::Connection;
+use rusqlite::{backup::Backup, Connection};
+use std::time::Duration;
 
 use super::run::run_post_migration_hook;
 use super::state::{applied_versions, has_migration_table};
@@ -13,12 +14,12 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
     let applied = infer_applied_versions(real_conn, raw_current_version)?;
     let current_version = logical_current_version(raw_current_version, &applied);
 
-    let test_conn = Connection::open_in_memory()?;
-    if let Err(error) = clone_schema(real_conn, &test_conn) {
+    let mut test_conn = Connection::open_in_memory()?;
+    if let Err(error) = clone_database(real_conn, &mut test_conn) {
         return Ok(DryRunResult {
             current_version,
             pending_count: applied_pending_count(&applied),
-            error: Some(format!("schema clone: {}", error)),
+            error: Some(format!("database clone: {}", error)),
         });
     }
     if raw_current_version >= OLD_BASELINE_VERSION || has_migration_table(real_conn) {
@@ -106,40 +107,8 @@ fn logical_current_version(raw_current_version: i64, applied: &[i64]) -> i64 {
     raw_current_version.max(OLD_BASELINE_VERSION - 1 + latest_applied)
 }
 
-fn clone_schema(src: &Connection, dst: &Connection) -> Result<()> {
-    // Migration-system tables that must not be replicated into the dry-run
-    // database. Matched against the unquoted `name` column so bracket-quoted
-    // and backtick-quoted DDL variants are handled transparently.
-    const INTERNAL_TABLES: &[&str] = &["_schema_migrations"];
-
-    let mut stmt = src.prepare(
-        "SELECT type, name, tbl_name, sql FROM sqlite_master
-         WHERE sql IS NOT NULL AND type IN ('table', 'index', 'trigger')
-         ORDER BY CASE type WHEN 'table' THEN 0 WHEN 'index' THEN 1 WHEN 'trigger' THEN 2 ELSE 3 END, name",
-    )?;
-    let rows: Vec<(String, String, String, String)> = stmt
-        .query_map([], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
-        })?
-        .filter_map(|r| r.ok())
-        .collect();
-
-    for (obj_type, name, tbl_name, sql) in &rows {
-        if sql.contains("fts5") {
-            continue;
-        }
-        // Skip internal tables and any indexes/triggers that belong to them.
-        let is_internal = if obj_type == "table" {
-            INTERNAL_TABLES.contains(&name.as_str())
-        } else {
-            INTERNAL_TABLES.contains(&tbl_name.as_str())
-        };
-        if is_internal {
-            continue;
-        }
-        let safe = sql.replace("CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ");
-        let safe = safe.replace("CREATE INDEX ", "CREATE INDEX IF NOT EXISTS ");
-        dst.execute_batch(&safe)?;
-    }
+fn clone_database(src: &Connection, dst: &mut Connection) -> Result<()> {
+    let backup = Backup::new(src, dst)?;
+    backup.run_to_completion(100, Duration::from_millis(1), None)?;
     Ok(())
 }

--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -57,6 +57,7 @@ fn run_migrations_locked(conn: &Connection) -> Result<()> {
                 migration.version, migration.name
             )
         })?;
+        run_post_migration_hook(conn, migration.version, migration.name)?;
         mark_applied(conn, migration.version, migration.name)?;
         crate::log::info(
             "migrate",
@@ -73,5 +74,18 @@ fn run_migrations_locked(conn: &Connection) -> Result<()> {
         .unwrap_or(0);
     let user_version = current_user_version.max(OLD_BASELINE_VERSION - 1 + latest);
     conn.execute_batch(&format!("PRAGMA user_version = {}", user_version))?;
+    Ok(())
+}
+
+fn run_post_migration_hook(conn: &Connection, version: i64, name: &str) -> Result<()> {
+    if version == 15 {
+        let rebuilt = crate::memory::search_context::rebuild_all(conn).with_context(|| {
+            format!("migration v{version:03}_{name} failed to rebuild memory search contexts")
+        })?;
+        crate::log::info(
+            "migrate",
+            &format!("rebuilt search_context for {rebuilt} memories"),
+        );
+    }
     Ok(())
 }

--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -77,7 +77,7 @@ fn run_migrations_locked(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-fn run_post_migration_hook(conn: &Connection, version: i64, name: &str) -> Result<()> {
+pub(super) fn run_post_migration_hook(conn: &Connection, version: i64, name: &str) -> Result<()> {
     if version == 15 {
         let rebuilt = crate::memory::search_context::rebuild_all(conn).with_context(|| {
             format!("migration v{version:03}_{name} failed to rebuild memory search contexts")

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -62,10 +62,13 @@ fn full_migration_on_empty_db() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+    assert_eq!(
+        applied,
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 26);
+    assert_eq!(user_version, 27);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -128,7 +131,8 @@ fn memory_search_context_migration_backfills_and_indexes_metadata() -> Result<()
         "INSERT INTO memories(project, topic_key, title, content, memory_type, files,
             created_at_epoch, updated_at_epoch, status)
          VALUES ('proj', 'cache-key-timeout', 'Runtime failure',
-            'Canonical body stays unchanged', 'bugfix',
+            'Symptom: cache key timeout. Fix: run `cargo test retrieval::memory_search`.',
+            'bugfix',
             '[\"src/retrieval/contextprobe.rs\"]', 100, 100, 'active')",
         [],
     )?;
@@ -150,6 +154,9 @@ fn memory_search_context_migration_backfills_and_indexes_metadata() -> Result<()
     assert!(search_context.contains("type: bugfix"));
     assert!(search_context.contains("topic: cache key timeout"));
     assert!(search_context.contains("src/retrieval/contextprobe.rs"));
+    assert!(search_context.contains("symptom: cache key timeout"));
+    assert!(search_context.contains("fix: run `cargo test retrieval::memory_search`"));
+    assert!(search_context.contains("commands: cargo test retrieval::memory_search"));
 
     let after: i64 = conn.query_row(
         "SELECT COUNT(*) FROM memories_fts WHERE memories_fts MATCH 'contextprobe'",
@@ -162,7 +169,10 @@ fn memory_search_context_migration_backfills_and_indexes_metadata() -> Result<()
         conn.query_row("SELECT content FROM memories WHERE id = 1", [], |row| {
             row.get(0)
         })?;
-    assert_eq!(content, "Canonical body stays unchanged");
+    assert_eq!(
+        content,
+        "Symptom: cache key timeout. Fix: run `cargo test retrieval::memory_search`."
+    );
     Ok(())
 }
 
@@ -311,7 +321,7 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 26);
+    assert_eq!(user_version, 27);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -351,7 +361,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 26);
+    assert_eq!(result.current_version, 27);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -498,6 +498,60 @@ fn dry_run_skips_schema_migrations_regardless_of_sql_quoting() -> Result<()> {
 }
 
 #[test]
+fn dry_run_pending_runs_post_migration_hooks() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch(
+        "PRAGMA user_version = 26;
+         CREATE TABLE memories (
+            id INTEGER PRIMARY KEY,
+            session_id TEXT,
+            project TEXT NOT NULL,
+            topic_key TEXT,
+            title TEXT NOT NULL,
+            memory_type TEXT NOT NULL,
+            files TEXT,
+            created_at_epoch INTEGER NOT NULL,
+            updated_at_epoch INTEGER NOT NULL,
+            status TEXT NOT NULL DEFAULT 'active',
+            branch TEXT,
+            scope TEXT DEFAULT 'project',
+            search_context TEXT
+         );
+         CREATE TABLE sdk_sessions (id INTEGER PRIMARY KEY, content_session_id TEXT UNIQUE NOT NULL, memory_session_id TEXT NOT NULL, project TEXT, user_prompt TEXT, started_at TEXT, started_at_epoch INTEGER, status TEXT DEFAULT 'active', prompt_counter INTEGER DEFAULT 1);
+         CREATE TABLE observations (id INTEGER PRIMARY KEY, memory_session_id TEXT NOT NULL, project TEXT, type TEXT NOT NULL, title TEXT, subtitle TEXT, narrative TEXT, facts TEXT, concepts TEXT, files_read TEXT, files_modified TEXT, prompt_number INTEGER, created_at TEXT, created_at_epoch INTEGER, discovery_tokens INTEGER DEFAULT 0, status TEXT DEFAULT 'active', last_accessed_epoch INTEGER, branch TEXT, commit_sha TEXT);
+         CREATE TABLE session_summaries (id INTEGER PRIMARY KEY, memory_session_id TEXT NOT NULL, project TEXT, request TEXT, completed TEXT, decisions TEXT, learned TEXT, next_steps TEXT, preferences TEXT, prompt_number INTEGER, created_at TEXT, created_at_epoch INTEGER, discovery_tokens INTEGER DEFAULT 0);
+         CREATE TABLE pending_observations (id INTEGER PRIMARY KEY, session_id TEXT NOT NULL, project TEXT NOT NULL, tool_name TEXT NOT NULL, tool_input TEXT, tool_response TEXT, cwd TEXT, created_at_epoch INTEGER NOT NULL, updated_at_epoch INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'pending', attempt_count INTEGER NOT NULL DEFAULT 0, next_retry_epoch INTEGER, last_error TEXT, lease_owner TEXT, lease_expires_epoch INTEGER);
+         CREATE TABLE events (id INTEGER PRIMARY KEY, session_id TEXT NOT NULL, project TEXT NOT NULL, event_type TEXT NOT NULL, summary TEXT NOT NULL, detail TEXT, files TEXT, exit_code INTEGER, created_at_epoch INTEGER NOT NULL);
+         CREATE TABLE summarize_cooldown (project TEXT PRIMARY KEY, last_summarize_epoch INTEGER NOT NULL, last_message_hash TEXT);
+         CREATE TABLE summarize_locks (project TEXT PRIMARY KEY, lock_epoch INTEGER NOT NULL);
+         CREATE TABLE _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_epoch INTEGER NOT NULL
+         );",
+    )?;
+    for migration in &MIGRATIONS[..14] {
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, ?2, 1700000000)",
+            params![migration.version, migration.name],
+        )?;
+    }
+
+    let result = dry_run_pending(&conn)?;
+
+    assert_eq!(result.pending_count, 1);
+    let error = result.error.as_deref().unwrap_or("");
+    assert!(
+        !error.is_empty(),
+        "v015 post-migration hook failure should surface in dry-run"
+    );
+    assert!(error.contains("v015_rebuild_memory_search_context post-migration hook"));
+    assert!(error.contains("failed to rebuild memory search contexts"));
+    Ok(())
+}
+
+#[test]
 fn applied_versions_propagates_row_error() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     // TEXT column so we can insert a non-numeric value that fails i64 deserialization.

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -594,6 +594,47 @@ fn dry_run_pending_runs_hooks_against_complete_fts_clone() -> Result<()> {
 }
 
 #[test]
+fn dry_run_pending_clones_non_default_page_size_database() -> Result<()> {
+    let path = unique_temp_db_path("migrate-page-size");
+    {
+        let conn = Connection::open(&path)?;
+        conn.execute_batch("PRAGMA page_size = 8192; PRAGMA foreign_keys=ON;")?;
+        for migration in &MIGRATIONS[..14] {
+            conn.execute_batch(migration.sql)?;
+        }
+        conn.execute_batch(
+            "PRAGMA user_version = 26;
+             CREATE TABLE _schema_migrations (
+                version INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                applied_at_epoch INTEGER NOT NULL
+             );",
+        )?;
+        for migration in &MIGRATIONS[..14] {
+            conn.execute(
+                "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+                 VALUES (?1, ?2, 1700000000)",
+                params![migration.version, migration.name],
+            )?;
+        }
+
+        let page_size: i64 = conn.query_row("PRAGMA page_size", [], |row| row.get(0))?;
+        assert_eq!(page_size, 8192);
+
+        let result = dry_run_pending(&conn)?;
+
+        assert_eq!(result.pending_count, 1);
+        assert!(
+            result.error.is_none(),
+            "dry-run clone should preserve non-default source page size, got {:?}",
+            result.error
+        );
+    }
+    cleanup_temp_db_files(&path);
+    Ok(())
+}
+
+#[test]
 fn applied_versions_propagates_row_error() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     // TEXT column so we can insert a non-numeric value that fails i64 deserialization.

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -442,10 +442,10 @@ fn dry_run_pending_reports_backfill_error_for_broken_schema() -> Result<()> {
     Ok(())
 }
 
-/// Regression: clone_schema used to skip ALL underscore-prefixed tables but not
-/// their dependent indexes. A non-migration _-prefixed table with an explicit index
-/// caused clone_schema to fail with "no such table" because the table DDL was
-/// omitted while the index DDL was still executed.
+/// Regression: the old hand-written schema clone skipped ALL underscore-prefixed
+/// tables but not their dependent indexes. A non-migration _-prefixed table with
+/// an explicit index caused dry-run cloning to fail with "no such table" because
+/// the table DDL was omitted while the index DDL was still executed.
 #[test]
 fn dry_run_clones_non_migration_underscore_table_with_dependent_index() -> Result<()> {
     let conn = Connection::open_in_memory()?;
@@ -466,18 +466,17 @@ fn dry_run_clones_non_migration_underscore_table_with_dependent_index() -> Resul
     let result = dry_run_pending(&conn)?;
     assert!(
         result.error.is_none(),
-        "clone_schema must not fail for non-migration underscore tables with indexes: {:?}",
+        "dry-run clone must not fail for non-migration underscore tables with indexes: {:?}",
         result.error
     );
     Ok(())
 }
 
-/// Regression: clone_schema used SQL-prefix matching to identify _schema_migrations,
-/// which is sensitive to quoting. Bracket-quoted DDL (`CREATE TABLE [_schema_migrations]`)
-/// was not caught, allowing the internal table to bleed into the dry-run database.
-/// Matching on the unquoted `name` column from sqlite_master is immune to quoting.
+/// Regression: the old hand-written schema clone used SQL-prefix matching to
+/// identify _schema_migrations, which is sensitive to quoting. Bracket-quoted
+/// DDL (`CREATE TABLE [_schema_migrations]`) was not caught.
 #[test]
-fn dry_run_skips_schema_migrations_regardless_of_sql_quoting() -> Result<()> {
+fn dry_run_handles_schema_migrations_regardless_of_sql_quoting() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     conn.execute_batch("PRAGMA user_version = 13;")?;
     create_v13_schema_without_scope(&conn)?;
@@ -491,7 +490,7 @@ fn dry_run_skips_schema_migrations_regardless_of_sql_quoting() -> Result<()> {
     let result = dry_run_pending(&conn)?;
     assert!(
         result.error.is_none(),
-        "dry_run must not fail with bracket-quoted _schema_migrations: {:?}",
+        "dry-run clone must not fail with bracket-quoted _schema_migrations: {:?}",
         result.error
     );
     Ok(())
@@ -548,6 +547,49 @@ fn dry_run_pending_runs_post_migration_hooks() -> Result<()> {
     );
     assert!(error.contains("v015_rebuild_memory_search_context post-migration hook"));
     assert!(error.contains("failed to rebuild memory search contexts"));
+    Ok(())
+}
+
+#[test]
+fn dry_run_pending_runs_hooks_against_complete_fts_clone() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+    for migration in &MIGRATIONS[..14] {
+        conn.execute_batch(migration.sql)?;
+    }
+    conn.execute_batch(
+        "PRAGMA user_version = 26;
+         CREATE TABLE _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_epoch INTEGER NOT NULL
+         );",
+    )?;
+    for migration in &MIGRATIONS[..14] {
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, ?2, 1700000000)",
+            params![migration.version, migration.name],
+        )?;
+    }
+    conn.execute(
+        "INSERT INTO memories(project, topic_key, title, content, memory_type, files,
+            created_at_epoch, updated_at_epoch, status)
+         VALUES ('proj', 'dry-run-fts', 'Dry run FTS',
+            'Issue: dry-run hook update should not fail on memories_fts.',
+            'bugfix',
+            '[\"src/migrate/dry_run.rs\"]', 100, 100, 'active')",
+        [],
+    )?;
+
+    let result = dry_run_pending(&conn)?;
+
+    assert_eq!(result.pending_count, 1);
+    assert!(
+        result.error.is_none(),
+        "dry-run hook should run against complete FTS clone, got {:?}",
+        result.error
+    );
     Ok(())
 }
 

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -75,6 +75,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "procedure_verifications",
         sql: include_str!("../migrations/v014_procedure_verifications.sql"),
     },
+    Migration {
+        version: 15,
+        name: "rebuild_memory_search_context",
+        sql: include_str!("../migrations/v015_rebuild_memory_search_context.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v015_rebuild_memory_search_context.sql
+++ b/src/migrations/v015_rebuild_memory_search_context.sql
@@ -1,0 +1,6 @@
+-- v015_rebuild_memory_search_context: marker migration.
+--
+-- The Rust migration runner rebuilds `memories.search_context` for this version
+-- using memory::search_context::build_search_context so migrated rows get the
+-- same labeled, command, topic, and file hints as newly written rows.
+

--- a/src/migrations/v015_rebuild_memory_search_context.sql
+++ b/src/migrations/v015_rebuild_memory_search_context.sql
@@ -3,4 +3,3 @@
 -- The Rust migration runner rebuilds `memories.search_context` for this version
 -- using memory::search_context::build_search_context so migrated rows get the
 -- same labeled, command, topic, and file hints as newly written rows.
-


### PR DESCRIPTION
## Summary
- align memory candidate auto-promotion with the extractor default observation confidence
- score golden nDCG against unique matched evidence refs
- add a v15 migration hook to rebuild `search_context` with the same Rust extraction used for new memories
- treat model-declared memory candidate defer output as terminal for the worker retry loop

## Already covered on main
- lifecycle update/invalidate operations already run transactionally
- procedure promotion is wired from observation extraction
- procedure grouping uses event-time branch from captured events
- procedure verification history is persisted across extraction windows

## Verification
- `cargo test memory_candidate --lib`
- `cargo test eval::golden --lib`
- `cargo test migrate::tests --lib`
- `cargo test memory::lifecycle --lib`
- `cargo test memory::procedure --lib`
- `cargo test observation_extract --lib`
- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo test`