### PR TITLE
[codex] gate Codex context injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +276,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +326,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -467,6 +505,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1176,6 +1224,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "toml_edit",
  "tower-http",
@@ -1442,6 +1491,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1734,6 +1794,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tower-http = { version = "0.6.8", features = ["cors"] }
 getrandom = "0.3"
 toml_edit = "0.22"
 libc = "0.2"
+sha2 = "0.10"
 
 [profile.release]
 opt-level = "z"

--- a/docs/sessionstart-context-smoke.md
+++ b/docs/sessionstart-context-smoke.md
@@ -8,6 +8,17 @@ REMEM_CONTEXT_HOST=claude-code cargo run --quiet -- context --cwd /Users/lifcc/D
 REMEM_CONTEXT_DEBUG=1 REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/remem
 ```
 
+Codex duplicate-injection gate:
+
+```bash
+tmpdir="$(mktemp -d)"
+printf '{"session_id":"gate-smoke","cwd":"%s","transcript_path":"/tmp/remem-gate-smoke.jsonl"}' "$PWD" \
+  | REMEM_DATA_DIR="$tmpdir" REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context | wc -c
+printf '{"session_id":"gate-smoke","cwd":"%s","transcript_path":"/tmp/remem-gate-smoke.jsonl"}' "$PWD" \
+  | REMEM_DATA_DIR="$tmpdir" REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context | wc -c
+rm -rf "$tmpdir"
+```
+
 Expected checks:
 
 - Normal output has no `## Debug Trace` section.
@@ -15,3 +26,4 @@ Expected checks:
 - Project preferences render by default; global preferences require `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT`.
 - Long session requests are truncated inside the Sessions section.
 - Total truncation keeps the truncation marker and stats footer when both fit.
+- Codex gate smoke emits bytes on the first command and `0` bytes on the second unchanged same-session command.

--- a/docs/spec-codex-context-injection-gating-2026-05-25.md
+++ b/docs/spec-codex-context-injection-gating-2026-05-25.md
@@ -1,0 +1,582 @@
+# Spec: Codex Context Injection Gating
+
+**Status**: Draft
+**Date**: 2026-05-25
+**Related**: `docs/spec-context-compiler.md`, `docs/sessionstart-context-smoke.md`
+
+## 1. Background
+
+Codex runs `SessionStart` hooks at the start of an agent task/turn. The hook output is recorded as developer context in the conversation history, and later model requests are built from the accumulated session history.
+
+For remem, the installed Codex hook currently runs:
+
+```text
+REMEM_CONTEXT_HOST=codex-cli remem context
+```
+
+`remem context` renders a full startup context block every time it is invoked. In a single visible Codex thread, multiple user requests can create multiple tasks/turns. Each task can therefore append another full remem context block to the same conversation history.
+
+This is correct from Codex's hook lifecycle, but it is not the desired remem behavior.
+
+## 2. Problem
+
+Repeated full context injection causes:
+
+- prompt noise: the same preferences, core memories, workstreams, and sessions appear multiple times;
+- token waste: each injected block remains eligible for future prompts until compaction or truncation;
+- accidental re-weighting: repeated memories may look more important to the model than they are;
+- poor UX: users see memory text "inserted in the middle" of a long chat;
+- stale context risk: an old injected block can stay in history after a newer block is injected.
+
+The core issue is not retrieval quality. It is lifecycle mismatch:
+
+```text
+remem assumes SessionStart means one visible conversation start
+Codex uses SessionStart for task/turn startup inside a persistent thread
+```
+
+## 3. Goals
+
+- Prevent duplicate full `remem context` blocks in the same Codex thread.
+- Preserve high-quality first-turn context for new Codex sessions.
+- Allow updated context to appear only when it materially changes.
+- Keep the behavior deterministic and testable without vectors or external services.
+- Keep failures safe: if gating state cannot be read or written, output the context and log the reason.
+- Provide debug visibility so users can prove why context was emitted or suppressed.
+- Keep Claude Code behavior unchanged unless explicitly enabled later.
+
+## 4. Non-Goals
+
+- No vector/reranker/hybrid retrieval change.
+- No change to MCP tool contracts.
+- No deletion or mutation of memories as part of injection gating.
+- No Codex source patch in this work.
+- No attempt to suppress Codex's own conversation history.
+- No silent loss of first-turn context.
+- No global one-context-per-project rule; independent Codex sessions must still get startup context.
+
+## 5. Design Principle
+
+SessionStart output should be **idempotent per Codex conversation**, not per process invocation.
+
+The renderer still builds a high-quality context block. A new gate decides whether that block should be printed to stdout:
+
+```text
+hook stdin / CLI args
+  -> ContextInvocation
+  -> render candidate context
+  -> fingerprint candidate context
+  -> ContextInjectionGate
+  -> emit full context | emit compact update | emit nothing
+```
+
+No stdout means no developer context is injected by Codex. Diagnostics must go to remem logs or debug-only stderr, not stdout.
+
+## 6. Current Code Anchors
+
+| Area | Current behavior |
+| --- | --- |
+| `src/install/config.rs` | Installs Codex `SessionStart` as `REMEM_CONTEXT_HOST=codex-cli remem context`. |
+| `src/cli/types.rs` | `context` already accepts `--session_id`, `--host`, `--debug`, but install does not pass session data. |
+| `src/cli/dispatch.rs` | `Commands::Context` calls `context::generate_context(...)` directly and does not parse hook stdin. |
+| `src/context/render.rs` | Opens DB, loads context data, renders all sections, prints to stdout. |
+| `src/context/host.rs` | Codex profile is host-aware and already records that Codex is Stop/context-focused. |
+| `docs/spec-context-compiler.md` | Defines the desired host-aware context compiler direction. |
+
+## 7. Proposed Behavior
+
+### 7.1 Default Codex Policy
+
+For `REMEM_CONTEXT_HOST=codex-cli`:
+
+1. First invocation for a Codex session emits full context.
+2. Later invocations for the same session emit nothing if the rendered context fingerprint is unchanged.
+3. Later invocations may emit a compact update only when the fingerprint changes.
+4. If the session cannot be identified, use a short fallback cooldown keyed by host + project + cwd + transcript path when available.
+5. If gating fails due to DB or state errors, emit full context and log `gate=fail_open`.
+
+For `claude-code` and `unknown`:
+
+- preserve current behavior in the first implementation slice;
+- allow future opt-in via env var after Codex behavior is stable.
+
+### 7.2 Full Context
+
+The full context is the existing rendered output:
+
+```text
+# [project @branch] context ...
+Use `search`/`get_observations` ...
+...
+context memories loaded ...
+```
+
+It is emitted when:
+
+- no prior successful full context exists for the same injection key;
+- the caller uses `REMEM_CONTEXT_GATE=off`;
+- debug smoke tests explicitly request `--debug --force`;
+- gating state cannot be trusted and fail-open applies.
+
+### 7.3 Suppressed Context
+
+When context is unchanged for the same Codex session, stdout must be empty.
+
+Log line:
+
+```text
+[context-gate] suppress host=codex-cli key=... reason=same_hash age=...s hash=...
+```
+
+The log is enough for diagnosis. Printing a "context skipped" message to stdout would still be injected into Codex history, so it is not allowed by default.
+
+### 7.4 Compact Update
+
+When the rendered context fingerprint changed within the same session, default behavior should still be conservative:
+
+- emit a compact update, not the full block;
+- include only changed section names, counts, and retrieval instruction;
+- stay under `REMEM_CONTEXT_DELTA_CHAR_LIMIT` default `1200`.
+
+Example:
+
+```text
+# [project @branch] remem context update
+Memory context changed since the last injection. Use `search`/`get_observations` for details.
+
+Changed sections: preferences, workstreams
+Stats: 16 memories, 6 core, 10 indexed, 11 preferences, 5 sessions.
+```
+
+Rationale: a long-running Codex thread already has prior full context in history. The update should inform the model that retrievable context changed without duplicating the whole memory map.
+
+## 8. Identity Model
+
+### 8.1 Hook Input Parsing
+
+Add a lightweight hook envelope parser for `remem context`.
+
+Codex `SessionStart` hook input can include:
+
+```json
+{
+  "session_id": "...",
+  "cwd": "...",
+  "transcript_path": "...",
+  "model": "...",
+  "target": {
+    "type": "SessionStart",
+    "source": "Startup"
+  }
+}
+```
+
+The parser must:
+
+- read stdin with a short timeout, reusing the existing `read_stdin_with_timeout` pattern;
+- accept empty stdin for manual CLI use;
+- prefer CLI args over stdin values when both exist;
+- never log the full raw stdin payload unless debug is enabled and truncated.
+
+Proposed type:
+
+```rust
+pub(super) struct ContextInvocation {
+    pub cwd: String,
+    pub project: String,
+    pub session_id: Option<String>,
+    pub transcript_path: Option<String>,
+    pub host: HostKind,
+    pub source: Option<String>,
+    pub model: Option<String>,
+    pub force: bool,
+    pub debug: bool,
+}
+```
+
+### 8.2 Injection Key
+
+Primary key:
+
+```text
+host + session_id + project
+```
+
+Fallback key when `session_id` is missing:
+
+```text
+host + project + normalized_cwd + transcript_path_hash
+```
+
+Last fallback:
+
+```text
+host + project + normalized_cwd
+```
+
+The last fallback must use a short cooldown because it can group unrelated manual invocations.
+
+## 9. State Storage
+
+Add a small runtime table to the main remem DB:
+
+```sql
+CREATE TABLE IF NOT EXISTS context_injections (
+    id INTEGER PRIMARY KEY,
+    host TEXT NOT NULL,
+    project TEXT NOT NULL,
+    injection_key TEXT NOT NULL,
+    session_id TEXT,
+    transcript_path TEXT,
+    context_hash TEXT NOT NULL,
+    output_mode TEXT NOT NULL,
+    output_chars INTEGER NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    last_emitted_epoch INTEGER NOT NULL,
+    emit_count INTEGER NOT NULL DEFAULT 1,
+    suppress_count INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(host, injection_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_context_injections_project_seen
+    ON context_injections(project, updated_at_epoch DESC);
+```
+
+`output_mode` values:
+
+- `full`
+- `delta`
+- `suppressed`
+- `fail_open`
+
+State retention:
+
+- keep at least 30 days;
+- delete rows older than `REMEM_CONTEXT_GATE_RETENTION_DAYS`, default `30`;
+- cleanup can run opportunistically during context gate evaluation.
+
+## 10. Fingerprint
+
+Hash the rendered candidate context after:
+
+- section rendering;
+- total char limit enforcement;
+- stats footer generation.
+
+Do not include:
+
+- wall-clock timestamp in the header;
+- debug trace;
+- ANSI colors.
+
+If the existing header contains a timestamp, the fingerprint function must normalize it before hashing. Otherwise unchanged memories would look changed every invocation.
+
+Recommended fingerprint input:
+
+```text
+host
+project
+branch
+retrieval_hint
+preferences section body
+core section body
+index section body
+workstreams section body
+sessions section body
+stats excluding total chars if affected only by timestamp
+```
+
+Use SHA-256 rather than `DefaultHasher`, because this is persisted across process runs.
+
+## 11. Configuration
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `REMEM_CONTEXT_GATE` | `auto` | `auto`, `off`, `strict`, `delta` |
+| `REMEM_CONTEXT_GATE_HOSTS` | `codex-cli` | Comma-separated hosts where gating applies. |
+| `REMEM_CONTEXT_GATE_FALLBACK_COOLDOWN_SECS` | `900` | Cooldown when no session id exists. |
+| `REMEM_CONTEXT_DELTA_CHAR_LIMIT` | `1200` | Max chars for compact update output. |
+| `REMEM_CONTEXT_GATE_RETENTION_DAYS` | `30` | State retention. |
+| `REMEM_CONTEXT_FORCE` | `0` | Emit full context and update gate state. |
+| `REMEM_CONTEXT_GATE_DEBUG` | `0` | Log gate decision details. |
+
+Mode semantics:
+
+- `auto`: full once per session, suppress unchanged repeats, delta on changed hash.
+- `off`: always emit full context; matches current behavior.
+- `strict`: full once per session, suppress all later repeats even if hash changes.
+- `delta`: same as auto, but always prefer delta over full after first emission.
+
+CLI additions:
+
+```text
+remem context --force
+remem context --gate off|auto|strict|delta
+```
+
+The CLI flags override env vars.
+
+## 12. Algorithm
+
+```text
+run context command
+  parse CLI args
+  parse hook stdin with timeout
+  resolve ContextInvocation
+  build ContextRequest
+  render candidate context into String, not stdout
+  if host not gated:
+      print candidate
+      return
+  compute normalized context hash
+  load context_injections row by host + injection_key
+  if force or no row:
+      upsert row output_mode=full, hash=current_hash, emit_count += 1
+      print full candidate
+      return
+  if row.context_hash == current_hash:
+      update suppress_count += 1, updated_at_epoch=now, output_mode=suppressed
+      print nothing
+      return
+  if gate mode strict:
+      update suppress_count += 1, context_hash=current_hash, output_mode=suppressed
+      print nothing
+      return
+  build compact delta
+  update row context_hash=current_hash, output_mode=delta, emit_count += 1
+  print compact delta
+```
+
+Important: "print nothing" means no stdout at all, including trailing newline.
+
+## 13. Failure Policy
+
+This feature must be fail-open for first-turn context quality.
+
+| Failure | Behavior |
+| --- | --- |
+| Cannot read stdin | Continue with CLI/env/cwd values. |
+| Cannot parse stdin | Continue, log truncated parse error. |
+| Cannot open DB | Existing `render_empty_state` behavior can stay for no-data cases; gate logs `fail_open_no_db`. |
+| Cannot read gate table | Print full candidate, log `fail_open_gate_read`. |
+| Cannot write gate row | Print full candidate, log `fail_open_gate_write`. |
+| Cannot hash context | Print full candidate, log `fail_open_hash`. |
+
+Do not silently suppress context on errors.
+
+## 14. Implementation Plan
+
+### Step 1: Render-to-buffer boundary
+
+Refactor `src/context/render.rs`:
+
+- keep `generate_context(...) -> Result<()>` as CLI boundary;
+- add `render_context(request: &ContextRequest) -> Result<RenderedContext>`;
+- move `print!("{}", output)` to the outer boundary;
+- include stats and section metadata in `RenderedContext`.
+
+Suggested type:
+
+```rust
+pub(super) struct RenderedContext {
+    pub output: String,
+    pub stats: ContextRenderStats,
+    pub section_hash_inputs: Vec<SectionHashInput>,
+}
+```
+
+### Step 2: Context hook input parser
+
+Add `src/context/invocation.rs`:
+
+- parse CLI args + optional stdin;
+- reuse or extract `read_stdin_with_timeout`;
+- produce `ContextInvocation`;
+- unit-test empty stdin, Codex stdin, CLI override, malformed JSON.
+
+### Step 3: Gate state module
+
+Add `src/context/gate.rs`:
+
+- `ContextGateMode`;
+- `ContextInjectionKey`;
+- `ContextFingerprint`;
+- `ContextGateDecision`;
+- `evaluate_context_gate(conn, invocation, rendered)`.
+
+Keep SQL isolated in this module.
+
+### Step 4: Migration
+
+Add migration:
+
+```text
+v016_context_injection_gate.sql
+```
+
+Update:
+
+- `src/migrate/types.rs`
+- `src/migrate/tests.rs`
+- any schema status checks if needed.
+
+### Step 5: CLI and install updates
+
+Update:
+
+- `src/cli/types.rs`: add `--force`, `--gate`.
+- `src/cli/dispatch.rs`: route through invocation parser and gate.
+- `src/install/config.rs`: keep command simple if stdin parsing works.
+- `src/install/tests.rs`: assert Codex hook command remains host-tagged.
+
+Do not add shell redirection in the installed hook. Suppression belongs in remem, not in the hook command.
+
+### Step 6: Smoke docs
+
+Update `docs/sessionstart-context-smoke.md` with:
+
+```bash
+printf '{"session_id":"sess-1","cwd":"%s","transcript_path":"/tmp/codex.jsonl"}' "$PWD" \
+  | REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context
+
+printf '{"session_id":"sess-1","cwd":"%s","transcript_path":"/tmp/codex.jsonl"}' "$PWD" \
+  | REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context | wc -c
+```
+
+Expected:
+
+- first command emits full context;
+- second command emits `0` bytes when context hash is unchanged.
+
+## 15. Tests
+
+### Unit Tests
+
+Context invocation:
+
+- parses Codex `SessionStart` JSON stdin;
+- empty stdin falls back to cwd;
+- CLI `--cwd` and `--session_id` override stdin;
+- malformed stdin logs but does not fail the command.
+
+Fingerprint:
+
+- same context with different header timestamps has the same hash;
+- changed preference/core/workstream/session content changes the hash;
+- debug trace does not affect the hash.
+
+Gate:
+
+- first Codex invocation emits full context;
+- second same-session same-hash invocation emits empty stdout;
+- same session changed hash emits delta in `auto`;
+- same session changed hash emits empty stdout in `strict`;
+- `REMEM_CONTEXT_GATE=off` emits full every time;
+- missing session id uses fallback cooldown;
+- DB write failure fail-opens.
+
+Migration:
+
+- full migration on empty DB includes `context_injections`;
+- migration SQL has no non-constant ALTER defaults;
+- migration is idempotent.
+
+### Integration / Smoke
+
+Run:
+
+```bash
+cargo fmt --check
+cargo check
+cargo test context:: --lib
+cargo test migrate:: --lib
+cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tool/remem --host codex-cli --force
+printf '{"session_id":"gate-smoke","cwd":"/Users/lifcc/Desktop/code/AI/tool/remem","transcript_path":"/tmp/remem-gate-smoke.jsonl"}' \
+  | REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context | wc -c
+printf '{"session_id":"gate-smoke","cwd":"/Users/lifcc/Desktop/code/AI/tool/remem","transcript_path":"/tmp/remem-gate-smoke.jsonl"}' \
+  | REMEM_CONTEXT_HOST=codex-cli cargo run --quiet -- context | wc -c
+```
+
+Expected:
+
+- first `wc -c` is greater than `0`;
+- second `wc -c` is `0` when no context changed.
+
+Before submission:
+
+```bash
+cargo test
+cargo clippy -- -D warnings
+```
+
+## 16. Observability
+
+Add log lines with stable fields:
+
+```text
+[context-gate] emit host=codex-cli key=... mode=full hash=... chars=...
+[context-gate] suppress host=codex-cli key=... reason=same_hash hash=...
+[context-gate] emit host=codex-cli key=... mode=delta old_hash=... new_hash=... chars=...
+[context-gate] fail_open host=codex-cli reason=gate_write error=...
+```
+
+Extend debug trace only when `REMEM_CONTEXT_DEBUG=1` or `--debug`:
+
+```text
+## Debug Trace
+- gate mode=auto decision=suppressed key=... hash=...
+```
+
+Do not include gate debug trace in suppressed stdout. Suppressed means empty stdout.
+
+## 17. Backward Compatibility
+
+- Existing installed hooks keep working.
+- Manual `remem context --cwd .` still prints full context unless host gating applies.
+- `REMEM_CONTEXT_GATE=off` restores old behavior.
+- Existing DBs migrate forward without data loss.
+- No change to memory selection, scoring, or rendering quality in this spec.
+
+## 18. Rollout
+
+1. Land render-to-buffer and hook input parser behind no behavior change.
+2. Land gate table and code with default `REMEM_CONTEXT_GATE=off` in tests only.
+3. Enable default gating for `codex-cli`.
+4. Run local Codex transcript smoke:
+   - start a thread;
+   - verify first task injects full context;
+   - send a second user message in the same thread;
+   - verify no duplicate remem developer block appears when hash is unchanged.
+5. Update README / architecture docs after behavior is verified.
+
+## 19. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| First task loses context due to bad gate state | fail-open; `--force`; `REMEM_CONTEXT_GATE=off`. |
+| Different Codex sessions collapse into one fallback key | prefer `session_id`; fallback cooldown only when session id missing. |
+| Context changes are hidden too aggressively | default `auto` emits compact delta on hash change. |
+| Timestamp makes every hash different | normalize timestamp before hashing. |
+| Debug output gets injected | debug trace only when emitting; suppressed stdout stays empty. |
+| State table grows forever | retention cleanup default 30 days. |
+
+## 20. Open Questions
+
+- Should `delta` include changed section item titles, or only section names and counts?
+- Should `claude-code` opt into the same gate after Codex behavior proves stable?
+- Should `remem doctor --target codex` report duplicate context injection count from `context_injections`?
+- Should `remem status` expose recent gate suppressions and fail-open events?
+
+## 21. Recommended First Slice
+
+The first implementation slice should be deliberately small:
+
+1. parse Codex hook stdin for `session_id`, `cwd`, and `transcript_path`;
+2. render context to a buffer;
+3. persist `context_injections`;
+4. for `codex-cli`, emit full once per `session_id + project`, suppress identical repeats;
+5. add `REMEM_CONTEXT_GATE=off` escape hatch;
+6. add unit tests and the two-command smoke check.
+
+Do not implement rich delta rendering in the first slice unless the suppress/full behavior is already stable.

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -18,12 +18,13 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             host,
             color,
             debug,
+            force,
+            gate,
         } => {
             if remem_hooks_disabled() {
                 return Ok(());
             }
-            let cwd = resolve_cwd_arg(cwd);
-            context::generate_context(&cwd, session_id.as_deref(), color, host.as_deref(), debug)?;
+            context::generate_context_from_cli(cwd, session_id, color, host, debug, force, gate)?;
         }
         Commands::SessionInit => {
             if remem_hooks_disabled() {

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -27,6 +27,10 @@ pub(super) enum Commands {
         color: bool,
         #[arg(long)]
         debug: bool,
+        #[arg(long)]
+        force: bool,
+        #[arg(long)]
+        gate: Option<String>,
     },
     SessionInit,
     Observe,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,8 @@
 pub mod claude_memory;
 mod format;
 mod host;
+mod injection_gate;
+mod invocation;
 mod memory_traits;
 mod policy;
 mod query;
@@ -11,4 +13,4 @@ mod sections;
 mod tests;
 mod types;
 
-pub use render::generate_context;
+pub use render::{generate_context, generate_context_from_cli};

--- a/src/context/host.rs
+++ b/src/context/host.rs
@@ -39,7 +39,6 @@ pub(super) struct RetrievalHints {
 }
 
 pub(super) trait ContextHostProfile {
-    fn host(&self) -> HostKind;
     fn capabilities(&self) -> HostCapabilities;
     fn default_policy(&self) -> ContextPolicy;
     fn retrieval_hints(&self) -> RetrievalHints;
@@ -50,10 +49,6 @@ pub(super) struct CodexCliContextProfile;
 pub(super) struct UnknownContextProfile;
 
 impl ContextHostProfile for ClaudeCodeContextProfile {
-    fn host(&self) -> HostKind {
-        HostKind::ClaudeCode
-    }
-
     fn capabilities(&self) -> HostCapabilities {
         HostCapabilities {
             has_mcp_tools: true,
@@ -76,10 +71,6 @@ impl ContextHostProfile for ClaudeCodeContextProfile {
 }
 
 impl ContextHostProfile for CodexCliContextProfile {
-    fn host(&self) -> HostKind {
-        HostKind::CodexCli
-    }
-
     fn capabilities(&self) -> HostCapabilities {
         HostCapabilities {
             has_mcp_tools: true,
@@ -102,10 +93,6 @@ impl ContextHostProfile for CodexCliContextProfile {
 }
 
 impl ContextHostProfile for UnknownContextProfile {
-    fn host(&self) -> HostKind {
-        HostKind::Unknown
-    }
-
     fn capabilities(&self) -> HostCapabilities {
         HostCapabilities {
             has_mcp_tools: true,

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -1,0 +1,406 @@
+use anyhow::Result;
+use rusqlite::{params, OptionalExtension};
+use sha2::{Digest, Sha256};
+
+use super::host::HostKind;
+use super::invocation::ContextInvocation;
+
+const DEFAULT_GATE_HOSTS: &str = "codex-cli";
+const DEFAULT_FALLBACK_COOLDOWN_SECS: i64 = 900;
+const DEFAULT_RETENTION_DAYS: i64 = 30;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContextGateMode {
+    Auto,
+    Off,
+    Strict,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ContextGateAction {
+    Bypassed,
+    EmittedFull,
+    Suppressed,
+    FailOpen,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ContextGateDecision {
+    pub output: String,
+    pub action: ContextGateAction,
+    pub reason: &'static str,
+}
+
+#[derive(Debug)]
+struct GateRow {
+    context_hash: String,
+    updated_at_epoch: i64,
+}
+
+pub(super) fn apply_context_gate(
+    invocation: &ContextInvocation,
+    output: String,
+) -> ContextGateDecision {
+    if output.is_empty() {
+        return decision(output, ContextGateAction::Bypassed, "empty_output");
+    }
+    if !host_is_gated(invocation.host) {
+        return decision(output, ContextGateAction::Bypassed, "host_not_gated");
+    }
+
+    let mode = resolve_gate_mode(invocation.gate_mode.as_deref());
+    if mode == ContextGateMode::Off {
+        return decision(output, ContextGateAction::Bypassed, "gate_off");
+    }
+
+    let hash = context_fingerprint(&output);
+    let key = injection_key(invocation);
+    let now = chrono::Utc::now().timestamp();
+    let conn = match crate::db::open_db() {
+        Ok(conn) => conn,
+        Err(error) => {
+            crate::log::warn(
+                "context-gate",
+                &format!("fail_open reason=open_db error={}", error),
+            );
+            return decision(output, ContextGateAction::FailOpen, "open_db");
+        }
+    };
+
+    cleanup_old_rows(&conn, now);
+    let row = match load_gate_row(&conn, invocation.host.as_env_value(), &key) {
+        Ok(row) => row,
+        Err(error) => {
+            crate::log::warn(
+                "context-gate",
+                &format!("fail_open reason=gate_read error={}", error),
+            );
+            return decision(output, ContextGateAction::FailOpen, "gate_read");
+        }
+    };
+
+    let Some(row) = row else {
+        return match upsert_emit_row(&conn, invocation, &key, &hash, output.chars().count(), now) {
+            Ok(()) => {
+                log_gate("emit", invocation, &key, "full", &hash);
+                decision(output, ContextGateAction::EmittedFull, "first_or_forced")
+            }
+            Err(error) => fail_open(output, "gate_write", error),
+        };
+    };
+
+    if invocation.force {
+        return match upsert_emit_row(&conn, invocation, &key, &hash, output.chars().count(), now) {
+            Ok(()) => {
+                log_gate("emit", invocation, &key, "full", &hash);
+                decision(output, ContextGateAction::EmittedFull, "first_or_forced")
+            }
+            Err(error) => fail_open(output, "gate_write", error),
+        };
+    }
+    if row.context_hash == hash && fallback_cooldown_allows_suppression(invocation, &row, now) {
+        return match record_suppression(&conn, invocation.host.as_env_value(), &key, now) {
+            Ok(()) => {
+                log_gate("suppress", invocation, &key, "same_hash", &hash);
+                decision(String::new(), ContextGateAction::Suppressed, "same_hash")
+            }
+            Err(error) => fail_open(output, "gate_write", error),
+        };
+    }
+
+    if mode == ContextGateMode::Strict {
+        return match record_suppression(&conn, invocation.host.as_env_value(), &key, now) {
+            Ok(()) => {
+                log_gate("suppress", invocation, &key, "strict", &hash);
+                decision(String::new(), ContextGateAction::Suppressed, "strict")
+            }
+            Err(error) => fail_open(output, "gate_write", error),
+        };
+    }
+
+    match upsert_emit_row(&conn, invocation, &key, &hash, output.chars().count(), now) {
+        Ok(()) => {
+            log_gate("emit", invocation, &key, "changed_hash", &hash);
+            decision(output, ContextGateAction::EmittedFull, "changed_hash")
+        }
+        Err(error) => fail_open(output, "gate_write", error),
+    }
+}
+
+fn decision(
+    output: String,
+    action: ContextGateAction,
+    reason: &'static str,
+) -> ContextGateDecision {
+    ContextGateDecision {
+        output,
+        action,
+        reason,
+    }
+}
+
+fn fail_open(output: String, reason: &'static str, error: anyhow::Error) -> ContextGateDecision {
+    crate::log::warn(
+        "context-gate",
+        &format!("fail_open reason={} error={}", reason, error),
+    );
+    decision(output, ContextGateAction::FailOpen, reason)
+}
+
+fn resolve_gate_mode(cli_value: Option<&str>) -> ContextGateMode {
+    let env_value = std::env::var("REMEM_CONTEXT_GATE").ok();
+    cli_value
+        .or(env_value.as_deref())
+        .and_then(parse_gate_mode)
+        .unwrap_or(ContextGateMode::Auto)
+}
+
+fn parse_gate_mode(value: &str) -> Option<ContextGateMode> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "auto" | "delta" => Some(ContextGateMode::Auto),
+        "off" | "false" | "0" => Some(ContextGateMode::Off),
+        "strict" => Some(ContextGateMode::Strict),
+        _ => None,
+    }
+}
+
+fn host_is_gated(host: HostKind) -> bool {
+    let hosts = std::env::var("REMEM_CONTEXT_GATE_HOSTS")
+        .unwrap_or_else(|_| DEFAULT_GATE_HOSTS.to_string());
+    hosts
+        .split(',')
+        .map(|host| host.trim())
+        .any(|candidate| candidate == host.as_env_value())
+}
+
+fn fallback_cooldown_allows_suppression(
+    invocation: &ContextInvocation,
+    row: &GateRow,
+    now: i64,
+) -> bool {
+    if invocation.session_id.is_some() {
+        return true;
+    }
+    let cooldown = read_i64_env(
+        "REMEM_CONTEXT_GATE_FALLBACK_COOLDOWN_SECS",
+        DEFAULT_FALLBACK_COOLDOWN_SECS,
+    );
+    now.saturating_sub(row.updated_at_epoch) <= cooldown
+}
+
+fn read_i64_env(key: &str, default: i64) -> i64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|value| value.parse::<i64>().ok())
+        .filter(|value| *value >= 0)
+        .unwrap_or(default)
+}
+
+fn cleanup_old_rows(conn: &rusqlite::Connection, now: i64) {
+    let retention_days = read_i64_env("REMEM_CONTEXT_GATE_RETENTION_DAYS", DEFAULT_RETENTION_DAYS);
+    let cutoff = now.saturating_sub(retention_days.saturating_mul(86_400));
+    if let Err(error) = conn.execute(
+        "DELETE FROM context_injections WHERE updated_at_epoch < ?1",
+        [cutoff],
+    ) {
+        crate::log::warn(
+            "context-gate",
+            &format!("retention cleanup failed: {}", error),
+        );
+    }
+}
+
+fn load_gate_row(conn: &rusqlite::Connection, host: &str, key: &str) -> Result<Option<GateRow>> {
+    conn.query_row(
+        "SELECT context_hash, updated_at_epoch
+         FROM context_injections
+         WHERE host = ?1 AND injection_key = ?2",
+        params![host, key],
+        |row| {
+            Ok(GateRow {
+                context_hash: row.get(0)?,
+                updated_at_epoch: row.get(1)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn upsert_emit_row(
+    conn: &rusqlite::Connection,
+    invocation: &ContextInvocation,
+    key: &str,
+    hash: &str,
+    output_chars: usize,
+    now: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO context_injections
+         (host, project, injection_key, session_id, transcript_path, context_hash, output_mode,
+          output_chars, created_at_epoch, updated_at_epoch, last_emitted_epoch, emit_count,
+          suppress_count)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'full', ?7, ?8, ?8, ?8, 1, 0)
+         ON CONFLICT(host, injection_key) DO UPDATE SET
+          project = excluded.project,
+          session_id = excluded.session_id,
+          transcript_path = excluded.transcript_path,
+          context_hash = excluded.context_hash,
+          output_mode = 'full',
+          output_chars = excluded.output_chars,
+          updated_at_epoch = excluded.updated_at_epoch,
+          last_emitted_epoch = excluded.last_emitted_epoch,
+          emit_count = context_injections.emit_count + 1",
+        params![
+            invocation.host.as_env_value(),
+            invocation.project,
+            key,
+            invocation.session_id,
+            invocation.transcript_path,
+            hash,
+            output_chars as i64,
+            now,
+        ],
+    )?;
+    Ok(())
+}
+
+fn record_suppression(conn: &rusqlite::Connection, host: &str, key: &str, now: i64) -> Result<()> {
+    conn.execute(
+        "UPDATE context_injections
+         SET output_mode = 'suppressed',
+             updated_at_epoch = ?3,
+             suppress_count = suppress_count + 1
+         WHERE host = ?1 AND injection_key = ?2",
+        params![host, key, now],
+    )?;
+    Ok(())
+}
+
+fn injection_key(invocation: &ContextInvocation) -> String {
+    if let Some(session_id) = invocation.session_id.as_deref() {
+        return format!("session:{}:{}", invocation.project, session_id);
+    }
+    if let Some(transcript_path) = invocation.transcript_path.as_deref() {
+        return format!(
+            "fallback:{}:{}:{}",
+            invocation.project,
+            invocation.cwd,
+            sha256_hex(transcript_path)
+        );
+    }
+    format!("fallback:{}:{}", invocation.project, invocation.cwd)
+}
+
+fn context_fingerprint(output: &str) -> String {
+    sha256_hex(&normalize_context_for_hash(output))
+}
+
+fn normalize_context_for_hash(output: &str) -> String {
+    let without_debug = output
+        .find("\n## Debug Trace\n")
+        .map(|idx| &output[..idx])
+        .unwrap_or(output);
+    let mut normalized = String::new();
+    for (idx, line) in without_debug.lines().enumerate() {
+        if idx == 0 {
+            if let Some(prefix_end) = line.find("] context ") {
+                normalized.push_str(&line[..prefix_end + "] context ".len()]);
+                normalized.push_str("<timestamp>\n");
+                continue;
+            }
+        }
+        normalized.push_str(line);
+        normalized.push('\n');
+    }
+    normalized
+}
+
+fn sha256_hex(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push_str(&format!("{:02x}", byte));
+    }
+    out
+}
+
+fn log_gate(action: &str, invocation: &ContextInvocation, key: &str, reason: &str, hash: &str) {
+    crate::log::info(
+        "context-gate",
+        &format!(
+            "{} host={} key={} reason={} hash={} project={}",
+            action,
+            invocation.host.as_env_value(),
+            key,
+            reason,
+            hash,
+            invocation.project
+        ),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_conn() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(include_str!(
+            "../migrations/v016_context_injection_gate.sql"
+        ))
+        .unwrap();
+        conn
+    }
+
+    fn invocation(session_id: Option<&str>) -> ContextInvocation {
+        ContextInvocation {
+            cwd: "/tmp/remem".to_string(),
+            project: "/tmp/remem".to_string(),
+            session_id: session_id.map(str::to_string),
+            transcript_path: Some("/tmp/remem.jsonl".to_string()),
+            host: HostKind::CodexCli,
+            use_colors: false,
+            debug: false,
+            force: false,
+            gate_mode: None,
+        }
+    }
+
+    #[test]
+    fn fingerprint_ignores_header_timestamp() {
+        let a = "# [/tmp/remem] context 2026-05-25 1:00pm\nBody\n";
+        let b = "# [/tmp/remem] context 2026-05-25 2:00pm\nBody\n";
+
+        assert_eq!(context_fingerprint(a), context_fingerprint(b));
+    }
+
+    #[test]
+    fn first_same_session_context_emits_and_second_suppresses() {
+        let conn = setup_conn();
+        let invocation = invocation(Some("sess-1"));
+        let key = injection_key(&invocation);
+        let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
+
+        assert!(load_gate_row(&conn, invocation.host.as_env_value(), &key)
+            .unwrap()
+            .is_none());
+        upsert_emit_row(&conn, &invocation, &key, &hash, 32, 100).unwrap();
+        let row = load_gate_row(&conn, invocation.host.as_env_value(), &key)
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.context_hash, hash);
+
+        record_suppression(&conn, invocation.host.as_env_value(), &key, 101).unwrap();
+        let suppress_count: i64 = conn
+            .query_row(
+                "SELECT suppress_count FROM context_injections WHERE host = ?1 AND injection_key = ?2",
+                params![invocation.host.as_env_value(), key],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(suppress_count, 1);
+    }
+}

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -152,11 +152,32 @@ pub(super) fn apply_context_gate(
             Err(error) => fail_open(output, "gate_write", error),
         };
     }
-    if row.context_hash == hash && fallback_cooldown_allows_suppression(invocation, &row, now) {
-        return match record_suppression(&conn, invocation, &key, now) {
+    if row.context_hash == hash {
+        if fallback_cooldown_allows_suppression(invocation, &row, now) {
+            return match record_suppression(&conn, invocation, &key, now) {
+                Ok(()) => {
+                    log_gate("suppress", invocation, &key, "same_hash", &hash);
+                    decision(String::new(), ContextGateAction::Suppressed, "same_hash")
+                }
+                Err(error) => fail_open(output, "gate_write", error),
+            };
+        }
+        return match upsert_emit_row(
+            &conn,
+            invocation,
+            &key,
+            &hash,
+            "full",
+            output.chars().count(),
+            now,
+        ) {
             Ok(()) => {
-                log_gate("suppress", invocation, &key, "same_hash", &hash);
-                decision(String::new(), ContextGateAction::Suppressed, "same_hash")
+                log_gate("emit", invocation, &key, "fallback_cooldown_expired", &hash);
+                decision(
+                    output,
+                    ContextGateAction::EmittedFull,
+                    "fallback_cooldown_expired",
+                )
             }
             Err(error) => fail_open(output, "gate_write", error),
         };
@@ -693,54 +714,6 @@ mod tests {
         assert_eq!(restart.action, ContextGateAction::EmittedFull);
         assert_eq!(restart.reason, "restart_source");
         assert_eq!(restart.output, output);
-    }
-
-    #[test]
-    fn delta_mode_emits_compact_changed_hash() -> Result<()> {
-        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-delta");
-        let mut invocation = invocation(Some("sess-delta"));
-        invocation.gate_mode = Some("delta".to_string());
-        let first_output = "# [/tmp/remem] context now\nBody A\n".to_string();
-        let first = apply_context_gate(&invocation, first_output);
-        assert_eq!(first.action, ContextGateAction::EmittedFull);
-
-        let changed_output = format!(
-            "# [/tmp/remem] context later\n{}\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=3000 chars/~750 tokens limit=12000 truncated=no\n",
-            "Body B ".repeat(400)
-        );
-        let second = apply_context_gate(&invocation, changed_output.clone());
-        assert_eq!(second.action, ContextGateAction::EmittedDelta);
-        assert_eq!(second.reason, "changed_hash");
-        assert_ne!(second.output, changed_output);
-        assert!(second.output.contains("context delta"));
-        assert!(second.output.chars().count() <= 1200);
-
-        let key = injection_key(&invocation);
-        let mode: String = crate::db::open_db()?.query_row(
-            "SELECT output_mode FROM context_injections WHERE host = ?1 AND injection_key = ?2",
-            params![invocation.host.as_env_value(), key],
-            |row| row.get(0),
-        )?;
-        assert_eq!(mode, "delta");
-        Ok(())
-    }
-
-    #[test]
-    fn auto_mode_emits_delta_on_changed_hash() {
-        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-auto-delta");
-        let invocation = invocation(Some("sess-auto-delta"));
-        let first = apply_context_gate(
-            &invocation,
-            "# [/tmp/remem] context now\nBody A\n".to_string(),
-        );
-        assert_eq!(first.action, ContextGateAction::EmittedFull);
-
-        let second = apply_context_gate(
-            &invocation,
-            "# [/tmp/remem] context now\nBody B\n".to_string(),
-        );
-        assert_eq!(second.action, ContextGateAction::EmittedDelta);
-        assert_eq!(second.reason, "changed_hash");
     }
 
     #[test]

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -98,8 +98,17 @@ pub(super) fn apply_context_gate(
             Err(error) => fail_open(output, "gate_write", error),
         };
     }
+    if source_requires_fresh_emission(invocation.source.as_deref()) {
+        return match upsert_emit_row(&conn, invocation, &key, &hash, output.chars().count(), now) {
+            Ok(()) => {
+                log_gate("emit", invocation, &key, "restart_source", &hash);
+                decision(output, ContextGateAction::EmittedFull, "restart_source")
+            }
+            Err(error) => fail_open(output, "gate_write", error),
+        };
+    }
     if row.context_hash == hash && fallback_cooldown_allows_suppression(invocation, &row, now) {
-        return match record_suppression(&conn, invocation.host.as_env_value(), &key) {
+        return match record_suppression(&conn, invocation, &key, now) {
             Ok(()) => {
                 log_gate("suppress", invocation, &key, "same_hash", &hash);
                 decision(String::new(), ContextGateAction::Suppressed, "same_hash")
@@ -109,7 +118,7 @@ pub(super) fn apply_context_gate(
     }
 
     if mode == ContextGateMode::Strict {
-        return match record_suppression(&conn, invocation.host.as_env_value(), &key) {
+        return match record_suppression(&conn, invocation, &key, now) {
             Ok(()) => {
                 log_gate("suppress", invocation, &key, "strict", &hash);
                 decision(String::new(), ContextGateAction::Suppressed, "strict")
@@ -171,6 +180,13 @@ fn host_is_gated(host: HostKind) -> bool {
         .split(',')
         .map(|host| host.trim())
         .any(|candidate| candidate == host.as_env_value())
+}
+
+fn source_requires_fresh_emission(source: Option<&str>) -> bool {
+    matches!(
+        source.map(|value| value.trim().to_ascii_lowercase()),
+        Some(value) if value == "clear" || value == "compact"
+    )
 }
 
 fn fallback_cooldown_allows_suppression(
@@ -237,14 +253,15 @@ fn upsert_emit_row(
 ) -> Result<()> {
     conn.execute(
         "INSERT INTO context_injections
-         (host, project, injection_key, session_id, transcript_path, context_hash, output_mode,
+         (host, project, injection_key, session_id, transcript_path, hook_source, context_hash, output_mode,
           output_chars, created_at_epoch, updated_at_epoch, last_emitted_epoch, emit_count,
           suppress_count)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'full', ?7, ?8, ?8, ?8, 1, 0)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'full', ?8, ?9, ?9, ?9, 1, 0)
          ON CONFLICT(host, injection_key) DO UPDATE SET
           project = excluded.project,
           session_id = excluded.session_id,
           transcript_path = excluded.transcript_path,
+          hook_source = excluded.hook_source,
           context_hash = excluded.context_hash,
           output_mode = 'full',
           output_chars = excluded.output_chars,
@@ -257,6 +274,7 @@ fn upsert_emit_row(
             key,
             invocation.session_id,
             invocation.transcript_path,
+            invocation.source,
             hash,
             output_chars as i64,
             now,
@@ -265,13 +283,20 @@ fn upsert_emit_row(
     Ok(())
 }
 
-fn record_suppression(conn: &rusqlite::Connection, host: &str, key: &str) -> Result<()> {
+fn record_suppression(
+    conn: &rusqlite::Connection,
+    invocation: &ContextInvocation,
+    key: &str,
+    now: i64,
+) -> Result<()> {
     conn.execute(
         "UPDATE context_injections
          SET output_mode = 'suppressed',
+             hook_source = ?3,
+             updated_at_epoch = ?4,
              suppress_count = suppress_count + 1
          WHERE host = ?1 AND injection_key = ?2",
-        params![host, key],
+        params![invocation.host.as_env_value(), key, invocation.source, now,],
     )?;
     Ok(())
 }
@@ -361,6 +386,7 @@ mod tests {
             project: "/tmp/remem".to_string(),
             session_id: session_id.map(str::to_string),
             transcript_path: Some("/tmp/remem.jsonl".to_string()),
+            source: None,
             host: HostKind::CodexCli,
             use_colors: false,
             debug: false,
@@ -390,7 +416,7 @@ mod tests {
             .ok_or_else(|| anyhow::anyhow!("missing context injection gate row"))?;
         assert_eq!(row.context_hash, hash);
 
-        record_suppression(&conn, invocation.host.as_env_value(), &key)?;
+        record_suppression(&conn, &invocation, &key, 101)?;
         let suppress_count: i64 = conn.query_row(
             "SELECT suppress_count FROM context_injections WHERE host = ?1 AND injection_key = ?2",
             params![invocation.host.as_env_value(), key],
@@ -408,7 +434,7 @@ mod tests {
         let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
 
         upsert_emit_row(&conn, &invocation, &key, &hash, 32, 100)?;
-        record_suppression(&conn, invocation.host.as_env_value(), &key)?;
+        record_suppression(&conn, &invocation, &key, 150)?;
 
         let (updated_at_epoch, last_emitted_epoch, suppress_count): (i64, i64, i64) = conn
             .query_row(
@@ -419,9 +445,58 @@ mod tests {
                 |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
             )?;
 
-        assert_eq!(updated_at_epoch, 100);
+        assert_eq!(updated_at_epoch, 150);
         assert_eq!(last_emitted_epoch, 100);
         assert_eq!(suppress_count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn restart_source_requires_fresh_emission() {
+        assert!(source_requires_fresh_emission(Some("clear")));
+        assert!(source_requires_fresh_emission(Some("Compact")));
+        assert!(!source_requires_fresh_emission(Some("startup")));
+        assert!(!source_requires_fresh_emission(None));
+    }
+
+    #[test]
+    fn restart_source_reemits_same_hash_context() {
+        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-restart");
+        let mut invocation = invocation(Some("sess-restart"));
+        let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+        let first = apply_context_gate(&invocation, output.clone());
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let second = apply_context_gate(&invocation, output.clone());
+        assert_eq!(second.action, ContextGateAction::Suppressed);
+
+        invocation.source = Some("clear".to_string());
+        let restart = apply_context_gate(&invocation, output.clone());
+        assert_eq!(restart.action, ContextGateAction::EmittedFull);
+        assert_eq!(restart.reason, "restart_source");
+        assert_eq!(restart.output, output);
+    }
+
+    #[test]
+    fn emit_and_suppress_persist_hook_source() -> Result<()> {
+        let conn = setup_conn();
+        let mut invocation = invocation(Some("sess-source"));
+        invocation.source = Some("startup".to_string());
+        let key = injection_key(&invocation);
+        let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
+
+        upsert_emit_row(&conn, &invocation, &key, &hash, 32, 100)?;
+        invocation.source = Some("resume".to_string());
+        record_suppression(&conn, &invocation, &key, 101)?;
+
+        let hook_source: Option<String> = conn.query_row(
+            "SELECT hook_source FROM context_injections WHERE host = ?1 AND injection_key = ?2",
+            params![invocation.host.as_env_value(), key],
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(hook_source.as_deref(), Some("resume"));
         Ok(())
     }
 

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -335,10 +335,63 @@ fn normalize_context_for_hash(output: &str) -> String {
                 continue;
             }
         }
-        normalized.push_str(line);
+        normalized.push_str(&normalize_stats_footer_totals(line));
         normalized.push('\n');
     }
     normalized
+}
+
+fn normalize_stats_footer_totals(line: &str) -> String {
+    const TOTAL_PREFIX: &str = " total=";
+    const CHARS_TOKEN: &str = " chars/~";
+    const TOKENS_SUFFIX: &str = " tokens";
+
+    if !is_context_stats_footer(line) {
+        return line.to_string();
+    }
+
+    let Some(total_start) = line.find(TOTAL_PREFIX) else {
+        return line.to_string();
+    };
+    let total_value_start = total_start + TOTAL_PREFIX.len();
+    let Some(chars_offset) = line[total_value_start..].find(CHARS_TOKEN) else {
+        return line.to_string();
+    };
+    let total_value_end = total_value_start + chars_offset;
+    if !line[total_value_start..total_value_end]
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+    {
+        return line.to_string();
+    }
+
+    let token_value_start = total_value_end + CHARS_TOKEN.len();
+    let Some(tokens_offset) = line[token_value_start..].find(TOKENS_SUFFIX) else {
+        return line.to_string();
+    };
+    let token_value_end = token_value_start + tokens_offset;
+    if !line[token_value_start..token_value_end]
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+    {
+        return line.to_string();
+    }
+
+    let mut normalized = String::with_capacity(line.len());
+    normalized.push_str(&line[..total_value_start]);
+    normalized.push_str("<total>");
+    normalized.push_str(CHARS_TOKEN);
+    normalized.push_str("<tokens>");
+    normalized.push_str(&line[token_value_end..]);
+    normalized
+}
+
+fn is_context_stats_footer(line: &str) -> bool {
+    line.contains(" context memories loaded. ")
+        && line.contains(" host=")
+        && line.contains(" branch=")
+        && line.contains(" total=")
+        && line.contains(" truncated=")
 }
 
 fn sha256_hex(value: &str) -> String {
@@ -401,6 +454,22 @@ mod tests {
         let b = "# [/tmp/remem] context 2026-05-25 2:00pm\nBody\n";
 
         assert_eq!(context_fingerprint(a), context_fingerprint(b));
+    }
+
+    #[test]
+    fn fingerprint_ignores_footer_totals_derived_from_header_width() {
+        let a = "# [/tmp/remem] context 2026-05-25 9:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n";
+        let b = "# [/tmp/remem] context 2026-05-25 10:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=101 chars/~26 tokens limit=12000 truncated=no\n";
+
+        assert_eq!(context_fingerprint(a), context_fingerprint(b));
+    }
+
+    #[test]
+    fn fingerprint_keeps_non_footer_total_text() {
+        let a = "# [/tmp/remem] context now\nBody total=100 chars/~25 tokens\n";
+        let b = "# [/tmp/remem] context now\nBody total=101 chars/~26 tokens\n";
+
+        assert_ne!(context_fingerprint(a), context_fingerprint(b));
     }
 
     #[test]

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -53,6 +53,22 @@ pub(super) fn apply_context_gate(
     if mode == ContextGateMode::Off {
         return decision(output, ContextGateAction::Bypassed, "gate_off");
     }
+    if !has_trusted_gate_identity(invocation) {
+        crate::log::warn(
+            "context-gate",
+            &format!(
+                "fail_open reason=missing_session_identity host={} project={} cwd={}",
+                invocation.host.as_env_value(),
+                invocation.project,
+                invocation.cwd
+            ),
+        );
+        return decision(
+            output,
+            ContextGateAction::FailOpen,
+            "missing_session_identity",
+        );
+    }
 
     let hash = context_fingerprint(&output);
     let key = injection_key(invocation);
@@ -188,6 +204,10 @@ fn source_requires_fresh_emission(source: Option<&str>) -> bool {
         source.map(|value| value.trim().to_ascii_lowercase()),
         Some(value) if value == "clear" || value == "compact"
     )
+}
+
+fn has_trusted_gate_identity(invocation: &ContextInvocation) -> bool {
+    invocation.session_id.is_some() || invocation.transcript_path.is_some()
 }
 
 fn fallback_cooldown_allows_suppression(
@@ -553,6 +573,24 @@ mod tests {
 
         assert_eq!(injection_key(&direct), injection_key(&dotted));
         Ok(())
+    }
+
+    #[test]
+    fn cwd_only_fallback_identity_fails_open_without_suppressing() {
+        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-cwd-only");
+        let mut invocation = invocation(None);
+        invocation.transcript_path = None;
+        let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+        let first = apply_context_gate(&invocation, output.clone());
+        assert_eq!(first.action, ContextGateAction::FailOpen);
+        assert_eq!(first.reason, "missing_session_identity");
+        assert_eq!(first.output, output);
+
+        let second = apply_context_gate(&invocation, output.clone());
+        assert_eq!(second.action, ContextGateAction::FailOpen);
+        assert_eq!(second.reason, "missing_session_identity");
+        assert_eq!(second.output, output);
     }
 
     #[test]

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -34,7 +34,7 @@ pub(super) struct ContextGateDecision {
 #[derive(Debug)]
 struct GateRow {
     context_hash: String,
-    updated_at_epoch: i64,
+    last_emitted_epoch: i64,
 }
 
 pub(super) fn apply_context_gate(
@@ -99,7 +99,7 @@ pub(super) fn apply_context_gate(
         };
     }
     if row.context_hash == hash && fallback_cooldown_allows_suppression(invocation, &row, now) {
-        return match record_suppression(&conn, invocation.host.as_env_value(), &key, now) {
+        return match record_suppression(&conn, invocation.host.as_env_value(), &key) {
             Ok(()) => {
                 log_gate("suppress", invocation, &key, "same_hash", &hash);
                 decision(String::new(), ContextGateAction::Suppressed, "same_hash")
@@ -109,7 +109,7 @@ pub(super) fn apply_context_gate(
     }
 
     if mode == ContextGateMode::Strict {
-        return match record_suppression(&conn, invocation.host.as_env_value(), &key, now) {
+        return match record_suppression(&conn, invocation.host.as_env_value(), &key) {
             Ok(()) => {
                 log_gate("suppress", invocation, &key, "strict", &hash);
                 decision(String::new(), ContextGateAction::Suppressed, "strict")
@@ -185,7 +185,7 @@ fn fallback_cooldown_allows_suppression(
         "REMEM_CONTEXT_GATE_FALLBACK_COOLDOWN_SECS",
         DEFAULT_FALLBACK_COOLDOWN_SECS,
     );
-    now.saturating_sub(row.updated_at_epoch) <= cooldown
+    now.saturating_sub(row.last_emitted_epoch) <= cooldown
 }
 
 fn read_i64_env(key: &str, default: i64) -> i64 {
@@ -212,14 +212,14 @@ fn cleanup_old_rows(conn: &rusqlite::Connection, now: i64) {
 
 fn load_gate_row(conn: &rusqlite::Connection, host: &str, key: &str) -> Result<Option<GateRow>> {
     conn.query_row(
-        "SELECT context_hash, updated_at_epoch
+        "SELECT context_hash, last_emitted_epoch
          FROM context_injections
          WHERE host = ?1 AND injection_key = ?2",
         params![host, key],
         |row| {
             Ok(GateRow {
                 context_hash: row.get(0)?,
-                updated_at_epoch: row.get(1)?,
+                last_emitted_epoch: row.get(1)?,
             })
         },
     )
@@ -265,14 +265,13 @@ fn upsert_emit_row(
     Ok(())
 }
 
-fn record_suppression(conn: &rusqlite::Connection, host: &str, key: &str, now: i64) -> Result<()> {
+fn record_suppression(conn: &rusqlite::Connection, host: &str, key: &str) -> Result<()> {
     conn.execute(
         "UPDATE context_injections
          SET output_mode = 'suppressed',
-             updated_at_epoch = ?3,
              suppress_count = suppress_count + 1
          WHERE host = ?1 AND injection_key = ?2",
-        params![host, key, now],
+        params![host, key],
     )?;
     Ok(())
 }
@@ -297,8 +296,9 @@ fn context_fingerprint(output: &str) -> String {
 }
 
 fn normalize_context_for_hash(output: &str) -> String {
+    const GENERATED_DEBUG_TRACE_MARKER: &str = "\n## Debug Trace\n- request host=";
     let without_debug = output
-        .find("\n## Debug Trace\n")
+        .rfind(GENERATED_DEBUG_TRACE_MARKER)
         .map(|idx| &output[..idx])
         .unwrap_or(output);
     let mut normalized = String::new();
@@ -378,29 +378,73 @@ mod tests {
     }
 
     #[test]
-    fn first_same_session_context_emits_and_second_suppresses() {
+    fn first_same_session_context_emits_and_second_suppresses() -> Result<()> {
         let conn = setup_conn();
         let invocation = invocation(Some("sess-1"));
         let key = injection_key(&invocation);
         let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
 
-        assert!(load_gate_row(&conn, invocation.host.as_env_value(), &key)
-            .unwrap()
-            .is_none());
-        upsert_emit_row(&conn, &invocation, &key, &hash, 32, 100).unwrap();
-        let row = load_gate_row(&conn, invocation.host.as_env_value(), &key)
-            .unwrap()
-            .unwrap();
+        assert!(load_gate_row(&conn, invocation.host.as_env_value(), &key)?.is_none());
+        upsert_emit_row(&conn, &invocation, &key, &hash, 32, 100)?;
+        let row = load_gate_row(&conn, invocation.host.as_env_value(), &key)?
+            .ok_or_else(|| anyhow::anyhow!("missing context injection gate row"))?;
         assert_eq!(row.context_hash, hash);
 
-        record_suppression(&conn, invocation.host.as_env_value(), &key, 101).unwrap();
-        let suppress_count: i64 = conn
-            .query_row(
-                "SELECT suppress_count FROM context_injections WHERE host = ?1 AND injection_key = ?2",
-                params![invocation.host.as_env_value(), key],
-                |row| row.get(0),
-            )
-            .unwrap();
+        record_suppression(&conn, invocation.host.as_env_value(), &key)?;
+        let suppress_count: i64 = conn.query_row(
+            "SELECT suppress_count FROM context_injections WHERE host = ?1 AND injection_key = ?2",
+            params![invocation.host.as_env_value(), key],
+            |row| row.get(0),
+        )?;
         assert_eq!(suppress_count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn suppression_does_not_extend_fallback_cooldown() -> Result<()> {
+        let conn = setup_conn();
+        let invocation = invocation(None);
+        let key = injection_key(&invocation);
+        let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
+
+        upsert_emit_row(&conn, &invocation, &key, &hash, 32, 100)?;
+        record_suppression(&conn, invocation.host.as_env_value(), &key)?;
+
+        let (updated_at_epoch, last_emitted_epoch, suppress_count): (i64, i64, i64) = conn
+            .query_row(
+                "SELECT updated_at_epoch, last_emitted_epoch, suppress_count
+                 FROM context_injections
+                 WHERE host = ?1 AND injection_key = ?2",
+                params![invocation.host.as_env_value(), key],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
+
+        assert_eq!(updated_at_epoch, 100);
+        assert_eq!(last_emitted_epoch, 100);
+        assert_eq!(suppress_count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn fingerprint_keeps_user_debug_trace_heading() {
+        let a = "# [/tmp/remem] context now\nBody\n## Debug Trace\nUser note A\n";
+        let b = "# [/tmp/remem] context now\nBody\n## Debug Trace\nUser note B\n";
+
+        assert_ne!(context_fingerprint(a), context_fingerprint(b));
+    }
+
+    #[test]
+    fn fingerprint_ignores_generated_debug_trace() {
+        let base = "# [/tmp/remem] context now\nBody\n";
+        let a = format!(
+            "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=main session=sess-1\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n",
+            base
+        );
+        let b = format!(
+            "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=dev session=sess-2\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=dev total=120 chars/~30 tokens limit=12000 truncated=no\n",
+            base
+        );
+
+        assert_eq!(context_fingerprint(&a), context_fingerprint(&b));
     }
 }

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -6,6 +6,8 @@ use std::path::{Component, Path, PathBuf};
 use super::host::HostKind;
 use super::invocation::ContextInvocation;
 
+mod delta;
+
 const DEFAULT_GATE_HOSTS: &str = "codex-cli";
 const DEFAULT_FALLBACK_COOLDOWN_SECS: i64 = 900;
 const DEFAULT_RETENTION_DAYS: i64 = 30;
@@ -13,6 +15,7 @@ const DEFAULT_RETENTION_DAYS: i64 = 30;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ContextGateMode {
     Auto,
+    Delta,
     Off,
     Strict,
 }
@@ -21,6 +24,7 @@ enum ContextGateMode {
 pub(super) enum ContextGateAction {
     Bypassed,
     EmittedFull,
+    EmittedDelta,
     Suppressed,
     FailOpen,
 }
@@ -97,7 +101,15 @@ pub(super) fn apply_context_gate(
     };
 
     let Some(row) = row else {
-        return match upsert_emit_row(&conn, invocation, &key, &hash, output.chars().count(), now) {
+        return match upsert_emit_row(
+            &conn,
+            invocation,
+            &key,
+            &hash,
+            "full",
+            output.chars().count(),
+            now,
+        ) {
             Ok(()) => {
                 log_gate("emit", invocation, &key, "full", &hash);
                 decision(output, ContextGateAction::EmittedFull, "first_or_forced")
@@ -107,7 +119,15 @@ pub(super) fn apply_context_gate(
     };
 
     if invocation.force {
-        return match upsert_emit_row(&conn, invocation, &key, &hash, output.chars().count(), now) {
+        return match upsert_emit_row(
+            &conn,
+            invocation,
+            &key,
+            &hash,
+            "full",
+            output.chars().count(),
+            now,
+        ) {
             Ok(()) => {
                 log_gate("emit", invocation, &key, "full", &hash);
                 decision(output, ContextGateAction::EmittedFull, "first_or_forced")
@@ -116,7 +136,15 @@ pub(super) fn apply_context_gate(
         };
     }
     if source_requires_fresh_emission(invocation.source.as_deref()) {
-        return match upsert_emit_row(&conn, invocation, &key, &hash, output.chars().count(), now) {
+        return match upsert_emit_row(
+            &conn,
+            invocation,
+            &key,
+            &hash,
+            "full",
+            output.chars().count(),
+            now,
+        ) {
             Ok(()) => {
                 log_gate("emit", invocation, &key, "restart_source", &hash);
                 decision(output, ContextGateAction::EmittedFull, "restart_source")
@@ -144,10 +172,29 @@ pub(super) fn apply_context_gate(
         };
     }
 
-    match upsert_emit_row(&conn, invocation, &key, &hash, output.chars().count(), now) {
+    let (output, action, output_mode) =
+        if matches!(mode, ContextGateMode::Auto | ContextGateMode::Delta) {
+            (
+                delta::build_delta_output(&output),
+                ContextGateAction::EmittedDelta,
+                "delta",
+            )
+        } else {
+            (output, ContextGateAction::EmittedFull, "full")
+        };
+
+    match upsert_emit_row(
+        &conn,
+        invocation,
+        &key,
+        &hash,
+        output_mode,
+        output.chars().count(),
+        now,
+    ) {
         Ok(()) => {
-            log_gate("emit", invocation, &key, "changed_hash", &hash);
-            decision(output, ContextGateAction::EmittedFull, "changed_hash")
+            log_gate("emit", invocation, &key, output_mode, &hash);
+            decision(output, action, "changed_hash")
         }
         Err(error) => fail_open(output, "gate_write", error),
     }
@@ -183,7 +230,8 @@ fn resolve_gate_mode(cli_value: Option<&str>) -> ContextGateMode {
 
 fn parse_gate_mode(value: &str) -> Option<ContextGateMode> {
     match value.trim().to_ascii_lowercase().as_str() {
-        "auto" | "delta" => Some(ContextGateMode::Auto),
+        "auto" => Some(ContextGateMode::Auto),
+        "delta" => Some(ContextGateMode::Delta),
         "off" | "false" | "0" => Some(ContextGateMode::Off),
         "strict" => Some(ContextGateMode::Strict),
         _ => None,
@@ -269,6 +317,7 @@ fn upsert_emit_row(
     invocation: &ContextInvocation,
     key: &str,
     hash: &str,
+    output_mode: &str,
     output_chars: usize,
     now: i64,
 ) -> Result<()> {
@@ -277,14 +326,14 @@ fn upsert_emit_row(
          (host, project, injection_key, session_id, transcript_path, hook_source, context_hash, output_mode,
           output_chars, created_at_epoch, updated_at_epoch, last_emitted_epoch, emit_count,
           suppress_count)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'full', ?8, ?9, ?9, ?9, 1, 0)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10, ?10, 1, 0)
          ON CONFLICT(host, injection_key) DO UPDATE SET
           project = excluded.project,
           session_id = excluded.session_id,
           transcript_path = excluded.transcript_path,
           hook_source = excluded.hook_source,
           context_hash = excluded.context_hash,
-          output_mode = 'full',
+          output_mode = excluded.output_mode,
           output_chars = excluded.output_chars,
           updated_at_epoch = excluded.updated_at_epoch,
           last_emitted_epoch = excluded.last_emitted_epoch,
@@ -297,6 +346,7 @@ fn upsert_emit_row(
             invocation.transcript_path,
             invocation.source,
             hash,
+            output_mode,
             output_chars as i64,
             now,
         ],
@@ -532,7 +582,7 @@ mod tests {
         let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
 
         assert!(load_gate_row(&conn, invocation.host.as_env_value(), &key)?.is_none());
-        upsert_emit_row(&conn, &invocation, &key, &hash, 32, 100)?;
+        upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
         let row = load_gate_row(&conn, invocation.host.as_env_value(), &key)?
             .ok_or_else(|| anyhow::anyhow!("missing context injection gate row"))?;
         assert_eq!(row.context_hash, hash);
@@ -600,7 +650,7 @@ mod tests {
         let key = injection_key(&invocation);
         let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
 
-        upsert_emit_row(&conn, &invocation, &key, &hash, 32, 100)?;
+        upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
         record_suppression(&conn, &invocation, &key, 150)?;
 
         let (updated_at_epoch, last_emitted_epoch, suppress_count): (i64, i64, i64) = conn
@@ -646,6 +696,54 @@ mod tests {
     }
 
     #[test]
+    fn delta_mode_emits_compact_changed_hash() -> Result<()> {
+        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-delta");
+        let mut invocation = invocation(Some("sess-delta"));
+        invocation.gate_mode = Some("delta".to_string());
+        let first_output = "# [/tmp/remem] context now\nBody A\n".to_string();
+        let first = apply_context_gate(&invocation, first_output);
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let changed_output = format!(
+            "# [/tmp/remem] context later\n{}\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=3000 chars/~750 tokens limit=12000 truncated=no\n",
+            "Body B ".repeat(400)
+        );
+        let second = apply_context_gate(&invocation, changed_output.clone());
+        assert_eq!(second.action, ContextGateAction::EmittedDelta);
+        assert_eq!(second.reason, "changed_hash");
+        assert_ne!(second.output, changed_output);
+        assert!(second.output.contains("context delta"));
+        assert!(second.output.chars().count() <= 1200);
+
+        let key = injection_key(&invocation);
+        let mode: String = crate::db::open_db()?.query_row(
+            "SELECT output_mode FROM context_injections WHERE host = ?1 AND injection_key = ?2",
+            params![invocation.host.as_env_value(), key],
+            |row| row.get(0),
+        )?;
+        assert_eq!(mode, "delta");
+        Ok(())
+    }
+
+    #[test]
+    fn auto_mode_emits_delta_on_changed_hash() {
+        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-auto-delta");
+        let invocation = invocation(Some("sess-auto-delta"));
+        let first = apply_context_gate(
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        );
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let second = apply_context_gate(
+            &invocation,
+            "# [/tmp/remem] context now\nBody B\n".to_string(),
+        );
+        assert_eq!(second.action, ContextGateAction::EmittedDelta);
+        assert_eq!(second.reason, "changed_hash");
+    }
+
+    #[test]
     fn emit_and_suppress_persist_hook_source() -> Result<()> {
         let conn = setup_conn();
         let mut invocation = invocation(Some("sess-source"));
@@ -653,7 +751,7 @@ mod tests {
         let key = injection_key(&invocation);
         let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
 
-        upsert_emit_row(&conn, &invocation, &key, &hash, 32, 100)?;
+        upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
         invocation.source = Some("resume".to_string());
         record_suppression(&conn, &invocation, &key, 101)?;
 

--- a/src/context/injection_gate/delta.rs
+++ b/src/context/injection_gate/delta.rs
@@ -83,3 +83,99 @@ fn read_usize_env(key: &str, default: usize) -> usize {
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(default)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+    use anyhow::Result;
+    use rusqlite::params;
+
+    fn invocation(session_id: Option<&str>) -> ContextInvocation {
+        ContextInvocation {
+            cwd: "/tmp/remem".to_string(),
+            project: "/tmp/remem".to_string(),
+            session_id: session_id.map(str::to_string),
+            transcript_path: Some("/tmp/remem.jsonl".to_string()),
+            source: None,
+            host: HostKind::CodexCli,
+            use_colors: false,
+            debug: false,
+            force: false,
+            gate_mode: None,
+        }
+    }
+
+    #[test]
+    fn delta_mode_emits_compact_changed_hash() -> Result<()> {
+        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-delta");
+        let mut invocation = invocation(Some("sess-delta"));
+        invocation.gate_mode = Some("delta".to_string());
+        let first = apply_context_gate(
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        );
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let changed_output = format!(
+            "# [/tmp/remem] context later\n{}\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=3000 chars/~750 tokens limit=12000 truncated=no\n",
+            "Body B ".repeat(400)
+        );
+        let second = apply_context_gate(&invocation, changed_output.clone());
+        assert_eq!(second.action, ContextGateAction::EmittedDelta);
+        assert_eq!(second.reason, "changed_hash");
+        assert_ne!(second.output, changed_output);
+        assert!(second.output.contains("context delta"));
+        assert!(second.output.chars().count() <= 1200);
+
+        let key = injection_key(&invocation);
+        let mode: String = crate::db::open_db()?.query_row(
+            "SELECT output_mode FROM context_injections WHERE host = ?1 AND injection_key = ?2",
+            params![invocation.host.as_env_value(), key],
+            |row| row.get(0),
+        )?;
+        assert_eq!(mode, "delta");
+        Ok(())
+    }
+
+    #[test]
+    fn auto_mode_emits_delta_on_changed_hash() {
+        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-auto-delta");
+        let invocation = invocation(Some("sess-auto-delta"));
+        let first = apply_context_gate(
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        );
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let second = apply_context_gate(
+            &invocation,
+            "# [/tmp/remem] context now\nBody B\n".to_string(),
+        );
+        assert_eq!(second.action, ContextGateAction::EmittedDelta);
+        assert_eq!(second.reason, "changed_hash");
+    }
+
+    #[test]
+    fn fallback_cooldown_expiry_reemits_full_for_same_hash() -> Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-fallback-expired");
+        let invocation = invocation(None);
+        let output = "# [/tmp/remem] context now\nBody\n".to_string();
+        let first = apply_context_gate(&invocation, output.clone());
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let key = injection_key(&invocation);
+        crate::db::open_db()?.execute(
+            "UPDATE context_injections
+             SET last_emitted_epoch = 0
+             WHERE host = ?1 AND injection_key = ?2",
+            params![invocation.host.as_env_value(), key],
+        )?;
+
+        let second = apply_context_gate(&invocation, output.clone());
+        assert_eq!(second.action, ContextGateAction::EmittedFull);
+        assert_eq!(second.reason, "fallback_cooldown_expired");
+        assert_eq!(second.output, output);
+        Ok(())
+    }
+}

--- a/src/context/injection_gate/delta.rs
+++ b/src/context/injection_gate/delta.rs
@@ -1,0 +1,85 @@
+const DEFAULT_DELTA_CHAR_LIMIT: usize = 1200;
+
+pub(super) fn build_delta_output(output: &str) -> String {
+    let limit = read_usize_env("REMEM_CONTEXT_DELTA_CHAR_LIMIT", DEFAULT_DELTA_CHAR_LIMIT);
+    if limit == 0 {
+        return String::new();
+    }
+
+    let (body, footer) = split_stats_footer(output);
+    let mut delta = String::new();
+    delta.push_str(&delta_header(body));
+    delta.push_str(
+        "remem context changed since the previous injection. Compact delta shown; run `remem context --force` for a full refresh.\n\n",
+    );
+    let body_without_header = body
+        .split_once('\n')
+        .map(|(_, rest)| rest)
+        .unwrap_or_default();
+    delta.push_str(body_without_header.trim_start_matches('\n'));
+
+    enforce_char_limit_preserving_footer(&mut delta, limit, footer);
+    delta
+}
+
+fn split_stats_footer(output: &str) -> (&str, &str) {
+    let Some(last_line_start) = output.trim_end_matches('\n').rfind('\n') else {
+        return (output, "");
+    };
+    let footer_start = last_line_start + 1;
+    let footer = &output[footer_start..];
+    if super::is_context_stats_footer(footer.trim_end_matches('\n')) {
+        (&output[..footer_start], footer)
+    } else {
+        (output, "")
+    }
+}
+
+fn delta_header(output: &str) -> String {
+    let first_line = output.lines().next().unwrap_or("# remem context");
+    if let Some(context_idx) = first_line.find("] context ") {
+        let mut header = String::new();
+        header.push_str(&first_line[..context_idx]);
+        header.push_str("] context delta ");
+        header.push_str(&first_line[context_idx + "] context ".len()..]);
+        header.push('\n');
+        return header;
+    }
+    "# remem context delta\n".to_string()
+}
+
+fn enforce_char_limit_preserving_footer(output: &mut String, char_limit: usize, footer: &str) {
+    if output.chars().count() <= char_limit {
+        return;
+    }
+
+    let marker = "\n[remem context delta truncated]\n";
+    let marker_chars = marker.chars().count();
+    let footer_chars = footer.chars().count();
+
+    if !footer.is_empty() && marker_chars + footer_chars < char_limit {
+        let keep_chars = char_limit - marker_chars - footer_chars;
+        let mut truncated: String = output.chars().take(keep_chars).collect();
+        truncated.push_str(marker);
+        truncated.push_str(footer);
+        *output = truncated;
+        return;
+    }
+
+    if marker_chars >= char_limit {
+        *output = output.chars().take(char_limit).collect();
+        return;
+    }
+
+    let keep_chars = char_limit - marker_chars;
+    let mut truncated: String = output.chars().take(keep_chars).collect();
+    truncated.push_str(marker);
+    *output = truncated;
+}
+
+fn read_usize_env(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}

--- a/src/context/invocation.rs
+++ b/src/context/invocation.rs
@@ -39,11 +39,27 @@ pub(super) struct ContextCliOptions {
 }
 
 pub(super) fn resolve_context_invocation(options: ContextCliOptions) -> Result<ContextInvocation> {
-    let stdin = crate::hook_stdin::read_stdin_with_timeout(CONTEXT_STDIN_TIMEOUT_MS)?;
-    Ok(resolve_context_invocation_from_parts(
+    Ok(resolve_context_invocation_from_stdin_result(
         options,
-        stdin.as_deref(),
+        crate::hook_stdin::read_stdin_with_timeout(CONTEXT_STDIN_TIMEOUT_MS),
     ))
+}
+
+fn resolve_context_invocation_from_stdin_result(
+    options: ContextCliOptions,
+    stdin_result: Result<Option<String>>,
+) -> ContextInvocation {
+    let stdin = match stdin_result {
+        Ok(stdin) => stdin,
+        Err(error) => {
+            crate::log::warn(
+                "context",
+                &format!("failed to read context hook stdin, ignoring: {}", error),
+            );
+            None
+        }
+    };
+    resolve_context_invocation_from_parts(options, stdin.as_deref())
 }
 
 pub(super) fn direct_context_invocation(
@@ -186,5 +202,20 @@ mod tests {
     #[test]
     fn codex_hook_stdin_timeout_allows_normal_startup_latency() {
         assert!(CONTEXT_STDIN_TIMEOUT_MS >= 1000);
+    }
+
+    #[test]
+    fn stdin_read_failure_falls_back_to_cli_values() {
+        let invocation = resolve_context_invocation_from_stdin_result(
+            ContextCliOptions {
+                cwd: Some("/tmp/cli".to_string()),
+                host: Some("codex-cli".to_string()),
+                ..ContextCliOptions::default()
+            },
+            Err(anyhow::anyhow!("stdin read failed")),
+        );
+
+        assert_eq!(invocation.cwd, "/tmp/cli");
+        assert_eq!(invocation.session_id, None);
     }
 }

--- a/src/context/invocation.rs
+++ b/src/context/invocation.rs
@@ -1,0 +1,185 @@
+use anyhow::Result;
+use serde::Deserialize;
+
+use crate::db;
+
+use super::host::{resolve_host_kind, HostKind};
+
+const CONTEXT_STDIN_TIMEOUT_MS: u64 = 50;
+
+#[derive(Debug, Clone)]
+pub(super) struct ContextInvocation {
+    pub cwd: String,
+    pub project: String,
+    pub session_id: Option<String>,
+    pub transcript_path: Option<String>,
+    pub host: HostKind,
+    pub use_colors: bool,
+    pub debug: bool,
+    pub force: bool,
+    pub gate_mode: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContextHookInput {
+    session_id: Option<String>,
+    cwd: Option<String>,
+    transcript_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct ContextCliOptions {
+    pub cwd: Option<String>,
+    pub session_id: Option<String>,
+    pub host: Option<String>,
+    pub use_colors: bool,
+    pub debug: bool,
+    pub force: bool,
+    pub gate_mode: Option<String>,
+}
+
+pub(super) fn resolve_context_invocation(options: ContextCliOptions) -> Result<ContextInvocation> {
+    let stdin = crate::hook_stdin::read_stdin_with_timeout(CONTEXT_STDIN_TIMEOUT_MS)?;
+    Ok(resolve_context_invocation_from_parts(
+        options,
+        stdin.as_deref(),
+    ))
+}
+
+pub(super) fn direct_context_invocation(
+    cwd: &str,
+    session_id: Option<&str>,
+    use_colors: bool,
+    host_arg: Option<&str>,
+    debug: bool,
+) -> ContextInvocation {
+    let host = resolve_host_kind(host_arg);
+    let project = db::project_from_cwd(cwd);
+    ContextInvocation {
+        cwd: cwd.to_string(),
+        project,
+        session_id: clean_optional(session_id.map(str::to_string)),
+        transcript_path: None,
+        host,
+        use_colors,
+        debug,
+        force: true,
+        gate_mode: Some("off".to_string()),
+    }
+}
+
+pub(super) fn resolve_context_invocation_from_parts(
+    options: ContextCliOptions,
+    stdin: Option<&str>,
+) -> ContextInvocation {
+    let hook = parse_hook_input(stdin);
+    let cwd = options
+        .cwd
+        .or_else(|| {
+            hook.as_ref()
+                .and_then(|hook| clean_optional(hook.cwd.clone()))
+        })
+        .unwrap_or_else(current_cwd);
+    let project = db::project_from_cwd(&cwd);
+    let session_id = clean_optional(options.session_id).or_else(|| {
+        hook.as_ref()
+            .and_then(|hook| clean_optional(hook.session_id.clone()))
+    });
+    let transcript_path = hook
+        .as_ref()
+        .and_then(|hook| clean_optional(hook.transcript_path.clone()));
+    let host = resolve_host_kind(options.host.as_deref());
+    ContextInvocation {
+        cwd,
+        project,
+        session_id,
+        transcript_path,
+        host,
+        use_colors: options.use_colors,
+        debug: options.debug,
+        force: options.force,
+        gate_mode: clean_optional(options.gate_mode),
+    }
+}
+
+fn parse_hook_input(stdin: Option<&str>) -> Option<ContextHookInput> {
+    let raw = stdin?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    match serde_json::from_str(raw) {
+        Ok(hook) => Some(hook),
+        Err(error) => {
+            crate::log::warn(
+                "context",
+                &format!("invalid context hook payload, ignoring: {}", error),
+            );
+            None
+        }
+    }
+}
+
+fn current_cwd() -> String {
+    std::env::current_dir()
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|_| ".".to_string())
+}
+
+fn clean_optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_codex_hook_stdin() {
+        let invocation = resolve_context_invocation_from_parts(
+            ContextCliOptions {
+                host: Some("codex-cli".to_string()),
+                ..ContextCliOptions::default()
+            },
+            Some(r#"{"session_id":"sess-1","cwd":"/tmp/remem","transcript_path":"/tmp/t.jsonl"}"#),
+        );
+
+        assert_eq!(invocation.session_id.as_deref(), Some("sess-1"));
+        assert_eq!(invocation.cwd, "/tmp/remem");
+        assert_eq!(invocation.project, db::project_from_cwd("/tmp/remem"));
+        assert_eq!(invocation.transcript_path.as_deref(), Some("/tmp/t.jsonl"));
+        assert_eq!(invocation.host, HostKind::CodexCli);
+    }
+
+    #[test]
+    fn cli_values_override_hook_stdin() {
+        let invocation = resolve_context_invocation_from_parts(
+            ContextCliOptions {
+                cwd: Some("/tmp/cli".to_string()),
+                session_id: Some("cli-session".to_string()),
+                host: Some("codex-cli".to_string()),
+                ..ContextCliOptions::default()
+            },
+            Some(r#"{"session_id":"hook-session","cwd":"/tmp/hook"}"#),
+        );
+
+        assert_eq!(invocation.session_id.as_deref(), Some("cli-session"));
+        assert_eq!(invocation.cwd, "/tmp/cli");
+    }
+
+    #[test]
+    fn malformed_hook_stdin_falls_back_to_cli_values() {
+        let invocation = resolve_context_invocation_from_parts(
+            ContextCliOptions {
+                cwd: Some("/tmp/cli".to_string()),
+                host: Some("codex-cli".to_string()),
+                ..ContextCliOptions::default()
+            },
+            Some("not-json"),
+        );
+
+        assert_eq!(invocation.cwd, "/tmp/cli");
+        assert_eq!(invocation.session_id, None);
+    }
+}

--- a/src/context/invocation.rs
+++ b/src/context/invocation.rs
@@ -13,6 +13,7 @@ pub(super) struct ContextInvocation {
     pub project: String,
     pub session_id: Option<String>,
     pub transcript_path: Option<String>,
+    pub source: Option<String>,
     pub host: HostKind,
     pub use_colors: bool,
     pub debug: bool,
@@ -25,6 +26,13 @@ struct ContextHookInput {
     session_id: Option<String>,
     cwd: Option<String>,
     transcript_path: Option<String>,
+    source: Option<String>,
+    target: Option<ContextHookTarget>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContextHookTarget {
+    source: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -76,6 +84,7 @@ pub(super) fn direct_context_invocation(
         project,
         session_id: clean_optional(session_id.map(str::to_string)),
         transcript_path: None,
+        source: None,
         host,
         use_colors,
         debug,
@@ -104,18 +113,28 @@ pub(super) fn resolve_context_invocation_from_parts(
     let transcript_path = hook
         .as_ref()
         .and_then(|hook| clean_optional(hook.transcript_path.clone()));
+    let source = hook.as_ref().and_then(hook_source);
     let host = resolve_host_kind(options.host.as_deref());
     ContextInvocation {
         cwd,
         project,
         session_id,
         transcript_path,
+        source,
         host,
         use_colors: options.use_colors,
         debug: options.debug,
         force: options.force,
         gate_mode: clean_optional(options.gate_mode),
     }
+}
+
+fn hook_source(hook: &ContextHookInput) -> Option<String> {
+    clean_optional(hook.source.clone()).or_else(|| {
+        hook.target
+            .as_ref()
+            .and_then(|target| clean_optional(target.source.clone()))
+    })
 }
 
 fn parse_hook_input(stdin: Option<&str>) -> Option<ContextHookInput> {
@@ -158,14 +177,30 @@ mod tests {
                 host: Some("codex-cli".to_string()),
                 ..ContextCliOptions::default()
             },
-            Some(r#"{"session_id":"sess-1","cwd":"/tmp/remem","transcript_path":"/tmp/t.jsonl"}"#),
+            Some(
+                r#"{"session_id":"sess-1","cwd":"/tmp/remem","transcript_path":"/tmp/t.jsonl","target":{"type":"SessionStart","source":"Startup"}}"#,
+            ),
         );
 
         assert_eq!(invocation.session_id.as_deref(), Some("sess-1"));
         assert_eq!(invocation.cwd, "/tmp/remem");
         assert_eq!(invocation.project, db::project_from_cwd("/tmp/remem"));
         assert_eq!(invocation.transcript_path.as_deref(), Some("/tmp/t.jsonl"));
+        assert_eq!(invocation.source.as_deref(), Some("Startup"));
         assert_eq!(invocation.host, HostKind::CodexCli);
+    }
+
+    #[test]
+    fn parses_root_hook_source() {
+        let invocation = resolve_context_invocation_from_parts(
+            ContextCliOptions {
+                host: Some("codex-cli".to_string()),
+                ..ContextCliOptions::default()
+            },
+            Some(r#"{"session_id":"sess-1","cwd":"/tmp/remem","source":"compact"}"#),
+        );
+
+        assert_eq!(invocation.source.as_deref(), Some("compact"));
     }
 
     #[test]

--- a/src/context/invocation.rs
+++ b/src/context/invocation.rs
@@ -5,7 +5,7 @@ use crate::db;
 
 use super::host::{resolve_host_kind, HostKind};
 
-const CONTEXT_STDIN_TIMEOUT_MS: u64 = 50;
+const CONTEXT_STDIN_TIMEOUT_MS: u64 = 1000;
 
 #[derive(Debug, Clone)]
 pub(super) struct ContextInvocation {
@@ -181,5 +181,10 @@ mod tests {
 
         assert_eq!(invocation.cwd, "/tmp/cli");
         assert_eq!(invocation.session_id, None);
+    }
+
+    #[test]
+    fn codex_hook_stdin_timeout_allows_normal_startup_latency() {
+        assert!(CONTEXT_STDIN_TIMEOUT_MS >= 1000);
     }
 }

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -1,17 +1,25 @@
 use anyhow::Result;
 
 use crate::db;
-use crate::db::project_from_cwd;
 
 use super::format::{char_len, format_header_datetime, truncate_chars_with_ellipsis};
-use super::host::{resolve_host_kind, resolve_profile};
+use super::host::resolve_profile;
+use super::injection_gate::{apply_context_gate, ContextGateAction, ContextGateDecision};
+use super::invocation::{
+    direct_context_invocation, resolve_context_invocation, ContextCliOptions, ContextInvocation,
+};
 use super::policy::{ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
-    render_core_memory_with_limits, render_empty_state, render_memory_index_with_limits_excluding,
+    empty_state_output, render_core_memory_with_limits, render_memory_index_with_limits_excluding,
     render_recent_sessions_with_limit, render_workstreams_with_limits,
 };
 use super::types::ContextRequest;
+
+struct RenderedContext {
+    output: String,
+    stats: ContextRenderStats,
+}
 
 pub fn generate_context(
     cwd: &str,
@@ -20,33 +28,92 @@ pub fn generate_context(
     host_arg: Option<&str>,
     debug: bool,
 ) -> Result<()> {
-    let timer = crate::log::Timer::start("context", &format!("cwd={}", cwd));
-    let project = project_from_cwd(cwd);
-    let current_branch = db::detect_git_branch(cwd);
-    let host = resolve_host_kind(host_arg);
-    let profile = resolve_profile(host);
-    let policy = profile.default_policy();
-    let debug = debug || context_debug_enabled();
-    let request = ContextRequest {
-        cwd: cwd.to_string(),
-        project: project.clone(),
-        session_id: session_id.map(str::to_string),
-        current_branch: current_branch.clone(),
-        host: profile.host(),
-        use_colors,
-    };
-    let capabilities = profile.capabilities();
+    let invocation = direct_context_invocation(cwd, session_id, use_colors, host_arg, debug);
+    generate_context_for_invocation(invocation, false)
+}
 
+pub fn generate_context_from_cli(
+    cwd: Option<String>,
+    session_id: Option<String>,
+    use_colors: bool,
+    host: Option<String>,
+    debug: bool,
+    force: bool,
+    gate_mode: Option<String>,
+) -> Result<()> {
+    let invocation = resolve_context_invocation(ContextCliOptions {
+        cwd,
+        session_id,
+        host,
+        use_colors,
+        debug,
+        force,
+        gate_mode,
+    })?;
+    generate_context_for_invocation(invocation, true)
+}
+
+fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool) -> Result<()> {
+    let timer = crate::log::Timer::start("context", &format!("cwd={}", invocation.cwd));
+    let request = ContextRequest {
+        cwd: invocation.cwd.clone(),
+        project: invocation.project.clone(),
+        session_id: invocation.session_id.clone(),
+        current_branch: db::detect_git_branch(&invocation.cwd),
+        host: invocation.host,
+        use_colors: invocation.use_colors,
+    };
+    let rendered = render_context_output(&request, invocation.debug || context_debug_enabled())?;
+    let decision = if use_gate {
+        apply_context_gate(&invocation, rendered.output)
+    } else {
+        ContextGateDecision {
+            output: rendered.output,
+            action: ContextGateAction::Bypassed,
+            reason: "legacy_direct",
+        }
+    };
+    print!("{}", decision.output);
+
+    let capabilities = resolve_profile(request.host).capabilities();
+    timer.done(&format!(
+        "project={} cwd={} session={} host={} colors={} gate={:?}:{} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] context_memories={} core={} index={} preferences={} sessions={} workstreams={}",
+        request.project,
+        request.cwd,
+        request.session_id.as_deref().unwrap_or("-"),
+        request.host.as_env_value(),
+        request.use_colors,
+        decision.action,
+        decision.reason,
+        capabilities.has_mcp_tools,
+        capabilities.has_session_start_hook,
+        capabilities.has_user_prompt_submit_hook,
+        capabilities.observes_native_file_edits,
+        capabilities.observes_bash,
+        rendered.stats.memories_loaded,
+        rendered.stats.core.count,
+        rendered.stats.index.count,
+        rendered.stats.preferences.count,
+        rendered.stats.sessions.count,
+        rendered.stats.workstreams.count,
+    ));
+    Ok(())
+}
+
+fn render_context_output(request: &ContextRequest, debug: bool) -> Result<RenderedContext> {
+    let profile = resolve_profile(request.host);
+    let policy = profile.default_policy();
     let conn = match db::open_db() {
         Ok(connection) => connection,
         Err(error) => {
             crate::log::warn(
                 "context",
-                &format!("open_db failed for project={}: {}", project, error),
+                &format!("open_db failed for project={}: {}", request.project, error),
             );
-            render_empty_state(&project);
-            timer.done("empty (no DB)");
-            return Ok(());
+            return Ok(RenderedContext {
+                output: empty_state_output(&request.project),
+                stats: empty_stats(request),
+            });
         }
     };
 
@@ -57,7 +124,7 @@ pub fn generate_context(
         &policy,
     );
     let (preference_output, preference_summary) =
-        match render_preferences_to_buffer(&conn, &project, cwd, &policy) {
+        match render_preferences_to_buffer(&conn, &request.project, &request.cwd, &policy) {
             Ok(rendered) => rendered,
             Err(error) => {
                 crate::log::warn("context", &format!("render_preferences failed: {}", error));
@@ -73,9 +140,10 @@ pub fn generate_context(
         && loaded.summaries.is_empty()
         && loaded.workstreams.is_empty()
     {
-        render_empty_state(&project);
-        timer.done("empty (no data)");
-        return Ok(());
+        return Ok(RenderedContext {
+            output: empty_state_output(&request.project),
+            stats: empty_stats(request),
+        });
     }
 
     let mut output = String::new();
@@ -103,14 +171,12 @@ pub fn generate_context(
         chars: char_len(&output).saturating_sub(before),
     };
 
-    let mut core_count = 0;
-    let mut index_count = 0;
     if !loaded.memories.is_empty() {
         let render_limits = section_render_limits(&policy);
         let before = char_len(&output);
         let core_summary =
             render_core_memory_with_limits(&mut output, &loaded.memories, &render_limits);
-        core_count = core_summary.count;
+        let core_count = core_summary.count;
         stats.core_ids = core_summary.ids.clone();
         stats.core = SectionRenderStats {
             count: core_count,
@@ -118,7 +184,7 @@ pub fn generate_context(
         };
         let before = char_len(&output);
         let core_ids = core_summary.ids.into_iter().collect();
-        index_count = render_memory_index_with_limits_excluding(
+        let index_count = render_memory_index_with_limits_excluding(
             &mut output,
             &loaded.memories,
             &render_limits,
@@ -157,7 +223,7 @@ pub fn generate_context(
 
     if debug {
         output.push_str(&build_context_debug_trace(
-            &request, &policy, &loaded, &stats,
+            request, &policy, &loaded, &stats,
         ));
     }
 
@@ -173,28 +239,15 @@ pub fn generate_context(
         policy.limits.total_char_limit,
         &stats_footer,
     );
-    print!("{}", output);
+    Ok(RenderedContext { output, stats })
+}
 
-    timer.done(&format!(
-        "project={} cwd={} session={} host={} colors={} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] context_memories={} core={} index={} preferences={} summaries={} workstreams={}",
-        request.project,
-        request.cwd,
-        request.session_id.as_deref().unwrap_or("-"),
-        request.host.as_env_value(),
-        request.use_colors,
-        capabilities.has_mcp_tools,
-        capabilities.has_session_start_hook,
-        capabilities.has_user_prompt_submit_hook,
-        capabilities.observes_native_file_edits,
-        capabilities.observes_bash,
-        loaded.memories.len(),
-        core_count,
-        index_count,
-        preference_summary.rendered,
-        loaded.summaries.len(),
-        loaded.workstreams.len(),
-    ));
-    Ok(())
+fn empty_stats(request: &ContextRequest) -> ContextRenderStats {
+    ContextRenderStats {
+        host: request.host.as_env_value().to_string(),
+        branch: request.current_branch.clone(),
+        ..ContextRenderStats::default()
+    }
 }
 
 fn section_render_limits(policy: &ContextPolicy) -> super::policy::ContextLimits {

--- a/src/context/sections.rs
+++ b/src/context/sections.rs
@@ -7,7 +7,7 @@ mod workstreams;
 #[cfg(test)]
 pub(super) use core::render_core_memory;
 pub(super) use core::render_core_memory_with_limits;
-pub(super) use empty::render_empty_state;
+pub(super) use empty::empty_state_output;
 #[cfg(test)]
 pub(super) use index::render_memory_index;
 #[cfg(test)]

--- a/src/context/sections/empty.rs
+++ b/src/context/sections/empty.rs
@@ -1,9 +1,9 @@
 use super::super::format::format_header_datetime;
 
-pub(in crate::context) fn render_empty_state(project: &str) {
-    println!(
-        "# [{}] context {}\nNo previous sessions found.",
+pub(in crate::context) fn empty_state_output(project: &str) -> String {
+    format!(
+        "# [{}] context {}\nNo previous sessions found.\n",
         project,
         format_header_datetime()
-    );
+    )
 }

--- a/src/hook_stdin.rs
+++ b/src/hook_stdin.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+
+pub(crate) fn read_stdin_with_timeout(timeout_ms: u64) -> Result<Option<String>> {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let (tx, rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let input = std::io::read_to_string(std::io::stdin());
+        let _ = tx.send(input);
+    });
+
+    match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
+        Ok(Ok(input)) => {
+            if input.trim().is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(input))
+            }
+        }
+        Ok(Err(error)) => Err(error.into()),
+        Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Ok(None),
+    }
+}

--- a/src/hook_stdin.rs
+++ b/src/hook_stdin.rs
@@ -1,8 +1,20 @@
 use anyhow::Result;
+use std::io::IsTerminal;
 
 pub(crate) fn read_stdin_with_timeout(timeout_ms: u64) -> Result<Option<String>> {
+    read_stdin_with_timeout_inner(timeout_ms, std::io::stdin().is_terminal())
+}
+
+fn read_stdin_with_timeout_inner(
+    timeout_ms: u64,
+    stdin_is_terminal: bool,
+) -> Result<Option<String>> {
     use std::sync::mpsc;
     use std::time::Duration;
+
+    if stdin_is_terminal {
+        return Ok(None);
+    }
 
     let (tx, rx) = mpsc::sync_channel(1);
     std::thread::spawn(move || {
@@ -21,5 +33,21 @@ pub(crate) fn read_stdin_with_timeout(timeout_ms: u64) -> Result<Option<String>>
         Ok(Err(error)) => Err(error.into()),
         Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
         Err(mpsc::RecvTimeoutError::Disconnected) => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_stdin_skips_timeout_read() -> Result<()> {
+        let started = std::time::Instant::now();
+
+        let input = read_stdin_with_timeout_inner(1000, true)?;
+
+        assert!(input.is_none());
+        assert!(started.elapsed() < std::time::Duration::from_millis(100));
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod dream;
 pub mod eval;
 mod extraction_worker;
 pub mod git_util;
+mod hook_stdin;
 pub mod identity;
 pub mod install;
 pub mod log;

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -62,10 +62,13 @@ fn full_migration_on_empty_db() -> Result<()> {
     run_migrations(&conn)?;
 
     let applied = applied_versions(&conn)?;
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+    assert_eq!(
+        applied,
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16]
+    );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 26);
+    assert_eq!(user_version, 28);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -89,6 +92,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "memory_candidates",
         "memory_facts",
         "procedure_verifications",
+        "context_injections",
         "rule_candidates",
     ] {
         let exists: bool = conn
@@ -311,7 +315,7 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 26);
+    assert_eq!(user_version, 28);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -351,7 +355,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 26);
+    assert_eq!(result.current_version, 28);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -75,6 +75,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "procedure_verifications",
         sql: include_str!("../migrations/v014_procedure_verifications.sql"),
     },
+    Migration {
+        version: 16,
+        name: "context_injection_gate",
+        sql: include_str!("../migrations/v016_context_injection_gate.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v016_context_injection_gate.sql
+++ b/src/migrations/v016_context_injection_gate.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS context_injections (
     injection_key TEXT NOT NULL,
     session_id TEXT,
     transcript_path TEXT,
+    hook_source TEXT,
     context_hash TEXT NOT NULL,
     output_mode TEXT NOT NULL,
     output_chars INTEGER NOT NULL,

--- a/src/migrations/v016_context_injection_gate.sql
+++ b/src/migrations/v016_context_injection_gate.sql
@@ -1,0 +1,24 @@
+-- v016_context_injection_gate: Track context hook emissions so hosts with
+-- task-scoped SessionStart hooks can avoid injecting duplicate startup context
+-- into one conversation history.
+
+CREATE TABLE IF NOT EXISTS context_injections (
+    id INTEGER PRIMARY KEY,
+    host TEXT NOT NULL,
+    project TEXT NOT NULL,
+    injection_key TEXT NOT NULL,
+    session_id TEXT,
+    transcript_path TEXT,
+    context_hash TEXT NOT NULL,
+    output_mode TEXT NOT NULL,
+    output_chars INTEGER NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    last_emitted_epoch INTEGER NOT NULL,
+    emit_count INTEGER NOT NULL DEFAULT 1,
+    suppress_count INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(host, injection_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_context_injections_project_seen
+    ON context_injections(project, updated_at_epoch DESC);

--- a/src/summarize/input.rs
+++ b/src/summarize/input.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use serde::Deserialize;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -47,37 +46,4 @@ pub(super) fn extract_last_assistant_message(transcript_path: &str) -> Option<St
     }
 
     None
-}
-
-pub(super) fn read_stdin_with_timeout(timeout_ms: u64) -> Result<Option<String>> {
-    use std::sync::mpsc;
-    use std::time::Duration;
-
-    let (tx, rx) = mpsc::sync_channel(1);
-    std::thread::spawn(move || {
-        let input = std::io::read_to_string(std::io::stdin());
-        let _ = tx.send(input);
-    });
-
-    match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
-        Ok(Ok(input)) => {
-            if input.trim().is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(input))
-            }
-        }
-        Ok(Err(err)) => Err(err.into()),
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            crate::log::warn(
-                "summarize",
-                &format!("stdin read timed out after {}ms, skipping", timeout_ms),
-            );
-            Ok(None)
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            crate::log::warn("summarize", "stdin reader disconnected, skipping");
-            Ok(None)
-        }
-    }
 }

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 
 use crate::db;
+use crate::hook_stdin::read_stdin_with_timeout;
 
 use super::super::constants::SUMMARIZE_STDIN_TIMEOUT_MS;
-use super::super::input::{read_stdin_with_timeout, SummarizeInput};
+use super::super::input::SummarizeInput;
 
 pub async fn summarize() -> Result<()> {
     let Some(input) = read_stdin_with_timeout(SUMMARIZE_STDIN_TIMEOUT_MS)? else {


### PR DESCRIPTION
## Summary

- Add Codex SessionStart context injection gating so repeated same-session hooks suppress unchanged context output.
- Parse Codex hook stdin for `session_id`, `cwd`, and `transcript_path` before rendering context.
- Add `context_injections` migration state, stable SHA-256 context fingerprints, and `--force` / `--gate` escape hatches.
- Document the full design and add Codex duplicate-injection smoke checks.

## Root Cause

Codex runs `SessionStart` at agent task/turn startup, not just at the visible beginning of a chat. remem treated every `SessionStart` as a fresh conversation start, so one Codex thread could accumulate repeated full memory context blocks as developer messages.

## User Impact

The first Codex task still gets full remem context. Later unchanged tasks in the same Codex session emit empty stdout, avoiding duplicate prompt history, token waste, and mid-chat context noise. Failures remain fail-open so context quality is not silently lost.

Closes #205

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo test context:: --lib`
- `cargo test migrate:: --lib`
- `cargo clippy -- -D warnings`
- `cargo test`
- Codex-style smoke: first same-session context command emitted `105` bytes; second unchanged same-session command emitted `0` bytes.
