### PR TITLE
feat: add progressive MCP search envelope

### DIFF
--- a/src/mcp/server/context_tools.rs
+++ b/src/mcp/server/context_tools.rs
@@ -78,7 +78,7 @@ impl MemoryServer {
     }
 
     #[tool(
-        description = "Fetch complete observation details (narrative, facts, concepts, files_read, files_modified) by IDs. Use after search() to get full context. This is the second step in the search → get_observations workflow. Supports both 'memory' and 'observation' sources."
+        description = "Fetch complete details by IDs. Use after search(): pass selected IDs and the exact source from search.next_step.source or each result.source. Supports source='memory' for curated memories and source='observation' for legacy observations."
     )]
     pub(super) fn get_observations(
         &self,
@@ -94,31 +94,42 @@ impl MemoryServer {
             ),
         );
         self.with_conn(|conn| {
-            let results = if source == "observation" {
-                let observations =
-                    db::get_observations_by_ids(conn, &params.ids, params.project.as_deref())
-                        .map_err(|e| {
-                            crate::log::warn("mcp", &format!("get_observations failed: {}", e));
-                            e.to_string()
-                        })?;
-                let accessed_ids: Vec<i64> = observations
-                    .iter()
-                    .map(|observation| observation.id)
-                    .collect();
-                if !accessed_ids.is_empty() {
-                    if let Err(err) = db::update_last_accessed(conn, &accessed_ids) {
-                        crate::log::warn("mcp", &format!("update_last_accessed failed: {}", err));
+            let results = match source {
+                "observation" => {
+                    let observations_result =
+                        db::get_observations_by_ids(conn, &params.ids, params.project.as_deref());
+                    let observations = observations_result.map_err(|e| {
+                        crate::log::warn("mcp", &format!("get_observations failed: {}", e));
+                        e.to_string()
+                    })?;
+                    let accessed_ids: Vec<i64> = observations
+                        .iter()
+                        .map(|observation| observation.id)
+                        .collect();
+                    if !accessed_ids.is_empty() {
+                        if let Err(err) = db::update_last_accessed(conn, &accessed_ids) {
+                            crate::log::warn(
+                                "mcp",
+                                &format!("update_last_accessed failed: {}", err),
+                            );
+                        }
                     }
+                    serde_json::to_value(&observations).map_err(|e| e.to_string())?
                 }
-                serde_json::to_value(&observations).map_err(|e| e.to_string())?
-            } else {
-                let memories =
-                    memory::get_memories_by_ids(conn, &params.ids, params.project.as_deref())
-                        .map_err(|e| {
-                            crate::log::warn("mcp", &format!("get_memories failed: {}", e));
-                            e.to_string()
-                        })?;
-                serde_json::to_value(&memories).map_err(|e| e.to_string())?
+                "memory" => {
+                    let memories_result =
+                        memory::get_memories_by_ids(conn, &params.ids, params.project.as_deref());
+                    let memories = memories_result.map_err(|e| {
+                        crate::log::warn("mcp", &format!("get_memories failed: {}", e));
+                        e.to_string()
+                    })?;
+                    serde_json::to_value(&memories).map_err(|e| e.to_string())?
+                }
+                other => {
+                    return Err(format!(
+                        "unsupported source '{other}'; expected 'memory' or 'observation'"
+                    ));
+                }
             };
             crate::log::info(
                 "mcp",

--- a/src/mcp/server/raw_tools.rs
+++ b/src/mcp/server/raw_tools.rs
@@ -50,6 +50,7 @@ impl MemoryServer {
                 .into_iter()
                 .map(|msg| RawSearchHit {
                     id: msg.id,
+                    source_type: "raw_archive".to_string(),
                     session_id: msg.session_id,
                     project: msg.project,
                     role: msg.role,

--- a/src/mcp/server/runtime.rs
+++ b/src/mcp/server/runtime.rs
@@ -9,11 +9,11 @@ const SERVER_INSTRUCTIONS: &str = r#"Persistent memory for Claude Code and Codex
 
 ## Workflow
 1. **Context index** is auto-injected at session start (titles + types, ~50 tokens each)
-2. When you need details: `search(query)` → get matching IDs
-3. Then: `get_observations(ids)` → full narrative, facts, concepts, files
+2. When you need details: `search(query)` → compact envelope with result IDs and `next_step.source`
+3. Then: `get_observations(ids, source)` → full narrative, facts, concepts, files
 4. Use `timeline(anchor/query)` to understand chronological context around a change
 5. Use `save_memory(text)` to persist important decisions or discoveries (and local markdown backup)
-6. If curated `search` is empty/sparse, it auto-attaches `raw_hits` from the raw archive (every user/assistant turn captured at Stop time). Call `search_raw(query)` directly when you need to recall a literal phrase that was never summarized or promoted.
+6. If curated `search` is empty/sparse, it auto-attaches `raw_hits` labeled `source_type="raw_archive"` (every user/assistant turn captured at Stop time). Call `search_raw(query)` directly when you need to recall a literal phrase that was never summarized or promoted.
 
 ## Local document rule
 - If user asks to save/write/update a document, create or edit a local file first

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -10,7 +10,7 @@ const RAW_PREVIEW_CHARS: usize = 300;
 #[tool_router(router = tool_router_search, vis = "pub(super)")]
 impl MemoryServer {
     #[tool(
-        description = "Search past memories by keyword/project/type. Returns compact results (id, type, title, topic_key, 300-char preview). WORKFLOW: search → find relevant IDs → get_observations(ids) for full details.\n\n**Multi-step retrieval strategy** (follow this for complex questions):\n1. **Decompose**: Break complex questions into 2-3 focused sub-queries and search each separately. E.g. 'What do Melanie's kids like?' → search('Melanie children names') + search('Melanie kids hobbies').\n2. **Iterate**: If first search returns <5 results, extract key entities/names from results and search again with those entities.\n3. **Multi-hop**: Set multi_hop=true when the question spans multiple people/topics — this triggers entity graph expansion automatically.\n\nUse when: user asks about past work, you need implementation context, or debugging a previously-fixed issue."
+        description = "Search past memories by keyword/project/type. Always returns a compact envelope: { mode, results, next_step, pagination }. Use result IDs with next_step.source in get_observations(ids, source) to fetch full details. raw_hits are raw_archive rows, not curated memories; use search_raw for literal chat recall.\n\n**Multi-step retrieval strategy** (follow this for complex questions):\n1. **Decompose**: Break complex questions into 2-3 focused sub-queries and search each separately. E.g. 'What do Melanie's kids like?' → search('Melanie children names') + search('Melanie kids hobbies').\n2. **Iterate**: If first search returns <5 results, extract key entities/names from results and search again with those entities.\n3. **Multi-hop**: Set multi_hop=true when the question spans multiple people/topics — this triggers entity graph expansion automatically.\n\nUse when: user asks about past work, you need implementation context, or debugging a previously-fixed issue."
     )]
     pub(super) fn search(
         &self,
@@ -73,6 +73,7 @@ impl MemoryServer {
                         topic_key: memory.topic_key,
                         preview: Some(preview),
                         source: "memory".to_string(),
+                        source_type: "memory".to_string(),
                         updated_at: updated,
                         project: memory.project,
                         status: memory.status,
@@ -84,6 +85,7 @@ impl MemoryServer {
                 .into_iter()
                 .map(|msg| RawSearchHit {
                     id: msg.id,
+                    source_type: "raw_archive".to_string(),
                     session_id: msg.session_id,
                     project: msg.project,
                     role: msg.role,
@@ -116,26 +118,43 @@ impl MemoryServer {
                 ),
             );
 
-            if multi_hop.is_some() || !raw_hits_json.is_empty() || has_more {
-                let mut response = serde_json::json!({ "results": search_results });
-                if let Some(meta) = multi_hop {
-                    response["multi_hop"] = serde_json::json!({
-                        "hops": meta.hops,
-                        "entities_discovered": meta.entities_discovered,
-                    });
+            let result_ids: Vec<i64> = search_results.iter().map(|result| result.id).collect();
+            let next_offset = has_more.then_some(req_offset + req_limit);
+            let mut response = serde_json::json!({
+                "mode": "compact",
+                "results": search_results,
+                "next_step": {
+                    "tool": "get_observations",
+                    "source": "memory",
+                    "ids": result_ids,
+                    "reason": "Pass selected compact result IDs with source='memory' to fetch full details."
+                },
+                "pagination": {
+                    "limit": req_limit,
+                    "offset": req_offset,
+                    "has_more": has_more,
+                    "next_offset": next_offset,
                 }
-                if !raw_hits_json.is_empty() {
-                    response["raw_hits"] =
-                        serde_json::to_value(&raw_hits_json).map_err(|e| e.to_string())?;
-                }
-                if has_more {
-                    response["has_more"] = serde_json::Value::Bool(true);
-                    response["next_offset"] = serde_json::Value::from(req_offset + req_limit);
-                }
-                serde_json::to_string_pretty(&response).map_err(|e| e.to_string())
-            } else {
-                serde_json::to_string_pretty(&search_results).map_err(|e| e.to_string())
+            });
+            if let Some(meta) = multi_hop {
+                response["multi_hop"] = serde_json::json!({
+                    "hops": meta.hops,
+                    "entities_discovered": meta.entities_discovered,
+                });
             }
+            if !raw_hits_json.is_empty() {
+                response["raw_hits"] =
+                    serde_json::to_value(&raw_hits_json).map_err(|e| e.to_string())?;
+                response["raw_hits_note"] = serde_json::Value::String(
+                    "raw_hits are source_type='raw_archive' chat rows, not curated memories; use search_raw for literal recall."
+                        .to_string(),
+                );
+            }
+            if has_more {
+                response["has_more"] = serde_json::Value::Bool(true);
+                response["next_offset"] = serde_json::Value::from(req_offset + req_limit);
+            }
+            serde_json::to_string_pretty(&response).map_err(|e| e.to_string())
         })
     }
 }

--- a/src/mcp/server/tests.rs
+++ b/src/mcp/server/tests.rs
@@ -1,8 +1,11 @@
 use rmcp::handler::server::wrapper::Parameters;
+use serde_json::Value;
 
-use super::super::types::SearchParams;
+use super::super::types::{GetObservationsParams, SearchParams};
 use super::MemoryServer;
 use crate::db::test_support::ScopedTestDataDir;
+use crate::memory;
+use crate::memory::raw_archive::{insert_raw_message, ROLE_USER, SOURCE_HOOK};
 use crate::memory::service::{resolve_local_note_path, sanitize_segment};
 
 #[test]
@@ -65,4 +68,138 @@ fn search_reopens_database_after_file_removal() {
     }));
     assert!(second.is_ok());
     assert!(test_dir.db_path().exists());
+}
+
+#[test]
+fn search_returns_stable_compact_envelope_with_expansion_hint() {
+    let _dir = ScopedTestDataDir::new("mcp-search-envelope");
+    let conn = crate::db::open_db().expect("db opens");
+    let memory_id = memory::insert_memory(
+        &conn,
+        Some("session-1"),
+        "/repo",
+        Some("aurora-contract"),
+        "Aurora contract decision",
+        "The aurora recall contract keeps search compact before expansion.",
+        "decision",
+        None,
+    )
+    .expect("memory insert succeeds");
+    drop(conn);
+
+    let server = MemoryServer::new().expect("memory server should initialize");
+    let response = server
+        .search(Parameters(SearchParams {
+            query: Some("aurora".to_string()),
+            limit: Some(5),
+            project: Some("/repo".to_string()),
+            r#type: None,
+            offset: Some(0),
+            include_stale: Some(true),
+            branch: None,
+            multi_hop: Some(false),
+        }))
+        .expect("search succeeds");
+    let json: Value = serde_json::from_str(&response).expect("search returns json");
+
+    assert_eq!(json["mode"], "compact");
+    assert!(json["results"].is_array());
+    assert_eq!(json["results"][0]["id"], memory_id);
+    assert_eq!(json["results"][0]["source"], "memory");
+    assert_eq!(json["results"][0]["source_type"], "memory");
+    assert_eq!(json["next_step"]["tool"], "get_observations");
+    assert_eq!(json["next_step"]["source"], "memory");
+    assert_eq!(json["next_step"]["ids"][0], memory_id);
+    assert_eq!(json["pagination"]["has_more"], false);
+
+    let expanded = server
+        .get_observations(Parameters(GetObservationsParams {
+            ids: vec![memory_id],
+            project: Some("/repo".to_string()),
+            source: json["next_step"]["source"].as_str().map(str::to_string),
+        }))
+        .expect("expansion succeeds");
+    let expanded_json: Value = serde_json::from_str(&expanded).expect("expanded json");
+    assert_eq!(expanded_json[0]["id"], memory_id);
+}
+
+#[test]
+fn search_labels_sparse_result_raw_fallback_as_raw_archive() {
+    let _dir = ScopedTestDataDir::new("mcp-search-raw-fallback");
+    let conn = crate::db::open_db().expect("db opens");
+    insert_raw_message(
+        &conn,
+        "session-raw",
+        "/repo",
+        ROLE_USER,
+        "literal fallback needle only exists in raw archive",
+        SOURCE_HOOK,
+        Some("main"),
+        None,
+    )
+    .expect("raw insert succeeds");
+    drop(conn);
+
+    let server = MemoryServer::new().expect("memory server should initialize");
+    let response = server
+        .search(Parameters(SearchParams {
+            query: Some("needle".to_string()),
+            limit: Some(5),
+            project: Some("/repo".to_string()),
+            r#type: None,
+            offset: Some(0),
+            include_stale: Some(true),
+            branch: Some("main".to_string()),
+            multi_hop: Some(false),
+        }))
+        .expect("search succeeds");
+    let json: Value = serde_json::from_str(&response).expect("search returns json");
+
+    assert_eq!(json["mode"], "compact");
+    assert_eq!(json["raw_hits"][0]["source_type"], "raw_archive");
+    assert_eq!(json["raw_hits"][0]["source"], SOURCE_HOOK);
+    assert!(json["raw_hits_note"]
+        .as_str()
+        .expect("raw note should be present")
+        .contains("not curated memories"));
+}
+
+#[test]
+fn search_preserves_multi_hop_metadata_in_compact_envelope() {
+    let _dir = ScopedTestDataDir::new("mcp-search-multi-hop");
+    let server = MemoryServer::new().expect("memory server should initialize");
+
+    let response = server
+        .search(Parameters(SearchParams {
+            query: None,
+            limit: Some(5),
+            project: Some("/repo".to_string()),
+            r#type: None,
+            offset: Some(0),
+            include_stale: Some(true),
+            branch: None,
+            multi_hop: Some(true),
+        }))
+        .expect("search succeeds");
+    let json: Value = serde_json::from_str(&response).expect("search returns json");
+
+    assert_eq!(json["mode"], "compact");
+    assert_eq!(json["multi_hop"]["hops"], 1);
+    assert!(json["results"].is_array());
+    assert!(json["next_step"]["ids"].is_array());
+}
+
+#[test]
+fn get_observations_rejects_unknown_source() {
+    let _dir = ScopedTestDataDir::new("mcp-get-observations-source");
+    let server = MemoryServer::new().expect("memory server should initialize");
+
+    let result = server.get_observations(Parameters(GetObservationsParams {
+        ids: vec![1],
+        project: None,
+        source: Some("raw_archive".to_string()),
+    }));
+
+    let err = result.expect_err("unknown source should be rejected");
+    assert!(err.contains("expected 'memory' or 'observation'"));
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -127,6 +127,7 @@ pub(super) struct SearchResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preview: Option<String>,
     pub source: String,
+    pub source_type: String,
     pub updated_at: String,
     pub project: String,
     pub status: String,
@@ -155,6 +156,7 @@ pub(super) struct SearchRawParams {
 #[derive(Debug, Serialize)]
 pub(super) struct RawSearchHit {
     pub id: i64,
+    pub source_type: String,
     pub session_id: String,
     pub project: String,
     pub role: String,


### PR DESCRIPTION
## Summary

Formalizes the MCP recall flow from #209 by making `search` always return a compact progressive-disclosure envelope with explicit expansion metadata.

Closes #209

## Changes

- Return a stable `{ mode, results, next_step, pagination }` envelope from MCP `search`
- Add `source_type` labels for curated memory results and raw archive fallback hits
- Make `get_observations` reject unknown sources instead of silently defaulting to memory
- Update MCP tool/server instructions for the two-step search -> expansion workflow
- Add MCP server tests for compact search, expansion, raw fallback labeling, multi-hop metadata, and source validation

## Test plan

- `cargo fmt --check`
- `cargo test mcp::server::tests`
- `cargo check`
- `cargo test`