### PR TITLE
feat: add lesson memory layer

### DIFF
--- a/src/context/format.rs
+++ b/src/context/format.rs
@@ -10,6 +10,7 @@ pub(super) fn type_label(memory_type: &str) -> &'static str {
         "bugfix" => "Bug Fixes",
         "architecture" => "Architecture",
         "discovery" => "Discoveries",
+        "lesson" => "Lessons",
         "preference" => "Preferences",
         "session_activity" => "Sessions",
         _ => "Other",

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -581,8 +581,8 @@ mod tests {
 
     #[test]
     fn fingerprint_ignores_footer_totals_derived_from_header_width() {
-        let a = "# [/tmp/remem] context 2026-05-25 9:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n";
-        let b = "# [/tmp/remem] context 2026-05-25 10:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=101 chars/~26 tokens limit=12000 truncated=no\n";
+        let a = "# [/tmp/remem] context 2026-05-25 9:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n";
+        let b = "# [/tmp/remem] context 2026-05-25 10:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=101 chars/~26 tokens limit=12000 truncated=no\n";
 
         assert_eq!(context_fingerprint(a), context_fingerprint(b));
     }
@@ -750,11 +750,11 @@ mod tests {
     fn fingerprint_ignores_generated_debug_trace() {
         let base = "# [/tmp/remem] context now\nBody\n";
         let a = format!(
-            "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=main session=sess-1\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n",
+            "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=main session=sess-1\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n",
             base
         );
         let b = format!(
-            "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=dev session=sess-2\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=dev total=120 chars/~30 tokens limit=12000 truncated=no\n",
+            "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=dev session=sess-2\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=dev total=120 chars/~30 tokens limit=12000 truncated=no\n",
             base
         );
 

--- a/src/context/injection_gate/delta.rs
+++ b/src/context/injection_gate/delta.rs
@@ -117,7 +117,7 @@ mod tests {
         assert_eq!(first.action, ContextGateAction::EmittedFull);
 
         let changed_output = format!(
-            "# [/tmp/remem] context later\n{}\n\n1 context memories loaded. 1 core (10 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=3000 chars/~750 tokens limit=12000 truncated=no\n",
+            "# [/tmp/remem] context later\n{}\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=3000 chars/~750 tokens limit=12000 truncated=no\n",
             "Body B ".repeat(400)
         );
         let second = apply_context_gate(&invocation, changed_output.clone());

--- a/src/context/policy.rs
+++ b/src/context/policy.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum SectionKind {
     Preferences,
+    Lessons,
     Core,
     Workstreams,
     MemoryIndex,
@@ -30,6 +31,8 @@ pub(super) struct ContextLimits {
     pub preference_project_limit: usize,
     pub preference_global_limit: usize,
     pub preference_char_limit: usize,
+    pub lesson_limit: usize,
+    pub lesson_char_limit: usize,
 }
 
 impl Default for ContextLimits {
@@ -46,6 +49,8 @@ impl Default for ContextLimits {
             preference_project_limit: 20,
             preference_global_limit: 0,
             preference_char_limit: 1_500,
+            lesson_limit: 4,
+            lesson_char_limit: 1_200,
         }
     }
 }
@@ -117,6 +122,16 @@ impl ContextLimits {
                 "REMEM_CONTEXT_PREFERENCE_CHAR_LIMIT",
                 defaults.preference_char_limit,
             ),
+            lesson_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_LESSON_LIMIT",
+                defaults.lesson_limit,
+            ),
+            lesson_char_limit: read_usize(
+                &mut read,
+                "REMEM_CONTEXT_LESSON_CHAR_LIMIT",
+                defaults.lesson_char_limit,
+            ),
         }
     }
 }
@@ -144,11 +159,18 @@ impl ContextPolicy {
                     exclude_types: vec![],
                 },
                 SectionPolicy {
+                    kind: SectionKind::Lessons,
+                    item_limit: limits.lesson_limit,
+                    char_limit: limits.lesson_char_limit,
+                    include_types: vec!["lesson"],
+                    exclude_types: vec![],
+                },
+                SectionPolicy {
                     kind: SectionKind::Core,
                     item_limit: limits.core_item_limit,
                     char_limit: limits.core_char_limit,
                     include_types: vec!["bugfix", "architecture", "decision", "discovery"],
-                    exclude_types: vec!["preference", "session_activity"],
+                    exclude_types: vec!["preference", "lesson", "session_activity"],
                 },
                 SectionPolicy {
                     kind: SectionKind::Workstreams,
@@ -162,7 +184,7 @@ impl ContextPolicy {
                     item_limit: limits.memory_index_limit,
                     char_limit: limits.memory_index_char_limit,
                     include_types: vec![],
-                    exclude_types: vec!["preference"],
+                    exclude_types: vec!["preference", "lesson"],
                 },
                 SectionPolicy {
                     kind: SectionKind::Sessions,

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -35,6 +35,7 @@ pub(super) fn load_context_data_with_policy(
     let lessons = memory::lesson::list_lessons_for_context(
         conn,
         project,
+        current_branch,
         policy.section_item_limit(SectionKind::Lessons, policy.limits.lesson_limit) as i64,
     )
     .unwrap_or_else(|e| {

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -32,6 +32,18 @@ pub(super) fn load_context_data_with_policy(
 ) -> LoadedContext {
     let mut memories = load_project_memories(conn, project, current_branch, policy);
     sort_memories_by_branch(&mut memories, current_branch);
+    let lessons = memory::lesson::list_lessons_for_context(
+        conn,
+        project,
+        policy.section_item_limit(SectionKind::Lessons, policy.limits.lesson_limit) as i64,
+    )
+    .unwrap_or_else(|e| {
+        crate::log::error(
+            "context",
+            &format!("failed to load lessons for {project}: {e}"),
+        );
+        Vec::new()
+    });
 
     let summaries = query_recent_summaries(conn, project, policy.limits.session_limit)
         .unwrap_or_else(|e| {
@@ -52,6 +64,7 @@ pub(super) fn load_context_data_with_policy(
 
     LoadedContext {
         memories,
+        lessons,
         summaries,
         workstreams,
     }

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -11,8 +11,9 @@ use super::invocation::{
 use super::policy::{ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
-    empty_state_output, render_core_memory_with_limits, render_memory_index_with_limits_excluding,
-    render_recent_sessions_with_limit, render_workstreams_with_limits,
+    empty_state_output, render_core_memory_with_limits, render_lessons_with_limit,
+    render_memory_index_with_limits_excluding, render_recent_sessions_with_limit,
+    render_workstreams_with_limits,
 };
 use super::types::ContextRequest;
 
@@ -77,7 +78,7 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
 
     let capabilities = resolve_profile(request.host).capabilities();
     timer.done(&format!(
-        "project={} cwd={} session={} host={} colors={} gate={:?}:{} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] context_memories={} core={} index={} preferences={} sessions={} workstreams={}",
+        "project={} cwd={} session={} host={} colors={} gate={:?}:{} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] context_memories={} core={} lessons={} index={} preferences={} sessions={} workstreams={}",
         request.project,
         request.cwd,
         request.session_id.as_deref().unwrap_or("-"),
@@ -92,6 +93,7 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         capabilities.observes_bash,
         rendered.stats.memories_loaded,
         rendered.stats.core.count,
+        rendered.stats.lessons.count,
         rendered.stats.index.count,
         rendered.stats.preferences.count,
         rendered.stats.sessions.count,
@@ -137,6 +139,7 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
 
     if preference_summary.rendered == 0
         && loaded.memories.is_empty()
+        && loaded.lessons.is_empty()
         && loaded.summaries.is_empty()
         && loaded.workstreams.is_empty()
     {
@@ -158,7 +161,7 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
         host: request.host.as_env_value().to_string(),
         branch: request.current_branch.clone(),
         total_char_limit: policy.limits.total_char_limit,
-        memories_loaded: loaded.memories.len(),
+        memories_loaded: loaded.memories.len() + loaded.lessons.len(),
         project_preferences: preference_summary.project_rendered,
         global_preferences: preference_summary.global_rendered,
         ..ContextRenderStats::default()
@@ -171,6 +174,19 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
         chars: char_len(&output).saturating_sub(before),
     };
 
+    if !loaded.lessons.is_empty() {
+        let before = char_len(&output);
+        let lesson_count = render_lessons_with_limit(
+            &mut output,
+            &loaded.lessons,
+            policy.section_item_limit(SectionKind::Lessons, policy.limits.lesson_limit),
+            policy.section_char_limit(SectionKind::Lessons, policy.limits.lesson_char_limit),
+        );
+        stats.lessons = SectionRenderStats {
+            count: lesson_count,
+            chars: char_len(&output).saturating_sub(before),
+        };
+    }
     if !loaded.memories.is_empty() {
         let render_limits = section_render_limits(&policy);
         let before = char_len(&output);
@@ -294,6 +310,7 @@ pub(in crate::context) struct ContextRenderStats {
     pub total_char_limit: usize,
     pub memories_loaded: usize,
     pub core: SectionRenderStats,
+    pub lessons: SectionRenderStats,
     pub index: SectionRenderStats,
     pub preferences: SectionRenderStats,
     pub project_preferences: usize,
@@ -309,10 +326,12 @@ pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats)
     let branch = stats.branch.as_deref().unwrap_or("-");
     let estimated_tokens = estimate_tokens(stats.output_chars);
     format!(
-        "{} context memories loaded. {} core ({} chars). {} indexed ({} chars). {} preferences (project:{} global:{}, {} chars). {} sessions ({} chars). host={} branch={} total={} chars/~{} tokens limit={} truncated={}\n",
+        "{} context memories loaded. {} core ({} chars). {} lessons ({} chars). {} indexed ({} chars). {} preferences (project:{} global:{}, {} chars). {} sessions ({} chars). host={} branch={} total={} chars/~{} tokens limit={} truncated={}\n",
         stats.memories_loaded,
         stats.core.count,
         stats.core.chars,
+        stats.lessons.count,
+        stats.lessons.chars,
         stats.index.count,
         stats.index.chars,
         stats.preferences.count,
@@ -346,10 +365,12 @@ fn build_context_debug_trace(
         request.session_id.as_deref().unwrap_or("-")
     ));
     trace.push_str(&format!(
-        "- limits total={} core_items={} core_chars={} index_items={} index_chars={} sessions={} preferences(project={}, global={}, chars={})\n",
+        "- limits total={} core_items={} core_chars={} lessons={} lesson_chars={} index_items={} index_chars={} sessions={} preferences(project={}, global={}, chars={})\n",
         policy.limits.total_char_limit,
         policy.limits.core_item_limit,
         policy.limits.core_char_limit,
+        policy.limits.lesson_limit,
+        policy.limits.lesson_char_limit,
         policy.limits.memory_index_limit,
         policy.limits.memory_index_char_limit,
         policy.limits.session_limit,
@@ -358,8 +379,9 @@ fn build_context_debug_trace(
         policy.limits.preference_char_limit
     ));
     trace.push_str(&format!(
-        "- rendered core={} index={} preferences={} sessions={} workstreams={}\n",
+        "- rendered core={} lessons={} index={} preferences={} sessions={} workstreams={}\n",
         stats.core.count,
+        stats.lessons.count,
         stats.index.count,
         stats.preferences.count,
         stats.sessions.count,
@@ -369,6 +391,18 @@ fn build_context_debug_trace(
         "- preferences project_rendered={} global_rendered={} reason=scope_limits_then_claude_md_dedup\n",
         stats.project_preferences, stats.global_preferences
     ));
+    for (rank, lesson) in loaded.lessons.iter().enumerate() {
+        trace.push_str(&format!(
+            "- lesson rank={} id={} confidence={:.2} reinforced={} scope={} topic={} title={}\n",
+            rank + 1,
+            lesson.memory.id,
+            lesson.metadata.confidence,
+            lesson.metadata.reinforcement_count,
+            lesson.memory.scope,
+            lesson.memory.topic_key.as_deref().unwrap_or("-"),
+            truncate_chars_with_ellipsis(&lesson.memory.title, 120)
+        ));
+    }
     for (rank, memory) in loaded.memories.iter().take(30).enumerate() {
         let target = if stats.core_ids.contains(&memory.id) {
             "core"

--- a/src/context/sections.rs
+++ b/src/context/sections.rs
@@ -1,6 +1,7 @@
 mod core;
 mod empty;
 mod index;
+mod lessons;
 mod sessions;
 mod workstreams;
 
@@ -13,6 +14,7 @@ pub(super) use index::render_memory_index;
 #[cfg(test)]
 pub(super) use index::render_memory_index_with_limits;
 pub(super) use index::render_memory_index_with_limits_excluding;
+pub(super) use lessons::render_lessons_with_limit;
 #[cfg(test)]
 pub(super) use sessions::render_recent_sessions;
 pub(super) use sessions::render_recent_sessions_with_limit;

--- a/src/context/sections/index.rs
+++ b/src/context/sections/index.rs
@@ -36,6 +36,7 @@ pub(in crate::context) fn render_memory_index_with_limits_excluding(
     for memory in memories
         .iter()
         .filter(|memory| memory.memory_type != "preference")
+        .filter(|memory| memory.memory_type != "lesson")
         .filter(|memory| !excluded_ids.contains(&memory.id))
         .take(limits.memory_index_limit)
     {

--- a/src/context/sections/lessons.rs
+++ b/src/context/sections/lessons.rs
@@ -1,0 +1,62 @@
+use crate::memory::lesson::LessonMemory;
+
+use super::super::format::{char_len, format_epoch_short, truncate_chars_with_ellipsis};
+
+const PREVIEW_LEN: usize = 180;
+
+pub(in crate::context) fn render_lessons_with_limit(
+    output: &mut String,
+    lessons: &[LessonMemory],
+    item_limit: usize,
+    char_limit: usize,
+) -> usize {
+    if lessons.is_empty() || item_limit == 0 || char_limit == 0 {
+        return 0;
+    }
+    let header = "## Lessons\n";
+    let trailer_chars = 1;
+    let mut total_chars = char_len(header) + trailer_chars;
+    if total_chars >= char_limit {
+        return 0;
+    }
+
+    let mut body = String::new();
+    let mut rendered = 0usize;
+    for lesson in lessons.iter().take(item_limit) {
+        let memory = &lesson.memory;
+        let metadata = &lesson.metadata;
+        let title = format!(
+            "**#{} {}** (confidence {:.2}, reinforced {}, {})\n",
+            memory.id,
+            memory.title,
+            metadata.confidence,
+            metadata.reinforcement_count,
+            format_epoch_short(metadata.last_reinforced_at_epoch)
+        );
+        let fixed_chars = char_len(&title) + 1;
+        if total_chars + fixed_chars >= char_limit {
+            break;
+        }
+        let preview_limit = (char_limit - total_chars - fixed_chars).min(PREVIEW_LEN);
+        let preview = truncate_chars_with_ellipsis(&memory.text, preview_limit);
+        if preview.is_empty() {
+            continue;
+        }
+        let item_chars = fixed_chars + char_len(&preview);
+        if total_chars + item_chars > char_limit {
+            break;
+        }
+        body.push_str(&title);
+        body.push_str(&preview);
+        body.push('\n');
+        total_chars += item_chars;
+        rendered += 1;
+    }
+    if rendered == 0 {
+        return 0;
+    }
+    output.push_str(header);
+    output.push_str(&body);
+    output.push('\n');
+    rendered
+}

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -344,6 +344,7 @@ fn load_context_data_loads_lessons_separately_from_main_memory_pool() {
             content: "Lesson: after repeated build failures, stop and challenge the hypothesis.",
             confidence: 0.9,
             source_evidence: Some("build failed repeatedly"),
+            files: None,
             branch: None,
             scope: "project",
             created_at_epoch: Some(now),
@@ -377,6 +378,47 @@ fn load_context_data_loads_lessons_separately_from_main_memory_pool() {
 }
 
 #[test]
+fn load_context_data_filters_lessons_by_current_branch() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/remem";
+
+    for (title, branch) in [
+        ("Main lesson", Some("main")),
+        ("Feature lesson", Some("feature/context")),
+    ] {
+        save_lesson(
+            &conn,
+            &SaveLessonRequest {
+                session_id: Some("s1"),
+                project,
+                topic_key: Some(&title.replace(' ', "-").to_lowercase()),
+                title,
+                content:
+                    "Lesson: branch-specific lessons should follow the current context branch.",
+                confidence: 0.9,
+                source_evidence: None,
+                files: None,
+                branch,
+                scope: "project",
+                created_at_epoch: None,
+                stale_after_epoch: None,
+            },
+        )
+        .unwrap();
+    }
+
+    let loaded = load_context_data(&conn, project, Some("main"));
+    let titles: Vec<_> = loaded
+        .lessons
+        .iter()
+        .map(|lesson| lesson.memory.title.as_str())
+        .collect();
+
+    assert_eq!(titles, vec!["Main lesson"]);
+}
+
+#[test]
 fn load_context_data_filters_lessons_before_candidate_limit_and_keeps_core_memory() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);
@@ -402,6 +444,7 @@ fn load_context_data_filters_lessons_before_candidate_limit_and_keeps_core_memor
                 content: "Lesson: this should not enter context because confidence is too low.",
                 confidence: 0.2,
                 source_evidence: None,
+                files: None,
                 branch: None,
                 scope: "project",
                 created_at_epoch: Some(now + idx),

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -1,3 +1,4 @@
+use crate::memory::lesson::{save_lesson, SaveLessonRequest};
 use crate::memory::types::tests_helper::setup_memory_schema;
 use rusqlite::Connection;
 
@@ -324,6 +325,113 @@ fn load_context_data_excludes_preferences_before_candidate_limit() {
         .memories
         .iter()
         .any(|memory| memory.title == "Keep core memories visible"));
+}
+
+#[test]
+fn load_context_data_loads_lessons_separately_from_main_memory_pool() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("s1"),
+            project,
+            topic_key: Some("lesson-build-loop"),
+            title: "Stop build-fix loops",
+            content: "Lesson: after repeated build failures, stop and challenge the hypothesis.",
+            confidence: 0.9,
+            source_evidence: Some("build failed repeatedly"),
+            branch: None,
+            scope: "project",
+            created_at_epoch: Some(now),
+            stale_after_epoch: None,
+        },
+    )
+    .unwrap();
+    insert_memory(
+        &conn,
+        200,
+        project,
+        Some("context-budget-decision"),
+        "decision",
+        "Keep context bounded",
+        "Separate lessons from the normal memory index",
+        now - 1,
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+
+    assert_eq!(loaded.lessons.len(), 1);
+    assert_eq!(loaded.lessons[0].memory.title, "Stop build-fix loops");
+    assert!(loaded
+        .memories
+        .iter()
+        .all(|memory| memory.memory_type != "lesson"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Keep context bounded"));
+}
+
+#[test]
+fn load_context_data_filters_lessons_before_candidate_limit_and_keeps_core_memory() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+    let limits = ContextLimits {
+        candidate_fetch_limit: 1,
+        lesson_limit: 10,
+        memory_index_limit: 10,
+        core_item_limit: 3,
+        ..ContextLimits::default()
+    };
+    let policy = ContextPolicy::from_limits(limits);
+
+    for idx in 0..20 {
+        save_lesson(
+            &conn,
+            &SaveLessonRequest {
+                session_id: Some("s1"),
+                project,
+                topic_key: Some(&format!("low-confidence-lesson-{idx}")),
+                title: &format!("Low confidence lesson {idx}"),
+                content: "Lesson: this should not enter context because confidence is too low.",
+                confidence: 0.2,
+                source_evidence: None,
+                branch: None,
+                scope: "project",
+                created_at_epoch: Some(now + idx),
+                stale_after_epoch: None,
+            },
+        )
+        .unwrap();
+    }
+    insert_memory(
+        &conn,
+        200,
+        project,
+        Some("keep-core-decision"),
+        "decision",
+        "Keep core decision visible",
+        "Low-confidence lessons must not crowd out core decisions.",
+        now - 1_000,
+    );
+
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy);
+
+    assert!(loaded.lessons.is_empty());
+    assert!(loaded
+        .memories
+        .iter()
+        .all(|memory| memory.memory_type != "lesson"));
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Keep core decision visible"));
 }
 
 #[test]

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -1,12 +1,13 @@
+use crate::memory::lesson::{LessonMemory, LessonMetadata};
 use crate::workstream::{WorkStream, WorkStreamStatus};
 
 use super::super::policy::ContextLimits;
 use super::super::render::{build_context_stats_footer, ContextRenderStats, SectionRenderStats};
 use super::super::sections::{
-    render_core_memory, render_core_memory_with_limits, render_memory_index,
-    render_memory_index_with_limits, render_memory_index_with_limits_excluding,
-    render_recent_sessions, render_recent_sessions_with_limit, render_workstreams,
-    render_workstreams_with_limits,
+    render_core_memory, render_core_memory_with_limits, render_lessons_with_limit,
+    render_memory_index, render_memory_index_with_limits,
+    render_memory_index_with_limits_excluding, render_recent_sessions,
+    render_recent_sessions_with_limit, render_workstreams, render_workstreams_with_limits,
 };
 use super::super::types::SessionSummaryBrief;
 use super::{sample_memory, sample_memory_with_epoch, sample_workstream};
@@ -99,6 +100,39 @@ fn render_memory_index_excludes_preferences() {
     assert!(output.contains("Decision title"));
     assert!(!output.contains("Preference title"));
     assert!(!output.contains("**Preferences**"));
+}
+
+#[test]
+fn render_memory_index_excludes_lessons() {
+    let mut output = String::new();
+    let memories = vec![
+        sample_memory(1, "lesson", "Lesson title"),
+        sample_memory(2, "decision", "Decision title"),
+    ];
+
+    render_memory_index(&mut output, &memories);
+
+    assert!(output.contains("Decision title"));
+    assert!(!output.contains("Lesson title"));
+    assert!(!output.contains("**Lessons**"));
+}
+
+#[test]
+fn render_lessons_respects_item_and_char_limits() {
+    let mut output = String::new();
+    let lessons = vec![
+        sample_lesson(1, "First lesson", 0.9, 3),
+        sample_lesson(2, "Second lesson", 0.8, 1),
+    ];
+
+    let rendered = render_lessons_with_limit(&mut output, &lessons, 1, 240);
+
+    assert_eq!(rendered, 1);
+    assert!(output.contains("## Lessons"));
+    assert!(output.contains("First lesson"));
+    assert!(output.contains("reinforced 3"));
+    assert!(!output.contains("Second lesson"));
+    assert!(output.chars().count() <= 240);
 }
 
 #[test]
@@ -324,6 +358,10 @@ fn context_stats_footer_reports_budget_scope_and_truncation() {
             count: 2,
             chars: 430,
         },
+        lessons: SectionRenderStats {
+            count: 1,
+            chars: 180,
+        },
         index: SectionRenderStats {
             count: 5,
             chars: 800,
@@ -349,9 +387,24 @@ fn context_stats_footer_reports_budget_scope_and_truncation() {
 
     assert!(footer.contains("7 context memories loaded"));
     assert!(footer.contains("2 core (430 chars)"));
+    assert!(footer.contains("1 lessons (180 chars)"));
     assert!(footer.contains("3 preferences (project:2 global:1"));
     assert!(footer.contains("host=codex-cli"));
     assert!(footer.contains("branch=fix/context"));
     assert!(footer.contains("total=3200 chars/~800 tokens"));
     assert!(footer.contains("truncated=yes"));
+}
+
+fn sample_lesson(id: i64, title: &str, confidence: f64, reinforcement_count: i64) -> LessonMemory {
+    LessonMemory {
+        memory: sample_memory(id, "lesson", title),
+        metadata: LessonMetadata {
+            memory_id: id,
+            confidence,
+            reinforcement_count,
+            source_evidence: None,
+            last_reinforced_at_epoch: 1_710_000_000,
+            stale_after_epoch: None,
+        },
+    }
 }

--- a/src/context/types.rs
+++ b/src/context/types.rs
@@ -1,3 +1,4 @@
+use crate::memory::lesson::LessonMemory;
 use crate::memory::Memory;
 use crate::workstream::WorkStream;
 
@@ -23,6 +24,7 @@ pub(super) struct SessionSummaryBrief {
 #[derive(Debug)]
 pub(super) struct LoadedContext {
     pub memories: Vec<Memory>,
+    pub lessons: Vec<LessonMemory>,
     pub summaries: Vec<SessionSummaryBrief>,
     pub workstreams: Vec<WorkStream>,
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -2,6 +2,7 @@ pub mod dedup;
 pub mod events;
 pub mod facts;
 pub mod format;
+pub mod lesson;
 pub mod lifecycle;
 pub mod preference;
 pub mod procedure;

--- a/src/memory/lesson.rs
+++ b/src/memory/lesson.rs
@@ -31,6 +31,7 @@ pub struct SaveLessonRequest<'a> {
     pub content: &'a str,
     pub confidence: f64,
     pub source_evidence: Option<&'a str>,
+    pub files: Option<&'a str>,
     pub branch: Option<&'a str>,
     pub scope: &'a str,
     pub created_at_epoch: Option<i64>,
@@ -56,7 +57,7 @@ pub fn save_lesson(conn: &Connection, req: &SaveLessonRequest<'_>) -> Result<i64
         req.title,
         req.content,
         "lesson",
-        None,
+        req.files,
         req.branch,
         scope,
         req.created_at_epoch,
@@ -105,7 +106,7 @@ fn upsert_lesson_metadata(
            reinforcement_count = memory_lessons.reinforcement_count + ?6,
            source_evidence = COALESCE(excluded.source_evidence, memory_lessons.source_evidence),
            last_reinforced_at_epoch = excluded.last_reinforced_at_epoch,
-           stale_after_epoch = COALESCE(excluded.stale_after_epoch, memory_lessons.stale_after_epoch)",
+           stale_after_epoch = excluded.stale_after_epoch",
         params![
             memory_id,
             confidence,
@@ -133,6 +134,7 @@ pub fn get_lesson_metadata(conn: &Connection, memory_id: i64) -> Result<Option<L
 pub fn list_lessons_for_context(
     conn: &Connection,
     project: &str,
+    current_branch: Option<&str>,
     limit: i64,
 ) -> Result<Vec<LessonMemory>> {
     if limit <= 0 {
@@ -150,16 +152,23 @@ pub fn list_lessons_for_context(
            AND (m.project = ?1 OR m.scope = 'global')
            AND l.confidence >= ?2
            AND (l.stale_after_epoch IS NULL OR l.stale_after_epoch > ?3)
+           AND (?4 IS NULL OR m.branch = ?4 OR m.branch IS NULL)
          ORDER BY
            CASE WHEN m.project = ?1 THEN 0 ELSE 1 END,
            l.confidence DESC,
            l.reinforcement_count DESC,
            l.last_reinforced_at_epoch DESC
-         LIMIT ?4",
+         LIMIT ?5",
         cols = prefixed_memory_cols("m")
     ))?;
     let rows = stmt.query_map(
-        params![project, MIN_CONFIDENCE_FOR_CONTEXT, now, limit],
+        params![
+            project,
+            MIN_CONFIDENCE_FOR_CONTEXT,
+            now,
+            current_branch,
+            limit
+        ],
         |row| {
             let memory = map_memory_row_pub(row)?;
             let metadata = map_lesson_metadata_from_offset(row, 13)?;

--- a/src/memory/lesson.rs
+++ b/src/memory/lesson.rs
@@ -1,0 +1,222 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::promote::slugify_for_topic;
+use super::types::{map_memory_row_pub, Memory, MEMORY_COLS};
+
+const MIN_CONFIDENCE_FOR_CONTEXT: f64 = 0.5;
+
+#[derive(Debug, Clone)]
+pub struct LessonMetadata {
+    pub memory_id: i64,
+    pub confidence: f64,
+    pub reinforcement_count: i64,
+    pub source_evidence: Option<String>,
+    pub last_reinforced_at_epoch: i64,
+    pub stale_after_epoch: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LessonMemory {
+    pub memory: Memory,
+    pub metadata: LessonMetadata,
+}
+
+#[derive(Debug, Clone)]
+pub struct SaveLessonRequest<'a> {
+    pub session_id: Option<&'a str>,
+    pub project: &'a str,
+    pub topic_key: Option<&'a str>,
+    pub title: &'a str,
+    pub content: &'a str,
+    pub confidence: f64,
+    pub source_evidence: Option<&'a str>,
+    pub branch: Option<&'a str>,
+    pub scope: &'a str,
+    pub created_at_epoch: Option<i64>,
+    pub stale_after_epoch: Option<i64>,
+}
+
+pub fn save_lesson(conn: &Connection, req: &SaveLessonRequest<'_>) -> Result<i64> {
+    let topic_key = req
+        .topic_key
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("lesson-{}", slugify_for_topic(req.content, 64)));
+    let scope = if req.scope.trim().is_empty() {
+        "project"
+    } else {
+        req.scope
+    };
+    let existing_id = existing_lesson_id(conn, req.project, &topic_key, scope)?;
+    let id = crate::memory::insert_memory_full(
+        conn,
+        req.session_id,
+        req.project,
+        Some(&topic_key),
+        req.title,
+        req.content,
+        "lesson",
+        None,
+        req.branch,
+        scope,
+        req.created_at_epoch,
+    )?;
+    upsert_lesson_metadata(conn, id, req, existing_id.is_some())?;
+    Ok(id)
+}
+
+fn existing_lesson_id(
+    conn: &Connection,
+    project: &str,
+    topic_key: &str,
+    scope: &str,
+) -> Result<Option<i64>> {
+    let id = conn
+        .query_row(
+            "SELECT id FROM memories
+             WHERE project = ?1
+               AND topic_key = ?2
+               AND COALESCE(scope, 'project') = ?3
+               AND memory_type = 'lesson'
+             LIMIT 1",
+            params![project, topic_key, scope],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(id)
+}
+
+fn upsert_lesson_metadata(
+    conn: &Connection,
+    memory_id: i64,
+    req: &SaveLessonRequest<'_>,
+    existed: bool,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let confidence = req.confidence.clamp(0.0, 1.0);
+    let reinforcement_delta = if existed { 1 } else { 0 };
+    conn.execute(
+        "INSERT INTO memory_lessons
+         (memory_id, confidence, reinforcement_count, source_evidence,
+          last_reinforced_at_epoch, stale_after_epoch)
+         VALUES (?1, ?2, 1, ?3, ?4, ?5)
+         ON CONFLICT(memory_id) DO UPDATE SET
+           confidence = MAX(memory_lessons.confidence, excluded.confidence),
+           reinforcement_count = memory_lessons.reinforcement_count + ?6,
+           source_evidence = COALESCE(excluded.source_evidence, memory_lessons.source_evidence),
+           last_reinforced_at_epoch = excluded.last_reinforced_at_epoch,
+           stale_after_epoch = COALESCE(excluded.stale_after_epoch, memory_lessons.stale_after_epoch)",
+        params![
+            memory_id,
+            confidence,
+            req.source_evidence,
+            now,
+            req.stale_after_epoch,
+            reinforcement_delta
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn get_lesson_metadata(conn: &Connection, memory_id: i64) -> Result<Option<LessonMetadata>> {
+    conn.query_row(
+        "SELECT memory_id, confidence, reinforcement_count, source_evidence,
+                last_reinforced_at_epoch, stale_after_epoch
+         FROM memory_lessons WHERE memory_id = ?1",
+        [memory_id],
+        map_lesson_metadata_row,
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub fn list_lessons_for_context(
+    conn: &Connection,
+    project: &str,
+    limit: i64,
+) -> Result<Vec<LessonMemory>> {
+    if limit <= 0 {
+        return Ok(vec![]);
+    }
+    let now = chrono::Utc::now().timestamp();
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {cols},
+                l.memory_id, l.confidence, l.reinforcement_count, l.source_evidence,
+                l.last_reinforced_at_epoch, l.stale_after_epoch
+         FROM memories m
+         JOIN memory_lessons l ON l.memory_id = m.id
+         WHERE m.memory_type = 'lesson'
+           AND m.status = 'active'
+           AND (m.project = ?1 OR m.scope = 'global')
+           AND l.confidence >= ?2
+           AND (l.stale_after_epoch IS NULL OR l.stale_after_epoch > ?3)
+         ORDER BY
+           CASE WHEN m.project = ?1 THEN 0 ELSE 1 END,
+           l.confidence DESC,
+           l.reinforcement_count DESC,
+           l.last_reinforced_at_epoch DESC
+         LIMIT ?4",
+        cols = prefixed_memory_cols("m")
+    ))?;
+    let rows = stmt.query_map(
+        params![project, MIN_CONFIDENCE_FOR_CONTEXT, now, limit],
+        |row| {
+            let memory = map_memory_row_pub(row)?;
+            let metadata = map_lesson_metadata_from_offset(row, 13)?;
+            Ok(LessonMemory { memory, metadata })
+        },
+    )?;
+    crate::db::query::collect_rows(rows)
+}
+
+pub fn is_lesson_candidate(text: &str) -> bool {
+    let normalized = text.trim().to_lowercase();
+    if normalized.len() < 30 {
+        return false;
+    }
+    const SIGNALS: &[&str] = &[
+        "lesson:",
+        "root cause",
+        "avoid ",
+        "do not ",
+        "don't ",
+        "never ",
+        "must ",
+        "should ",
+        "proven ",
+        "workflow",
+        "pitfall",
+        "prevent",
+        "regression",
+    ];
+    SIGNALS.iter().any(|signal| normalized.contains(signal))
+}
+
+fn prefixed_memory_cols(alias: &str) -> String {
+    MEMORY_COLS
+        .split(',')
+        .map(|col| format!("{alias}.{}", col.trim()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn map_lesson_metadata_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<LessonMetadata> {
+    map_lesson_metadata_from_offset(row, 0)
+}
+
+fn map_lesson_metadata_from_offset(
+    row: &rusqlite::Row<'_>,
+    offset: usize,
+) -> rusqlite::Result<LessonMetadata> {
+    Ok(LessonMetadata {
+        memory_id: row.get(offset)?,
+        confidence: row.get(offset + 1)?,
+        reinforcement_count: row.get(offset + 2)?,
+        source_evidence: row.get(offset + 3)?,
+        last_reinforced_at_epoch: row.get(offset + 4)?,
+        stale_after_epoch: row.get(offset + 5)?,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/memory/lesson/tests.rs
+++ b/src/memory/lesson/tests.rs
@@ -1,0 +1,249 @@
+use rusqlite::{params, Connection};
+
+use super::*;
+use crate::memory::types::tests_helper::setup_memory_schema;
+
+#[test]
+fn save_lesson_creates_metadata() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    let id = save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("s1"),
+            project: "/repo",
+            topic_key: Some("lesson-build-failure"),
+            title: "Avoid build failure loops",
+            content: "Lesson: after repeated build failures, stop and challenge the hypothesis.",
+            confidence: 0.8,
+            source_evidence: Some("cargo check failed twice"),
+            branch: Some("main"),
+            scope: "project",
+            created_at_epoch: None,
+            stale_after_epoch: None,
+        },
+    )
+    .unwrap();
+
+    let metadata = get_lesson_metadata(&conn, id)
+        .unwrap()
+        .expect("metadata should exist");
+    assert_eq!(metadata.memory_id, id);
+    assert_eq!(metadata.reinforcement_count, 1);
+    assert_eq!(
+        metadata.source_evidence.as_deref(),
+        Some("cargo check failed twice")
+    );
+}
+
+#[test]
+fn save_lesson_reinforces_duplicate_topic() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    let req = SaveLessonRequest {
+        session_id: Some("s1"),
+        project: "/repo",
+        topic_key: Some("lesson-build-failure"),
+        title: "Avoid build failure loops",
+        content: "Lesson: after repeated build failures, stop and challenge the hypothesis.",
+        confidence: 0.6,
+        source_evidence: Some("first run"),
+        branch: None,
+        scope: "project",
+        created_at_epoch: None,
+        stale_after_epoch: None,
+    };
+    let first_id = save_lesson(&conn, &req).unwrap();
+
+    let second_id = save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            confidence: 0.9,
+            source_evidence: Some("second run"),
+            ..req
+        },
+    )
+    .unwrap();
+
+    assert_eq!(first_id, second_id);
+    let metadata = get_lesson_metadata(&conn, first_id).unwrap().unwrap();
+    assert_eq!(metadata.reinforcement_count, 2);
+    assert_eq!(metadata.confidence, 0.9);
+    assert_eq!(metadata.source_evidence.as_deref(), Some("second run"));
+}
+
+#[test]
+fn list_lessons_for_context_filters_low_confidence_and_stale() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let now = chrono::Utc::now().timestamp();
+
+    for (idx, confidence, stale_after_epoch) in
+        [(1, 0.9, None), (2, 0.2, None), (3, 0.8, Some(now - 1))]
+    {
+        save_lesson(
+            &conn,
+            &SaveLessonRequest {
+                session_id: Some("s1"),
+                project: "/repo",
+                topic_key: Some(&format!("lesson-{idx}")),
+                title: &format!("Lesson {idx}"),
+                content: "Lesson: use evidence-backed fixes for recurring failures.",
+                confidence,
+                source_evidence: None,
+                branch: None,
+                scope: "project",
+                created_at_epoch: None,
+                stale_after_epoch,
+            },
+        )
+        .unwrap();
+    }
+
+    let lessons = list_lessons_for_context(&conn, "/repo", 10).unwrap();
+    assert_eq!(lessons.len(), 1);
+    assert_eq!(lessons[0].memory.title, "Lesson 1");
+}
+
+#[test]
+fn list_lessons_for_context_keeps_project_before_global_scope() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("s1"),
+            project: "/global",
+            topic_key: Some("lesson-global"),
+            title: "Global lesson",
+            content: "Lesson: use the verified workflow when every project hits this failure.",
+            confidence: 0.99,
+            source_evidence: None,
+            branch: None,
+            scope: "global",
+            created_at_epoch: None,
+            stale_after_epoch: None,
+        },
+    )
+    .unwrap();
+    save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("s1"),
+            project: "/other",
+            topic_key: Some("lesson-other-project"),
+            title: "Other project lesson",
+            content: "Lesson: this project-local item should not leak into unrelated projects.",
+            confidence: 0.95,
+            source_evidence: None,
+            branch: None,
+            scope: "project",
+            created_at_epoch: None,
+            stale_after_epoch: None,
+        },
+    )
+    .unwrap();
+    save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("s1"),
+            project: "/repo",
+            topic_key: Some("lesson-project"),
+            title: "Project lesson",
+            content: "Lesson: prefer the project-specific workflow before global advice.",
+            confidence: 0.6,
+            source_evidence: None,
+            branch: None,
+            scope: "project",
+            created_at_epoch: None,
+            stale_after_epoch: None,
+        },
+    )
+    .unwrap();
+
+    let lessons = list_lessons_for_context(&conn, "/repo", 10).unwrap();
+    let titles: Vec<_> = lessons
+        .iter()
+        .map(|lesson| lesson.memory.title.as_str())
+        .collect();
+
+    assert_eq!(titles, vec!["Project lesson", "Global lesson"]);
+}
+
+#[test]
+fn list_lessons_for_context_ranks_confidence_reinforcement_and_recency() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    let high_confidence = save_ranked_lesson(&conn, "high-confidence", 0.9).unwrap();
+    let older_reinforced = save_ranked_lesson(&conn, "older-reinforced", 0.7).unwrap();
+    let newer_reinforced = save_ranked_lesson(&conn, "newer-reinforced", 0.7).unwrap();
+    let lower_reinforced = save_ranked_lesson(&conn, "lower-reinforced", 0.7).unwrap();
+    set_lesson_rank(&conn, high_confidence, 1, 100);
+    set_lesson_rank(&conn, older_reinforced, 3, 100);
+    set_lesson_rank(&conn, newer_reinforced, 3, 200);
+    set_lesson_rank(&conn, lower_reinforced, 2, 300);
+
+    let lessons = list_lessons_for_context(&conn, "/repo", 10).unwrap();
+    let titles: Vec<_> = lessons
+        .iter()
+        .map(|lesson| lesson.memory.title.as_str())
+        .collect();
+
+    assert_eq!(
+        titles,
+        vec![
+            "high-confidence",
+            "newer-reinforced",
+            "older-reinforced",
+            "lower-reinforced"
+        ]
+    );
+}
+
+#[test]
+fn is_lesson_candidate_requires_actionable_signal() {
+    assert!(is_lesson_candidate(
+        "Root cause: unchecked fallback hid the real error; avoid warning-only degradation."
+    ));
+    assert!(!is_lesson_candidate(
+        "FTS5 trigram tokenizer handles CJK without word boundaries"
+    ));
+}
+
+fn save_ranked_lesson(conn: &Connection, title: &str, confidence: f64) -> anyhow::Result<i64> {
+    save_lesson(
+        conn,
+        &SaveLessonRequest {
+            session_id: Some("s1"),
+            project: "/repo",
+            topic_key: Some(title),
+            title,
+            content: "Lesson: keep deterministic ranking when many lessons compete for context.",
+            confidence,
+            source_evidence: None,
+            branch: None,
+            scope: "project",
+            created_at_epoch: None,
+            stale_after_epoch: None,
+        },
+    )
+}
+
+fn set_lesson_rank(
+    conn: &Connection,
+    memory_id: i64,
+    reinforcement_count: i64,
+    last_reinforced_at_epoch: i64,
+) {
+    conn.execute(
+        "UPDATE memory_lessons
+         SET reinforcement_count = ?2, last_reinforced_at_epoch = ?3
+         WHERE memory_id = ?1",
+        params![memory_id, reinforcement_count, last_reinforced_at_epoch],
+    )
+    .unwrap();
+}

--- a/src/memory/lesson/tests.rs
+++ b/src/memory/lesson/tests.rs
@@ -18,6 +18,7 @@ fn save_lesson_creates_metadata() {
             content: "Lesson: after repeated build failures, stop and challenge the hypothesis.",
             confidence: 0.8,
             source_evidence: Some("cargo check failed twice"),
+            files: None,
             branch: Some("main"),
             scope: "project",
             created_at_epoch: None,
@@ -50,6 +51,7 @@ fn save_lesson_reinforces_duplicate_topic() {
         content: "Lesson: after repeated build failures, stop and challenge the hypothesis.",
         confidence: 0.6,
         source_evidence: Some("first run"),
+        files: None,
         branch: None,
         scope: "project",
         created_at_epoch: None,
@@ -75,6 +77,50 @@ fn save_lesson_reinforces_duplicate_topic() {
 }
 
 #[test]
+fn save_lesson_reinforcement_clears_stale_deadline() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let now = chrono::Utc::now().timestamp();
+
+    let req = SaveLessonRequest {
+        session_id: Some("s1"),
+        project: "/repo",
+        topic_key: Some("lesson-stale-refresh"),
+        title: "Refresh stale lesson",
+        content:
+            "Lesson: a reinforced lesson should become usable again when it is no longer stale.",
+        confidence: 0.7,
+        source_evidence: Some("first run"),
+        files: None,
+        branch: None,
+        scope: "project",
+        created_at_epoch: None,
+        stale_after_epoch: Some(now - 1),
+    };
+    let id = save_lesson(&conn, &req).unwrap();
+    assert!(list_lessons_for_context(&conn, "/repo", None, 10)
+        .unwrap()
+        .is_empty());
+
+    let refreshed_id = save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            source_evidence: Some("second run"),
+            stale_after_epoch: None,
+            ..req
+        },
+    )
+    .unwrap();
+
+    assert_eq!(id, refreshed_id);
+    let metadata = get_lesson_metadata(&conn, id).unwrap().unwrap();
+    assert_eq!(metadata.stale_after_epoch, None);
+    let lessons = list_lessons_for_context(&conn, "/repo", None, 10).unwrap();
+    assert_eq!(lessons.len(), 1);
+    assert_eq!(lessons[0].memory.title, "Refresh stale lesson");
+}
+
+#[test]
 fn list_lessons_for_context_filters_low_confidence_and_stale() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);
@@ -93,6 +139,7 @@ fn list_lessons_for_context_filters_low_confidence_and_stale() {
                 content: "Lesson: use evidence-backed fixes for recurring failures.",
                 confidence,
                 source_evidence: None,
+                files: None,
                 branch: None,
                 scope: "project",
                 created_at_epoch: None,
@@ -102,9 +149,55 @@ fn list_lessons_for_context_filters_low_confidence_and_stale() {
         .unwrap();
     }
 
-    let lessons = list_lessons_for_context(&conn, "/repo", 10).unwrap();
+    let lessons = list_lessons_for_context(&conn, "/repo", None, 10).unwrap();
     assert_eq!(lessons.len(), 1);
     assert_eq!(lessons[0].memory.title, "Lesson 1");
+}
+
+#[test]
+fn list_lessons_for_context_filters_other_branches() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    for (title, branch) in [
+        ("Main branch lesson", Some("main")),
+        ("Feature branch lesson", Some("feature/search")),
+        ("Branchless lesson", None),
+    ] {
+        save_lesson(
+            &conn,
+            &SaveLessonRequest {
+                session_id: Some("s1"),
+                project: "/repo",
+                topic_key: Some(&title.replace(' ', "-").to_lowercase()),
+                title,
+                content: "Lesson: branch-specific context should not leak into unrelated branches.",
+                confidence: 0.8,
+                source_evidence: None,
+                files: None,
+                branch,
+                scope: "project",
+                created_at_epoch: None,
+                stale_after_epoch: None,
+            },
+        )
+        .unwrap();
+    }
+
+    let mut titles: Vec<_> = list_lessons_for_context(&conn, "/repo", Some("main"), 10)
+        .unwrap()
+        .into_iter()
+        .map(|lesson| lesson.memory.title)
+        .collect();
+    titles.sort();
+    assert_eq!(titles, vec!["Branchless lesson", "Main branch lesson"]);
+
+    let all_titles: Vec<_> = list_lessons_for_context(&conn, "/repo", None, 10)
+        .unwrap()
+        .into_iter()
+        .map(|lesson| lesson.memory.title)
+        .collect();
+    assert!(all_titles.contains(&"Feature branch lesson".to_string()));
 }
 
 #[test]
@@ -122,6 +215,7 @@ fn list_lessons_for_context_keeps_project_before_global_scope() {
             content: "Lesson: use the verified workflow when every project hits this failure.",
             confidence: 0.99,
             source_evidence: None,
+            files: None,
             branch: None,
             scope: "global",
             created_at_epoch: None,
@@ -139,6 +233,7 @@ fn list_lessons_for_context_keeps_project_before_global_scope() {
             content: "Lesson: this project-local item should not leak into unrelated projects.",
             confidence: 0.95,
             source_evidence: None,
+            files: None,
             branch: None,
             scope: "project",
             created_at_epoch: None,
@@ -156,6 +251,7 @@ fn list_lessons_for_context_keeps_project_before_global_scope() {
             content: "Lesson: prefer the project-specific workflow before global advice.",
             confidence: 0.6,
             source_evidence: None,
+            files: None,
             branch: None,
             scope: "project",
             created_at_epoch: None,
@@ -164,7 +260,7 @@ fn list_lessons_for_context_keeps_project_before_global_scope() {
     )
     .unwrap();
 
-    let lessons = list_lessons_for_context(&conn, "/repo", 10).unwrap();
+    let lessons = list_lessons_for_context(&conn, "/repo", None, 10).unwrap();
     let titles: Vec<_> = lessons
         .iter()
         .map(|lesson| lesson.memory.title.as_str())
@@ -187,7 +283,7 @@ fn list_lessons_for_context_ranks_confidence_reinforcement_and_recency() {
     set_lesson_rank(&conn, newer_reinforced, 3, 200);
     set_lesson_rank(&conn, lower_reinforced, 2, 300);
 
-    let lessons = list_lessons_for_context(&conn, "/repo", 10).unwrap();
+    let lessons = list_lessons_for_context(&conn, "/repo", None, 10).unwrap();
     let titles: Vec<_> = lessons
         .iter()
         .map(|lesson| lesson.memory.title.as_str())
@@ -225,6 +321,7 @@ fn save_ranked_lesson(conn: &Connection, title: &str, confidence: f64) -> anyhow
             content: "Lesson: keep deterministic ranking when many lessons compete for context.",
             confidence,
             source_evidence: None,
+            files: None,
             branch: None,
             scope: "project",
             created_at_epoch: None,

--- a/src/memory/promote/summary.rs
+++ b/src/memory/promote/summary.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
+use crate::memory::lesson::{is_lesson_candidate, save_lesson, SaveLessonRequest};
 use crate::memory::{insert_memory, insert_memory_full};
 
 use super::format::{
@@ -39,18 +40,7 @@ pub fn promote_summary_to_memories(
     }
 
     if let Some(text) = learned {
-        count += promote_standard_items(
-            conn,
-            session_id,
-            project,
-            request_text,
-            text,
-            MIN_LEARNED_LEN,
-            "learned",
-            "learned",
-            "discovery",
-            "discovery",
-        )?;
+        count += promote_learned_items(conn, session_id, project, request_text, text)?;
     }
 
     if let Some(text) = preferences {
@@ -86,6 +76,89 @@ pub fn promote_summary_to_memories(
     }
 
     Ok(count)
+}
+
+fn promote_learned_items(
+    conn: &Connection,
+    session_id: &str,
+    project: &str,
+    request_text: &str,
+    text: &str,
+) -> Result<usize> {
+    let text = text.trim();
+    if text.len() < MIN_LEARNED_LEN {
+        return Ok(0);
+    }
+
+    let split_items = split_into_items(text);
+    let items: Vec<&str> = if split_items.len() > 1 {
+        split_items
+            .iter()
+            .map(String::as_str)
+            .filter(|item| item.len() >= MIN_LEARNED_LEN)
+            .collect()
+    } else {
+        vec![text]
+    };
+
+    let mut count = 0;
+    for (index, item) in items.iter().enumerate() {
+        let content = build_content(item, request_text);
+        if is_lesson_candidate(item) {
+            let title = if items.len() > 1 {
+                build_item_title(item, "lesson", index)
+            } else {
+                build_title(item, request_text, "lesson")
+            };
+            let topic_key = format!("lesson-{}", content_hash(item));
+            save_lesson(
+                conn,
+                &SaveLessonRequest {
+                    session_id: Some(session_id),
+                    project,
+                    topic_key: Some(&topic_key),
+                    title: &title,
+                    content: &content,
+                    confidence: lesson_confidence(item),
+                    source_evidence: (!request_text.is_empty()).then_some(request_text),
+                    branch: None,
+                    scope: "project",
+                    created_at_epoch: None,
+                    stale_after_epoch: None,
+                },
+            )?;
+        } else {
+            let title = if items.len() > 1 {
+                build_item_title(item, "learned", index)
+            } else {
+                build_title(item, request_text, "learned")
+            };
+            let topic_key = format!("discovery-{}", content_hash(item));
+            insert_memory(
+                conn,
+                Some(session_id),
+                project,
+                Some(&topic_key),
+                &title,
+                &content,
+                "discovery",
+                None,
+            )?;
+        }
+        count += 1;
+    }
+    Ok(count)
+}
+
+fn lesson_confidence(item: &str) -> f64 {
+    let normalized = item.to_lowercase();
+    if normalized.contains("root cause") || normalized.contains("lesson:") {
+        0.85
+    } else if normalized.contains("never ") || normalized.contains("do not ") {
+        0.8
+    } else {
+        0.7
+    }
 }
 
 fn promote_standard_items(

--- a/src/memory/promote/summary.rs
+++ b/src/memory/promote/summary.rs
@@ -121,6 +121,7 @@ fn promote_learned_items(
                     content: &content,
                     confidence: lesson_confidence(item),
                     source_evidence: (!request_text.is_empty()).then_some(request_text),
+                    files: None,
                     branch: None,
                     scope: "project",
                     created_at_epoch: None,

--- a/src/memory/promote/tests/promote.rs
+++ b/src/memory/promote/tests/promote.rs
@@ -57,6 +57,75 @@ fn test_promote_multi_learned() {
     )
     .unwrap();
     assert_eq!(count, 2);
+
+    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
+    assert!(memories
+        .iter()
+        .all(|memory| memory.memory_type == "discovery"));
+}
+
+#[test]
+fn test_promote_actionable_learned_as_lesson() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    let learned = "Root cause: warning-only fallback hid missing data; avoid silent degradation.";
+    let count = promote_summary_to_memories(
+        &conn,
+        "session-1",
+        "test/proj",
+        Some("Fix missing memory output"),
+        None,
+        Some(learned),
+        None,
+    )
+    .unwrap();
+    assert_eq!(count, 1);
+
+    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
+    assert_eq!(memories.len(), 1);
+    assert_eq!(memories[0].memory_type, "lesson");
+    let metadata = crate::memory::lesson::get_lesson_metadata(&conn, memories[0].id)
+        .unwrap()
+        .expect("lesson metadata should exist");
+    assert_eq!(metadata.reinforcement_count, 1);
+    assert!(metadata.confidence >= 0.8);
+}
+
+#[test]
+fn test_promote_duplicate_lesson_reinforces_existing() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    let learned = "Lesson: after three failed fixes, stop and challenge the hypothesis.";
+    promote_summary_to_memories(
+        &conn,
+        "session-1",
+        "test/proj",
+        Some("Fix build loop"),
+        None,
+        Some(learned),
+        None,
+    )
+    .unwrap();
+    promote_summary_to_memories(
+        &conn,
+        "session-2",
+        "test/proj",
+        Some("Fix build loop again"),
+        None,
+        Some(learned),
+        None,
+    )
+    .unwrap();
+
+    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
+    assert_eq!(memories.len(), 1);
+    assert_eq!(memories[0].memory_type, "lesson");
+    let metadata = crate::memory::lesson::get_lesson_metadata(&conn, memories[0].id)
+        .unwrap()
+        .expect("lesson metadata should exist");
+    assert_eq!(metadata.reinforcement_count, 2);
 }
 
 #[test]

--- a/src/memory/service/save.rs
+++ b/src/memory/service/save.rs
@@ -8,6 +8,7 @@ use super::local_copy::{
     write_local_note,
 };
 use super::types::{SaveMemoryRequest, SaveMemoryResult};
+use crate::memory::lesson::{save_lesson, SaveLessonRequest};
 
 pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMemoryResult> {
     let project = req.project.as_deref().unwrap_or("manual");
@@ -22,19 +23,41 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
     let mut local_copy = prepare_local_copy(project, title, req)?;
     write_local_copy(&mut local_copy)?;
 
-    let id = match crate::memory::insert_memory_full(
-        conn,
-        None,
-        project,
-        req.topic_key.as_deref(),
-        title,
-        &req.text,
-        memory_type,
-        files_json.as_deref(),
-        req.branch.as_deref(),
-        scope,
-        req.created_at_epoch,
-    ) {
+    let save_result = if memory_type == "lesson" {
+        save_lesson(
+            conn,
+            &SaveLessonRequest {
+                session_id: None,
+                project,
+                topic_key: req.topic_key.as_deref(),
+                title,
+                content: &req.text,
+                confidence: 0.7,
+                source_evidence: None,
+                files: files_json.as_deref(),
+                branch: req.branch.as_deref(),
+                scope,
+                created_at_epoch: req.created_at_epoch,
+                stale_after_epoch: None,
+            },
+        )
+    } else {
+        crate::memory::insert_memory_full(
+            conn,
+            None,
+            project,
+            req.topic_key.as_deref(),
+            title,
+            &req.text,
+            memory_type,
+            files_json.as_deref(),
+            req.branch.as_deref(),
+            scope,
+            req.created_at_epoch,
+        )
+    };
+
+    let id = match save_result {
         Ok(id) => id,
         Err(err) => {
             if let Err(cleanup_err) = cleanup_local_copy(&local_copy) {

--- a/src/memory/service/tests.rs
+++ b/src/memory/service/tests.rs
@@ -79,6 +79,41 @@ fn save_memory_preference_defaults_to_project_scope() {
 }
 
 #[test]
+fn save_memory_lesson_creates_lesson_metadata() {
+    let _dir = ScopedTestDataDir::new("lesson-save-metadata");
+    let conn = db::open_db().expect("db should open");
+    let req = SaveMemoryRequest {
+        text:
+            "Lesson: route generic lesson saves through the lesson writer so context can load them."
+                .to_string(),
+        title: Some("Lesson metadata".to_string()),
+        project: Some("proj".to_string()),
+        topic_key: Some("lesson-save-metadata".to_string()),
+        memory_type: Some("lesson".to_string()),
+        files: Some(vec!["src/memory/service/save.rs".to_string()]),
+        branch: Some("main".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+
+    let saved = save_memory(&conn, &req).expect("lesson save should succeed");
+
+    let (metadata_count, files, branch): (i64, String, String) = conn
+        .query_row(
+            "SELECT COUNT(l.memory_id), m.files, m.branch
+             FROM memories m
+             LEFT JOIN memory_lessons l ON l.memory_id = m.id
+             WHERE m.id = ?1",
+            [saved.id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("lesson metadata query should succeed");
+    assert_eq!(metadata_count, 1);
+    assert_eq!(branch, "main");
+    assert!(files.contains("src/memory/service/save.rs"));
+}
+
+#[test]
 fn save_memory_outside_local_path_does_not_persist_memory() {
     let _dir = ScopedTestDataDir::new("save-outside-path-no-db-write");
     let conn = db::open_db().expect("db should open");

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -41,6 +41,7 @@ pub const MEMORY_TYPES: &[&str] = &[
     "discovery",
     "bugfix",
     "architecture",
+    "lesson",
     "preference",
     "procedure",
     "session_activity",
@@ -156,6 +157,14 @@ pub mod tests_helper {
                 memory_id INTEGER NOT NULL,
                 entity_id INTEGER NOT NULL,
                 PRIMARY KEY(memory_id, entity_id)
+            );
+            CREATE TABLE IF NOT EXISTS memory_lessons (
+                memory_id INTEGER PRIMARY KEY,
+                confidence REAL NOT NULL DEFAULT 0.7,
+                reinforcement_count INTEGER NOT NULL DEFAULT 1,
+                source_evidence TEXT,
+                last_reinforced_at_epoch INTEGER NOT NULL,
+                stale_after_epoch INTEGER
             );",
         )
         .unwrap();

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -335,19 +335,39 @@ pub(super) fn promote_candidate_to_memory(
     evidence_json: &str,
 ) -> Result<i64> {
     let title = candidate_title(candidate);
-    let memory_id = crate::memory::insert_memory_full(
-        conn,
-        session_id,
-        project,
-        Some(&candidate.topic_key),
-        &title,
-        &candidate.text,
-        &candidate.memory_type,
-        None,
-        None,
-        &candidate.scope,
-        None,
-    )?;
+    let memory_id = if candidate.memory_type == "lesson" {
+        crate::memory::lesson::save_lesson(
+            conn,
+            &crate::memory::lesson::SaveLessonRequest {
+                session_id,
+                project,
+                topic_key: Some(&candidate.topic_key),
+                title: &title,
+                content: &candidate.text,
+                confidence: candidate.confidence,
+                source_evidence: Some(evidence_json),
+                files: None,
+                branch: None,
+                scope: &candidate.scope,
+                created_at_epoch: None,
+                stale_after_epoch: None,
+            },
+        )?
+    } else {
+        crate::memory::insert_memory_full(
+            conn,
+            session_id,
+            project,
+            Some(&candidate.topic_key),
+            &title,
+            &candidate.text,
+            &candidate.memory_type,
+            None,
+            None,
+            &candidate.scope,
+            None,
+        )?
+    };
     conn.execute(
         "UPDATE memories
          SET evidence_event_ids = ?1,

--- a/src/memory_candidate/review.rs
+++ b/src/memory_candidate/review.rs
@@ -336,6 +336,16 @@ mod tests {
         text: &str,
         scope: &str,
     ) -> Result<i64> {
+        insert_pending_candidate_with_scope_and_type(conn, topic_key, text, scope, "decision")
+    }
+
+    fn insert_pending_candidate_with_scope_and_type(
+        conn: &mut Connection,
+        topic_key: &str,
+        text: &str,
+        scope: &str,
+        memory_type: &str,
+    ) -> Result<i64> {
         record_captured_event(
             conn,
             &CaptureEventInput {
@@ -358,9 +368,17 @@ mod tests {
             "INSERT INTO memory_candidates
              (project_id, scope, memory_type, topic_key, text, evidence_event_ids,
               confidence, risk_class, review_status, created_at_epoch, updated_at_epoch)
-             VALUES (?1, ?2, 'decision', ?3, ?4, ?5, 0.72, 'medium',
-                     'pending_review', ?6, ?6)",
-            params![task.project_id, scope, topic_key, text, evidence_json, now],
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0.72, 'medium',
+                     'pending_review', ?7, ?7)",
+            params![
+                task.project_id,
+                scope,
+                memory_type,
+                topic_key,
+                text,
+                evidence_json,
+                now
+            ],
         )?;
         Ok(conn.last_insert_rowid())
     }
@@ -398,6 +416,32 @@ mod tests {
         )?;
         assert_eq!(status, "approved");
         assert_eq!(source_candidate_id, id);
+        Ok(())
+    }
+
+    #[test]
+    fn review_approve_lesson_candidate_creates_metadata() -> Result<()> {
+        let mut conn = setup_conn();
+        let id = insert_pending_candidate_with_scope_and_type(
+            &mut conn,
+            "review-lesson",
+            "Lesson: generic lesson promotions must keep metadata so context can load them.",
+            "project",
+            "lesson",
+        )?;
+
+        let memory_id = approve_candidate(&mut conn, id)?.expect("candidate should approve");
+
+        let (memory_type, metadata_count): (String, i64) = conn.query_row(
+            "SELECT m.memory_type, COUNT(l.memory_id)
+             FROM memories m
+             LEFT JOIN memory_lessons l ON l.memory_id = m.id
+             WHERE m.id = ?1",
+            params![memory_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(memory_type, "lesson");
+        assert_eq!(metadata_count, 1);
         Ok(())
     }
 

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -64,11 +64,11 @@ fn full_migration_on_empty_db() -> Result<()> {
     let applied = applied_versions(&conn)?;
     assert_eq!(
         applied,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 28);
+    assert_eq!(user_version, 29);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -93,6 +93,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "memory_facts",
         "procedure_verifications",
         "context_injections",
+        "memory_lessons",
         "rule_candidates",
     ] {
         let exists: bool = conn
@@ -322,7 +323,7 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 28);
+    assert_eq!(user_version, 29);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -362,7 +363,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 28);
+    assert_eq!(result.current_version, 29);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())
@@ -540,7 +541,7 @@ fn dry_run_pending_runs_post_migration_hooks() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.pending_count, 2);
+    assert_eq!(result.pending_count, MIGRATIONS.len() - 14);
     let error = result.error.as_deref().unwrap_or("");
     assert!(
         !error.is_empty(),
@@ -585,7 +586,7 @@ fn dry_run_pending_runs_hooks_against_complete_fts_clone() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.pending_count, 2);
+    assert_eq!(result.pending_count, MIGRATIONS.len() - 14);
     assert!(
         result.error.is_none(),
         "dry-run hook should run against complete FTS clone, got {:?}",
@@ -624,7 +625,7 @@ fn dry_run_pending_clones_non_default_page_size_database() -> Result<()> {
 
         let result = dry_run_pending(&conn)?;
 
-        assert_eq!(result.pending_count, 2);
+        assert_eq!(result.pending_count, MIGRATIONS.len() - 14);
         assert!(
             result.error.is_none(),
             "dry-run clone should preserve non-default source page size, got {:?}",

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -30,6 +30,7 @@ const CONVERGENCE_TABLES: &[&str] = &[
     "events",
     "entities",
     "memory_entities",
+    "memory_lessons",
     "ai_usage_events",
     "jobs",
     "workstreams",

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -85,6 +85,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "context_injection_gate",
         sql: include_str!("../migrations/v016_context_injection_gate.sql"),
     },
+    Migration {
+        version: 17,
+        name: "memory_lessons",
+        sql: include_str!("../migrations/v017_memory_lessons.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v017_memory_lessons.sql
+++ b/src/migrations/v017_memory_lessons.sql
@@ -1,0 +1,18 @@
+-- v017_memory_lessons: first-class metadata for lesson memories.
+--
+-- The memory body remains in `memories` with memory_type='lesson' so search,
+-- dedup, branch, scope, and local tooling keep working. This side table stores
+-- lesson-specific lifecycle signals used for reinforcement and bounded context
+-- injection.
+
+CREATE TABLE IF NOT EXISTS memory_lessons (
+    memory_id INTEGER PRIMARY KEY REFERENCES memories(id) ON DELETE CASCADE,
+    confidence REAL NOT NULL DEFAULT 0.7 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    reinforcement_count INTEGER NOT NULL DEFAULT 1 CHECK (reinforcement_count >= 1),
+    source_evidence TEXT,
+    last_reinforced_at_epoch INTEGER NOT NULL,
+    stale_after_epoch INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_lessons_rank
+ON memory_lessons(confidence DESC, reinforcement_count DESC, last_reinforced_at_epoch DESC);


### PR DESCRIPTION
## What

Adds a first-class \`lesson\` memory layer with lesson metadata, actionable learned-item promotion, duplicate reinforcement, and a bounded Lessons context section.

Fixes #210

## Why

Repeated mistakes and operational learnings should not be buried as generic discovery memories. Lessons now have their own lifecycle, ranking, scope handling, and context budget without adding vector search or making lessons global by default.

## Test Plan

- [x] \`cargo fmt --check\`
- [x] \`cargo check\`
- [x] \`cargo test memory::lesson\`
- [x] \`cargo test memory::promote::tests::promote\`
- [x] \`cargo test context::tests\`
- [x] \`cargo test migrate::tests\`
- [x] \`cargo test\`