### PR TITLE
feat: add audited memory governance

### DIFF
--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -12,7 +12,7 @@ mod usage;
 pub(super) use admin::run_admin;
 pub(super) use eval::{run_eval, run_eval_local};
 pub(super) use import::run_import;
-pub(super) use maintenance::{run_cleanup, run_dream, run_encrypt};
+pub(super) use maintenance::{run_cleanup, run_dream, run_encrypt, run_governance};
 pub(super) use pending::run_pending;
 pub(super) use preferences::run_preferences;
 pub(super) use query::{run_backfill_entities, run_search, run_show, run_status};

--- a/src/cli/actions/maintenance.rs
+++ b/src/cli/actions/maintenance.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+use crate::cli::types::MemoryGovernanceCliAction;
 use crate::{db, memory};
 
 pub(in crate::cli) async fn run_dream(project: Option<&str>, dry_run: bool) -> Result<()> {
@@ -61,5 +62,53 @@ pub(in crate::cli) fn run_cleanup() -> Result<()> {
         "  Stale memories archived (>180 days): {}",
         memories_archived
     );
+    Ok(())
+}
+
+pub(in crate::cli) fn run_governance(
+    project: Option<&str>,
+    action: MemoryGovernanceCliAction,
+    reason: Option<&str>,
+    actor: Option<&str>,
+    confirm_destructive: bool,
+    dry_run: bool,
+    ids: &[i64],
+) -> Result<()> {
+    let cwd = crate::cli::cwd::resolve_cwd_arg(None);
+    let project = project
+        .map(str::to_owned)
+        .unwrap_or_else(|| db::project_from_cwd(&cwd));
+    let action = match action {
+        MemoryGovernanceCliAction::Delete => memory::governance::MemoryGovernanceAction::Delete,
+        MemoryGovernanceCliAction::Reject => memory::governance::MemoryGovernanceAction::Reject,
+        MemoryGovernanceCliAction::Stale => memory::governance::MemoryGovernanceAction::MarkStale,
+    };
+    let conn = db::open_db()?;
+    let result = memory::governance::govern_memories(
+        &conn,
+        &memory::governance::GovernMemoryRequest {
+            project: &project,
+            ids,
+            action,
+            reason,
+            actor,
+            dry_run,
+            confirm_destructive,
+        },
+    )?;
+    let mode = if result.dry_run { "dry-run" } else { "applied" };
+    println!(
+        "memory governance {} action={} project={} affected={}",
+        mode,
+        result.action,
+        project,
+        result.affected.len()
+    );
+    for memory in result.affected {
+        println!(
+            "  id={} {} -> {} title={}",
+            memory.id, memory.previous_status, memory.new_status, memory.title
+        );
+    }
     Ok(())
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -4,8 +4,8 @@ use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 
 use super::actions::{
     run_admin, run_backfill_entities, run_cleanup, run_dream, run_encrypt, run_eval,
-    run_eval_local, run_import, run_pending, run_preferences, run_review, run_search, run_show,
-    run_status, run_usage,
+    run_eval_local, run_governance, run_import, run_pending, run_preferences, run_review,
+    run_search, run_show, run_status, run_usage,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands};
@@ -57,6 +57,23 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         Commands::Preferences { action } => run_preferences(action)?,
         Commands::Pending { action } => run_pending(action)?,
         Commands::Review { action } => run_review(action)?,
+        Commands::Govern {
+            project,
+            action,
+            reason,
+            actor,
+            confirm_destructive,
+            dry_run,
+            ids,
+        } => run_governance(
+            project.as_deref(),
+            action,
+            reason.as_deref(),
+            actor.as_deref(),
+            confirm_destructive,
+            dry_run,
+            &ids,
+        )?,
         Commands::Usage {
             project,
             days,

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,5 +1,5 @@
 use super::cwd::resolve_cwd_arg;
-use super::types::{Cli, Commands, ReviewAction};
+use super::types::{Cli, Commands, MemoryGovernanceCliAction, ReviewAction};
 use clap::Parser;
 
 #[test]
@@ -96,6 +96,46 @@ fn cli_parses_search_type_alias_and_multi_hop_filters() {
             assert!(!explain);
         }
         _ => panic!("expected search command"),
+    }
+}
+
+#[test]
+fn cli_parses_governance_delete_options() {
+    let cli = Cli::parse_from([
+        "remem",
+        "govern",
+        "--project",
+        "/tmp/remem",
+        "--action",
+        "delete",
+        "--reason",
+        "bad memory",
+        "--actor",
+        "codex",
+        "--confirm-destructive",
+        "42",
+        "43",
+    ]);
+
+    match cli.command {
+        Commands::Govern {
+            project,
+            action,
+            reason,
+            actor,
+            confirm_destructive,
+            dry_run,
+            ids,
+        } => {
+            assert_eq!(project.as_deref(), Some("/tmp/remem"));
+            assert!(matches!(action, MemoryGovernanceCliAction::Delete));
+            assert_eq!(reason.as_deref(), Some("bad memory"));
+            assert_eq!(actor.as_deref(), Some("codex"));
+            assert!(confirm_destructive);
+            assert!(!dry_run);
+            assert_eq!(ids, vec![42, 43]);
+        }
+        _ => panic!("expected govern command"),
     }
 }
 

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 pub(super) use crate::install::InstallTarget;
@@ -72,6 +72,22 @@ pub(super) enum Commands {
     Review {
         #[command(subcommand)]
         action: ReviewAction,
+    },
+    Govern {
+        #[arg(long, short)]
+        project: Option<String>,
+        #[arg(long, value_enum)]
+        action: MemoryGovernanceCliAction,
+        #[arg(long)]
+        reason: Option<String>,
+        #[arg(long)]
+        actor: Option<String>,
+        #[arg(long)]
+        confirm_destructive: bool,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(required = true)]
+        ids: Vec<i64>,
     },
     Usage {
         /// Restrict usage totals to one project path.
@@ -249,4 +265,11 @@ pub(in crate::cli) enum ReviewAction {
         #[arg(long)]
         scope: Option<String>,
     },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(in crate::cli) enum MemoryGovernanceCliAction {
+    Delete,
+    Reject,
+    Stale,
 }

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -327,6 +327,47 @@ fn load_context_data_excludes_preferences_before_candidate_limit() {
 }
 
 #[test]
+fn load_context_data_excludes_deleted_and_rejected_memories() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    for (idx, title, status) in [
+        (1, "Deleted memory", "deleted"),
+        (2, "Rejected memory", "rejected"),
+        (3, "Active memory", "active"),
+    ] {
+        insert_memory(
+            &conn,
+            idx,
+            project,
+            Some(&format!("governance-status-{idx}")),
+            "decision",
+            title,
+            "Context should include only active governed memories.",
+            now + idx,
+        );
+        if status != "active" {
+            conn.execute(
+                "UPDATE memories SET status = ?1 WHERE id = ?2",
+                rusqlite::params![status, idx],
+            )
+            .unwrap();
+        }
+    }
+
+    let loaded = load_context_data(&conn, project, None);
+    let titles: Vec<_> = loaded
+        .memories
+        .iter()
+        .map(|memory| memory.title.as_str())
+        .collect();
+
+    assert_eq!(titles, vec!["Active memory"]);
+}
+
+#[test]
 fn load_context_data_excludes_global_non_preferences_from_main_memory_pool() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);

--- a/src/mcp/server/write_tools.rs
+++ b/src/mcp/server/write_tools.rs
@@ -2,7 +2,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::{tool, tool_router};
 use serde_json::json;
 
-use super::super::types::{SaveMemoryParams, TimelineReportParams};
+use super::super::types::{GovernMemoryParams, SaveMemoryParams, TimelineReportParams};
 use super::MemoryServer;
 use crate::{db, memory::service};
 
@@ -82,6 +82,58 @@ impl MemoryServer {
                 "local_path": saved.local_path,
             }))
             .map_err(|e| e.to_string())
+        })
+    }
+
+    #[tool(
+        description = "Auditably delete, reject, or mark curated memories stale. \
+        Use dry_run=true first to preview affected IDs. Non-dry-run mutations require \
+        confirm_destructive=true and an explicit reason. This never deletes raw archive data."
+    )]
+    pub(super) fn govern_memory(
+        &self,
+        Parameters(params): Parameters<GovernMemoryParams>,
+    ) -> Result<String, String> {
+        crate::log::info(
+            "mcp",
+            &format!(
+                "govern_memory called action={} project={:?} ids={} dry_run={:?}",
+                params.action,
+                params.project,
+                params.ids.len(),
+                params.dry_run
+            ),
+        );
+        let action = crate::memory::governance::MemoryGovernanceAction::parse(&params.action)
+            .map_err(|e| e.to_string())?;
+        let project = params
+            .project
+            .clone()
+            .filter(|project| !project.trim().is_empty())
+            .unwrap_or_else(|| {
+                std::env::current_dir()
+                    .ok()
+                    .map(|cwd| db::project_from_cwd(&cwd.to_string_lossy()))
+                    .unwrap_or_else(|| "unknown".to_string())
+            });
+        self.with_conn(move |conn| {
+            let result = crate::memory::governance::govern_memories(
+                conn,
+                &crate::memory::governance::GovernMemoryRequest {
+                    project: &project,
+                    ids: &params.ids,
+                    action,
+                    reason: params.reason.as_deref(),
+                    actor: params.actor.as_deref().or(Some("mcp")),
+                    dry_run: params.dry_run.unwrap_or(false),
+                    confirm_destructive: params.confirm_destructive.unwrap_or(false),
+                },
+            )
+            .map_err(|e| {
+                crate::log::warn("mcp", &format!("govern_memory failed: {}", e));
+                e.to_string()
+            })?;
+            serde_json::to_string(&result).map_err(|e| e.to_string())
         })
     }
 

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -90,6 +90,26 @@ pub(super) struct SaveMemoryParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub(super) struct GovernMemoryParams {
+    #[schemars(description = "Curated memory IDs to mutate. Use dry_run=true first to preview.")]
+    pub ids: Vec<i64>,
+    #[schemars(description = "Project name filter. Defaults to the MCP process current project.")]
+    pub project: Option<String>,
+    #[schemars(description = "Governance action: delete, reject, or stale.")]
+    pub action: String,
+    #[schemars(description = "Explicit user-visible reason for the mutation.")]
+    pub reason: Option<String>,
+    #[schemars(description = "Actor initiating the mutation, e.g. user, codex, claude.")]
+    pub actor: Option<String>,
+    #[schemars(
+        description = "Preview affected memories without writing status changes or audit events."
+    )]
+    pub dry_run: Option<bool>,
+    #[schemars(description = "Required true for non-dry-run destructive governance mutations.")]
+    pub confirm_destructive: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub(super) struct TimelineReportParams {
     #[schemars(description = "Project name (required)")]
     pub project: String,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -2,6 +2,7 @@ pub mod dedup;
 pub mod events;
 pub mod facts;
 pub mod format;
+pub mod governance;
 pub mod lifecycle;
 pub mod preference;
 pub mod procedure;

--- a/src/memory/governance.rs
+++ b/src/memory/governance.rs
@@ -1,0 +1,205 @@
+use anyhow::{anyhow, bail, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryGovernanceAction {
+    Delete,
+    Reject,
+    MarkStale,
+}
+
+impl MemoryGovernanceAction {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_lowercase().as_str() {
+            "delete" | "deleted" => Ok(Self::Delete),
+            "reject" | "rejected" => Ok(Self::Reject),
+            "stale" | "mark_stale" | "mark-stale" | "invalidate" => Ok(Self::MarkStale),
+            other => bail!("unsupported memory governance action: {other}"),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Delete => "delete",
+            Self::Reject => "reject",
+            Self::MarkStale => "stale",
+        }
+    }
+
+    pub fn target_status(self) -> &'static str {
+        match self {
+            Self::Delete => "deleted",
+            Self::Reject => "rejected",
+            Self::MarkStale => "stale",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GovernMemoryRequest<'a> {
+    pub project: &'a str,
+    pub ids: &'a [i64],
+    pub action: MemoryGovernanceAction,
+    pub reason: Option<&'a str>,
+    pub actor: Option<&'a str>,
+    pub dry_run: bool,
+    pub confirm_destructive: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GovernedMemory {
+    pub id: i64,
+    pub title: String,
+    pub previous_status: String,
+    pub new_status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GovernMemoryResult {
+    pub dry_run: bool,
+    pub action: String,
+    pub reason: Option<String>,
+    pub affected: Vec<GovernedMemory>,
+}
+
+pub fn govern_memories(
+    conn: &Connection,
+    req: &GovernMemoryRequest<'_>,
+) -> Result<GovernMemoryResult> {
+    let ids = unique_ids(req.ids);
+    if ids.is_empty() {
+        bail!("memory governance requires at least one memory id");
+    }
+    let reason = normalized_reason(req)?;
+    let target_status = req.action.target_status();
+    let tx = conn.unchecked_transaction()?;
+    let mut affected = Vec::with_capacity(ids.len());
+    for id in ids {
+        let target = load_target(&tx, req.project, id)?;
+        affected.push(GovernedMemory {
+            id: target.id,
+            title: target.title.clone(),
+            previous_status: target.status.clone(),
+            new_status: target_status.to_string(),
+        });
+        if req.dry_run {
+            continue;
+        }
+        let now = chrono::Utc::now().timestamp();
+        let updated = tx.execute(
+            "UPDATE memories
+             SET status = ?1, updated_at_epoch = ?2
+             WHERE id = ?3 AND project = ?4",
+            params![target_status, now, target.id, req.project],
+        )?;
+        if updated != 1 {
+            return Err(anyhow!(
+                "failed to update memory governance status: id={} project={}",
+                target.id,
+                req.project
+            ));
+        }
+        insert_audit_event(&tx, req, &target, target_status, reason.as_deref(), now)?;
+    }
+    tx.commit()?;
+    Ok(GovernMemoryResult {
+        dry_run: req.dry_run,
+        action: req.action.as_str().to_string(),
+        reason,
+        affected,
+    })
+}
+
+fn unique_ids(ids: &[i64]) -> Vec<i64> {
+    let mut seen = std::collections::HashSet::with_capacity(ids.len());
+    ids.iter()
+        .copied()
+        .filter(|id| *id > 0 && seen.insert(*id))
+        .collect()
+}
+
+fn normalized_reason(req: &GovernMemoryRequest<'_>) -> Result<Option<String>> {
+    let reason = req.reason.map(str::trim).filter(|value| !value.is_empty());
+    if req.dry_run {
+        return Ok(reason.map(str::to_string));
+    }
+    if !req.confirm_destructive {
+        bail!("memory governance mutation requires confirm_destructive=true");
+    }
+    let Some(reason) = reason else {
+        bail!("memory governance mutation requires an explicit reason");
+    };
+    Ok(Some(reason.to_string()))
+}
+
+struct GovernanceTarget {
+    id: i64,
+    title: String,
+    status: String,
+}
+
+fn load_target(conn: &Connection, project: &str, id: i64) -> Result<GovernanceTarget> {
+    conn.query_row(
+        "SELECT id, title, status
+         FROM memories
+         WHERE id = ?1 AND project = ?2",
+        params![id, project],
+        |row| {
+            Ok(GovernanceTarget {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                status: row.get(2)?,
+            })
+        },
+    )
+    .optional()?
+    .ok_or_else(|| anyhow!("memory id={} not found in project={}", id, project))
+}
+
+fn insert_audit_event(
+    conn: &Connection,
+    req: &GovernMemoryRequest<'_>,
+    target: &GovernanceTarget,
+    new_status: &str,
+    reason: Option<&str>,
+    now: i64,
+) -> Result<()> {
+    let actor = req.actor.map(str::trim).filter(|value| !value.is_empty());
+    let detail = serde_json::json!({
+        "action": req.action.as_str(),
+        "memory_id": target.id,
+        "title": target.title,
+        "previous_status": target.status,
+        "new_status": new_status,
+        "reason": reason,
+        "actor": actor,
+    })
+    .to_string();
+    let summary = format!(
+        "{} memory {}: {} -> {}{}",
+        req.action.as_str(),
+        target.id,
+        target.status,
+        new_status,
+        reason
+            .map(|value| format!(" ({value})"))
+            .unwrap_or_default()
+    );
+    conn.execute(
+        "INSERT INTO events
+         (session_id, project, event_type, summary, detail, files, exit_code, created_at_epoch)
+         VALUES (?1, ?2, 'memory_governance', ?3, ?4, NULL, NULL, ?5)",
+        params![
+            actor.unwrap_or("memory-governance"),
+            req.project,
+            summary,
+            detail,
+            now
+        ],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/memory/governance/tests.rs
+++ b/src/memory/governance/tests.rs
@@ -1,0 +1,215 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use super::*;
+use crate::memory::insert_memory;
+use crate::memory::tests_helper::setup_memory_schema;
+
+#[test]
+fn govern_memories_requires_reason_and_confirmation_for_mutation() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let id = insert_memory(
+        &conn,
+        Some("s1"),
+        "proj",
+        Some("bad-memory"),
+        "Bad memory",
+        "This memory should be rejected.",
+        "discovery",
+        None,
+    )?;
+
+    let no_confirm = govern_memories(
+        &conn,
+        &GovernMemoryRequest {
+            project: "proj",
+            ids: &[id],
+            action: MemoryGovernanceAction::Reject,
+            reason: Some("wrong"),
+            actor: Some("test"),
+            dry_run: false,
+            confirm_destructive: false,
+        },
+    )
+    .expect_err("mutation should require confirmation");
+    assert!(no_confirm.to_string().contains("confirm_destructive"));
+
+    let no_reason = govern_memories(
+        &conn,
+        &GovernMemoryRequest {
+            project: "proj",
+            ids: &[id],
+            action: MemoryGovernanceAction::Reject,
+            reason: None,
+            actor: Some("test"),
+            dry_run: false,
+            confirm_destructive: true,
+        },
+    )
+    .expect_err("mutation should require reason");
+    assert!(no_reason.to_string().contains("explicit reason"));
+
+    let status: String =
+        conn.query_row("SELECT status FROM memories WHERE id = ?1", [id], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(status, "active");
+    Ok(())
+}
+
+#[test]
+fn govern_memories_dry_run_lists_targets_without_mutation_or_audit() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let id = insert_memory(
+        &conn,
+        Some("s1"),
+        "proj",
+        Some("bad-memory"),
+        "Bad memory",
+        "This memory should be previewed.",
+        "discovery",
+        None,
+    )?;
+
+    let result = govern_memories(
+        &conn,
+        &GovernMemoryRequest {
+            project: "proj",
+            ids: &[id],
+            action: MemoryGovernanceAction::Delete,
+            reason: None,
+            actor: Some("test"),
+            dry_run: true,
+            confirm_destructive: false,
+        },
+    )?;
+
+    assert!(result.dry_run);
+    assert_eq!(result.affected.len(), 1);
+    assert_eq!(result.affected[0].previous_status, "active");
+    assert_eq!(result.affected[0].new_status, "deleted");
+    let status: String =
+        conn.query_row("SELECT status FROM memories WHERE id = ?1", [id], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(status, "active");
+    let audit_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM events WHERE event_type = 'memory_governance'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(audit_count, 0);
+    Ok(())
+}
+
+#[test]
+fn govern_memories_writes_audit_and_removes_deleted_memory_from_fts() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let id = insert_memory(
+        &conn,
+        Some("s1"),
+        "proj",
+        Some("bad-memory"),
+        "Bad needle memory",
+        "This needle should disappear from FTS after deletion.",
+        "discovery",
+        None,
+    )?;
+    assert_eq!(
+        crate::memory::search_memories_fts(&conn, "needle", Some("proj"), None, 10, 0)?.len(),
+        1
+    );
+
+    let result = govern_memories(
+        &conn,
+        &GovernMemoryRequest {
+            project: "proj",
+            ids: &[id],
+            action: MemoryGovernanceAction::Delete,
+            reason: Some("incorrect memory"),
+            actor: Some("codex-test"),
+            dry_run: false,
+            confirm_destructive: true,
+        },
+    )?;
+
+    assert_eq!(result.affected.len(), 1);
+    assert_eq!(result.affected[0].new_status, "deleted");
+    assert!(
+        crate::memory::search_memories_fts(&conn, "needle", Some("proj"), None, 10, 0)?.is_empty()
+    );
+    let (summary, detail): (String, String) = conn.query_row(
+        "SELECT summary, detail FROM events WHERE event_type = 'memory_governance'",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert!(summary.contains("active -> deleted"));
+    assert!(detail.contains("\"memory_id\":"));
+    assert!(detail.contains("\"previous_status\":\"active\""));
+    assert!(detail.contains("\"new_status\":\"deleted\""));
+    assert!(detail.contains("incorrect memory"));
+    Ok(())
+}
+
+#[test]
+fn rejected_memories_stay_hidden_when_include_stale_is_true() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let rejected = insert_memory(
+        &conn,
+        Some("s1"),
+        "proj",
+        Some("rejected-memory"),
+        "Rejected memory",
+        "Rejected governance content.",
+        "discovery",
+        None,
+    )?;
+    let archived = insert_memory(
+        &conn,
+        Some("s1"),
+        "proj",
+        Some("archived-memory"),
+        "Archived memory",
+        "Archived governance content.",
+        "discovery",
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memories SET status = 'archived' WHERE id = ?1",
+        params![archived],
+    )?;
+    govern_memories(
+        &conn,
+        &GovernMemoryRequest {
+            project: "proj",
+            ids: &[rejected],
+            action: MemoryGovernanceAction::Reject,
+            reason: Some("bad extraction"),
+            actor: Some("codex-test"),
+            dry_run: false,
+            confirm_destructive: true,
+        },
+    )?;
+
+    let results = crate::memory::service::search_memories(
+        &conn,
+        &crate::memory::service::SearchRequest {
+            project: Some("proj".to_string()),
+            include_stale: true,
+            limit: 10,
+            ..crate::memory::service::SearchRequest::default()
+        },
+    )?;
+    let titles: Vec<_> = results
+        .memories
+        .iter()
+        .map(|memory| memory.title.as_str())
+        .collect();
+
+    assert_eq!(titles, vec!["Archived memory"]);
+    Ok(())
+}

--- a/src/memory/store/read.rs
+++ b/src/memory/store/read.rs
@@ -18,7 +18,7 @@ pub fn get_recent_memories_excluding_types(
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
     let mut idx = 1;
     idx = push_project_filter_required("project", project, idx, &mut conditions, &mut params);
-    conditions.push("status = 'active'".to_string());
+    conditions.push(crate::memory::memory_status_filter_sql("status", false));
 
     if !excluded_types.is_empty() {
         let placeholders: Vec<String> = excluded_types
@@ -61,7 +61,7 @@ pub fn get_recent_project_memories_excluding_types(
     params.push(Box::new(project.to_string()));
     idx += 1;
     conditions.push("COALESCE(scope, 'project') != 'global'".to_string());
-    conditions.push("status = 'active'".to_string());
+    conditions.push(crate::memory::memory_status_filter_sql("status", false));
 
     if !excluded_types.is_empty() {
         let placeholders: Vec<String> = excluded_types
@@ -109,7 +109,7 @@ pub fn search_project_memories_excluding_types(
     params.push(Box::new(project.to_string()));
     idx += 1;
     conditions.push("COALESCE(scope, 'project') != 'global'".to_string());
-    conditions.push("status = 'active'".to_string());
+    conditions.push(crate::memory::memory_status_filter_sql("status", false));
 
     let like_pattern = format!("%{query}%");
     conditions.push(format!("(title LIKE ?{idx} OR content LIKE ?{idx})"));
@@ -167,9 +167,10 @@ pub fn list_memories(
     let mut idx = 1;
     idx = push_project_filter_required("project", project, idx, &mut conditions, &mut params);
 
-    if !include_inactive {
-        conditions.push("status = 'active'".to_string());
-    }
+    conditions.push(crate::memory::memory_status_filter_sql(
+        "status",
+        include_inactive,
+    ));
     if let Some(memory_type) = memory_type {
         conditions.push(format!("memory_type = ?{idx}"));
         params.push(Box::new(memory_type.to_string()));

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -49,6 +49,14 @@ pub const MEMORY_TYPES: &[&str] = &[
 pub const MEMORY_COLS: &str = "id, session_id, project, topic_key, title, content, memory_type, \
                               files, created_at_epoch, updated_at_epoch, status, branch, scope";
 
+pub fn memory_status_filter_sql(column: &str, include_inactive: bool) -> String {
+    if include_inactive {
+        format!("{column} IN ('active', 'stale', 'archived')")
+    } else {
+        format!("{column} = 'active'")
+    }
+}
+
 pub fn map_memory_row_pub(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
     map_memory_row(row)
 }

--- a/src/retrieval/entity/graph/sql.rs
+++ b/src/retrieval/entity/graph/sql.rs
@@ -70,10 +70,6 @@ fn branch_filter_sql(param_idx: usize) -> String {
     format!("(m.branch = ?{param_idx} OR m.branch IS NULL)")
 }
 
-fn status_filter_sql(include_inactive: bool) -> &'static str {
-    if include_inactive {
-        "1=1"
-    } else {
-        "m.status = 'active'"
-    }
+fn status_filter_sql(include_inactive: bool) -> String {
+    crate::memory::memory_status_filter_sql("m.status", include_inactive)
 }

--- a/src/retrieval/entity/search/sql.rs
+++ b/src/retrieval/entity/search/sql.rs
@@ -6,10 +6,6 @@ pub(super) fn branch_filter_sql(param_idx: usize) -> String {
     format!("(m.branch = ?{param_idx} OR m.branch IS NULL)")
 }
 
-pub(super) fn status_filter_sql(include_inactive: bool) -> &'static str {
-    if include_inactive {
-        "1=1"
-    } else {
-        "m.status = 'active'"
-    }
+pub(super) fn status_filter_sql(include_inactive: bool) -> String {
+    crate::memory::memory_status_filter_sql("m.status", include_inactive)
 }

--- a/src/retrieval/memory_search/fts.rs
+++ b/src/retrieval/memory_search/fts.rs
@@ -40,9 +40,10 @@ pub fn search_memories_fts_filtered(
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(query.to_string())];
 
     let mut idx = 2;
-    if !include_inactive {
-        conditions.push("m.status = 'active'".to_string());
-    }
+    conditions.push(crate::memory::memory_status_filter_sql(
+        "m.status",
+        include_inactive,
+    ));
 
     idx = push_project_filter(
         "m.project",

--- a/src/retrieval/memory_search/like.rs
+++ b/src/retrieval/memory_search/like.rs
@@ -44,9 +44,10 @@ pub fn search_memories_like_filtered(
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
     let mut idx = 1;
 
-    if !include_inactive {
-        conditions.push("m.status = 'active'".to_string());
-    }
+    conditions.push(crate::memory::memory_status_filter_sql(
+        "m.status",
+        include_inactive,
+    ));
 
     for token in tokens {
         let like_pattern = format!("%{token}%");

--- a/src/retrieval/temporal/search.rs
+++ b/src/retrieval/temporal/search.rs
@@ -30,9 +30,10 @@ pub fn search_by_time_filtered(
     ];
     let mut idx = 3;
 
-    if !include_inactive {
-        conditions.push("status = 'active'".to_string());
-    }
+    conditions.push(crate::memory::memory_status_filter_sql(
+        "status",
+        include_inactive,
+    ));
     if let Some(project) = project {
         conditions.push(crate::retrieval::memory_search::project_or_global_clause(
             "project", idx,


### PR DESCRIPTION
## What

Adds an audited governance workflow for curated memories: delete, reject, and stale actions update memory status, write one audit event per mutation, and provide dry-run previews through CLI and MCP.

Fixes #211

## Why

Bad curated memories need a user-visible way to be suppressed without touching raw archive data or leaving stale search/context state behind.

## Test Plan

- [x] `cargo fmt --check`
- [x] `cargo test memory::governance`
- [x] `cargo test cli::tests::cli_parses_governance_delete_options`
- [x] `cargo test context::tests::load::load_context_data_excludes_deleted_and_rejected_memories`
- [x] `cargo test mcp::server::tests`
- [x] `cargo test retrieval::`
- [x] `cargo check`
- [x] `cargo test`