### PR TITLE
Link git commits to memory sessions

### DIFF
--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -15,6 +15,6 @@ pub(super) use import::run_import;
 pub(super) use maintenance::{run_cleanup, run_dream, run_encrypt};
 pub(super) use pending::run_pending;
 pub(super) use preferences::run_preferences;
-pub(super) use query::{run_backfill_entities, run_search, run_show, run_status};
+pub(super) use query::{run_backfill_entities, run_commit, run_search, run_show, run_status};
 pub(super) use review::run_review;
 pub(super) use usage::run_usage;

--- a/src/cli/actions/query.rs
+++ b/src/cli/actions/query.rs
@@ -1,4 +1,5 @@
 mod backfill;
+mod commit;
 mod search;
 mod show;
 mod status;
@@ -6,6 +7,7 @@ mod status;
 mod tests;
 
 pub(in crate::cli) use backfill::run_backfill_entities;
+pub(in crate::cli) use commit::run_commit;
 pub(in crate::cli) use search::run_search;
 pub(in crate::cli) use show::run_show;
 pub(in crate::cli) use status::run_status;

--- a/src/cli/actions/query/commit.rs
+++ b/src/cli/actions/query/commit.rs
@@ -1,0 +1,132 @@
+use anyhow::Result;
+
+use crate::cli::types::CommitAction;
+use crate::{db, git_trace};
+
+pub(in crate::cli) fn run_commit(action: CommitAction) -> Result<()> {
+    let conn = db::open_db()?;
+    match action {
+        CommitAction::Show { sha, project, json } => {
+            let results = git_trace::lookup_commit(&conn, project.as_deref(), &sha)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&results)?);
+                return Ok(());
+            }
+            if results.is_empty() {
+                println!("No commit metadata found for {sha}");
+                return Ok(());
+            }
+            for (index, result) in results.iter().enumerate() {
+                if index > 0 {
+                    println!();
+                }
+                print_commit_lookup(result);
+            }
+        }
+        CommitAction::Session {
+            session_id,
+            project,
+            limit,
+            json,
+        } => {
+            let results =
+                git_trace::commits_for_session(&conn, project.as_deref(), &session_id, limit)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&results)?);
+                return Ok(());
+            }
+            if results.is_empty() {
+                println!("No commits linked to session {session_id}");
+                return Ok(());
+            }
+            println!("Session: {session_id}");
+            for result in &results {
+                println!();
+                print_git_metadata(&result.git);
+                println!("Link metadata:");
+                println!("  content session: {}", result.link.session_id);
+                if let Some(memory_session_id) = &result.link.memory_session_id {
+                    println!("  memory session:  {memory_session_id}");
+                }
+                println!("  source:          {}", result.link.source);
+                println!(
+                    "  linked at:       {}",
+                    format_epoch(Some(result.link.linked_at_epoch))
+                );
+                print_summary(result.link.summary.as_ref());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_commit_lookup(result: &git_trace::CommitLookup) {
+    print_git_metadata(&result.git);
+    println!("Linked sessions:");
+    if result.sessions.is_empty() {
+        println!("  none");
+        return;
+    }
+    for session in &result.sessions {
+        println!("  content session: {}", session.session_id);
+        if let Some(memory_session_id) = &session.memory_session_id {
+            println!("  memory session:  {memory_session_id}");
+        }
+        println!("  source:          {}", session.source);
+        println!(
+            "  linked at:       {}",
+            format_epoch(Some(session.linked_at_epoch))
+        );
+        print_summary(session.summary.as_ref());
+    }
+}
+
+fn print_git_metadata(git: &git_trace::GitCommitRecord) {
+    println!("Commit {}", git.short_sha);
+    println!("Git metadata:");
+    println!("  full sha:  {}", git.sha);
+    println!("  project:   {}", git.project);
+    println!("  repo:      {}", git.repo_path);
+    if let Some(branch) = &git.branch {
+        println!("  branch:    {branch}");
+    }
+    if let Some(message) = &git.message {
+        println!("  message:   {message}");
+    }
+    println!("  authored:  {}", format_epoch(git.authored_at_epoch));
+    if git.changed_files.is_empty() {
+        println!("  files:     none recorded");
+    } else {
+        println!("  files:");
+        for file in &git.changed_files {
+            println!("    {file}");
+        }
+    }
+}
+
+fn print_summary(summary: Option<&git_trace::SessionSummaryTrace>) {
+    let Some(summary) = summary else {
+        println!("  memory summary: none linked");
+        return;
+    };
+    println!("  memory summary:");
+    print_optional_summary_field("request", summary.request.as_deref());
+    print_optional_summary_field("completed", summary.completed.as_deref());
+    print_optional_summary_field("decisions", summary.decisions.as_deref());
+    print_optional_summary_field("learned", summary.learned.as_deref());
+    print_optional_summary_field("next steps", summary.next_steps.as_deref());
+    print_optional_summary_field("preferences", summary.preferences.as_deref());
+}
+
+fn print_optional_summary_field(label: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        println!("    {label}: {value}");
+    }
+}
+
+fn format_epoch(epoch: Option<i64>) -> String {
+    epoch
+        .and_then(|value| chrono::DateTime::from_timestamp(value, 0))
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 
 use super::actions::{
-    run_admin, run_backfill_entities, run_cleanup, run_dream, run_encrypt, run_eval,
+    run_admin, run_backfill_entities, run_cleanup, run_commit, run_dream, run_encrypt, run_eval,
     run_eval_local, run_import, run_pending, run_preferences, run_review, run_search, run_show,
     run_status, run_usage,
 };
@@ -91,6 +91,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             multi_hop,
             explain,
         )?,
+        Commands::Commit { action } => run_commit(action)?,
         Commands::Show { id } => run_show(id)?,
         Commands::Eval { dataset, k } => run_eval(&dataset, k)?,
         Commands::EvalLocal => run_eval_local()?,

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,5 +1,5 @@
 use super::cwd::resolve_cwd_arg;
-use super::types::{Cli, Commands, ReviewAction};
+use super::types::{Cli, Commands, CommitAction, ReviewAction};
 use clap::Parser;
 
 #[test]
@@ -123,6 +123,55 @@ fn cli_parses_usage_options() {
             assert_eq!(weeks, 12);
         }
         _ => panic!("expected usage command"),
+    }
+}
+
+#[test]
+fn cli_parses_commit_show_and_session_lookup() {
+    let show = Cli::parse_from([
+        "remem",
+        "commit",
+        "show",
+        "abcdef1",
+        "--project",
+        "proj",
+        "--json",
+    ]);
+    match show.command {
+        Commands::Commit {
+            action: CommitAction::Show { sha, project, json },
+        } => {
+            assert_eq!(sha, "abcdef1");
+            assert_eq!(project.as_deref(), Some("proj"));
+            assert!(json);
+        }
+        _ => panic!("expected commit show command"),
+    }
+
+    let session = Cli::parse_from([
+        "remem",
+        "commit",
+        "session",
+        "content-session-1",
+        "--limit",
+        "7",
+    ]);
+    match session.command {
+        Commands::Commit {
+            action:
+                CommitAction::Session {
+                    session_id,
+                    project,
+                    limit,
+                    json,
+                },
+        } => {
+            assert_eq!(session_id, "content-session-1");
+            assert!(project.is_none());
+            assert_eq!(limit, 7);
+            assert!(!json);
+        }
+        _ => panic!("expected commit session command"),
     }
 }
 

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -114,6 +114,10 @@ pub(super) enum Commands {
         #[arg(long)]
         explain: bool,
     },
+    Commit {
+        #[command(subcommand)]
+        action: CommitAction,
+    },
     Show {
         id: i64,
     },
@@ -194,6 +198,28 @@ pub(in crate::cli) enum ImportAction {
         /// violations rather than failing.
         #[arg(long)]
         best_effort: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum CommitAction {
+    /// Look up git metadata and linked memory sessions for a full or short SHA.
+    Show {
+        sha: String,
+        #[arg(long, short)]
+        project: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// List commits linked to a content session ID or memory session ID.
+    Session {
+        session_id: String,
+        #[arg(long, short)]
+        project: Option<String>,
+        #[arg(long, short = 'n', default_value = "20")]
+        limit: i64,
+        #[arg(long)]
+        json: bool,
     },
 }
 

--- a/src/git_trace.rs
+++ b/src/git_trace.rs
@@ -1,0 +1,702 @@
+use anyhow::{bail, Result};
+use rusqlite::types::Type;
+use rusqlite::{params, Connection, OptionalExtension, Row};
+use serde::{Deserialize, Serialize};
+
+use crate::git_util::{short_sha_for, GitCommitMetadata};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GitCommitRecord {
+    pub id: i64,
+    pub project: String,
+    pub repo_path: String,
+    pub sha: String,
+    pub short_sha: String,
+    pub branch: Option<String>,
+    pub message: Option<String>,
+    pub authored_at_epoch: Option<i64>,
+    pub changed_files: Vec<String>,
+    pub created_at_epoch: i64,
+    pub updated_at_epoch: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionSummaryTrace {
+    pub request: Option<String>,
+    pub completed: Option<String>,
+    pub decisions: Option<String>,
+    pub learned: Option<String>,
+    pub next_steps: Option<String>,
+    pub preferences: Option<String>,
+    pub created_at_epoch: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommitSessionLink {
+    pub session_id: String,
+    pub memory_session_id: Option<String>,
+    pub source: String,
+    pub linked_at_epoch: i64,
+    pub summary: Option<SessionSummaryTrace>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommitLookup {
+    pub git: GitCommitRecord,
+    pub sessions: Vec<CommitSessionLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionCommit {
+    pub git: GitCommitRecord,
+    pub link: CommitSessionLink,
+}
+
+pub struct CommitMetadataInput<'a> {
+    pub project: &'a str,
+    pub repo_path: Option<&'a str>,
+    pub sha: &'a str,
+    pub short_sha: Option<&'a str>,
+    pub branch: Option<&'a str>,
+    pub message: Option<&'a str>,
+    pub authored_at_epoch: Option<i64>,
+    pub changed_files: &'a [String],
+}
+
+pub struct CommitLinkInput<'a> {
+    pub metadata: CommitMetadataInput<'a>,
+    pub session_id: &'a str,
+    pub memory_session_id: Option<&'a str>,
+    pub source: &'a str,
+}
+
+pub fn upsert_commit_metadata(conn: &Connection, input: &CommitMetadataInput<'_>) -> Result<i64> {
+    let sha = normalize_sha(input.sha)?;
+    let short_sha = input
+        .short_sha
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| short_sha_for(&sha));
+    let repo_path = input
+        .repo_path
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(input.project);
+    let changed_files = serde_json::to_string(input.changed_files)?;
+    let now = chrono::Utc::now().timestamp();
+
+    if sha != short_sha {
+        if let Some(id) = conn
+            .query_row(
+                "SELECT id FROM git_commits WHERE project = ?1 AND sha = ?2",
+                params![input.project, short_sha],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?
+        {
+            conn.execute(
+                "UPDATE git_commits SET
+                   repo_path = ?1,
+                   sha = ?2,
+                   short_sha = ?3,
+                   branch = COALESCE(?4, branch),
+                   message = COALESCE(?5, message),
+                   authored_at_epoch = COALESCE(?6, authored_at_epoch),
+                   changed_files = CASE WHEN ?7 != '[]' THEN ?7 ELSE changed_files END,
+                   updated_at_epoch = ?8
+                 WHERE id = ?9",
+                params![
+                    repo_path,
+                    sha,
+                    short_sha,
+                    input.branch,
+                    input.message,
+                    input.authored_at_epoch,
+                    changed_files,
+                    now,
+                    id
+                ],
+            )?;
+            return Ok(id);
+        }
+    }
+
+    conn.execute(
+        "INSERT INTO git_commits
+         (project, repo_path, sha, short_sha, branch, message, authored_at_epoch,
+          changed_files, created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)
+         ON CONFLICT(project, sha) DO UPDATE SET
+           repo_path = excluded.repo_path,
+           short_sha = excluded.short_sha,
+           branch = COALESCE(excluded.branch, git_commits.branch),
+           message = COALESCE(excluded.message, git_commits.message),
+           authored_at_epoch = COALESCE(excluded.authored_at_epoch, git_commits.authored_at_epoch),
+           changed_files = CASE
+             WHEN excluded.changed_files != '[]' THEN excluded.changed_files
+             ELSE git_commits.changed_files
+           END,
+           updated_at_epoch = excluded.updated_at_epoch",
+        params![
+            input.project,
+            repo_path,
+            sha,
+            short_sha,
+            input.branch,
+            input.message,
+            input.authored_at_epoch,
+            changed_files,
+            now
+        ],
+    )?;
+
+    let id = conn.query_row(
+        "SELECT id FROM git_commits WHERE project = ?1 AND sha = ?2",
+        params![input.project, sha],
+        |row| row.get(0),
+    )?;
+    Ok(id)
+}
+
+pub fn link_commit_to_session(conn: &Connection, input: &CommitLinkInput<'_>) -> Result<i64> {
+    let session_id = input.session_id.trim();
+    if session_id.is_empty() {
+        bail!("session_id is required to link a commit");
+    }
+    let source = input.source.trim();
+    if source.is_empty() {
+        bail!("source is required to link a commit");
+    }
+
+    let commit_id = upsert_commit_metadata(conn, &input.metadata)?;
+    link_session_to_commit_id(conn, commit_id, session_id, input.memory_session_id, source)?;
+    Ok(commit_id)
+}
+
+pub fn link_git_metadata_to_session(
+    conn: &Connection,
+    project: &str,
+    session_id: &str,
+    memory_session_id: &str,
+    metadata: &GitCommitMetadata,
+    source: &str,
+) -> Result<i64> {
+    link_commit_to_session(
+        conn,
+        &CommitLinkInput {
+            metadata: CommitMetadataInput {
+                project,
+                repo_path: Some(&metadata.repo_path),
+                sha: &metadata.sha,
+                short_sha: Some(&metadata.short_sha),
+                branch: metadata.branch.as_deref(),
+                message: metadata.message.as_deref(),
+                authored_at_epoch: metadata.authored_at_epoch,
+                changed_files: &metadata.changed_files,
+            },
+            session_id,
+            memory_session_id: Some(memory_session_id),
+            source,
+        },
+    )
+}
+
+pub fn link_observed_commit_to_session(
+    conn: &Connection,
+    project: &str,
+    session_id: &str,
+    memory_session_id: &str,
+    commit_sha: &str,
+    branch: Option<&str>,
+    metadata: Option<&GitCommitMetadata>,
+) -> Result<i64> {
+    if let Some(metadata) = metadata.filter(|metadata| metadata.matches_sha(commit_sha)) {
+        return link_git_metadata_to_session(
+            conn,
+            project,
+            session_id,
+            memory_session_id,
+            metadata,
+            "git_metadata",
+        );
+    }
+
+    if let Some(commit_id) = find_existing_commit_id(conn, project, commit_sha)? {
+        link_session_to_commit_id(
+            conn,
+            commit_id,
+            session_id,
+            Some(memory_session_id),
+            "observations",
+        )?;
+        return Ok(commit_id);
+    }
+
+    let changed_files = Vec::new();
+    link_commit_to_session(
+        conn,
+        &CommitLinkInput {
+            metadata: CommitMetadataInput {
+                project,
+                repo_path: Some(project),
+                sha: commit_sha,
+                short_sha: None,
+                branch,
+                message: None,
+                authored_at_epoch: None,
+                changed_files: &changed_files,
+            },
+            session_id,
+            memory_session_id: Some(memory_session_id),
+            source: "observations",
+        },
+    )
+}
+
+pub fn link_observed_commits_for_session(
+    conn: &Connection,
+    project: &str,
+    session_id: &str,
+    memory_session_id: &str,
+) -> Result<usize> {
+    let mut stmt = conn.prepare(
+        "SELECT commit_sha, branch
+         FROM observations
+         WHERE project = ?1
+           AND memory_session_id = ?2
+           AND commit_sha IS NOT NULL
+           AND length(trim(commit_sha)) > 0
+         GROUP BY commit_sha, branch",
+    )?;
+    let rows = stmt.query_map(params![project, memory_session_id], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+    })?;
+    let observed = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+
+    for (commit_sha, branch) in &observed {
+        link_observed_commit_to_session(
+            conn,
+            project,
+            session_id,
+            memory_session_id,
+            commit_sha,
+            branch.as_deref(),
+            None,
+        )?;
+    }
+
+    Ok(observed.len())
+}
+
+fn find_existing_commit_id(
+    conn: &Connection,
+    project: &str,
+    sha_or_prefix: &str,
+) -> Result<Option<i64>> {
+    let needle = normalize_sha(sha_or_prefix)?;
+    let prefix = format!("{needle}%");
+    let mut stmt = conn.prepare(
+        "SELECT id
+         FROM git_commits
+         WHERE project = ?1
+           AND (sha = ?2 OR short_sha = ?2 OR sha LIKE ?3 OR short_sha LIKE ?3)
+         ORDER BY CASE WHEN sha = ?2 THEN 0 WHEN short_sha = ?2 THEN 1 ELSE 2 END,
+                  updated_at_epoch DESC
+         LIMIT 2",
+    )?;
+    let ids = stmt
+        .query_map(params![project, needle, prefix], |row| row.get::<_, i64>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    match ids.as_slice() {
+        [] => Ok(None),
+        [id] => Ok(Some(*id)),
+        _ => bail!("ambiguous commit SHA prefix: {sha_or_prefix}"),
+    }
+}
+
+fn link_session_to_commit_id(
+    conn: &Connection,
+    commit_id: i64,
+    session_id: &str,
+    memory_session_id: Option<&str>,
+    source: &str,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "INSERT INTO git_commit_sessions
+         (commit_id, session_id, memory_session_id, source, linked_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(commit_id, session_id) DO UPDATE SET
+           memory_session_id = COALESCE(excluded.memory_session_id, git_commit_sessions.memory_session_id),
+           source = excluded.source",
+        params![commit_id, session_id, memory_session_id, source, now],
+    )?;
+    Ok(())
+}
+
+pub fn lookup_commit(
+    conn: &Connection,
+    project: Option<&str>,
+    sha_or_prefix: &str,
+) -> Result<Vec<CommitLookup>> {
+    let needle = normalize_sha(sha_or_prefix)?;
+    let prefix = format!("{needle}%");
+    let commits = if let Some(project) = project {
+        let mut stmt = conn.prepare(
+            "SELECT id, project, repo_path, sha, short_sha, branch, message,
+                    authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch
+             FROM git_commits
+             WHERE project = ?1
+               AND (sha = ?2 OR short_sha = ?2 OR sha LIKE ?3 OR short_sha LIKE ?3)
+             ORDER BY CASE WHEN sha = ?2 THEN 0 WHEN short_sha = ?2 THEN 1 ELSE 2 END,
+                      updated_at_epoch DESC
+             LIMIT 20",
+        )?;
+        let rows = stmt.query_map(params![project, needle, prefix], commit_from_row)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    } else {
+        let mut stmt = conn.prepare(
+            "SELECT id, project, repo_path, sha, short_sha, branch, message,
+                    authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch
+             FROM git_commits
+             WHERE sha = ?1 OR short_sha = ?1 OR sha LIKE ?2 OR short_sha LIKE ?2
+             ORDER BY CASE WHEN sha = ?1 THEN 0 WHEN short_sha = ?1 THEN 1 ELSE 2 END,
+                      updated_at_epoch DESC
+             LIMIT 20",
+        )?;
+        let rows = stmt.query_map(params![needle, prefix], commit_from_row)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    };
+
+    commits
+        .into_iter()
+        .map(|git| {
+            let sessions = linked_sessions_for_commit(conn, git.id, &git.project)?;
+            Ok(CommitLookup { git, sessions })
+        })
+        .collect()
+}
+
+pub fn commits_for_session(
+    conn: &Connection,
+    project: Option<&str>,
+    session_id: &str,
+    limit: i64,
+) -> Result<Vec<SessionCommit>> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        bail!("session_id is required");
+    }
+    let limit = limit.clamp(1, 100);
+    if let Some(project) = project {
+        query_session_commits(
+            conn,
+            "WHERE c.project = ?1 AND (l.session_id = ?2 OR l.memory_session_id = ?2)",
+            params![project, session_id, limit],
+        )
+    } else {
+        query_session_commits(
+            conn,
+            "WHERE l.session_id = ?1 OR l.memory_session_id = ?1",
+            params![session_id, limit],
+        )
+    }
+}
+
+fn query_session_commits<P>(
+    conn: &Connection,
+    where_clause: &str,
+    params: P,
+) -> Result<Vec<SessionCommit>>
+where
+    P: rusqlite::Params,
+{
+    let sql = format!(
+        "SELECT c.id, c.project, c.repo_path, c.sha, c.short_sha, c.branch, c.message,
+                c.authored_at_epoch, c.changed_files, c.created_at_epoch, c.updated_at_epoch,
+                l.session_id, l.memory_session_id, l.source, l.linked_at_epoch,
+                ss.request, ss.completed, ss.decisions, ss.learned, ss.next_steps,
+                ss.preferences, ss.created_at_epoch
+         FROM git_commit_sessions l
+         JOIN git_commits c ON c.id = l.commit_id
+         LEFT JOIN session_summaries ss
+           ON ss.memory_session_id = l.memory_session_id
+          AND ss.project = c.project
+         {where_clause}
+         ORDER BY COALESCE(c.authored_at_epoch, c.updated_at_epoch) DESC, c.id DESC
+         LIMIT ?{}",
+        if where_clause.contains("?2") {
+            "3"
+        } else {
+            "2"
+        }
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params, |row| {
+        Ok(SessionCommit {
+            git: commit_from_row(row)?,
+            link: link_from_row(row, 11)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+fn linked_sessions_for_commit(
+    conn: &Connection,
+    commit_id: i64,
+    project: &str,
+) -> Result<Vec<CommitSessionLink>> {
+    let mut stmt = conn.prepare(
+        "SELECT l.session_id, l.memory_session_id, l.source, l.linked_at_epoch,
+                ss.request, ss.completed, ss.decisions, ss.learned, ss.next_steps,
+                ss.preferences, ss.created_at_epoch
+         FROM git_commit_sessions l
+         LEFT JOIN session_summaries ss
+           ON ss.memory_session_id = l.memory_session_id
+          AND ss.project = ?2
+         WHERE l.commit_id = ?1
+         ORDER BY l.linked_at_epoch DESC",
+    )?;
+    let rows = stmt.query_map(params![commit_id, project], |row| link_from_row(row, 0))?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+fn normalize_sha(raw: &str) -> Result<String> {
+    let sha = raw.trim();
+    if sha.is_empty() {
+        bail!("commit SHA is required");
+    }
+    Ok(sha.to_string())
+}
+
+fn commit_from_row(row: &Row<'_>) -> rusqlite::Result<GitCommitRecord> {
+    Ok(GitCommitRecord {
+        id: row.get(0)?,
+        project: row.get(1)?,
+        repo_path: row.get(2)?,
+        sha: row.get(3)?,
+        short_sha: row.get(4)?,
+        branch: row.get(5)?,
+        message: row.get(6)?,
+        authored_at_epoch: row.get(7)?,
+        changed_files: changed_files_from_row(row, 8)?,
+        created_at_epoch: row.get(9)?,
+        updated_at_epoch: row.get(10)?,
+    })
+}
+
+fn link_from_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<CommitSessionLink> {
+    let summary = summary_from_row(row, offset + 4)?;
+    Ok(CommitSessionLink {
+        session_id: row.get(offset)?,
+        memory_session_id: row.get(offset + 1)?,
+        source: row.get(offset + 2)?,
+        linked_at_epoch: row.get(offset + 3)?,
+        summary,
+    })
+}
+
+fn summary_from_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<Option<SessionSummaryTrace>> {
+    let summary = SessionSummaryTrace {
+        request: row.get(offset)?,
+        completed: row.get(offset + 1)?,
+        decisions: row.get(offset + 2)?,
+        learned: row.get(offset + 3)?,
+        next_steps: row.get(offset + 4)?,
+        preferences: row.get(offset + 5)?,
+        created_at_epoch: row.get(offset + 6)?,
+    };
+    if summary.request.is_none()
+        && summary.completed.is_none()
+        && summary.decisions.is_none()
+        && summary.learned.is_none()
+        && summary.next_steps.is_none()
+        && summary.preferences.is_none()
+        && summary.created_at_epoch.is_none()
+    {
+        Ok(None)
+    } else {
+        Ok(Some(summary))
+    }
+}
+
+fn changed_files_from_row(row: &Row<'_>, idx: usize) -> rusqlite::Result<Vec<String>> {
+    let raw: String = row.get(idx)?;
+    serde_json::from_str(&raw)
+        .map_err(|err| rusqlite::Error::FromSqlConversionFailure(idx, Type::Text, Box::new(err)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn migrated_db() -> Result<Connection> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        crate::migrate::run_migrations(&conn)?;
+        Ok(conn)
+    }
+
+    fn metadata_input<'a>(changed_files: &'a [String]) -> CommitMetadataInput<'a> {
+        CommitMetadataInput {
+            project: "proj",
+            repo_path: Some("/repo"),
+            sha: "abcdef1234567890abcdef1234567890abcdef12",
+            short_sha: Some("abcdef1"),
+            branch: Some("main"),
+            message: Some("Add traceability"),
+            authored_at_epoch: Some(1_700_000_000),
+            changed_files,
+        }
+    }
+
+    #[test]
+    fn link_lookup_and_session_reverse_lookup_are_idempotent() -> Result<()> {
+        let conn = migrated_db()?;
+        let changed_files = vec!["src/lib.rs".to_string(), "README.md".to_string()];
+        let input = CommitLinkInput {
+            metadata: metadata_input(&changed_files),
+            session_id: "content-session-1",
+            memory_session_id: Some("mem-session-1"),
+            source: "git_metadata",
+        };
+
+        let first_id = link_commit_to_session(&conn, &input)?;
+        let second_id = link_commit_to_session(&conn, &input)?;
+        assert_eq!(first_id, second_id);
+
+        let link_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM git_commit_sessions WHERE commit_id = ?1",
+            [first_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(link_count, 1);
+
+        let full = lookup_commit(
+            &conn,
+            Some("proj"),
+            "abcdef1234567890abcdef1234567890abcdef12",
+        )?;
+        assert_eq!(full.len(), 1);
+        assert_eq!(full[0].git.short_sha, "abcdef1");
+        assert_eq!(full[0].git.changed_files, changed_files);
+        assert_eq!(full[0].sessions.len(), 1);
+        assert_eq!(full[0].sessions[0].session_id, "content-session-1");
+
+        let short = lookup_commit(&conn, Some("proj"), "abcdef1")?;
+        assert_eq!(short.len(), 1);
+        assert_eq!(short[0].git.sha, full[0].git.sha);
+
+        let session_commits = commits_for_session(&conn, Some("proj"), "content-session-1", 10)?;
+        assert_eq!(session_commits.len(), 1);
+        assert_eq!(session_commits[0].git.short_sha, "abcdef1");
+
+        let memory_session_commits = commits_for_session(&conn, Some("proj"), "mem-session-1", 10)?;
+        assert_eq!(memory_session_commits.len(), 1);
+        assert_eq!(
+            memory_session_commits[0].link.memory_session_id.as_deref(),
+            Some("mem-session-1")
+        );
+
+        link_observed_commit_to_session(
+            &conn,
+            "proj",
+            "content-session-2",
+            "mem-session-2",
+            "abcdef1",
+            Some("main"),
+            None,
+        )?;
+        let commit_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM git_commits", [], |row| row.get(0))?;
+        assert_eq!(commit_count, 1);
+        let relinked = lookup_commit(&conn, Some("proj"), "abcdef1")?;
+        assert_eq!(relinked[0].sessions.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn full_metadata_upgrades_existing_short_sha_record() -> Result<()> {
+        let conn = migrated_db()?;
+        link_observed_commit_to_session(
+            &conn,
+            "proj",
+            "content-session-1",
+            "mem-session-1",
+            "abcdef1",
+            Some("main"),
+            None,
+        )?;
+
+        let changed_files = vec!["src/git_trace.rs".to_string()];
+        link_commit_to_session(
+            &conn,
+            &CommitLinkInput {
+                metadata: metadata_input(&changed_files),
+                session_id: "content-session-2",
+                memory_session_id: Some("mem-session-2"),
+                source: "git_metadata",
+            },
+        )?;
+
+        let commit_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM git_commits", [], |row| row.get(0))?;
+        assert_eq!(commit_count, 1);
+        let results = lookup_commit(
+            &conn,
+            Some("proj"),
+            "abcdef1234567890abcdef1234567890abcdef12",
+        )?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].git.short_sha, "abcdef1");
+        assert_eq!(results[0].git.changed_files, changed_files);
+        assert_eq!(results[0].sessions.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn commit_metadata_without_link_returns_no_sessions() -> Result<()> {
+        let conn = migrated_db()?;
+        let changed_files = Vec::new();
+        let commit_id = upsert_commit_metadata(&conn, &metadata_input(&changed_files))?;
+        assert!(commit_id > 0);
+
+        let results = lookup_commit(&conn, Some("proj"), "abcdef1")?;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].sessions.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn summary_is_memory_derived_and_optional() -> Result<()> {
+        let conn = migrated_db()?;
+        let changed_files = Vec::new();
+        conn.execute(
+            "INSERT INTO session_summaries
+             (memory_session_id, project, request, completed, created_at, created_at_epoch)
+             VALUES ('mem-session-1', 'proj', 'Need traceability', 'Linked commits',
+                     '2026-01-01T00:00:00Z', 1)",
+            [],
+        )?;
+        link_commit_to_session(
+            &conn,
+            &CommitLinkInput {
+                metadata: metadata_input(&changed_files),
+                session_id: "content-session-1",
+                memory_session_id: Some("mem-session-1"),
+                source: "git_metadata",
+            },
+        )?;
+
+        let results = lookup_commit(&conn, Some("proj"), "abcdef1")?;
+        let summary = results[0].sessions[0]
+            .summary
+            .as_ref()
+            .expect("linked summary should be returned");
+        assert_eq!(summary.request.as_deref(), Some("Need traceability"));
+        assert_eq!(summary.completed.as_deref(), Some("Linked commits"));
+        Ok(())
+    }
+}

--- a/src/git_trace.rs
+++ b/src/git_trace.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use rusqlite::types::Type;
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use rusqlite::{params, Connection, Row};
 use serde::{Deserialize, Serialize};
 
 use crate::git_util::{short_sha_for, GitCommitMetadata};
@@ -87,13 +87,8 @@ pub fn upsert_commit_metadata(conn: &Connection, input: &CommitMetadataInput<'_>
     let now = chrono::Utc::now().timestamp();
 
     if sha != short_sha {
-        if let Some(id) = conn
-            .query_row(
-                "SELECT id FROM git_commits WHERE project = ?1 AND sha = ?2",
-                params![input.project, short_sha],
-                |row| row.get::<_, i64>(0),
-            )
-            .optional()?
+        if let Some(id) =
+            find_upgradeable_placeholder_commit_id(conn, input.project, &sha, &short_sha)?
         {
             conn.execute(
                 "UPDATE git_commits SET
@@ -289,6 +284,46 @@ pub fn link_observed_commits_for_session(
     Ok(observed.len())
 }
 
+fn find_upgradeable_placeholder_commit_id(
+    conn: &Connection,
+    project: &str,
+    full_sha: &str,
+    short_sha: &str,
+) -> Result<Option<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT id
+         FROM git_commits
+         WHERE project = ?1
+           AND sha != ?2
+           AND (
+             sha = ?3
+             OR short_sha = ?3
+             OR ?2 LIKE sha || '%'
+             OR ?2 LIKE short_sha || '%'
+           )
+         ORDER BY
+           CASE
+             WHEN sha = ?3 THEN 0
+             WHEN short_sha = ?3 THEN 1
+             WHEN ?2 LIKE sha || '%' THEN 2
+             ELSE 3
+           END,
+           length(sha) DESC,
+           updated_at_epoch DESC
+         LIMIT 2",
+    )?;
+    let ids = stmt
+        .query_map(params![project, full_sha, short_sha], |row| {
+            row.get::<_, i64>(0)
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    match ids.as_slice() {
+        [] => Ok(None),
+        [id] => Ok(Some(*id)),
+        _ => bail!("ambiguous commit SHA placeholder: {full_sha}"),
+    }
+}
+
 fn find_existing_commit_id(
     conn: &Connection,
     project: &str,
@@ -300,7 +335,14 @@ fn find_existing_commit_id(
         "SELECT id
          FROM git_commits
          WHERE project = ?1
-           AND (sha = ?2 OR short_sha = ?2 OR sha LIKE ?3 OR short_sha LIKE ?3)
+           AND (
+             sha = ?2
+             OR short_sha = ?2
+             OR sha LIKE ?3
+             OR short_sha LIKE ?3
+             OR ?2 LIKE sha || '%'
+             OR ?2 LIKE short_sha || '%'
+           )
          ORDER BY CASE WHEN sha = ?2 THEN 0 WHEN short_sha = ?2 THEN 1 ELSE 2 END,
                   updated_at_epoch DESC
          LIMIT 2",
@@ -329,7 +371,11 @@ fn link_session_to_commit_id(
          VALUES (?1, ?2, ?3, ?4, ?5)
          ON CONFLICT(commit_id, session_id) DO UPDATE SET
            memory_session_id = COALESCE(excluded.memory_session_id, git_commit_sessions.memory_session_id),
-           source = excluded.source",
+           source = CASE
+             WHEN git_commit_sessions.source = 'git_metadata' THEN git_commit_sessions.source
+             WHEN excluded.source = 'git_metadata' THEN excluded.source
+             ELSE excluded.source
+           END",
         params![commit_id, session_id, memory_session_id, source, now],
     )?;
     Ok(())
@@ -653,6 +699,91 @@ mod tests {
         assert_eq!(results[0].git.short_sha, "abcdef1");
         assert_eq!(results[0].git.changed_files, changed_files);
         assert_eq!(results[0].sessions.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn full_metadata_upgrades_existing_long_abbrev_record() -> Result<()> {
+        let conn = migrated_db()?;
+        link_observed_commit_to_session(
+            &conn,
+            "proj",
+            "content-session-1",
+            "mem-session-1",
+            "abcdef123456",
+            Some("main"),
+            None,
+        )?;
+
+        let changed_files = vec!["src/git_trace.rs".to_string()];
+        link_commit_to_session(
+            &conn,
+            &CommitLinkInput {
+                metadata: metadata_input(&changed_files),
+                session_id: "content-session-2",
+                memory_session_id: Some("mem-session-2"),
+                source: "git_metadata",
+            },
+        )?;
+
+        let commit_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM git_commits", [], |row| row.get(0))?;
+        assert_eq!(commit_count, 1);
+        let results = lookup_commit(
+            &conn,
+            Some("proj"),
+            "abcdef1234567890abcdef1234567890abcdef12",
+        )?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].git.sha,
+            "abcdef1234567890abcdef1234567890abcdef12"
+        );
+        assert_eq!(results[0].git.short_sha, "abcdef1");
+        assert_eq!(results[0].sessions.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn relink_preserves_git_metadata_source() -> Result<()> {
+        let conn = migrated_db()?;
+        let changed_files = vec!["src/git_trace.rs".to_string()];
+        link_observed_commit_to_session(
+            &conn,
+            "proj",
+            "content-session-1",
+            "mem-session-1",
+            "abcdef1",
+            Some("main"),
+            None,
+        )?;
+        link_commit_to_session(
+            &conn,
+            &CommitLinkInput {
+                metadata: metadata_input(&changed_files),
+                session_id: "content-session-1",
+                memory_session_id: Some("mem-session-1"),
+                source: "git_metadata",
+            },
+        )?;
+        link_observed_commit_to_session(
+            &conn,
+            "proj",
+            "content-session-1",
+            "mem-session-1",
+            "abcdef1",
+            Some("main"),
+            None,
+        )?;
+
+        let source: String = conn.query_row(
+            "SELECT source
+             FROM git_commit_sessions
+             WHERE session_id = 'content-session-1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(source, "git_metadata");
         Ok(())
     }
 

--- a/src/git_util.rs
+++ b/src/git_util.rs
@@ -4,8 +4,20 @@
 //! would require tempdir + git init in the test environment, which adds an
 //! external dependency for a single helper).
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+const HEAD_AUTHORED_AT_ARGS: &[&str] = &["show", "-s", "--format=%at", "HEAD"];
+const HEAD_CHANGED_FILES_ARGS: &[&str] = &[
+    "diff-tree",
+    "--root",
+    "-m",
+    "--no-commit-id",
+    "--name-only",
+    "-r",
+    "HEAD",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitCommitMetadata {
@@ -56,12 +68,18 @@ pub fn resolve_toplevel(cwd: &Path) -> Option<PathBuf> {
 }
 
 pub fn parse_changed_files_output(stdout: &str) -> Vec<String> {
-    stdout
+    let mut seen = HashSet::new();
+    let mut files = Vec::new();
+    for file in stdout
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
-        .map(str::to_string)
-        .collect()
+    {
+        if seen.insert(file.to_string()) {
+            files.push(file.to_string());
+        }
+    }
+    files
 }
 
 pub fn parse_authored_epoch_output(stdout: &str) -> Option<i64> {
@@ -98,14 +116,11 @@ pub fn detect_commit_metadata(cwd: &str) -> Option<GitCommitMetadata> {
     let message = git_stdout(cwd, &["show", "-s", "--format=%s", "HEAD"])
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    let authored_at_epoch = git_stdout(cwd, &["show", "-s", "--format=%ct", "HEAD"])
+    let authored_at_epoch = git_stdout(cwd, HEAD_AUTHORED_AT_ARGS)
         .and_then(|value| parse_authored_epoch_output(&value));
-    let changed_files = git_stdout(
-        cwd,
-        &["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
-    )
-    .map(|value| parse_changed_files_output(&value))
-    .unwrap_or_default();
+    let changed_files = git_stdout(cwd, HEAD_CHANGED_FILES_ARGS)
+        .map(|value| parse_changed_files_output(&value))
+        .unwrap_or_default();
 
     Some(GitCommitMetadata {
         repo_path: repo_path.to_string_lossy().to_string(),
@@ -165,6 +180,24 @@ mod tests {
             parse_changed_files_output("src/lib.rs\n\n  README.md  \n"),
             vec!["src/lib.rs".to_string(), "README.md".to_string()]
         );
+    }
+
+    #[test]
+    fn parse_changed_files_deduplicates_merge_diff_output() {
+        assert_eq!(
+            parse_changed_files_output("src/lib.rs\nREADME.md\nsrc/lib.rs\nREADME.md\n"),
+            vec!["src/lib.rs".to_string(), "README.md".to_string()]
+        );
+    }
+
+    #[test]
+    fn metadata_detection_uses_author_time_and_root_merge_diff_args() {
+        assert_eq!(
+            HEAD_AUTHORED_AT_ARGS,
+            ["show", "-s", "--format=%at", "HEAD"]
+        );
+        assert!(HEAD_CHANGED_FILES_ARGS.contains(&"--root"));
+        assert!(HEAD_CHANGED_FILES_ARGS.contains(&"-m"));
     }
 
     #[test]

--- a/src/git_util.rs
+++ b/src/git_util.rs
@@ -7,6 +7,28 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitCommitMetadata {
+    pub repo_path: String,
+    pub sha: String,
+    pub short_sha: String,
+    pub branch: Option<String>,
+    pub message: Option<String>,
+    pub authored_at_epoch: Option<i64>,
+    pub changed_files: Vec<String>,
+}
+
+impl GitCommitMetadata {
+    pub fn matches_sha(&self, sha: &str) -> bool {
+        let needle = sha.trim();
+        !needle.is_empty()
+            && (self.sha == needle
+                || self.short_sha == needle
+                || self.sha.starts_with(needle)
+                || self.short_sha.starts_with(needle))
+    }
+}
+
 /// Parse the output of `git rev-parse --show-toplevel`. Returns `None` for
 /// empty or whitespace-only input so callers can fall back cleanly.
 pub fn parse_toplevel_output(stdout: &str) -> Option<PathBuf> {
@@ -31,6 +53,83 @@ pub fn resolve_toplevel(cwd: &Path) -> Option<PathBuf> {
         return None;
     }
     parse_toplevel_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+pub fn parse_changed_files_output(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+pub fn parse_authored_epoch_output(stdout: &str) -> Option<i64> {
+    stdout.trim().parse::<i64>().ok()
+}
+
+pub fn parse_branch_output(stdout: &str) -> Option<String> {
+    let branch = stdout.trim();
+    if branch.is_empty() || branch == "HEAD" {
+        None
+    } else {
+        Some(branch.to_string())
+    }
+}
+
+pub fn short_sha_for(sha: &str) -> String {
+    sha.chars().take(7).collect()
+}
+
+pub fn detect_commit_metadata(cwd: &str) -> Option<GitCommitMetadata> {
+    let repo_path = resolve_toplevel(Path::new(cwd))?;
+    let sha = git_stdout(cwd, &["rev-parse", "HEAD"])?;
+    let sha = sha.trim();
+    if sha.is_empty() {
+        return None;
+    }
+
+    let short_sha = git_stdout(cwd, &["rev-parse", "--short", "HEAD"])
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| short_sha_for(sha));
+    let branch = git_stdout(cwd, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .and_then(|value| parse_branch_output(&value));
+    let message = git_stdout(cwd, &["show", "-s", "--format=%s", "HEAD"])
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let authored_at_epoch = git_stdout(cwd, &["show", "-s", "--format=%ct", "HEAD"])
+        .and_then(|value| parse_authored_epoch_output(&value));
+    let changed_files = git_stdout(
+        cwd,
+        &["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+    )
+    .map(|value| parse_changed_files_output(&value))
+    .unwrap_or_default();
+
+    Some(GitCommitMetadata {
+        repo_path: repo_path.to_string_lossy().to_string(),
+        sha: sha.to_string(),
+        short_sha,
+        branch,
+        message,
+        authored_at_epoch,
+        changed_files,
+    })
+}
+
+fn git_stdout(cwd: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 #[cfg(test)]
@@ -58,5 +157,51 @@ mod tests {
             parse_toplevel_output("/path/with-spaces  \n\t"),
             Some(PathBuf::from("/path/with-spaces"))
         );
+    }
+
+    #[test]
+    fn parse_changed_files_ignores_blank_lines() {
+        assert_eq!(
+            parse_changed_files_output("src/lib.rs\n\n  README.md  \n"),
+            vec!["src/lib.rs".to_string(), "README.md".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_authored_epoch_requires_integer() {
+        assert_eq!(
+            parse_authored_epoch_output("1700000000\n"),
+            Some(1700000000)
+        );
+        assert_eq!(parse_authored_epoch_output("not-an-epoch"), None);
+    }
+
+    #[test]
+    fn parse_branch_ignores_detached_head() {
+        assert_eq!(
+            parse_branch_output("feature/x\n"),
+            Some("feature/x".to_string())
+        );
+        assert_eq!(parse_branch_output("HEAD\n"), None);
+        assert_eq!(parse_branch_output("\n"), None);
+    }
+
+    #[test]
+    fn commit_metadata_matches_full_short_and_prefix() {
+        let metadata = GitCommitMetadata {
+            repo_path: "/repo".to_string(),
+            sha: "abcdef1234567890".to_string(),
+            short_sha: "abcdef1".to_string(),
+            branch: Some("main".to_string()),
+            message: None,
+            authored_at_epoch: None,
+            changed_files: Vec::new(),
+        };
+
+        assert!(metadata.matches_sha("abcdef1234567890"));
+        assert!(metadata.matches_sha("abcdef1"));
+        assert!(metadata.matches_sha("abcdef"));
+        assert!(!metadata.matches_sha(""));
+        assert!(!metadata.matches_sha("fedcba"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod doctor;
 pub mod dream;
 pub mod eval;
 mod extraction_worker;
+pub mod git_trace;
 pub mod git_util;
 mod hook_stdin;
 pub mod identity;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,3 +1,4 @@
+mod commit_tools;
 mod context_tools;
 mod raw_tools;
 mod runtime;
@@ -20,6 +21,7 @@ impl MemoryServer {
         Ok(Self {
             tool_router: Self::tool_router_search()
                 + Self::tool_router_context()
+                + Self::tool_router_commit()
                 + Self::tool_router_write()
                 + Self::tool_router_workstream()
                 + Self::tool_router_raw(),

--- a/src/mcp/server/commit_tools.rs
+++ b/src/mcp/server/commit_tools.rs
@@ -1,0 +1,64 @@
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{tool, tool_router};
+
+use super::super::types::{CommitLookupParams, SessionCommitsParams};
+use super::MemoryServer;
+
+#[tool_router(router = tool_router_commit, vis = "pub(super)")]
+impl MemoryServer {
+    #[tool(
+        description = "Look up git commit metadata and linked memory sessions by full or short SHA. The response separates git metadata from memory-derived summaries so missing links are not inferred."
+    )]
+    pub(super) fn lookup_commit(
+        &self,
+        Parameters(params): Parameters<CommitLookupParams>,
+    ) -> Result<String, String> {
+        crate::log::info(
+            "mcp",
+            &format!(
+                "lookup_commit called sha={} project={:?}",
+                params.sha, params.project
+            ),
+        );
+        self.with_conn(|conn| {
+            let results =
+                crate::git_trace::lookup_commit(conn, params.project.as_deref(), &params.sha)
+                    .map_err(|err| {
+                        crate::log::warn("mcp", &format!("lookup_commit failed: {}", err));
+                        err.to_string()
+                    })?;
+            serde_json::to_string_pretty(&results).map_err(|err| err.to_string())
+        })
+    }
+
+    #[tool(
+        description = "List git commits linked to a content session ID or remem memory session ID. Returns link evidence plus git metadata; it does not guess commit intent when no link exists."
+    )]
+    pub(super) fn commits_for_session(
+        &self,
+        Parameters(params): Parameters<SessionCommitsParams>,
+    ) -> Result<String, String> {
+        crate::log::info(
+            "mcp",
+            &format!(
+                "commits_for_session called session_id={} project={:?} limit={}",
+                params.session_id,
+                params.project,
+                params.limit.unwrap_or(20)
+            ),
+        );
+        self.with_conn(|conn| {
+            let results = crate::git_trace::commits_for_session(
+                conn,
+                params.project.as_deref(),
+                &params.session_id,
+                params.limit.unwrap_or(20),
+            )
+            .map_err(|err| {
+                crate::log::warn("mcp", &format!("commits_for_session failed: {}", err));
+                err.to_string()
+            })?;
+            serde_json::to_string_pretty(&results).map_err(|err| err.to_string())
+        })
+    }
+}

--- a/src/mcp/server/tests.rs
+++ b/src/mcp/server/tests.rs
@@ -1,6 +1,6 @@
 use rmcp::handler::server::wrapper::Parameters;
 
-use super::super::types::SearchParams;
+use super::super::types::{CommitLookupParams, SearchParams, SessionCommitsParams};
 use super::MemoryServer;
 use crate::db::test_support::ScopedTestDataDir;
 use crate::memory::service::{resolve_local_note_path, sanitize_segment};
@@ -65,4 +65,57 @@ fn search_reopens_database_after_file_removal() {
     }));
     assert!(second.is_ok());
     assert!(test_dir.db_path().exists());
+}
+
+#[test]
+fn commit_tools_return_git_metadata_separate_from_session_summary() {
+    let _test_dir = ScopedTestDataDir::new("mcp-commit");
+    let server = MemoryServer::new().expect("memory server should initialize");
+    let conn = crate::db::open_db().expect("test database should open");
+    let changed_files = vec!["src/git_trace.rs".to_string()];
+    crate::git_trace::link_commit_to_session(
+        &conn,
+        &crate::git_trace::CommitLinkInput {
+            metadata: crate::git_trace::CommitMetadataInput {
+                project: "proj",
+                repo_path: Some("/repo"),
+                sha: "abcdef1234567890abcdef1234567890abcdef12",
+                short_sha: Some("abcdef1"),
+                branch: Some("main"),
+                message: Some("Add traceability"),
+                authored_at_epoch: Some(1_700_000_000),
+                changed_files: &changed_files,
+            },
+            session_id: "content-session-1",
+            memory_session_id: Some("mem-session-1"),
+            source: "git_metadata",
+        },
+    )
+    .expect("commit should link");
+
+    let lookup = server
+        .lookup_commit(Parameters(CommitLookupParams {
+            sha: "abcdef1".to_string(),
+            project: Some("proj".to_string()),
+        }))
+        .expect("lookup_commit should succeed");
+    let lookup_json: serde_json::Value =
+        serde_json::from_str(&lookup).expect("lookup response should be JSON");
+    assert_eq!(lookup_json[0]["git"]["short_sha"], "abcdef1");
+    assert_eq!(
+        lookup_json[0]["sessions"][0]["session_id"],
+        "content-session-1"
+    );
+
+    let session = server
+        .commits_for_session(Parameters(SessionCommitsParams {
+            session_id: "mem-session-1".to_string(),
+            project: Some("proj".to_string()),
+            limit: Some(5),
+        }))
+        .expect("commits_for_session should succeed");
+    let session_json: serde_json::Value =
+        serde_json::from_str(&session).expect("session response should be JSON");
+    assert_eq!(session_json[0]["git"]["short_sha"], "abcdef1");
+    assert_eq!(session_json[0]["link"]["source"], "git_metadata");
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -50,6 +50,24 @@ pub(super) struct GetObservationsParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub(super) struct CommitLookupParams {
+    #[schemars(description = "Full or short git commit SHA to look up")]
+    pub sha: String,
+    #[schemars(description = "Optional project filter")]
+    pub project: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(super) struct SessionCommitsParams {
+    #[schemars(description = "Content session ID or remem memory session ID")]
+    pub session_id: String,
+    #[schemars(description = "Optional project filter")]
+    pub project: Option<String>,
+    #[schemars(description = "Max linked commits to return (default 20, max 100)")]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub(super) struct SaveMemoryParams {
     #[schemars(description = "Memory text content")]
     pub text: String,

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -64,11 +64,11 @@ fn full_migration_on_empty_db() -> Result<()> {
     let applied = applied_versions(&conn)?;
     assert_eq!(
         applied,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18]
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 28);
+    assert_eq!(user_version, 30);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -94,6 +94,8 @@ fn full_migration_on_empty_db() -> Result<()> {
         "procedure_verifications",
         "context_injections",
         "rule_candidates",
+        "git_commits",
+        "git_commit_sessions",
     ] {
         let exists: bool = conn
             .query_row(
@@ -322,7 +324,7 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 28);
+    assert_eq!(user_version, 30);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -362,7 +364,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 28);
+    assert_eq!(result.current_version, 30);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())
@@ -540,7 +542,7 @@ fn dry_run_pending_runs_post_migration_hooks() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.pending_count, 2);
+    assert_eq!(result.pending_count, 3);
     let error = result.error.as_deref().unwrap_or("");
     assert!(
         !error.is_empty(),
@@ -585,7 +587,7 @@ fn dry_run_pending_runs_hooks_against_complete_fts_clone() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.pending_count, 2);
+    assert_eq!(result.pending_count, 3);
     assert!(
         result.error.is_none(),
         "dry-run hook should run against complete FTS clone, got {:?}",
@@ -624,7 +626,7 @@ fn dry_run_pending_clones_non_default_page_size_database() -> Result<()> {
 
         let result = dry_run_pending(&conn)?;
 
-        assert_eq!(result.pending_count, 2);
+        assert_eq!(result.pending_count, 3);
         assert!(
             result.error.is_none(),
             "dry-run clone should preserve non-default source page size, got {:?}",

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -34,6 +34,8 @@ const CONVERGENCE_TABLES: &[&str] = &[
     "jobs",
     "workstreams",
     "workstream_sessions",
+    "git_commits",
+    "git_commit_sessions",
 ];
 
 fn make_upgraded_v10_db() -> Result<Connection> {

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -85,6 +85,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "context_injection_gate",
         sql: include_str!("../migrations/v016_context_injection_gate.sql"),
     },
+    Migration {
+        version: 18,
+        name: "commit_session_links",
+        sql: include_str!("../migrations/v018_commit_session_links.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v018_commit_session_links.sql
+++ b/src/migrations/v018_commit_session_links.sql
@@ -1,0 +1,36 @@
+-- v018_commit_session_links: durable traceability between git commits and
+-- remem sessions. A commit can be linked to multiple sessions, and one session
+-- can produce or observe multiple commits.
+
+CREATE TABLE IF NOT EXISTS git_commits (
+    id INTEGER PRIMARY KEY,
+    project TEXT NOT NULL,
+    repo_path TEXT NOT NULL,
+    sha TEXT NOT NULL,
+    short_sha TEXT NOT NULL,
+    branch TEXT,
+    message TEXT,
+    authored_at_epoch INTEGER,
+    changed_files TEXT NOT NULL DEFAULT '[]',
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    UNIQUE(project, sha)
+);
+
+CREATE TABLE IF NOT EXISTS git_commit_sessions (
+    commit_id INTEGER NOT NULL REFERENCES git_commits(id) ON DELETE CASCADE,
+    session_id TEXT NOT NULL,
+    memory_session_id TEXT,
+    source TEXT NOT NULL,
+    linked_at_epoch INTEGER NOT NULL,
+    PRIMARY KEY(commit_id, session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_git_commits_project_short
+    ON git_commits(project, short_sha);
+CREATE INDEX IF NOT EXISTS idx_git_commits_project_updated
+    ON git_commits(project, updated_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_git_commit_sessions_session
+    ON git_commit_sessions(session_id);
+CREATE INDEX IF NOT EXISTS idx_git_commit_sessions_memory_session
+    ON git_commit_sessions(memory_session_id);

--- a/src/observe/flush/action/runner.rs
+++ b/src/observe/flush/action/runner.rs
@@ -134,8 +134,15 @@ pub(crate) async fn flush_action_batches(
 
         let usage = response.len() as i64 / 4;
         let batch_cwd = batch.first().and_then(|pending| pending.cwd.as_deref());
-        let batch_branch = batch_cwd.and_then(db::detect_git_branch);
-        let batch_commit = batch_cwd.and_then(db::detect_git_commit);
+        let batch_commit_metadata = batch_cwd.and_then(crate::git_util::detect_commit_metadata);
+        let batch_branch = batch_commit_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.branch.clone())
+            .or_else(|| batch_cwd.and_then(db::detect_git_branch));
+        let batch_commit = batch_commit_metadata
+            .as_ref()
+            .map(|metadata| metadata.short_sha.clone())
+            .or_else(|| batch_cwd.and_then(db::detect_git_commit));
         persist_flush_batch(
             conn,
             session_id,
@@ -146,6 +153,7 @@ pub(crate) async fn flush_action_batches(
             usage,
             batch_branch.as_deref(),
             batch_commit.as_deref(),
+            batch_commit_metadata.as_ref(),
         )?;
 
         _total_usage += usage;

--- a/src/observe/flush/persist.rs
+++ b/src/observe/flush/persist.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 use crate::db;
+use crate::git_util::GitCommitMetadata;
 use crate::memory::format::ParsedObservation;
 
 pub(crate) fn persist_flush_batch(
@@ -13,12 +14,25 @@ pub(crate) fn persist_flush_batch(
     usage: i64,
     branch: Option<&str>,
     commit_sha: Option<&str>,
+    commit_metadata: Option<&GitCommitMetadata>,
 ) -> Result<()> {
     let ids: Vec<i64> = batch.iter().map(|pending| pending.id).collect();
     let per_obs_usage = usage / observations.len().max(1) as i64;
 
     let tx = conn.transaction()?;
     let memory_session_id = db::upsert_session(&tx, session_id, project, None)?;
+
+    if let Some(commit_sha) = commit_sha {
+        crate::git_trace::link_observed_commit_to_session(
+            &tx,
+            project,
+            session_id,
+            &memory_session_id,
+            commit_sha,
+            branch,
+            commit_metadata,
+        )?;
+    }
 
     for obs in observations {
         let duplicate_id = if let Some(narrative) = &obs.narrative {

--- a/src/observe/flush/task.rs
+++ b/src/observe/flush/task.rs
@@ -97,8 +97,18 @@ where
     }
 
     let usage = response.len() as i64 / 4;
-    let branch = pending.cwd.as_deref().and_then(db::detect_git_branch);
-    let commit_sha = pending.cwd.as_deref().and_then(db::detect_git_commit);
+    let commit_metadata = pending
+        .cwd
+        .as_deref()
+        .and_then(crate::git_util::detect_commit_metadata);
+    let branch = commit_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.branch.clone())
+        .or_else(|| pending.cwd.as_deref().and_then(db::detect_git_branch));
+    let commit_sha = commit_metadata
+        .as_ref()
+        .map(|metadata| metadata.short_sha.clone())
+        .or_else(|| pending.cwd.as_deref().and_then(db::detect_git_commit));
     persist_flush_batch(
         conn,
         session_id,
@@ -109,6 +119,7 @@ where
         usage,
         branch.as_deref(),
         commit_sha.as_deref(),
+        commit_metadata.as_ref(),
     )?;
 
     Ok(observations.len())

--- a/src/summarize/summary_job/persist.rs
+++ b/src/summarize/summary_job/persist.rs
@@ -88,6 +88,19 @@ pub(super) fn finalize_summary(
         &format!("saved summary project={} session={}", project, session_id),
     );
 
+    let linked_commits =
+        crate::git_trace::link_observed_commits_for_session(conn, project, session_id, memory_sid)
+            .context("failed to link observed commits for summarized session")?;
+    if linked_commits > 0 {
+        crate::log::info(
+            "summary-job",
+            &format!(
+                "linked {} observed commit(s) project={} session={}",
+                linked_commits, project, session_id
+            ),
+        );
+    }
+
     if let Some(workstream) = parsed_workstream_from_summary(&summary) {
         match crate::workstream::upsert_workstream(conn, project, memory_sid, &workstream) {
             Ok(workstream_id) => crate::log::info(


### PR DESCRIPTION
Closes #212.

Summary:
- Add durable git commit/session traceability tables with idempotent many-to-many links.
- Link observed commits during flush and backfill from summary finalization without fabricating intent.
- Add CLI lookups via remem commit show/session and MCP lookup_commit/commits_for_session tools with git metadata separated from memory summaries.

Notes:
- Uses migration v018 to avoid colliding with the open lessons PR that already uses v017.
- No vector or embedding work.

Validation:
- cargo fmt --check
- cargo check
- cargo test