### PR TITLE
Return structured MCP tool errors

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,5 +1,6 @@
 mod commit_tools;
 mod context_tools;
+mod errors;
 mod raw_tools;
 mod runtime;
 mod search_tools;
@@ -10,6 +11,8 @@ mod write_tools;
 
 use anyhow::Result;
 use rmcp::handler::server::router::tool::ToolRouter;
+
+use errors::{McpToolError, McpToolResult};
 
 #[derive(Clone)]
 pub(super) struct MemoryServer {
@@ -28,11 +31,11 @@ impl MemoryServer {
         })
     }
 
-    fn with_conn<F, T>(&self, f: F) -> Result<T, String>
+    fn with_conn<F, T>(&self, tool: &'static str, f: F) -> McpToolResult<T>
     where
-        F: FnOnce(&rusqlite::Connection) -> Result<T, String>,
+        F: FnOnce(&rusqlite::Connection) -> McpToolResult<T>,
     {
-        let conn = crate::db::open_db().map_err(|e| format!("DB open failed: {}", e))?;
+        let conn = crate::db::open_db().map_err(|e| McpToolError::db_open(tool, e))?;
         f(&conn)
     }
 }

--- a/src/mcp/server/commit_tools.rs
+++ b/src/mcp/server/commit_tools.rs
@@ -2,6 +2,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::{tool, tool_router};
 
 use super::super::types::{CommitLookupParams, SessionCommitsParams};
+use super::errors::{self, McpToolError, McpToolResult};
 use super::MemoryServer;
 
 #[tool_router(router = tool_router_commit, vis = "pub(super)")]
@@ -12,7 +13,8 @@ impl MemoryServer {
     pub(super) fn lookup_commit(
         &self,
         Parameters(params): Parameters<CommitLookupParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "lookup_commit";
         crate::log::info(
             "mcp",
             &format!(
@@ -20,14 +22,14 @@ impl MemoryServer {
                 params.sha, params.project
             ),
         );
-        self.with_conn(|conn| {
+        self.with_conn(TOOL, |conn| {
             let results =
                 crate::git_trace::lookup_commit(conn, params.project.as_deref(), &params.sha)
                     .map_err(|err| {
                         crate::log::warn("mcp", &format!("lookup_commit failed: {}", err));
-                        err.to_string()
+                        McpToolError::db_query(TOOL, err)
                     })?;
-            serde_json::to_string_pretty(&results).map_err(|err| err.to_string())
+            errors::to_json_pretty(TOOL, &results)
         })
     }
 
@@ -37,7 +39,8 @@ impl MemoryServer {
     pub(super) fn commits_for_session(
         &self,
         Parameters(params): Parameters<SessionCommitsParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "commits_for_session";
         crate::log::info(
             "mcp",
             &format!(
@@ -47,7 +50,7 @@ impl MemoryServer {
                 params.limit.unwrap_or(20)
             ),
         );
-        self.with_conn(|conn| {
+        self.with_conn(TOOL, |conn| {
             let results = crate::git_trace::commits_for_session(
                 conn,
                 params.project.as_deref(),
@@ -56,9 +59,9 @@ impl MemoryServer {
             )
             .map_err(|err| {
                 crate::log::warn("mcp", &format!("commits_for_session failed: {}", err));
-                err.to_string()
+                McpToolError::db_query(TOOL, err)
             })?;
-            serde_json::to_string_pretty(&results).map_err(|err| err.to_string())
+            errors::to_json_pretty(TOOL, &results)
         })
     }
 }

--- a/src/mcp/server/commit_tools.rs
+++ b/src/mcp/server/commit_tools.rs
@@ -22,6 +22,12 @@ impl MemoryServer {
                 params.sha, params.project
             ),
         );
+        if params.sha.trim().is_empty() {
+            return Err(McpToolError::invalid_request(
+                TOOL,
+                "commit SHA is required",
+            ));
+        }
         self.with_conn(TOOL, |conn| {
             let results =
                 crate::git_trace::lookup_commit(conn, params.project.as_deref(), &params.sha)
@@ -50,6 +56,12 @@ impl MemoryServer {
                 params.limit.unwrap_or(20)
             ),
         );
+        if params.session_id.trim().is_empty() {
+            return Err(McpToolError::invalid_request(
+                TOOL,
+                "session_id is required",
+            ));
+        }
         self.with_conn(TOOL, |conn| {
             let results = crate::git_trace::commits_for_session(
                 conn,

--- a/src/mcp/server/context_tools.rs
+++ b/src/mcp/server/context_tools.rs
@@ -2,6 +2,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::{tool, tool_router};
 
 use super::super::types::{GetObservationsParams, TimelineParams};
+use super::errors::{self, McpToolError, McpToolResult};
 use super::MemoryServer;
 use crate::retrieval::search;
 use crate::{db, memory};
@@ -14,7 +15,8 @@ impl MemoryServer {
     pub(super) fn timeline(
         &self,
         Parameters(params): Parameters<TimelineParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "timeline";
         let start = std::time::Instant::now();
         crate::log::info(
             "mcp",
@@ -27,8 +29,19 @@ impl MemoryServer {
                 params.depth_after.unwrap_or(5),
             ),
         );
-        self.with_conn(|conn| {
+        self.with_conn(TOOL, |conn| {
             let anchor_id = if let Some(id) = params.anchor {
+                let anchor = db::get_observations_by_ids(conn, &[id], params.project.as_deref())
+                    .map_err(|e| {
+                        crate::log::warn("mcp", &format!("timeline anchor lookup failed: {}", e));
+                        McpToolError::db_query(TOOL, e)
+                    })?;
+                if anchor.is_empty() {
+                    return Err(McpToolError::not_found(
+                        TOOL,
+                        format!("No observation found for anchor id {id}"),
+                    ));
+                }
                 id
             } else if let Some(query) = &params.query {
                 let results = search::search(
@@ -42,14 +55,19 @@ impl MemoryServer {
                 )
                 .map_err(|e| {
                     crate::log::warn("mcp", &format!("timeline search failed: {}", e));
-                    e.to_string()
+                    McpToolError::db_query(TOOL, e)
                 })?;
                 results
                     .first()
                     .map(|observation| observation.id)
-                    .ok_or_else(|| "No results for query".to_string())?
+                    .ok_or_else(|| {
+                        McpToolError::not_found(TOOL, format!("No results for query '{query}'"))
+                    })?
             } else {
-                return Err("anchor or query required".to_string());
+                return Err(McpToolError::invalid_request(
+                    TOOL,
+                    "anchor or query required",
+                ));
             };
 
             let results = db::get_timeline_around(
@@ -61,7 +79,7 @@ impl MemoryServer {
             )
             .map_err(|e| {
                 crate::log::warn("mcp", &format!("timeline failed: {}", e));
-                e.to_string()
+                McpToolError::db_query(TOOL, e)
             })?;
 
             crate::log::info(
@@ -73,7 +91,7 @@ impl MemoryServer {
                     start.elapsed().as_millis()
                 ),
             );
-            serde_json::to_string_pretty(&results).map_err(|e| e.to_string())
+            errors::to_json_pretty(TOOL, &results)
         })
     }
 
@@ -83,7 +101,8 @@ impl MemoryServer {
     pub(super) fn get_observations(
         &self,
         Parameters(params): Parameters<GetObservationsParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "get_observations";
         let start = std::time::Instant::now();
         let source = params.source.as_deref().unwrap_or("memory");
         crate::log::info(
@@ -93,15 +112,21 @@ impl MemoryServer {
                 params.ids, params.project, source
             ),
         );
-        self.with_conn(|conn| {
+        self.with_conn(TOOL, |conn| {
             let results = match source {
                 "observation" => {
                     let observations_result =
                         db::get_observations_by_ids(conn, &params.ids, params.project.as_deref());
                     let observations = observations_result.map_err(|e| {
                         crate::log::warn("mcp", &format!("get_observations failed: {}", e));
-                        e.to_string()
+                        McpToolError::db_query(TOOL, e)
                     })?;
+                    ensure_requested_ids_found(
+                        TOOL,
+                        source,
+                        &params.ids,
+                        observations.iter().map(|observation| observation.id),
+                    )?;
                     let accessed_ids: Vec<i64> = observations
                         .iter()
                         .map(|observation| observation.id)
@@ -114,20 +139,27 @@ impl MemoryServer {
                             );
                         }
                     }
-                    serde_json::to_value(&observations).map_err(|e| e.to_string())?
+                    errors::to_json_value(TOOL, &observations)?
                 }
                 "memory" => {
                     let memories_result =
                         memory::get_memories_by_ids(conn, &params.ids, params.project.as_deref());
                     let memories = memories_result.map_err(|e| {
                         crate::log::warn("mcp", &format!("get_memories failed: {}", e));
-                        e.to_string()
+                        McpToolError::db_query(TOOL, e)
                     })?;
-                    serde_json::to_value(&memories).map_err(|e| e.to_string())?
+                    ensure_requested_ids_found(
+                        TOOL,
+                        source,
+                        &params.ids,
+                        memories.iter().map(|memory| memory.id),
+                    )?;
+                    errors::to_json_value(TOOL, &memories)?
                 }
                 other => {
-                    return Err(format!(
-                        "unsupported source '{other}'; expected 'memory' or 'observation'"
+                    return Err(McpToolError::unsupported_source(
+                        TOOL,
+                        format!("unsupported source '{other}'; expected 'memory' or 'observation'"),
                     ));
                 }
             };
@@ -140,7 +172,35 @@ impl MemoryServer {
                     start.elapsed().as_millis()
                 ),
             );
-            serde_json::to_string_pretty(&results).map_err(|e| e.to_string())
+            errors::to_json_pretty(TOOL, &results)
         })
     }
+}
+
+fn ensure_requested_ids_found(
+    tool: &'static str,
+    source: &str,
+    requested_ids: &[i64],
+    found_ids: impl Iterator<Item = i64>,
+) -> McpToolResult<()> {
+    if requested_ids.is_empty() {
+        return Ok(());
+    }
+
+    let found: std::collections::HashSet<i64> = found_ids.collect();
+    let missing: Vec<i64> = requested_ids
+        .iter()
+        .copied()
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .filter(|id| !found.contains(id))
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    Err(McpToolError::not_found(
+        tool,
+        format!("{source} id(s) not found: {missing:?}"),
+    ))
 }

--- a/src/mcp/server/errors.rs
+++ b/src/mcp/server/errors.rs
@@ -1,0 +1,144 @@
+use rmcp::model::{Content, IntoContents};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum McpErrorCode {
+    InvalidRequest,
+    NotFound,
+    DbOpenFailed,
+    DbQueryFailed,
+    SerializationFailed,
+    UnsupportedSource,
+}
+
+impl McpErrorCode {
+    pub(super) fn wire_code(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request",
+            Self::NotFound => "not_found",
+            Self::DbOpenFailed => "db_open_failed",
+            Self::DbQueryFailed => "db_query_failed",
+            Self::SerializationFailed => "serialization_failed",
+            Self::UnsupportedSource => "unsupported_source",
+        }
+    }
+
+    fn retryable(self) -> bool {
+        matches!(self, Self::DbOpenFailed | Self::DbQueryFailed)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct McpToolError {
+    tool: &'static str,
+    code: McpErrorCode,
+    message: String,
+    retryable: bool,
+}
+
+impl McpToolError {
+    pub(super) fn new(tool: &'static str, code: McpErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            tool,
+            code,
+            message: message.into(),
+            retryable: code.retryable(),
+        }
+    }
+
+    pub(super) fn db_open(tool: &'static str, err: impl std::fmt::Display) -> Self {
+        Self::new(
+            tool,
+            McpErrorCode::DbOpenFailed,
+            format!("DB open failed: {err}"),
+        )
+    }
+
+    pub(super) fn db_query(tool: &'static str, err: impl std::fmt::Display) -> Self {
+        Self::new(tool, McpErrorCode::DbQueryFailed, err.to_string())
+    }
+
+    pub(super) fn serialization(tool: &'static str, err: impl std::fmt::Display) -> Self {
+        Self::new(
+            tool,
+            McpErrorCode::SerializationFailed,
+            format!("serialization failed: {err}"),
+        )
+    }
+
+    pub(super) fn invalid_request(tool: &'static str, message: impl Into<String>) -> Self {
+        Self::new(tool, McpErrorCode::InvalidRequest, message)
+    }
+
+    pub(super) fn not_found(tool: &'static str, message: impl Into<String>) -> Self {
+        Self::new(tool, McpErrorCode::NotFound, message)
+    }
+
+    pub(super) fn unsupported_source(tool: &'static str, message: impl Into<String>) -> Self {
+        Self::new(tool, McpErrorCode::UnsupportedSource, message)
+    }
+
+    #[cfg(test)]
+    pub(super) fn code(&self) -> McpErrorCode {
+        self.code
+    }
+
+    pub(super) fn envelope(&self) -> Value {
+        json!({
+            "error": {
+                "code": self.code.wire_code(),
+                "message": self.message,
+                "retryable": self.retryable,
+                "tool": self.tool,
+            }
+        })
+    }
+
+    pub(super) fn to_json_string(&self) -> String {
+        serde_json::to_string(&self.envelope()).unwrap_or_else(|_| {
+            format!(
+                r#"{{"error":{{"code":"{}","message":"{}","retryable":{},"tool":"{}"}}}}"#,
+                self.code.wire_code(),
+                "failed to serialize MCP error envelope",
+                self.retryable,
+                self.tool
+            )
+        })
+    }
+}
+
+impl std::fmt::Display for McpToolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.to_json_string())
+    }
+}
+
+impl IntoContents for McpToolError {
+    fn into_contents(self) -> Vec<Content> {
+        vec![Content::text(self.to_json_string())]
+    }
+}
+
+pub(super) type McpToolResult<T> = Result<T, McpToolError>;
+
+pub(super) fn to_json_pretty<T: Serialize + ?Sized>(
+    tool: &'static str,
+    value: &T,
+) -> McpToolResult<String> {
+    serde_json::to_string_pretty(value).map_err(|err| McpToolError::serialization(tool, err))
+}
+
+pub(super) fn to_json_string<T: Serialize + ?Sized>(
+    tool: &'static str,
+    value: &T,
+) -> McpToolResult<String> {
+    serde_json::to_string(value).map_err(|err| McpToolError::serialization(tool, err))
+}
+
+pub(super) fn to_json_value<T: Serialize + ?Sized>(
+    tool: &'static str,
+    value: &T,
+) -> McpToolResult<Value> {
+    serde_json::to_value(value).map_err(|err| McpToolError::serialization(tool, err))
+}

--- a/src/mcp/server/raw_tools.rs
+++ b/src/mcp/server/raw_tools.rs
@@ -2,6 +2,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::{tool, tool_router};
 
 use super::super::types::{RawSearchHit, SearchRawParams};
+use super::errors::{self, McpToolError, McpToolResult};
 use super::MemoryServer;
 use crate::memory::raw_archive;
 
@@ -18,7 +19,8 @@ impl MemoryServer {
     pub(super) fn search_raw(
         &self,
         Parameters(params): Parameters<SearchRawParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "search_raw";
         let start = std::time::Instant::now();
         crate::log::info(
             "mcp",
@@ -32,7 +34,7 @@ impl MemoryServer {
                 params.offset.unwrap_or(0),
             ),
         );
-        self.with_conn(|conn| {
+        self.with_conn(TOOL, |conn| {
             let req = raw_archive::RawSearchRequest {
                 query: params.query.clone(),
                 project: params.project.clone(),
@@ -43,7 +45,7 @@ impl MemoryServer {
             };
             let hits = raw_archive::search_raw_messages(conn, &req).map_err(|e| {
                 crate::log::warn("mcp", &format!("search_raw failed: {}", e));
-                e.to_string()
+                McpToolError::db_query(TOOL, e)
             })?;
 
             let results: Vec<RawSearchHit> = hits
@@ -71,7 +73,7 @@ impl MemoryServer {
                     start.elapsed().as_millis()
                 ),
             );
-            serde_json::to_string_pretty(&results).map_err(|e| e.to_string())
+            errors::to_json_pretty(TOOL, &results)
         })
     }
 }

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -2,6 +2,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::{tool, tool_router};
 
 use super::super::types::{RawSearchHit, SearchParams, SearchResult};
+use super::errors::{self, McpToolError, McpToolResult};
 use super::MemoryServer;
 use crate::memory::service;
 
@@ -15,7 +16,8 @@ impl MemoryServer {
     pub(super) fn search(
         &self,
         Parameters(params): Parameters<SearchParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "search";
         let start = std::time::Instant::now();
         let requested_multi_hop = params.multi_hop.unwrap_or(false);
         crate::log::info(
@@ -31,7 +33,7 @@ impl MemoryServer {
                 params.offset.unwrap_or(0),
             ),
         );
-        self.with_conn(|conn| {
+        self.with_conn(TOOL, |conn| {
             let req = service::SearchRequest {
                 query: params.query.clone(),
                 project: params.project.clone(),
@@ -47,7 +49,7 @@ impl MemoryServer {
             };
             let search_set = service::search_memories(conn, &req).map_err(|e| {
                 crate::log::warn("mcp", &format!("search failed: {}", e));
-                e.to_string()
+                McpToolError::db_query(TOOL, e)
             })?;
             let req_limit = req.limit;
             let req_offset = req.offset;
@@ -144,7 +146,7 @@ impl MemoryServer {
             }
             if !raw_hits_json.is_empty() {
                 response["raw_hits"] =
-                    serde_json::to_value(&raw_hits_json).map_err(|e| e.to_string())?;
+                    errors::to_json_value(TOOL, &raw_hits_json)?;
                 response["raw_hits_note"] = serde_json::Value::String(
                     "raw_hits are source_type='raw_archive' chat rows, not curated memories; use search_raw for literal recall."
                         .to_string(),
@@ -154,7 +156,7 @@ impl MemoryServer {
                 response["has_more"] = serde_json::Value::Bool(true);
                 response["next_offset"] = serde_json::Value::from(req_offset + req_limit);
             }
-            serde_json::to_string_pretty(&response).map_err(|e| e.to_string())
+            errors::to_json_pretty(TOOL, &response)
         })
     }
 }

--- a/src/mcp/server/tests.rs
+++ b/src/mcp/server/tests.rs
@@ -4,11 +4,30 @@ use serde_json::Value;
 use super::super::types::{
     CommitLookupParams, GetObservationsParams, SearchParams, SessionCommitsParams,
 };
+use super::errors::{self, McpErrorCode, McpToolError};
 use super::MemoryServer;
 use crate::db::test_support::ScopedTestDataDir;
 use crate::memory;
 use crate::memory::raw_archive::{insert_raw_message, ROLE_USER, SOURCE_HOOK};
 use crate::memory::service::{resolve_local_note_path, sanitize_segment};
+
+fn assert_mcp_error(
+    err: McpToolError,
+    expected_code: McpErrorCode,
+    expected_tool: &str,
+    expected_retryable: bool,
+) -> Value {
+    assert_eq!(err.code(), expected_code);
+    let json: Value = match serde_json::from_str(&err.to_string()) {
+        Ok(json) => json,
+        Err(parse_err) => panic!("error should be JSON: {parse_err}"),
+    };
+    assert_eq!(json["error"]["code"], expected_code.wire_code());
+    assert_eq!(json["error"]["tool"], expected_tool);
+    assert_eq!(json["error"]["retryable"], expected_retryable);
+    assert!(json["error"]["message"].as_str().is_some());
+    json
+}
 
 #[test]
 fn sanitize_segment_collapses_invalid_chars() {
@@ -255,6 +274,178 @@ fn get_observations_rejects_unknown_source() {
         source: Some("raw_archive".to_string()),
     }));
 
-    let err = result.expect_err("unknown source should be rejected");
-    assert!(err.contains("expected 'memory' or 'observation'"));
+    let err = match result {
+        Ok(value) => panic!("unknown source should be rejected, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(
+        err,
+        McpErrorCode::UnsupportedSource,
+        "get_observations",
+        false,
+    );
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("expected 'memory' or 'observation'")));
+}
+
+#[test]
+fn get_observations_reports_missing_memory_ids_as_not_found() {
+    let _dir = ScopedTestDataDir::new("mcp-get-observations-missing");
+    let server = match MemoryServer::new() {
+        Ok(server) => server,
+        Err(err) => panic!("memory server should initialize: {err}"),
+    };
+
+    let result = server.get_observations(Parameters(GetObservationsParams {
+        ids: vec![999_999],
+        project: None,
+        source: Some("memory".to_string()),
+    }));
+
+    let err = match result {
+        Ok(value) => panic!("missing memory should be rejected, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(err, McpErrorCode::NotFound, "get_observations", false);
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("999999")));
+}
+
+#[test]
+fn timeline_rejects_missing_anchor_and_query_as_invalid_request() {
+    let _dir = ScopedTestDataDir::new("mcp-timeline-invalid-request");
+    let server = match MemoryServer::new() {
+        Ok(server) => server,
+        Err(err) => panic!("memory server should initialize: {err}"),
+    };
+
+    let result = server.timeline(Parameters(super::super::types::TimelineParams {
+        anchor: None,
+        query: None,
+        depth_before: None,
+        depth_after: None,
+        project: None,
+    }));
+
+    let err = match result {
+        Ok(value) => panic!("missing anchor and query should be rejected, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(err, McpErrorCode::InvalidRequest, "timeline", false);
+    assert_eq!(json["error"]["message"], "anchor or query required");
+}
+
+#[test]
+fn timeline_reports_query_miss_as_not_found() {
+    let _dir = ScopedTestDataDir::new("mcp-timeline-not-found");
+    let server = match MemoryServer::new() {
+        Ok(server) => server,
+        Err(err) => panic!("memory server should initialize: {err}"),
+    };
+
+    let result = server.timeline(Parameters(super::super::types::TimelineParams {
+        anchor: None,
+        query: Some("definitely-not-in-empty-db".to_string()),
+        depth_before: None,
+        depth_after: None,
+        project: None,
+    }));
+
+    let err = match result {
+        Ok(value) => panic!("query miss should be not_found, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(err, McpErrorCode::NotFound, "timeline", false);
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("No results for query")));
+}
+
+#[test]
+fn mcp_tool_errors_report_db_open_failure_as_retryable() {
+    let test_dir = ScopedTestDataDir::new("mcp-db-open-error");
+    if let Err(err) = std::fs::remove_dir_all(&test_dir.path) {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            panic!("remove temp dir: {err}");
+        }
+    }
+    if let Err(err) = std::fs::write(&test_dir.path, "not a directory") {
+        panic!("create blocking file: {err}");
+    }
+
+    let server = match MemoryServer::new() {
+        Ok(server) => server,
+        Err(err) => panic!("memory server should initialize: {err}"),
+    };
+    let result = server.search(Parameters(SearchParams {
+        query: None,
+        limit: Some(5),
+        project: None,
+        r#type: None,
+        offset: Some(0),
+        include_stale: Some(true),
+        branch: None,
+        multi_hop: Some(false),
+    }));
+
+    if let Err(err) = std::fs::remove_file(&test_dir.path) {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            panic!("remove blocking file: {err}");
+        }
+    }
+    let err = match result {
+        Ok(value) => panic!("blocking data dir file should fail DB open, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(err, McpErrorCode::DbOpenFailed, "search", true);
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("DB open failed")));
+}
+
+#[test]
+fn mcp_serialization_failures_use_structured_code() {
+    struct FailingSerialize;
+
+    impl serde::Serialize for FailingSerialize {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            Err(serde::ser::Error::custom("forced serialization failure"))
+        }
+    }
+
+    let err = match errors::to_json_pretty("search", &FailingSerialize) {
+        Ok(value) => panic!("forced serializer should fail, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(err, McpErrorCode::SerializationFailed, "search", false);
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("forced serialization failure")));
+}
+
+#[test]
+fn mcp_error_codes_are_stable() {
+    let cases = [
+        (McpErrorCode::InvalidRequest, "invalid_request", false),
+        (McpErrorCode::NotFound, "not_found", false),
+        (McpErrorCode::DbOpenFailed, "db_open_failed", true),
+        (McpErrorCode::DbQueryFailed, "db_query_failed", true),
+        (
+            McpErrorCode::SerializationFailed,
+            "serialization_failed",
+            false,
+        ),
+        (McpErrorCode::UnsupportedSource, "unsupported_source", false),
+    ];
+
+    for (code, expected_wire_code, expected_retryable) in cases {
+        let err = McpToolError::new("unit_test", code, "test message");
+        let json = assert_mcp_error(err, code, "unit_test", expected_retryable);
+        assert_eq!(json["error"]["code"], expected_wire_code);
+    }
 }

--- a/src/mcp/server/tests.rs
+++ b/src/mcp/server/tests.rs
@@ -2,7 +2,8 @@ use rmcp::handler::server::wrapper::Parameters;
 use serde_json::Value;
 
 use super::super::types::{
-    CommitLookupParams, GetObservationsParams, SearchParams, SessionCommitsParams,
+    CommitLookupParams, GetObservationsParams, GovernMemoryParams, SaveMemoryParams, SearchParams,
+    SessionCommitsParams,
 };
 use super::errors::{self, McpErrorCode, McpToolError};
 use super::MemoryServer;
@@ -142,6 +143,182 @@ fn commit_tools_return_git_metadata_separate_from_session_summary() {
         serde_json::from_str(&session).expect("session response should be JSON");
     assert_eq!(session_json[0]["git"]["short_sha"], "abcdef1");
     assert_eq!(session_json[0]["link"]["source"], "git_metadata");
+}
+
+#[test]
+fn lookup_commit_rejects_empty_sha_as_invalid_request() {
+    let _dir = ScopedTestDataDir::new("mcp-commit-empty-sha");
+    let server = match MemoryServer::new() {
+        Ok(server) => server,
+        Err(err) => panic!("memory server should initialize: {err}"),
+    };
+
+    let result = server.lookup_commit(Parameters(CommitLookupParams {
+        sha: "   ".to_string(),
+        project: None,
+    }));
+
+    let err = match result {
+        Ok(value) => panic!("empty commit SHA should be rejected, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(err, McpErrorCode::InvalidRequest, "lookup_commit", false);
+    assert_eq!(json["error"]["message"], "commit SHA is required");
+}
+
+#[test]
+fn commits_for_session_rejects_empty_session_id_as_invalid_request() {
+    let _dir = ScopedTestDataDir::new("mcp-commits-empty-session");
+    let server = match MemoryServer::new() {
+        Ok(server) => server,
+        Err(err) => panic!("memory server should initialize: {err}"),
+    };
+
+    let result = server.commits_for_session(Parameters(SessionCommitsParams {
+        session_id: "\t ".to_string(),
+        project: None,
+        limit: None,
+    }));
+
+    let err = match result {
+        Ok(value) => panic!("empty session_id should be rejected, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(
+        err,
+        McpErrorCode::InvalidRequest,
+        "commits_for_session",
+        false,
+    );
+    assert_eq!(json["error"]["message"], "session_id is required");
+}
+
+#[test]
+fn save_memory_local_copy_failures_are_invalid_request() {
+    let test_dir = ScopedTestDataDir::new("mcp-save-local-copy-error");
+    let server = match MemoryServer::new() {
+        Ok(server) => server,
+        Err(err) => panic!("memory server should initialize: {err}"),
+    };
+
+    let outside = server.save_memory(Parameters(SaveMemoryParams {
+        text: "body".to_string(),
+        title: Some("Memory".to_string()),
+        project: Some("proj".to_string()),
+        topic_key: None,
+        memory_type: None,
+        files: None,
+        local_path: Some("/etc/passwd".to_string()),
+        scope: None,
+        branch: None,
+        created_at_epoch: None,
+        local_copy_enabled: Some(true),
+    }));
+
+    let err = match outside {
+        Ok(value) => panic!("out-of-bounds local_path should be rejected, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(err, McpErrorCode::InvalidRequest, "save_memory", false);
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("outside the allowed directory")));
+
+    let blocking_file = test_dir.path.join("manual-notes").join("proj");
+    let parent = match blocking_file.parent() {
+        Some(parent) => parent,
+        None => panic!("blocking file should have a parent"),
+    };
+    if let Err(err) = std::fs::create_dir_all(parent) {
+        panic!("create blocking file parent: {err}");
+    }
+    if let Err(err) = std::fs::write(&blocking_file, "not a directory") {
+        panic!("create blocking file: {err}");
+    }
+    let local_path = blocking_file.join("forced-failure.md");
+
+    let write_failure = server.save_memory(Parameters(SaveMemoryParams {
+        text: "body".to_string(),
+        title: Some("Memory".to_string()),
+        project: Some("proj".to_string()),
+        topic_key: None,
+        memory_type: None,
+        files: None,
+        local_path: Some(local_path.display().to_string()),
+        scope: None,
+        branch: None,
+        created_at_epoch: None,
+        local_copy_enabled: Some(true),
+    }));
+
+    let err = match write_failure {
+        Ok(value) => panic!("local write failure should be rejected, got {value}"),
+        Err(err) => err,
+    };
+    let json = assert_mcp_error(err, McpErrorCode::InvalidRequest, "save_memory", false);
+    assert!(json["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("local copy")));
+}
+
+#[test]
+fn govern_memory_validation_failures_are_invalid_request() {
+    let _dir = ScopedTestDataDir::new("mcp-govern-validation");
+    let server = match MemoryServer::new() {
+        Ok(server) => server,
+        Err(err) => panic!("memory server should initialize: {err}"),
+    };
+
+    let cases = [
+        (
+            GovernMemoryParams {
+                ids: vec![],
+                project: Some("proj".to_string()),
+                action: "delete".to_string(),
+                reason: Some("cleanup".to_string()),
+                actor: None,
+                dry_run: Some(false),
+                confirm_destructive: Some(true),
+            },
+            "at least one memory id",
+        ),
+        (
+            GovernMemoryParams {
+                ids: vec![1],
+                project: Some("proj".to_string()),
+                action: "delete".to_string(),
+                reason: Some("cleanup".to_string()),
+                actor: None,
+                dry_run: Some(false),
+                confirm_destructive: Some(false),
+            },
+            "confirm_destructive=true",
+        ),
+        (
+            GovernMemoryParams {
+                ids: vec![1],
+                project: Some("proj".to_string()),
+                action: "delete".to_string(),
+                reason: Some("   ".to_string()),
+                actor: None,
+                dry_run: Some(false),
+                confirm_destructive: Some(true),
+            },
+            "explicit reason",
+        ),
+    ];
+
+    for (params, expected_message) in cases {
+        let result = server.govern_memory(Parameters(params));
+        let err = match result {
+            Ok(value) => panic!("governance validation should be rejected, got {value}"),
+            Err(err) => err,
+        };
+        let json = assert_mcp_error(err, McpErrorCode::InvalidRequest, "govern_memory", false);
+        assert!(json["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains(expected_message)));
+    }
 }
 
 #[test]

--- a/src/mcp/server/workstream_tools.rs
+++ b/src/mcp/server/workstream_tools.rs
@@ -3,6 +3,7 @@ use rmcp::{tool, tool_router};
 use serde_json::json;
 
 use super::super::types::{UpdateWorkStreamParams, WorkStreamsParams};
+use super::errors::{self, McpToolError, McpToolResult};
 use super::MemoryServer;
 
 #[tool_router(router = tool_router_workstream, vis = "pub(super)")]
@@ -13,7 +14,8 @@ impl MemoryServer {
     pub(super) fn workstreams(
         &self,
         Parameters(params): Parameters<WorkStreamsParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "workstreams";
         crate::log::info(
             "mcp",
             &format!(
@@ -21,19 +23,22 @@ impl MemoryServer {
                 params.project, params.status
             ),
         );
-        self.with_conn(|conn| {
+        self.with_conn(TOOL, |conn| {
             let project = params.project.as_deref().unwrap_or("");
             let results = if project.is_empty() {
-                return Ok(r#"{"error": "project parameter required"}"#.to_string());
+                return Err(McpToolError::invalid_request(
+                    TOOL,
+                    "project parameter required",
+                ));
             } else {
                 crate::workstream::query_workstreams(conn, project, params.status.as_deref())
                     .map_err(|e| {
                         crate::log::warn("mcp", &format!("workstreams query failed: {}", e));
-                        e.to_string()
+                        McpToolError::db_query(TOOL, e)
                     })?
             };
             crate::log::info("mcp", &format!("workstreams done count={}", results.len()));
-            serde_json::to_string_pretty(&results).map_err(|e| e.to_string())
+            errors::to_json_pretty(TOOL, &results)
         })
     }
 
@@ -43,7 +48,8 @@ impl MemoryServer {
     pub(super) fn update_workstream(
         &self,
         Parameters(params): Parameters<UpdateWorkStreamParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "update_workstream";
         crate::log::info(
             "mcp",
             &format!(
@@ -51,7 +57,7 @@ impl MemoryServer {
                 params.id, params.status
             ),
         );
-        self.with_conn(|conn| {
+        self.with_conn(TOOL, |conn| {
             let updated = crate::workstream::update_workstream_manual(
                 conn,
                 params.id,
@@ -61,7 +67,7 @@ impl MemoryServer {
             )
             .map_err(|e| {
                 crate::log::warn("mcp", &format!("update_workstream failed: {}", e));
-                e.to_string()
+                McpToolError::db_query(TOOL, e)
             })?;
             crate::log::info(
                 "mcp",
@@ -70,11 +76,13 @@ impl MemoryServer {
                     params.id, updated
                 ),
             );
-            serde_json::to_string(&json!({
-                "id": params.id,
-                "updated": updated,
-            }))
-            .map_err(|e| e.to_string())
+            errors::to_json_string(
+                TOOL,
+                &json!({
+                    "id": params.id,
+                    "updated": updated,
+                }),
+            )
         })
     }
 }

--- a/src/mcp/server/write_tools.rs
+++ b/src/mcp/server/write_tools.rs
@@ -3,6 +3,7 @@ use rmcp::{tool, tool_router};
 use serde_json::json;
 
 use super::super::types::{GovernMemoryParams, SaveMemoryParams, TimelineReportParams};
+use super::errors::{self, McpToolError, McpToolResult};
 use super::MemoryServer;
 use crate::{db, memory::service};
 
@@ -26,7 +27,8 @@ impl MemoryServer {
     pub(super) fn save_memory(
         &self,
         Parameters(params): Parameters<SaveMemoryParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "save_memory";
         crate::log::info(
             "mcp",
             &format!(
@@ -43,7 +45,7 @@ impl MemoryServer {
             .clone()
             .filter(|b| !b.trim().is_empty())
             .or_else(detect_branch_from_cwd);
-        self.with_conn(move |conn| {
+        self.with_conn(TOOL, move |conn| {
             let req = service::SaveMemoryRequest {
                 text: params.text.clone(),
                 title: params.title.clone(),
@@ -59,7 +61,7 @@ impl MemoryServer {
             };
             let saved = service::save_memory(conn, &req).map_err(|e| {
                 crate::log::warn("mcp", &format!("save_memory failed: {}", e));
-                e.to_string()
+                McpToolError::db_query(TOOL, e)
             })?;
 
             crate::log::info(
@@ -73,15 +75,17 @@ impl MemoryServer {
                     saved.local_path
                 ),
             );
-            serde_json::to_string(&json!({
-                "id": saved.id,
-                "status": saved.status,
-                "memory_type": saved.memory_type,
-                "upserted": saved.upserted,
-                "local_status": saved.local_status,
-                "local_path": saved.local_path,
-            }))
-            .map_err(|e| e.to_string())
+            errors::to_json_string(
+                TOOL,
+                &json!({
+                    "id": saved.id,
+                    "status": saved.status,
+                    "memory_type": saved.memory_type,
+                    "upserted": saved.upserted,
+                    "local_status": saved.local_status,
+                    "local_path": saved.local_path,
+                }),
+            )
         })
     }
 
@@ -93,7 +97,8 @@ impl MemoryServer {
     pub(super) fn govern_memory(
         &self,
         Parameters(params): Parameters<GovernMemoryParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "govern_memory";
         crate::log::info(
             "mcp",
             &format!(
@@ -105,7 +110,7 @@ impl MemoryServer {
             ),
         );
         let action = crate::memory::governance::MemoryGovernanceAction::parse(&params.action)
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| McpToolError::invalid_request(TOOL, e.to_string()))?;
         let project = params
             .project
             .clone()
@@ -116,7 +121,7 @@ impl MemoryServer {
                     .map(|cwd| db::project_from_cwd(&cwd.to_string_lossy()))
                     .unwrap_or_else(|| "unknown".to_string())
             });
-        self.with_conn(move |conn| {
+        self.with_conn(TOOL, move |conn| {
             let result = crate::memory::governance::govern_memories(
                 conn,
                 &crate::memory::governance::GovernMemoryRequest {
@@ -131,9 +136,9 @@ impl MemoryServer {
             )
             .map_err(|e| {
                 crate::log::warn("mcp", &format!("govern_memory failed: {}", e));
-                e.to_string()
+                McpToolError::db_query(TOOL, e)
             })?;
-            serde_json::to_string(&result).map_err(|e| e.to_string())
+            errors::to_json_string(TOOL, &result)
         })
     }
 
@@ -143,15 +148,16 @@ impl MemoryServer {
     pub(super) fn timeline_report(
         &self,
         Parameters(params): Parameters<TimelineReportParams>,
-    ) -> Result<String, String> {
+    ) -> McpToolResult<String> {
+        const TOOL: &str = "timeline_report";
         let full = params.full.unwrap_or(false);
         crate::log::info(
             "mcp",
             &format!("timeline_report project={:?} full={}", params.project, full),
         );
-        self.with_conn(|conn| {
+        self.with_conn(TOOL, |conn| {
             crate::timeline::generate_timeline_report(conn, &params.project, full)
-                .map_err(|e| e.to_string())
+                .map_err(|e| McpToolError::db_query(TOOL, e))
         })
     }
 }

--- a/src/mcp/server/write_tools.rs
+++ b/src/mcp/server/write_tools.rs
@@ -13,6 +13,47 @@ fn detect_branch_from_cwd() -> Option<String> {
     db::detect_git_branch(cwd_str)
 }
 
+fn map_save_memory_error(tool: &'static str, err: anyhow::Error) -> McpToolError {
+    if err.is::<service::LocalCopyError>() {
+        McpToolError::invalid_request(tool, err.to_string())
+    } else {
+        McpToolError::db_query(tool, err)
+    }
+}
+
+fn validate_governance_request(
+    tool: &'static str,
+    params: &GovernMemoryParams,
+) -> McpToolResult<()> {
+    if !params.ids.iter().any(|id| *id > 0) {
+        return Err(McpToolError::invalid_request(
+            tool,
+            "memory governance requires at least one memory id",
+        ));
+    }
+    if params.dry_run.unwrap_or(false) {
+        return Ok(());
+    }
+    if !params.confirm_destructive.unwrap_or(false) {
+        return Err(McpToolError::invalid_request(
+            tool,
+            "memory governance mutation requires confirm_destructive=true",
+        ));
+    }
+    let has_reason = params
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|reason| !reason.is_empty());
+    if !has_reason {
+        return Err(McpToolError::invalid_request(
+            tool,
+            "memory governance mutation requires an explicit reason",
+        ));
+    }
+    Ok(())
+}
+
 #[tool_router(router = tool_router_write, vis = "pub(super)")]
 impl MemoryServer {
     #[tool(
@@ -61,7 +102,7 @@ impl MemoryServer {
             };
             let saved = service::save_memory(conn, &req).map_err(|e| {
                 crate::log::warn("mcp", &format!("save_memory failed: {}", e));
-                McpToolError::db_query(TOOL, e)
+                map_save_memory_error(TOOL, e)
             })?;
 
             crate::log::info(
@@ -111,6 +152,7 @@ impl MemoryServer {
         );
         let action = crate::memory::governance::MemoryGovernanceAction::parse(&params.action)
             .map_err(|e| McpToolError::invalid_request(TOOL, e.to_string()))?;
+        validate_governance_request(TOOL, &params)?;
         let project = params
             .project
             .clone()

--- a/src/memory/service.rs
+++ b/src/memory/service.rs
@@ -6,7 +6,7 @@ mod tests;
 mod types;
 
 pub use local_copy::{resolve_local_note_path, sanitize_segment};
-pub use save::save_memory;
+pub use save::{save_memory, LocalCopyError};
 pub use search::search_memories;
 pub use types::{
     default_include_stale, MultiHopMeta, SaveMemoryRequest, SaveMemoryResult, SearchRequest,

--- a/src/memory/service/local_copy.rs
+++ b/src/memory/service/local_copy.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
 use std::path::{Component, Path, PathBuf};
 
@@ -186,9 +186,11 @@ pub(super) fn build_local_note_content(project: &str, title: &str, text: &str) -
 
 pub(super) fn write_local_note(path: &Path, content: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create local copy directory {}", parent.display()))?;
     }
-    std::fs::write(path, content)?;
+    std::fs::write(path, content)
+        .with_context(|| format!("write local copy at {}", path.display()))?;
     Ok(())
 }
 

--- a/src/memory/service/save.rs
+++ b/src/memory/service/save.rs
@@ -10,6 +10,27 @@ use super::local_copy::{
 use super::types::{SaveMemoryRequest, SaveMemoryResult};
 use crate::memory::lesson::{save_lesson, SaveLessonRequest};
 
+#[derive(Debug)]
+pub struct LocalCopyError {
+    message: String,
+}
+
+impl From<anyhow::Error> for LocalCopyError {
+    fn from(err: anyhow::Error) -> Self {
+        Self {
+            message: err.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for LocalCopyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for LocalCopyError {}
+
 pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMemoryResult> {
     let project = req.project.as_deref().unwrap_or("manual");
     let title = req.title.as_deref().unwrap_or("Memory");
@@ -20,8 +41,8 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         .and_then(|files| serde_json::to_string(files).ok());
 
     let scope = req.scope.as_deref().unwrap_or("project");
-    let mut local_copy = prepare_local_copy(project, title, req)?;
-    write_local_copy(&mut local_copy)?;
+    let mut local_copy = prepare_local_copy(project, title, req).map_err(LocalCopyError::from)?;
+    write_local_copy(&mut local_copy).map_err(LocalCopyError::from)?;
 
     let save_result = if memory_type == "lesson" {
         save_lesson(


### PR DESCRIPTION
## Summary
- add a typed MCP error envelope with stable code, message, retryable, and tool fields
- route MCP tool failures through structured JSON error content while preserving successful JSON string responses
- return not_found for missing requested observations/memories instead of empty success responses
- cover invalid request, not found, DB-open, serialization, unsupported source, and stable code behavior in MCP server tests

Closes #247.

## Validation
- cargo fmt --check
- cargo check
- cargo test mcp::server -- --nocapture
- cargo test
- cargo clippy -- -D warnings