### PR TITLE
Require token auth for REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ dependencies = [
  "sha2",
  "tokio",
  "toml_edit",
- "tower-http",
+ "tower",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,13 @@ tokio = { version = "1", features = ["full"] }
 rmcp = { version = "0.15", features = ["server", "transport-io", "macros"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 axum = { version = "0.8.8", features = ["json"] }
-tower-http = { version = "0.6.8", features = ["cors"] }
 getrandom = "0.3"
 toml_edit = "0.22"
 libc = "0.2"
 sha2 = "0.10"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
 
 [profile.release]
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ remem sync-memory --cwd .
 
 ```bash
 remem api --port 5567
+TOKEN=$(cat ~/.remem/.api-token)
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:5567/api/v1/status
 ```
 
 | Endpoint | Method | Description |
@@ -300,7 +302,9 @@ remem api --port 5567
 - SQLCipher encryption at rest (`remem encrypt`)
 - Data directory permissions (`0700`)
 - Key file permissions (`0600`)
-- API binds localhost only (`127.0.0.1`)
+- REST API binds localhost only (`127.0.0.1`) and requires
+  `Authorization: Bearer $(cat ~/.remem/.api-token)`
+- API token file permissions (`0600`)
 
 ## Architecture Docs
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ TOKEN=$(cat ~/.remem/.api-token)
 curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:5567/api/v1/status
 ```
 
+Library users who build the router directly should call
+`remem::api::ensure_api_token()` before `remem::api::build_router(...)`.
+
 | Endpoint | Method | Description |
 |---|---|---|
 | `/api/v1/search?query=&project=&type=&limit=&offset=&branch=&multi_hop=` | GET | Search memories |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -258,7 +258,12 @@ remem sync-memory --cwd .
 
 ```bash
 remem api --port 5567
+TOKEN=$(cat ~/.remem/.api-token)
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:5567/api/v1/status
 ```
+
+直接使用库 API 构建 router 的调用方，应在 `remem::api::build_router(...)`
+之前调用 `remem::api::ensure_api_token()`。
 
 | Endpoint | Method | 说明 |
 |---|---|---|
@@ -272,7 +277,9 @@ remem api --port 5567
 - SQLCipher 静态加密（`remem encrypt`）
 - 数据目录权限（`0700`）
 - 密钥文件权限（`0600`）
-- API 仅绑定本机（`127.0.0.1`）
+- REST API 仅绑定本机（`127.0.0.1`），并要求
+  `Authorization: Bearer $(cat ~/.remem/.api-token)`
+- API token 文件权限（`0600`）
 
 ## 架构文档
 

--- a/eval/local/run_local_eval.py
+++ b/eval/local/run_local_eval.py
@@ -12,6 +12,7 @@ Same pipeline as LoCoMo eval but against your actual memories:
 
 Usage:
   # Requires remem API running: remem api --port 5567
+  # Reads REMEM_API_TOKEN or ~/.remem/.api-token for REST API auth.
   python eval/local/run_local_eval.py
   python eval/local/run_local_eval.py --n 50 --model gpt-5.4
 """
@@ -47,6 +48,45 @@ def _load_env_file(path):
 
 # Project root .env (two levels up from eval/local/)
 _PROJECT_ENV = os.path.join(os.path.dirname(__file__), "..", "..", ".env")
+
+
+def load_remem_api_token(token_file=None):
+    env_token = os.environ.get("REMEM_API_TOKEN", "").strip()
+    if env_token:
+        return env_token
+
+    token_path = Path(
+        token_file
+        or os.environ.get("REMEM_API_TOKEN_FILE", "~/.remem/.api-token")
+    ).expanduser()
+    try:
+        token = token_path.read_text().strip()
+    except OSError as exc:
+        raise RuntimeError(
+            "remem API token unavailable. Start `remem api` once, set "
+            "REMEM_API_TOKEN, or pass --api-token-file."
+        ) from exc
+    if not token:
+        raise RuntimeError(f"remem API token file is empty: {token_path}")
+    return token
+
+
+def create_remem_client(token_file=None):
+    token = load_remem_api_token(token_file)
+    return httpx.Client(headers={"Authorization": f"Bearer {token}"})
+
+
+def response_excerpt(resp):
+    text = resp.text.strip()
+    return f": {text[:500]}" if text else ""
+
+
+def require_status(resp, expected, action):
+    if resp.status_code != expected:
+        raise RuntimeError(
+            f"remem API {action} failed: expected {expected}, "
+            f"got {resp.status_code}{response_excerpt(resp)}"
+        )
 
 
 def create_openai_client():
@@ -187,18 +227,14 @@ def generate_qa_pairs(openai_client, memories, model):
 
 def search_remem(http, base_url, project, question, top_k=20):
     """Search remem API."""
-    try:
-        resp = http.get(
-            f"{base_url}/api/v1/search",
-            params={"query": question, "project": project, "limit": top_k},
-            timeout=30,
-        )
-        if resp.status_code == 200:
-            data = resp.json()
-            return data.get("data", []) if isinstance(data, dict) else data
-    except Exception as e:
-        print(f"    Search error: {e}")
-    return []
+    resp = http.get(
+        f"{base_url}/api/v1/search",
+        params={"query": question, "project": project, "limit": top_k},
+        timeout=30,
+    )
+    require_status(resp, 200, "search local eval context")
+    data = resp.json()
+    return data.get("data", []) if isinstance(data, dict) else data
 
 
 # ---------------------------------------------------------------------------
@@ -365,13 +401,18 @@ def main():
     parser.add_argument("--top-k", type=int, default=20)
     parser.add_argument("--project", default=None, help="Filter by project")
     parser.add_argument("--skip-gen", action="store_true", help="Reuse cached QA pairs")
+    parser.add_argument(
+        "--api-token-file",
+        default=None,
+        help="Path to remem .api-token (default: REMEM_API_TOKEN_FILE or ~/.remem/.api-token)",
+    )
     args = parser.parse_args()
 
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
     qa_cache = RESULTS_DIR / "qa_pairs.json"
 
     openai_client = create_openai_client()
-    http = httpx.Client()
+    http = create_remem_client(args.api_token_file)
 
     if args.skip_gen and qa_cache.exists():
         print(f"Loading cached QA pairs from {qa_cache}")

--- a/eval/locomo/run_locomo.py
+++ b/eval/locomo/run_locomo.py
@@ -10,6 +10,7 @@ Optimizations:
 
 Usage:
     remem api --port 5567  # Start API first
+    # Reads REMEM_API_TOKEN or ~/.remem/.api-token for REST API auth.
     python run_locomo.py --sample-index 0  # Single conversation
     python run_locomo.py                    # All 10
 """
@@ -40,6 +41,50 @@ CATEGORY_NAMES = {
     4: "single-hop",
     5: "adversarial",
 }
+
+
+def load_remem_api_token(token_file=None):
+    env_token = os.environ.get("REMEM_API_TOKEN", "").strip()
+    if env_token:
+        return env_token
+
+    token_path = Path(
+        token_file
+        or os.environ.get("REMEM_API_TOKEN_FILE", "~/.remem/.api-token")
+    ).expanduser()
+    try:
+        token = token_path.read_text().strip()
+    except OSError as exc:
+        raise RuntimeError(
+            "remem API token unavailable. Start `remem api` once, set "
+            "REMEM_API_TOKEN, or pass --api-token-file."
+        ) from exc
+    if not token:
+        raise RuntimeError(f"remem API token file is empty: {token_path}")
+    return token
+
+
+def create_remem_client(token_file=None):
+    token = load_remem_api_token(token_file)
+    return httpx.Client(headers={"Authorization": f"Bearer {token}"})
+
+
+def response_excerpt(resp):
+    text = resp.text.strip()
+    return f": {text[:500]}" if text else ""
+
+
+def require_status(resp, expected, action):
+    if resp.status_code != expected:
+        raise RuntimeError(
+            f"remem API {action} failed: expected {expected}, "
+            f"got {resp.status_code}{response_excerpt(resp)}"
+        )
+
+
+def create_memory(http, base_url, payload, action):
+    resp = http.post(f"{base_url}/api/v1/memories", json=payload, timeout=30)
+    require_status(resp, 201, action)
 
 
 def create_openai_client():
@@ -272,9 +317,8 @@ def ingest_conversation(http, base_url, sample, openai_client=None, model="gpt-5
                 }
                 if session_epoch is not None:
                     payload["created_at_epoch"] = session_epoch + i  # slight offset to preserve order
-                resp = http.post(f"{base_url}/api/v1/memories", json=payload, timeout=30)
-                if resp.status_code == 201:
-                    count += 1
+                create_memory(http, base_url, payload, "save LoCoMo extracted fact")
+                count += 1
 
         # Layer 1b: Persona/preference extraction (for Open-domain QA)
         if openai_client is not None:
@@ -290,9 +334,8 @@ def ingest_conversation(http, base_url, sample, openai_client=None, model="gpt-5
                 }
                 if session_epoch is not None:
                     payload["created_at_epoch"] = session_epoch
-                resp = http.post(f"{base_url}/api/v1/memories", json=payload, timeout=30)
-                if resp.status_code == 201:
-                    count += 1
+                create_memory(http, base_url, payload, "save LoCoMo persona fact")
+                count += 1
 
         # Layer 2: Per-session timeline with timestamps (for temporal queries)
         lines = [f"[{date_time}] Session {sess_num} conversation:"]
@@ -314,9 +357,8 @@ def ingest_conversation(http, base_url, sample, openai_client=None, model="gpt-5
         }
         if session_epoch is not None:
             payload["created_at_epoch"] = session_epoch
-        resp = http.post(f"{base_url}/api/v1/memories", json=payload, timeout=30)
-        if resp.status_code == 201:
-            count += 1
+        create_memory(http, base_url, payload, "save LoCoMo session timeline")
+        count += 1
 
     return count
 
@@ -342,8 +384,7 @@ def retrieve_context(http, base_url, sample_id, question, top_k):
         params={"query": question, "project": f"locomo/{sample_id}", "limit": top_k},
         timeout=30,
     )
-    if resp.status_code != 200:
-        return []
+    require_status(resp, 200, "search LoCoMo context")
     return resp.json().get("data", [])
 
 
@@ -640,6 +681,11 @@ def main():
     parser.add_argument("--skip-ingest", action="store_true")
     parser.add_argument("--max-samples", type=int, default=0, help="0=all")
     parser.add_argument("--sample-index", type=int, default=-1)
+    parser.add_argument(
+        "--api-token-file",
+        default=None,
+        help="Path to remem .api-token (default: REMEM_API_TOKEN_FILE or ~/.remem/.api-token)",
+    )
     args = parser.parse_args()
 
     print(f"Loading dataset from {args.data_file}")
@@ -653,7 +699,7 @@ def main():
     print(f"  {len(samples)} conversations, {total_qa} QA pairs\n")
 
     openai_client = create_openai_client()
-    http = httpx.Client()
+    http = create_remem_client(args.api_token_file)
 
     t0 = time.time()
     results, category_scores = run_pipeline(

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,6 +6,6 @@ mod server;
 mod tests;
 mod types;
 
-pub(crate) use auth::{ensure_api_token, load_api_token};
+pub use auth::{ensure_api_token, load_api_token};
 pub use server::{build_router, run_api_server};
 pub use types::DbState;

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod handlers;
 mod helpers;
 mod server;
@@ -5,5 +6,6 @@ mod server;
 mod tests;
 mod types;
 
+pub(crate) use auth::{ensure_api_token, load_api_token};
 pub use server::{build_router, run_api_server};
 pub use types::DbState;

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,0 +1,222 @@
+use anyhow::{anyhow, Context, Result};
+use axum::{
+    extract::Request,
+    http::{header, HeaderMap, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use std::{io::Write, path::PathBuf};
+
+use super::helpers::error_response;
+
+const API_TOKEN_FILE: &str = ".api-token";
+const API_TOKEN_BYTES: usize = 32;
+
+pub(crate) fn api_token_path() -> PathBuf {
+    crate::db::data_dir().join(API_TOKEN_FILE)
+}
+
+pub(crate) fn ensure_api_token() -> Result<PathBuf> {
+    let path = api_token_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create API token parent {}", parent.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).with_context(
+                || format!("set API token parent permissions {}", parent.display()),
+            )?;
+        }
+    }
+
+    if path.exists() {
+        validate_existing_token(&path)?;
+        enforce_token_permissions(&path)?;
+        return Ok(path);
+    }
+
+    let token = generate_api_token()?;
+    write_new_token(&path, &token)?;
+    Ok(path)
+}
+
+pub(crate) fn load_api_token() -> Result<String> {
+    let path = api_token_path();
+    let token = std::fs::read_to_string(&path)
+        .with_context(|| format!("read API token from {}", path.display()))?;
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        return Err(anyhow!("API token file is empty: {}", path.display()));
+    }
+    Ok(token)
+}
+
+pub(in crate::api) async fn require_api_token(req: Request, next: Next) -> Response {
+    let expected = match load_api_token() {
+        Ok(token) => token,
+        Err(err) => {
+            crate::log::error("api", &format!("API token unavailable: {err}"));
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "api_token_unavailable",
+                "API token is not configured",
+            )
+            .into_response();
+        }
+    };
+
+    if request_has_token(req.headers(), &expected) {
+        next.run(req).await
+    } else {
+        error_response(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "Missing or invalid API token",
+        )
+        .into_response()
+    }
+}
+
+fn validate_existing_token(path: &std::path::Path) -> Result<()> {
+    let token = std::fs::read_to_string(path)
+        .with_context(|| format!("read existing API token {}", path.display()))?;
+    if token.trim().is_empty() {
+        return Err(anyhow!("existing API token is empty: {}", path.display()));
+    }
+    Ok(())
+}
+
+fn generate_api_token() -> Result<String> {
+    let mut bytes = [0u8; API_TOKEN_BYTES];
+    getrandom::fill(&mut bytes)
+        .map_err(|err| anyhow!("OS randomness unavailable while generating API token: {err}"))?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn write_new_token(path: &std::path::Path, token: &str) -> Result<()> {
+    #[cfg(unix)]
+    let mut file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        match std::fs::OpenOptions::new()
+            .mode(0o600)
+            .create_new(true)
+            .write(true)
+            .open(path)
+        {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                validate_existing_token(path)?;
+                enforce_token_permissions(path)?;
+                return Ok(());
+            }
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("create API token file {}", path.display()));
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let mut file = match std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            validate_existing_token(path)?;
+            enforce_token_permissions(path)?;
+            return Ok(());
+        }
+        Err(err) => {
+            return Err(err).with_context(|| format!("create API token file {}", path.display()));
+        }
+    };
+
+    if let Err(err) = file.write_all(token.as_bytes()) {
+        drop(file);
+        let _ = std::fs::remove_file(path);
+        return Err(anyhow!(
+            "write API token file {} failed: {}",
+            path.display(),
+            err
+        ));
+    }
+    enforce_token_permissions(path)?;
+    Ok(())
+}
+
+fn enforce_token_permissions(path: &std::path::Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("set API token permissions {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn request_has_token(headers: &HeaderMap, expected: &str) -> bool {
+    let Some(actual) = bearer_token(headers) else {
+        return false;
+    };
+    constant_time_eq(actual.as_bytes(), expected.as_bytes())
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let token = value.strip_prefix("Bearer ")?;
+    let token = token.trim();
+    (!token.is_empty()).then_some(token)
+}
+
+fn constant_time_eq(actual: &[u8], expected: &[u8]) -> bool {
+    if actual.len() != expected.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (left, right) in actual.iter().zip(expected.iter()) {
+        diff |= left ^ right;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{constant_time_eq, ensure_api_token, load_api_token};
+    use crate::db::test_support::ScopedTestDataDir;
+
+    #[test]
+    fn ensure_api_token_creates_and_preserves_token() {
+        let data_dir = ScopedTestDataDir::new("api-token");
+
+        let path = ensure_api_token().expect("token should be created");
+        assert_eq!(path, data_dir.path.join(".api-token"));
+        let first = load_api_token().expect("token should load");
+        assert_eq!(first.len(), 64);
+
+        let second_path = ensure_api_token().expect("existing token should be reused");
+        let second = load_api_token().expect("token should load again");
+        assert_eq!(second_path, path);
+        assert_eq!(second, first);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path)
+                .expect("token metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+    }
+
+    #[test]
+    fn constant_time_eq_requires_exact_match() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+    }
+}

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -16,7 +16,11 @@ pub(crate) fn api_token_path() -> PathBuf {
     crate::db::data_dir().join(API_TOKEN_FILE)
 }
 
-pub(crate) fn ensure_api_token() -> Result<PathBuf> {
+/// Ensure the REST API bearer token exists and return its path.
+///
+/// Call this before using [`crate::api::build_router`] directly. The
+/// `remem api` command calls it automatically.
+pub fn ensure_api_token() -> Result<PathBuf> {
     let path = api_token_path();
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
@@ -41,7 +45,8 @@ pub(crate) fn ensure_api_token() -> Result<PathBuf> {
     Ok(path)
 }
 
-pub(crate) fn load_api_token() -> Result<String> {
+/// Load the REST API bearer token from the remem data directory.
+pub fn load_api_token() -> Result<String> {
     let path = api_token_path();
     let token = std::fs::read_to_string(&path)
         .with_context(|| format!("read API token from {}", path.display()))?;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,50 +1,24 @@
 use axum::{
-    http::{header, Method},
+    middleware,
     routing::{get, post},
     Router,
 };
-use tower_http::cors::{AllowOrigin, CorsLayer};
 
+use super::auth::{ensure_api_token, require_api_token};
 use super::handlers::{handle_get_memory, handle_save_memory, handle_search, handle_status};
 use super::types::DbState;
 
 pub fn build_router(_port: u16) -> Router<DbState> {
-    // Allow any localhost origin (any port) so browser clients served from a
-    // different port than the API (common in dev and production setups) are not
-    // blocked.  Requests from non-localhost origins are still rejected.
-    let cors = CorsLayer::new()
-        .allow_origin(AllowOrigin::predicate(
-            |origin: &axum::http::HeaderValue, _| {
-                let b = origin.as_bytes();
-                // localhost — with or without explicit port, http or https
-                b == b"http://localhost"
-                || b == b"https://localhost"
-                || b.starts_with(b"http://localhost:")
-                || b.starts_with(b"https://localhost:")
-                // IPv4 loopback
-                || b == b"http://127.0.0.1"
-                || b == b"https://127.0.0.1"
-                || b.starts_with(b"http://127.0.0.1:")
-                || b.starts_with(b"https://127.0.0.1:")
-                // IPv6 loopback
-                || b == b"http://[::1]"
-                || b == b"https://[::1]"
-                || b.starts_with(b"http://[::1]:")
-                || b.starts_with(b"https://[::1]:")
-            },
-        ))
-        .allow_methods([Method::GET, Method::POST])
-        .allow_headers([header::CONTENT_TYPE]);
-
     Router::new()
         .route("/api/v1/search", get(handle_search))
         .route("/api/v1/memory", get(handle_get_memory))
         .route("/api/v1/memories", post(handle_save_memory))
         .route("/api/v1/status", get(handle_status))
-        .layer(cors)
+        .route_layer(middleware::from_fn(require_api_token))
 }
 
 pub async fn run_api_server(port: u16) -> anyhow::Result<()> {
+    let token_path = ensure_api_token()?;
     let app = build_router(port).with_state(DbState);
     let addr = format!("127.0.0.1:{}", port);
 
@@ -53,6 +27,10 @@ pub async fn run_api_server(port: u16) -> anyhow::Result<()> {
         "remem REST API v{} on http://{}",
         env!("CARGO_PKG_VERSION"),
         addr
+    );
+    println!(
+        "API token: Authorization: Bearer $(cat {})",
+        token_path.display()
     );
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1,6 +1,12 @@
-use axum::{body::to_bytes, extract::State, http::StatusCode, response::IntoResponse};
+use axum::{
+    body::{to_bytes, Body},
+    extract::State,
+    http::{header, Method, Request, StatusCode},
+    response::IntoResponse,
+};
 use rusqlite::params;
 use serde_json::Value;
+use tower::ServiceExt;
 
 use crate::db::test_support::ScopedTestDataDir;
 use crate::{db, memory};
@@ -8,6 +14,15 @@ use crate::{db, memory};
 use super::handlers::{handle_status, search_request_from_params};
 use super::types::SearchParams;
 use super::DbState;
+
+fn authorized_request(method: Method, uri: &str, token: &str, body: Body) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(body)
+        .expect("request should build")
+}
 
 #[test]
 fn db_state_is_stateless() {
@@ -71,6 +86,78 @@ async fn status_handler_reopens_database_after_file_removal() {
     let second = handle_status(State(DbState)).await.into_response();
     assert_eq!(second.status(), StatusCode::OK);
     assert!(test_dir.db_path().exists());
+}
+
+#[tokio::test]
+async fn router_rejects_missing_and_invalid_api_token() {
+    let _test_dir = ScopedTestDataDir::new("api-auth");
+    crate::api::ensure_api_token().expect("API token should be created");
+    let token = crate::api::load_api_token().expect("API token should load");
+    let app = super::build_router(0).with_state(DbState);
+
+    let missing = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/memories")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"text":"x","local_copy_enabled":false}"#))
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should complete");
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+
+    let invalid = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::GET,
+            "/api/v1/status",
+            "wrong-token",
+            Body::empty(),
+        ))
+        .await
+        .expect("request should complete");
+    assert_eq!(invalid.status(), StatusCode::UNAUTHORIZED);
+
+    let valid = app
+        .oneshot(authorized_request(
+            Method::GET,
+            "/api/v1/status",
+            &token,
+            Body::empty(),
+        ))
+        .await
+        .expect("request should complete");
+    assert_eq!(valid.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn router_does_not_emit_cors_allow_origin_for_localhost_origin() {
+    let _test_dir = ScopedTestDataDir::new("api-no-cors");
+    crate::api::ensure_api_token().expect("API token should be created");
+    let token = crate::api::load_api_token().expect("API token should load");
+    let app = super::build_router(0).with_state(DbState);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v1/status")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::ORIGIN, "http://localhost:3000")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should complete");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .is_none());
 }
 
 #[tokio::test]

--- a/src/eval/e2e.rs
+++ b/src/eval/e2e.rs
@@ -171,6 +171,8 @@ pub async fn run_sandbox_eval(options: E2eEvalOptions) -> Result<E2eEvalReport> 
     std::fs::create_dir_all(&data_dir)
         .with_context(|| format!("create eval data dir {}", data_dir.display()))?;
     let _restore = EnvRestore::set("REMEM_DATA_DIR", data_dir.as_os_str().to_os_string());
+    crate::api::ensure_api_token().context("create sandbox API token")?;
+    let api_token = crate::api::load_api_token().context("load sandbox API token")?;
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -190,7 +192,7 @@ pub async fn run_sandbox_eval(options: E2eEvalOptions) -> Result<E2eEvalReport> 
     });
 
     let client = reqwest::Client::new();
-    let run_result = run_api_boundary_eval(&client, &base_url, k).await;
+    let run_result = run_api_boundary_eval(&client, &base_url, &api_token, k).await;
     let _ = shutdown_tx.send(());
     let server_result = server.await.context("join sandbox eval API server")?;
     server_result.context("sandbox eval API server failed")?;
@@ -210,18 +212,20 @@ pub async fn run_sandbox_eval(options: E2eEvalOptions) -> Result<E2eEvalReport> 
 async fn run_api_boundary_eval(
     client: &reqwest::Client,
     base_url: &str,
+    api_token: &str,
     k: usize,
 ) -> Result<E2eEvalReport> {
-    wait_for_status(client, base_url).await?;
+    wait_for_status(client, base_url, api_token).await?;
     let mut saved_ids = Vec::with_capacity(CORPUS.len());
     for memory in CORPUS {
-        let saved = save_memory_via_api(client, base_url, memory).await?;
+        let saved = save_memory_via_api(client, base_url, api_token, memory).await?;
         saved_ids.push(saved.id);
     }
 
     let mut query_reports = Vec::with_capacity(QUERIES.len());
     for query in QUERIES {
-        let api_topic_keys = search_topic_keys_via_api(client, base_url, query.query, k).await?;
+        let api_topic_keys =
+            search_topic_keys_via_api(client, base_url, api_token, query.query, k).await?;
         let keyword_topic_keys = keyword_baseline_topic_keys(query.query, k);
         query_reports.push(E2eQueryReport {
             id: query.id.to_string(),
@@ -260,11 +264,11 @@ async fn run_api_boundary_eval(
     })
 }
 
-async fn wait_for_status(client: &reqwest::Client, base_url: &str) -> Result<()> {
+async fn wait_for_status(client: &reqwest::Client, base_url: &str, api_token: &str) -> Result<()> {
     let url = format!("{}/api/v1/status", base_url);
     let mut last_error = None;
     for _ in 0..20 {
-        match client.get(&url).send().await {
+        match client.get(&url).bearer_auth(api_token).send().await {
             Ok(response) if response.status().is_success() => return Ok(()),
             Ok(response) => last_error = Some(anyhow!("status returned {}", response.status())),
             Err(error) => last_error = Some(error.into()),
@@ -277,6 +281,7 @@ async fn wait_for_status(client: &reqwest::Client, base_url: &str) -> Result<()>
 async fn save_memory_via_api(
     client: &reqwest::Client,
     base_url: &str,
+    api_token: &str,
     memory: &CorpusMemory,
 ) -> Result<ApiSaveResponse> {
     let request = ApiSaveRequest {
@@ -290,6 +295,7 @@ async fn save_memory_via_api(
     };
     let response = client
         .post(format!("{}/api/v1/memories", base_url))
+        .bearer_auth(api_token)
         .json(&request)
         .send()
         .await
@@ -308,12 +314,14 @@ async fn save_memory_via_api(
 async fn search_topic_keys_via_api(
     client: &reqwest::Client,
     base_url: &str,
+    api_token: &str,
     query: &str,
     k: usize,
 ) -> Result<Vec<String>> {
     let limit = k.to_string();
     let response = client
         .get(format!("{}/api/v1/search", base_url))
+        .bearer_auth(api_token)
         .query(&[
             ("query", query),
             ("project", PROJECT),

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -40,6 +40,8 @@ pub fn install(target: InstallTarget, dry_run: bool) -> Result<()> {
     let data_dir = remem_data_dir();
     std::fs::create_dir_all(&data_dir)?;
     eprintln!("  data   -> {}", data_dir.display());
+    let api_token_path = crate::api::ensure_api_token()?;
+    eprintln!("  API    -> token {}", api_token_path.display());
     eprintln!("  binary -> {}", bin);
 
     let old_path = old_hooks_path();

--- a/tests/api_public.rs
+++ b/tests/api_public.rs
@@ -1,0 +1,58 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct TempDataDir {
+    _guard: MutexGuard<'static, ()>,
+    previous: Option<OsString>,
+    path: PathBuf,
+}
+
+impl TempDataDir {
+    fn new(label: &str) -> Self {
+        let guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let previous = std::env::var_os("REMEM_DATA_DIR");
+        let path = std::env::temp_dir().join(format!(
+            "remem-integration-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time before unix epoch")
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::env::set_var("REMEM_DATA_DIR", &path);
+        Self {
+            _guard: guard,
+            previous,
+            path,
+        }
+    }
+}
+
+impl Drop for TempDataDir {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.as_ref() {
+            std::env::set_var("REMEM_DATA_DIR", previous);
+        } else {
+            std::env::remove_var("REMEM_DATA_DIR");
+        }
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+#[test]
+fn public_api_token_helpers_prepare_router_auth() {
+    let _data_dir = TempDataDir::new("public-api-token");
+
+    let token_path = remem::api::ensure_api_token().expect("token setup should succeed");
+    let token = remem::api::load_api_token().expect("token should load");
+
+    assert!(token_path.ends_with(".api-token"));
+    assert_eq!(token.len(), 64);
+}


### PR DESCRIPTION
## Summary
- add a generated `~/.remem/.api-token` secret with owner-only permissions during install/API startup
- require `Authorization: Bearer <token>` on all REST API routes
- remove permissive localhost CORS behavior and update API eval/docs to send the token

Fixes #240

## Validation
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- live curl check: unauthenticated `POST /api/v1/memories` returned 401; authenticated POST returned 201; `.api-token` mode was 600; no `access-control-allow-origin` header for a localhost Origin
