### PR TITLE
Improve search CLI retrieval guidance

### DIFF
--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -15,6 +15,8 @@ pub(super) use import::run_import;
 pub(super) use maintenance::{run_cleanup, run_dream, run_encrypt, run_governance};
 pub(super) use pending::run_pending;
 pub(super) use preferences::run_preferences;
-pub(super) use query::{run_backfill_entities, run_commit, run_search, run_show, run_status};
+pub(super) use query::{
+    run_backfill_entities, run_commit, run_search, run_show, run_status, run_why,
+};
 pub(super) use review::run_review;
 pub(super) use usage::run_usage;

--- a/src/cli/actions/query.rs
+++ b/src/cli/actions/query.rs
@@ -5,9 +5,11 @@ mod show;
 mod status;
 #[cfg(test)]
 mod tests;
+mod why;
 
 pub(in crate::cli) use backfill::run_backfill_entities;
 pub(in crate::cli) use commit::run_commit;
 pub(in crate::cli) use search::run_search;
 pub(in crate::cli) use show::run_show;
 pub(in crate::cli) use status::run_status;
+pub(in crate::cli) use why::run_why;

--- a/src/cli/actions/query/search.rs
+++ b/src/cli/actions/query/search.rs
@@ -65,7 +65,8 @@ pub(super) fn build_search_request(
 pub(super) fn render_search_results(results: &SearchResultSet, offset: i64, limit: i64) -> String {
     let mut output = String::new();
     if results.memories.is_empty() && results.raw_hits.is_empty() {
-        output.push_str("No results found.\n");
+        output.push_str("No curated memories found.\n");
+        append_empty_search_guidance(&mut output);
         append_search_explain(&mut output, results.explain.as_ref());
         return output;
     }
@@ -81,12 +82,13 @@ pub(super) fn render_search_results(results: &SearchResultSet, offset: i64, limi
         for memory in &results.memories {
             output.push_str(&format_memory_line(memory));
         }
-        if results.has_more {
-            output.push_str(&format!(
-                "\nMore results available; use --offset {}.\n",
-                offset.max(0) + limit.max(1)
-            ));
-        }
+        append_curated_next_steps(
+            &mut output,
+            &results.memories[0],
+            results.has_more,
+            offset,
+            limit,
+        );
     }
 
     if !results.raw_hits.is_empty() {
@@ -98,10 +100,50 @@ pub(super) fn render_search_results(results: &SearchResultSet, offset: i64, limi
         for raw in &results.raw_hits {
             output.push_str(&format_raw_hit_line(raw));
         }
+        append_raw_fallback_next_step(&mut output);
     }
     append_search_explain(&mut output, results.explain.as_ref());
 
     output
+}
+
+fn append_empty_search_guidance(output: &mut String) {
+    output.push_str("\nTry:\n");
+    output.push_str("  remem search \"<query>\" --include-stale\n");
+    output.push_str("  remem search \"<query>\" --multi-hop\n");
+    output.push_str("  remem search \"<query>\" --project /path/to/repo\n");
+    output.push_str("  remem search \"<query>\" --explain\n");
+}
+
+fn append_curated_next_steps(
+    output: &mut String,
+    first_memory: &Memory,
+    has_more: bool,
+    offset: i64,
+    limit: i64,
+) {
+    output.push_str("\nNext:\n");
+    output.push_str(&format!(
+        "  remem show {}        # full details for one memory\n",
+        first_memory.id
+    ));
+    output.push_str(&format!(
+        "  remem why {}         # visibility and retrieval diagnostics\n",
+        first_memory.id
+    ));
+    if has_more {
+        output.push_str(&format!(
+            "  remem search \"<query>\" --offset {}\n",
+            offset.max(0) + limit.max(1)
+        ));
+    }
+}
+
+fn append_raw_fallback_next_step(output: &mut String) {
+    output.push_str("\nNext:\n");
+    output.push_str(
+        "  use raw hits for recall only; promote durable conclusions with review/save_memory.\n",
+    );
 }
 
 fn append_search_explain(output: &mut String, explain: Option<&SearchExplain>) {

--- a/src/cli/actions/query/tests.rs
+++ b/src/cli/actions/query/tests.rs
@@ -8,6 +8,7 @@ use crate::retrieval::search::{ChannelContribution, SearchExplain, SearchExplain
 use super::{
     search::{build_search_request, preview_raw_text, preview_text, render_search_results},
     show::format_memory_timestamp,
+    why::{render_why_memory, ContextGateSummary},
 };
 
 fn sample_memory() -> Memory {
@@ -138,9 +139,14 @@ fn cli_search_render_shows_multi_hop_has_more_and_raw_fallback() {
 
     assert!(output.contains("Multi-hop: hops=2 entities=Graphiti, Mem0"));
     assert!(output.contains("Found 1 result(s):"));
-    assert!(output.contains("More results available; use --offset 15."));
+    assert!(output.contains("remem show 1"));
+    assert!(output.contains("remem why 1"));
+    assert!(output.contains("remem search \"<query>\" --offset 15"));
     assert!(output.contains("Raw archive fallback:"));
     assert!(output.contains("[raw:9] user | proj | 1970-01-01 | branch=main"));
+    assert!(output.contains(
+        "use raw hits for recall only; promote durable conclusions with review/save_memory."
+    ));
 }
 
 #[test]
@@ -157,7 +163,7 @@ fn cli_search_render_uses_raw_fallback_when_curated_is_empty() {
 
     assert!(output.contains("No curated memories found."));
     assert!(output.contains("Raw archive fallback:"));
-    assert!(!output.contains("No results found."));
+    assert!(output.contains("use raw hits for recall only"));
 }
 
 #[test]
@@ -192,7 +198,10 @@ fn cli_search_render_includes_explain_for_empty_results() {
 
     let output = render_search_results(&result, 0, 10);
 
-    assert!(output.contains("No results found."));
+    assert!(output.contains("No curated memories found."));
+    assert!(output.contains("remem search \"<query>\" --include-stale"));
+    assert!(output.contains("remem search \"<query>\" --multi-hop"));
+    assert!(output.contains("remem search \"<query>\" --project /path/to/repo"));
     assert!(output.contains("Search explain:"));
     assert!(output.contains("fts_query: Some(\"\\\"needle\\\"\")"));
 }
@@ -205,4 +214,30 @@ fn cli_query_raw_preview_uses_first_line_and_truncates() {
 
     assert_eq!(preview.len(), 100);
     assert!(preview.chars().all(|ch| ch == 'r'));
+}
+
+#[test]
+fn cli_why_render_distinguishes_visibility_from_query_scoring() {
+    let gate = ContextGateSummary {
+        host: "codex-cli".to_string(),
+        project: "proj".to_string(),
+        output_mode: "suppressed".to_string(),
+        emit_count: 2,
+        suppress_count: 1,
+        updated_at_epoch: 0,
+        last_emitted_epoch: 0,
+    };
+
+    let output = render_why_memory(&sample_memory(), Some("proj"), Some("main"), Some(&gate));
+
+    assert!(output.contains("Memory #1"));
+    assert!(output.contains("project match: exact proj"));
+    assert!(output.contains("branch match: branchless; visible in branch-scoped search for main"));
+    assert!(output.contains("type: core memory type"));
+    assert!(output.contains("status: active; default search can include it"));
+    assert!(output.contains("query scoring: query-specific"));
+    assert!(output.contains("context visibility: memory index candidate and core candidate"));
+    assert!(output.contains("context gate: latest codex-cli output for proj: mode=suppressed"));
+    assert!(output.contains("gate rows are context-output level, not per-memory proof"));
+    assert!(output.contains("remem show 1"));
 }

--- a/src/cli/actions/query/why.rs
+++ b/src/cli/actions/query/why.rs
@@ -1,0 +1,243 @@
+use anyhow::{Context, Result};
+use rusqlite::OptionalExtension;
+
+use crate::{
+    db,
+    memory::{self, Memory},
+};
+
+use super::show::format_memory_timestamp;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ContextGateSummary {
+    pub(super) host: String,
+    pub(super) project: String,
+    pub(super) output_mode: String,
+    pub(super) emit_count: i64,
+    pub(super) suppress_count: i64,
+    pub(super) updated_at_epoch: i64,
+    pub(super) last_emitted_epoch: i64,
+}
+
+pub(in crate::cli) fn run_why(id: i64, project: Option<&str>, branch: Option<&str>) -> Result<()> {
+    let conn = db::open_db()?;
+    let memories = memory::get_memories_by_ids(&conn, &[id], None)?;
+
+    let Some(memory) = memories.first() else {
+        println!("Memory #{id} not found.");
+        return Ok(());
+    };
+
+    let current_project = resolve_current_project(project)?;
+    let current_branch = resolve_current_branch(branch)?;
+    let gate_project = context_gate_project(memory, current_project.as_deref());
+    let gate = load_latest_context_gate_summary(&conn, gate_project)?;
+
+    print!(
+        "{}",
+        render_why_memory(
+            memory,
+            current_project.as_deref(),
+            current_branch.as_deref(),
+            gate.as_ref()
+        )
+    );
+    Ok(())
+}
+
+fn resolve_current_project(explicit: Option<&str>) -> Result<Option<String>> {
+    if let Some(project) = explicit {
+        return Ok(Some(project.to_string()));
+    }
+    let cwd = std::env::current_dir().context("resolve current directory for why diagnostics")?;
+    Ok(Some(db::project_from_cwd(cwd.to_string_lossy().as_ref())))
+}
+
+fn resolve_current_branch(explicit: Option<&str>) -> Result<Option<String>> {
+    if let Some(branch) = explicit {
+        return Ok(Some(branch.to_string()));
+    }
+    let cwd =
+        std::env::current_dir().context("resolve current directory for branch diagnostics")?;
+    Ok(db::detect_git_branch(cwd.to_string_lossy().as_ref()))
+}
+
+fn context_gate_project<'a>(memory: &'a Memory, current_project: Option<&'a str>) -> &'a str {
+    if memory.scope == "global" {
+        current_project.unwrap_or(&memory.project)
+    } else {
+        &memory.project
+    }
+}
+
+fn load_latest_context_gate_summary(
+    conn: &rusqlite::Connection,
+    project: &str,
+) -> Result<Option<ContextGateSummary>> {
+    conn.query_row(
+        "SELECT host, project, output_mode, emit_count, suppress_count, updated_at_epoch,
+                last_emitted_epoch
+         FROM context_injections
+         WHERE project = ?1
+         ORDER BY updated_at_epoch DESC
+         LIMIT 1",
+        [project],
+        |row| {
+            Ok(ContextGateSummary {
+                host: row.get(0)?,
+                project: row.get(1)?,
+                output_mode: row.get(2)?,
+                emit_count: row.get(3)?,
+                suppress_count: row.get(4)?,
+                updated_at_epoch: row.get(5)?,
+                last_emitted_epoch: row.get(6)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub(super) fn render_why_memory(
+    memory: &Memory,
+    current_project: Option<&str>,
+    current_branch: Option<&str>,
+    gate: Option<&ContextGateSummary>,
+) -> String {
+    let mut output = String::new();
+    output.push_str(&format!("Memory #{}\n", memory.id));
+    output.push_str(&format!("  title: {}\n", memory.title));
+    output.push_str(&format!("  scope: {}\n", memory.scope));
+    output.push_str(&format!(
+        "  project match: {}\n",
+        project_visibility(memory, current_project)
+    ));
+    output.push_str(&format!(
+        "  branch match: {}\n",
+        branch_visibility(memory.branch.as_deref(), current_branch)
+    ));
+    output.push_str(&format!(
+        "  type: {}\n",
+        type_visibility(&memory.memory_type)
+    ));
+    output.push_str(&format!(
+        "  status: {}\n",
+        status_visibility(&memory.status)
+    ));
+    output.push_str(&format!(
+        "  recency: updated {}\n",
+        format_memory_timestamp(memory.updated_at_epoch)
+    ));
+    output.push_str(
+        "  query scoring: query-specific; run `remem search \"<query>\" --explain --limit 3`.\n",
+    );
+    output.push_str(&format!(
+        "  context visibility: {}\n",
+        context_visibility(&memory.memory_type, &memory.status)
+    ));
+    output.push_str(&format!(
+        "  context gate: {}\n",
+        context_gate_visibility(gate)
+    ));
+    output.push_str(&format!(
+        "\nNext:\n  remem show {}\n  remem search \"<query>\" --explain --limit 3\n",
+        memory.id
+    ));
+    output
+}
+
+fn project_visibility(memory: &Memory, current_project: Option<&str>) -> String {
+    if memory.scope == "global" {
+        return current_project
+            .map(|project| format!("global memory visible from {project}"))
+            .unwrap_or_else(|| "global memory visible from any project".to_string());
+    }
+
+    match current_project {
+        Some(project) if project == memory.project => format!("exact {project}"),
+        Some(project) => format!(
+            "mismatch: memory project={} current project={project}",
+            memory.project
+        ),
+        None => format!("not evaluated; memory project={}", memory.project),
+    }
+}
+
+fn branch_visibility(memory_branch: Option<&str>, current_branch: Option<&str>) -> String {
+    match (memory_branch, current_branch) {
+        (Some(memory_branch), Some(current_branch)) if memory_branch == current_branch => {
+            format!("exact {current_branch}")
+        }
+        (Some(memory_branch), Some(current_branch)) => format!(
+            "mismatch: memory branch={memory_branch} current branch={current_branch}; branch-scoped search filters it out"
+        ),
+        (None, Some(current_branch)) => {
+            format!("branchless; visible in branch-scoped search for {current_branch}")
+        }
+        (Some(memory_branch), None) => {
+            format!("memory branch={memory_branch}; unfiltered search can include it")
+        }
+        (None, None) => "branchless; visible without a branch filter".to_string(),
+    }
+}
+
+fn type_visibility(memory_type: &str) -> String {
+    match memory_type {
+        "preference" => {
+            "preference; search-visible and rendered in the preferences context section"
+        }
+        "lesson" => "lesson; search-visible and rendered in the lessons context section",
+        "bugfix" | "architecture" | "decision" | "discovery" => {
+            "core memory type; search-visible and eligible for core context"
+        }
+        "session_activity" => "session_activity; search-visible but excluded from core context",
+        "procedure" => "procedure; search-visible and eligible for the memory index",
+        _ => "custom type; search-visible when status/project/branch filters match",
+    }
+    .to_string()
+}
+
+fn status_visibility(status: &str) -> String {
+    match status {
+        "active" => "active; default search can include it".to_string(),
+        "stale" | "archived" => {
+            format!("{status}; hidden by default search, retry with --include-stale")
+        }
+        other => format!("{other}; not returned by the default active/stale/archive search filter"),
+    }
+}
+
+fn context_visibility(memory_type: &str, status: &str) -> String {
+    if status != "active" {
+        return format!("not context-eligible by default because status={status}");
+    }
+
+    match memory_type {
+        "preference" => {
+            "preferences section candidate; excluded from memory index/core".to_string()
+        }
+        "lesson" => "lessons section candidate; excluded from memory index/core".to_string(),
+        "bugfix" | "architecture" | "decision" | "discovery" => {
+            "memory index candidate and core candidate".to_string()
+        }
+        "session_activity" => "memory index candidate; excluded from core".to_string(),
+        _ => "memory index candidate if project/branch filters match".to_string(),
+    }
+}
+
+fn context_gate_visibility(gate: Option<&ContextGateSummary>) -> String {
+    let Some(gate) = gate else {
+        return "no recent context gate row for this project".to_string();
+    };
+
+    format!(
+        "latest {host} output for {project}: mode={mode}, emitted={emitted}, suppressed={suppressed}, updated={updated}, last_emitted={last_emitted}; gate rows are context-output level, not per-memory proof",
+        host = gate.host,
+        project = gate.project,
+        mode = gate.output_mode,
+        emitted = gate.emit_count,
+        suppressed = gate.suppress_count,
+        updated = format_memory_timestamp(gate.updated_at_epoch),
+        last_emitted = format_memory_timestamp(gate.last_emitted_epoch),
+    )
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -5,7 +5,7 @@ use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 use super::actions::{
     run_admin, run_backfill_entities, run_cleanup, run_commit, run_dream, run_encrypt, run_eval,
     run_eval_e2e, run_eval_local, run_governance, run_import, run_pending, run_preferences,
-    run_review, run_search, run_show, run_status, run_usage,
+    run_review, run_search, run_show, run_status, run_usage, run_why,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands};
@@ -110,6 +110,11 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         )?,
         Commands::Commit { action } => run_commit(action)?,
         Commands::Show { id } => run_show(id)?,
+        Commands::Why {
+            id,
+            project,
+            branch,
+        } => run_why(id, project.as_deref(), branch.as_deref())?,
         Commands::Eval { dataset, k } => run_eval(&dataset, k)?,
         Commands::EvalE2e {
             k,

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -100,6 +100,32 @@ fn cli_parses_search_type_alias_and_multi_hop_filters() {
 }
 
 #[test]
+fn cli_parses_why_project_and_branch_filters() {
+    let cli = Cli::parse_from([
+        "remem",
+        "why",
+        "78360",
+        "--project",
+        "/tmp/remem",
+        "--branch",
+        "main",
+    ]);
+
+    match cli.command {
+        Commands::Why {
+            id,
+            project,
+            branch,
+        } => {
+            assert_eq!(id, 78360);
+            assert_eq!(project.as_deref(), Some("/tmp/remem"));
+            assert_eq!(branch.as_deref(), Some("main"));
+        }
+        _ => panic!("expected why command"),
+    }
+}
+
+#[test]
 fn cli_parses_governance_delete_options() {
     let cli = Cli::parse_from([
         "remem",

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -137,6 +137,13 @@ pub(super) enum Commands {
     Show {
         id: i64,
     },
+    Why {
+        id: i64,
+        #[arg(long, short)]
+        project: Option<String>,
+        #[arg(long)]
+        branch: Option<String>,
+    },
     Eval {
         #[arg(long, default_value = "eval/golden.json")]
         dataset: String,


### PR DESCRIPTION
Closes #229.

## Summary
- Add guided empty-result suggestions and next-step hints after curated search results.
- Keep raw archive fallback clearly labeled and add recall-only guidance.
- Add remem why <id> for read-only visibility diagnostics.

## Validation
- cargo fmt --check
- cargo check
- cargo test
- cargo clippy -- -D warnings
- target/debug/remem search __unlikely_user_interaction_probe__
- target/debug/remem search "context gate" --limit 3
- target/debug/remem search "context gate" --explain --limit 3
- target/debug/remem why 38617 --project "/Users/apple/Library/Application Support/harness/workspaces/runtime-wf-repo-backlog-2e75a3b1"
- target/debug/remem why 999999999