### PR TITLE
[codex] Make compact context reloads visible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -458,6 +458,9 @@ fn normalize_context_for_hash(output: &str) -> String {
                 continue;
             }
         }
+        if line.starts_with("remem context source: ") || line.starts_with("REMEM_CONTEXT_SOURCE=") {
+            continue;
+        }
         normalized.push_str(&normalize_stats_footer_totals(line));
         normalized.push('\n');
     }
@@ -585,6 +588,18 @@ mod tests {
         let b = "# [/tmp/remem] context 2026-05-25 10:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=101 chars/~26 tokens limit=12000 truncated=no\n";
 
         assert_eq!(context_fingerprint(a), context_fingerprint(b));
+    }
+
+    #[test]
+    fn fingerprint_ignores_context_source_note() {
+        let normal =
+            "# [/tmp/remem] context now\nUse `search`/`get_observations` for details.\n\nBody\n";
+        let post_compact = "# [/tmp/remem] context now [REMEM POST-COMPACT RELOAD]\nUse `search`/`get_observations` for details.\nREMEM_CONTEXT_SOURCE=compact: Codex compact triggered this memory context reload.\n\nBody\n";
+
+        assert_eq!(
+            context_fingerprint(normal),
+            context_fingerprint(post_compact)
+        );
     }
 
     #[test]

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -60,6 +60,7 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         cwd: invocation.cwd.clone(),
         project: invocation.project.clone(),
         session_id: invocation.session_id.clone(),
+        hook_source: invocation.source.clone(),
         current_branch: db::detect_git_branch(&invocation.cwd),
         host: invocation.host,
         use_colors: invocation.use_colors,
@@ -153,13 +154,20 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
     output.push_str(&build_context_header(
         &request.project,
         request.current_branch.as_deref(),
+        request.hook_source.as_deref(),
     ));
     output.push_str(profile.retrieval_hints().line);
-    output.push_str("\n\n");
+    output.push('\n');
+    if let Some(note) = context_source_note(request.hook_source.as_deref()) {
+        output.push_str(note);
+        output.push('\n');
+    }
+    output.push('\n');
 
     let mut stats = ContextRenderStats {
         host: request.host.as_env_value().to_string(),
         branch: request.current_branch.clone(),
+        hook_source: request.hook_source.clone(),
         total_char_limit: policy.limits.total_char_limit,
         memories_loaded: loaded.memories.len() + loaded.lessons.len(),
         project_preferences: preference_summary.project_rendered,
@@ -262,6 +270,7 @@ fn empty_stats(request: &ContextRequest) -> ContextRenderStats {
     ContextRenderStats {
         host: request.host.as_env_value().to_string(),
         branch: request.current_branch.clone(),
+        hook_source: request.hook_source.clone(),
         ..ContextRenderStats::default()
     }
 }
@@ -307,6 +316,7 @@ pub(in crate::context) struct SectionRenderStats {
 pub(in crate::context) struct ContextRenderStats {
     pub host: String,
     pub branch: Option<String>,
+    pub hook_source: Option<String>,
     pub total_char_limit: usize,
     pub memories_loaded: usize,
     pub core: SectionRenderStats,
@@ -324,9 +334,10 @@ pub(in crate::context) struct ContextRenderStats {
 
 pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats) -> String {
     let branch = stats.branch.as_deref().unwrap_or("-");
+    let source = context_source_footer(stats.hook_source.as_deref());
     let estimated_tokens = estimate_tokens(stats.output_chars);
     format!(
-        "{} context memories loaded. {} core ({} chars). {} lessons ({} chars). {} indexed ({} chars). {} preferences (project:{} global:{}, {} chars). {} sessions ({} chars). host={} branch={} total={} chars/~{} tokens limit={} truncated={}\n",
+        "{} context memories loaded. {} core ({} chars). {} lessons ({} chars). {} indexed ({} chars). {} preferences (project:{} global:{}, {} chars). {} sessions ({} chars). host={} source={} branch={} total={} chars/~{} tokens limit={} truncated={}\n",
         stats.memories_loaded,
         stats.core.count,
         stats.core.chars,
@@ -341,6 +352,7 @@ pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats)
         stats.sessions.count,
         stats.sessions.chars,
         stats.host,
+        source,
         branch,
         stats.output_chars,
         estimated_tokens,
@@ -357,12 +369,13 @@ fn build_context_debug_trace(
 ) -> String {
     let mut trace = String::from("## Debug Trace\n");
     trace.push_str(&format!(
-        "- request host={} project={} cwd={} branch={} session={}\n",
+        "- request host={} project={} cwd={} branch={} session={} source={}\n",
         request.host.as_env_value(),
         request.project,
         request.cwd,
         request.current_branch.as_deref().unwrap_or("-"),
-        request.session_id.as_deref().unwrap_or("-")
+        request.session_id.as_deref().unwrap_or("-"),
+        request.hook_source.as_deref().unwrap_or("-")
     ));
     trace.push_str(&format!(
         "- limits total={} core_items={} core_chars={} lessons={} lesson_chars={} index_items={} index_chars={} sessions={} preferences(project={}, global={}, chars={})\n",
@@ -443,6 +456,18 @@ fn build_context_debug_trace(
     trace
 }
 
+fn context_source_note(source: Option<&str>) -> Option<&'static str> {
+    match source?.trim().to_ascii_lowercase().as_str() {
+        "compact" => Some(
+            "REMEM_CONTEXT_SOURCE=compact: Codex compact triggered this memory context reload.",
+        ),
+        "clear" => {
+            Some("REMEM_CONTEXT_SOURCE=clear: context was reloaded after an explicit clear.")
+        }
+        _ => None,
+    }
+}
+
 fn context_debug_enabled() -> bool {
     std::env::var("REMEM_CONTEXT_DEBUG")
         .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
@@ -492,14 +517,41 @@ pub(in crate::context) fn enforce_total_char_limit_preserving_footer(
     *output = truncated;
 }
 
-fn build_context_header(project: &str, current_branch: Option<&str>) -> String {
+pub(in crate::context) fn build_context_header(
+    project: &str,
+    current_branch: Option<&str>,
+    hook_source: Option<&str>,
+) -> String {
     let branch_label = current_branch
         .map(|branch| format!(" @{}", branch))
         .unwrap_or_default();
+    let source_label = context_source_header_label(hook_source)
+        .map(|label| format!(" [{}]", label))
+        .unwrap_or_default();
     format!(
-        "# [{}{}] context {}\n",
+        "# [{}{}] context {}{}\n",
         project,
         branch_label,
-        format_header_datetime()
+        format_header_datetime(),
+        source_label
     )
+}
+
+fn context_source_header_label(source: Option<&str>) -> Option<&'static str> {
+    match source?.trim().to_ascii_lowercase().as_str() {
+        "compact" => Some("REMEM POST-COMPACT RELOAD"),
+        "clear" => Some("REMEM CLEAR RELOAD"),
+        _ => None,
+    }
+}
+
+fn context_source_footer(source: Option<&str>) -> &'static str {
+    match source
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("compact") => "compact",
+        Some("clear") => "clear",
+        _ => "-",
+    }
 }

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -114,7 +114,7 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
                 &format!("open_db failed for project={}: {}", request.project, error),
             );
             return Ok(RenderedContext {
-                output: empty_state_output(&request.project),
+                output: empty_context_output(request),
                 stats: empty_stats(request),
             });
         }
@@ -145,7 +145,7 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
         && loaded.workstreams.is_empty()
     {
         return Ok(RenderedContext {
-            output: empty_state_output(&request.project),
+            output: empty_context_output(request),
             stats: empty_stats(request),
         });
     }
@@ -264,6 +264,15 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
         &stats_footer,
     );
     Ok(RenderedContext { output, stats })
+}
+
+pub(in crate::context) fn empty_context_output(request: &ContextRequest) -> String {
+    let header = build_context_header(
+        &request.project,
+        request.current_branch.as_deref(),
+        request.hook_source.as_deref(),
+    );
+    empty_state_output(&header, context_source_note(request.hook_source.as_deref()))
 }
 
 fn empty_stats(request: &ContextRequest) -> ContextRenderStats {

--- a/src/context/sections/empty.rs
+++ b/src/context/sections/empty.rs
@@ -1,9 +1,10 @@
-use super::super::format::format_header_datetime;
-
-pub(in crate::context) fn empty_state_output(project: &str) -> String {
-    format!(
-        "# [{}] context {}\nNo previous sessions found.\n",
-        project,
-        format_header_datetime()
-    )
+pub(in crate::context) fn empty_state_output(header: &str, source_note: Option<&str>) -> String {
+    let mut output = String::new();
+    output.push_str(header);
+    if let Some(note) = source_note {
+        output.push_str(note);
+        output.push('\n');
+    }
+    output.push_str("No previous sessions found.\n");
+    output
 }

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -1,9 +1,11 @@
 use crate::memory::lesson::{LessonMemory, LessonMetadata};
 use crate::workstream::{WorkStream, WorkStreamStatus};
 
+use super::super::host::HostKind;
 use super::super::policy::ContextLimits;
 use super::super::render::{
-    build_context_header, build_context_stats_footer, ContextRenderStats, SectionRenderStats,
+    build_context_header, build_context_stats_footer, empty_context_output, ContextRenderStats,
+    SectionRenderStats,
 };
 use super::super::sections::{
     render_core_memory, render_core_memory_with_limits, render_lessons_with_limit,
@@ -11,7 +13,7 @@ use super::super::sections::{
     render_memory_index_with_limits_excluding, render_recent_sessions,
     render_recent_sessions_with_limit, render_workstreams, render_workstreams_with_limits,
 };
-use super::super::types::SessionSummaryBrief;
+use super::super::types::{ContextRequest, SessionSummaryBrief};
 use super::{sample_memory, sample_memory_with_epoch, sample_workstream};
 
 #[test]
@@ -405,6 +407,24 @@ fn context_header_marks_compact_reload_visibly() {
 
     assert!(header.starts_with("# [/tmp/remem @main] context "));
     assert!(header.contains("[REMEM POST-COMPACT RELOAD]"));
+}
+
+#[test]
+fn empty_context_marks_compact_reload_visibly() {
+    let output = empty_context_output(&ContextRequest {
+        cwd: "/tmp/remem".to_string(),
+        project: "/tmp/remem".to_string(),
+        session_id: None,
+        hook_source: Some("compact".to_string()),
+        current_branch: Some("main".to_string()),
+        host: HostKind::CodexCli,
+        use_colors: false,
+    });
+
+    assert!(output.starts_with("# [/tmp/remem @main] context "));
+    assert!(output.contains("[REMEM POST-COMPACT RELOAD]"));
+    assert!(output.contains("REMEM_CONTEXT_SOURCE=compact"));
+    assert!(output.contains("No previous sessions found."));
 }
 
 fn sample_lesson(id: i64, title: &str, confidence: f64, reinforcement_count: i64) -> LessonMemory {

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -2,7 +2,9 @@ use crate::memory::lesson::{LessonMemory, LessonMetadata};
 use crate::workstream::{WorkStream, WorkStreamStatus};
 
 use super::super::policy::ContextLimits;
-use super::super::render::{build_context_stats_footer, ContextRenderStats, SectionRenderStats};
+use super::super::render::{
+    build_context_header, build_context_stats_footer, ContextRenderStats, SectionRenderStats,
+};
 use super::super::sections::{
     render_core_memory, render_core_memory_with_limits, render_lessons_with_limit,
     render_memory_index, render_memory_index_with_limits,
@@ -352,6 +354,7 @@ fn context_stats_footer_reports_budget_scope_and_truncation() {
     let footer = build_context_stats_footer(&ContextRenderStats {
         host: "codex-cli".to_string(),
         branch: Some("fix/context".to_string()),
+        hook_source: Some("compact".to_string()),
         total_char_limit: 12_000,
         memories_loaded: 7,
         core: SectionRenderStats {
@@ -390,9 +393,18 @@ fn context_stats_footer_reports_budget_scope_and_truncation() {
     assert!(footer.contains("1 lessons (180 chars)"));
     assert!(footer.contains("3 preferences (project:2 global:1"));
     assert!(footer.contains("host=codex-cli"));
+    assert!(footer.contains("source=compact"));
     assert!(footer.contains("branch=fix/context"));
     assert!(footer.contains("total=3200 chars/~800 tokens"));
     assert!(footer.contains("truncated=yes"));
+}
+
+#[test]
+fn context_header_marks_compact_reload_visibly() {
+    let header = build_context_header("/tmp/remem", Some("main"), Some("compact"));
+
+    assert!(header.starts_with("# [/tmp/remem @main] context "));
+    assert!(header.contains("[REMEM POST-COMPACT RELOAD]"));
 }
 
 fn sample_lesson(id: i64, title: &str, confidence: f64, reinforcement_count: i64) -> LessonMemory {

--- a/src/context/types.rs
+++ b/src/context/types.rs
@@ -9,6 +9,7 @@ pub(super) struct ContextRequest {
     pub cwd: String,
     pub project: String,
     pub session_id: Option<String>,
+    pub hook_source: Option<String>,
     pub current_branch: Option<String>,
     pub host: HostKind,
     pub use_colors: bool,


### PR DESCRIPTION
## Summary
- carry context hook source through rendering so compact/clear reloads are visible
- mark compact-triggered output in the first header line with `[REMEM POST-COMPACT RELOAD]`
- add `REMEM_CONTEXT_SOURCE=compact` near the top and `source=compact` in the footer
- ignore source markers during context fingerprinting so the marker itself does not cause repeated emissions
- bump crate metadata from 0.4.5 to 0.4.6 to match the locally installed hook binary line

## Root Cause
Codex can re-run SessionStart context after mid-chat compaction, but remem rendered the resulting block like a normal context injection. The hook source was not visible in the header/footer, so a compact reload was easy to misread as startup loading.

Fixes #262.

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test context_header_marks_compact_reload_visibly -- --nocapture`
- `cargo test fingerprint_ignores_context_source_note -- --nocapture`
- `cargo test context_stats_footer_reports_budget_scope_and_truncation -- --nocapture`
- `cargo test`
- live simulation: `printf '%s' '{"cwd":"/Users/lifcc/Desktop/code/work/infra/her","session_id":"test-compact-marker","source":"compact"}' | cargo run --quiet -- context --host codex-cli --gate off`