### PR TITLE
[codex] Improve AI usage accounting report

### DIFF
--- a/src/cli/actions/usage.rs
+++ b/src/cli/actions/usage.rs
@@ -1,9 +1,10 @@
 use anyhow::{bail, Result};
 
-use crate::db::{self, AiUsageSourceTotals, AiUsageTotals};
+use crate::db::{self, AiUsageBreakdown, AiUsageSourceTotals, AiUsageTotals};
 
 const SECS_PER_DAY: i64 = 86_400;
 const SECS_PER_WEEK: i64 = 7 * SECS_PER_DAY;
+const TOP_BREAKDOWN_LIMIT: i64 = 10;
 
 pub(in crate::cli) fn run_usage(project: Option<&str>, days: i64, weeks: i64) -> Result<()> {
     validate_window("days", days)?;
@@ -15,6 +16,8 @@ pub(in crate::cli) fn run_usage(project: Option<&str>, days: i64, weeks: i64) ->
     let weekly_since = now.saturating_sub(weeks.saturating_mul(SECS_PER_WEEK));
     let totals = db::query_ai_usage_totals(&conn, Some(weekly_since), project)?;
     let source_totals = db::query_ai_usage_source_totals(&conn, Some(weekly_since), project)?;
+    let breakdown =
+        db::query_ai_usage_breakdown(&conn, Some(weekly_since), project, TOP_BREAKDOWN_LIMIT)?;
     let daily = db::query_daily_ai_usage(&conn, daily_since, project, days)?;
     let weekly = db::query_weekly_ai_usage(&conn, weekly_since, project, weeks)?;
 
@@ -26,6 +29,10 @@ pub(in crate::cli) fn run_usage(project: Option<&str>, days: i64, weeks: i64) ->
     println!();
     print_totals(&format!("Last {weeks} weeks"), &totals);
     print_precision(&source_totals);
+    println!();
+    print_source_totals(&source_totals);
+    println!();
+    print_usage_breakdown(weeks, &breakdown);
     println!();
     print_daily(days, &daily);
     println!();
@@ -54,17 +61,103 @@ fn print_precision(rows: &[AiUsageSourceTotals]) {
         .filter(|row| row.usage_source == "text_estimate")
         .map(|row| row.total_tokens)
         .sum();
+    let estimated_cost: f64 = rows
+        .iter()
+        .filter(|row| row.usage_source == "text_estimate")
+        .map(|row| row.estimated_cost_usd)
+        .sum();
+    let exact_tokens: i64 = rows
+        .iter()
+        .filter(|row| row.usage_source != "text_estimate")
+        .map(|row| row.total_tokens)
+        .sum();
+    let exact_cost: f64 = rows
+        .iter()
+        .filter(|row| row.usage_source != "text_estimate")
+        .map(|row| row.estimated_cost_usd)
+        .sum();
 
     println!(
         "  Usage precision:       {:>12} exact/provider/log calls, {:>12} text-estimate calls",
         exact_calls, estimated_calls
     );
+    println!(
+        "  Accounted sources:     {:>12} provider/log tokens (${:<9.4}), {:>12} text-estimated tokens (${:<9.4})",
+        exact_tokens, exact_cost, estimated_tokens, estimated_cost
+    );
     if estimated_tokens > 0 {
         println!(
-            "  Precision note:        {:>12} tokens are text estimates, not provider invoice data",
-            estimated_tokens
+            "  Precision note:        text_estimate is prompt/output length only, not provider invoice data"
+        );
+        println!(
+            "  Host-side blind spot:  Claude Code project memory, system context, and cache usage are not visible here"
         );
     }
+}
+
+fn print_source_totals(rows: &[AiUsageSourceTotals]) {
+    println!("By usage source:");
+    if rows.is_empty() {
+        println!("  No usage events");
+        return;
+    }
+
+    println!(
+        "  {:<18} {:<18} {:>7} {:>12} {:>10}",
+        "Source", "Pricing", "Calls", "Total", "Cost"
+    );
+    for row in rows {
+        println!(
+            "  {:<18} {:<18} {:>7} {:>12} ${:>9.4}",
+            compact_cell(&row.usage_source, 18),
+            compact_cell(&row.pricing_source, 18),
+            row.calls,
+            row.total_tokens,
+            row.estimated_cost_usd
+        );
+    }
+}
+
+fn print_usage_breakdown(weeks: i64, rows: &[AiUsageBreakdown]) {
+    println!("Top project/executor sources (last {weeks} weeks):");
+    if rows.is_empty() {
+        println!("  No usage events");
+        return;
+    }
+
+    println!(
+        "  {:<32} {:<11} {:<15} {:<15} {:>7} {:>12} {:>10}",
+        "Project", "Executor", "Source", "Pricing", "Calls", "Total", "Cost"
+    );
+    for row in rows {
+        let project = row.project.as_deref().unwrap_or("<none>");
+        println!(
+            "  {:<32} {:<11} {:<15} {:<15} {:>7} {:>12} ${:>9.4}",
+            compact_cell(project, 32),
+            compact_cell(&row.executor, 11),
+            compact_cell(&row.usage_source, 15),
+            compact_cell(&row.pricing_source, 15),
+            row.calls,
+            row.total_tokens,
+            row.estimated_cost_usd
+        );
+    }
+}
+
+fn compact_cell(value: &str, width: usize) -> String {
+    let mut chars = value.chars();
+    let mut out = String::new();
+    for _ in 0..width {
+        let Some(ch) = chars.next() else {
+            return out;
+        };
+        out.push(ch);
+    }
+    if chars.next().is_some() && width > 0 {
+        out.pop();
+        out.push('~');
+    }
+    out
 }
 
 fn validate_window(name: &str, value: i64) -> Result<()> {

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -160,3 +160,14 @@ pub struct AiUsageSourceTotals {
     pub total_tokens: i64,
     pub estimated_cost_usd: f64,
 }
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AiUsageBreakdown {
+    pub project: Option<String>,
+    pub executor: String,
+    pub usage_source: String,
+    pub pricing_source: String,
+    pub calls: i64,
+    pub total_tokens: i64,
+    pub estimated_cost_usd: f64,
+}

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
-use crate::db::{AiUsageSourceTotals, AiUsageTotals, DailyAiUsage, WeeklyAiUsage};
+use crate::db::{
+    AiUsageBreakdown, AiUsageSourceTotals, AiUsageTotals, DailyAiUsage, WeeklyAiUsage,
+};
 
 use super::shared::collect_rows;
 
@@ -259,6 +261,49 @@ pub fn query_ai_usage_source_totals(
             calls: row.get(2)?,
             total_tokens: row.get(3)?,
             estimated_cost_usd: row.get(4)?,
+        })
+    })?;
+    collect_rows(rows)
+}
+
+pub fn query_ai_usage_breakdown(
+    conn: &Connection,
+    since_epoch: Option<i64>,
+    project: Option<&str>,
+    limit: i64,
+) -> Result<Vec<AiUsageBreakdown>> {
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT project,
+                executor,
+                usage_source,
+                pricing_source,
+                COUNT(*),
+                COALESCE(SUM(total_tokens), 0),
+                COALESCE(SUM(estimated_cost_usd), 0.0)
+         FROM ai_usage_events
+         WHERE (?1 IS NULL OR created_at_epoch >= ?1)
+           AND (?2 IS NULL OR project = ?2)
+         GROUP BY project, executor, usage_source, pricing_source
+         ORDER BY SUM(estimated_cost_usd) DESC,
+                  SUM(total_tokens) DESC,
+                  COUNT(*) DESC,
+                  project ASC,
+                  executor ASC
+         LIMIT ?3",
+    )?;
+    let rows = stmt.query_map(params![since_epoch, project, limit], |row| {
+        Ok(AiUsageBreakdown {
+            project: row.get(0)?,
+            executor: row.get(1)?,
+            usage_source: row.get(2)?,
+            pricing_source: row.get(3)?,
+            calls: row.get(4)?,
+            total_tokens: row.get(5)?,
+            estimated_cost_usd: row.get(6)?,
         })
     })?;
     collect_rows(rows)

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -1,10 +1,13 @@
 use rusqlite::Connection;
 
 use super::{DailyActivityStats, ProjectCount, SystemStats};
-use crate::db::models::{AiUsageSourceTotals, AiUsageTotals, DailyAiUsage, WeeklyAiUsage};
+use crate::db::models::{
+    AiUsageBreakdown, AiUsageSourceTotals, AiUsageTotals, DailyAiUsage, WeeklyAiUsage,
+};
 use crate::db::query::{
-    query_ai_usage_source_totals, query_ai_usage_totals, query_daily_activity_stats,
-    query_daily_ai_usage, query_system_stats, query_top_projects, query_weekly_ai_usage,
+    query_ai_usage_breakdown, query_ai_usage_source_totals, query_ai_usage_totals,
+    query_daily_activity_stats, query_daily_ai_usage, query_system_stats, query_top_projects,
+    query_weekly_ai_usage,
 };
 
 fn setup_stats_schema(conn: &Connection) {
@@ -254,29 +257,60 @@ fn insert_usage(
     cache_read_tokens: i64,
     estimated_cost_usd: f64,
 ) {
+    insert_usage_with_source(
+        conn,
+        Some(project),
+        created_at_epoch,
+        "codex-cli",
+        input_tokens,
+        output_tokens,
+        reasoning_tokens,
+        cache_read_tokens,
+        estimated_cost_usd,
+        "codex_log",
+        "remem_static",
+    );
+}
+
+fn insert_usage_with_source(
+    conn: &Connection,
+    project: Option<&str>,
+    created_at_epoch: i64,
+    executor: &str,
+    input_tokens: i64,
+    output_tokens: i64,
+    reasoning_tokens: i64,
+    cache_read_tokens: i64,
+    estimated_cost_usd: f64,
+    usage_source: &str,
+    pricing_source: &str,
+) {
     conn.execute(
         "INSERT INTO ai_usage_events
          (created_at, created_at_epoch, project, operation, executor, model,
           input_tokens, output_tokens, reasoning_tokens, cache_read_tokens, total_tokens,
           estimated_cost_usd, usage_source, pricing_source)
-         VALUES ('2026-01-01T00:00:00Z', ?1, ?2, 'summary', 'codex-cli', 'codex-default',
-                 ?3, ?4, ?5, ?6, ?7, ?8, 'codex_log', 'remem_static')",
+         VALUES ('2026-01-01T00:00:00Z', ?1, ?2, 'summary', ?3, 'codex-default',
+                 ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
         rusqlite::params![
             created_at_epoch,
             project,
+            executor,
             input_tokens,
             output_tokens,
             reasoning_tokens,
             cache_read_tokens,
             input_tokens + output_tokens + reasoning_tokens + cache_read_tokens,
-            estimated_cost_usd
+            estimated_cost_usd,
+            usage_source,
+            pricing_source
         ],
     )
     .expect("usage insert should succeed");
 }
 
 #[test]
-fn query_ai_usage_groups_daily_and_weekly_token_costs() {
+fn query_ai_usage_groups_daily_and_weekly_token_costs() -> anyhow::Result<()> {
     let conn = Connection::open_in_memory().expect("in-memory db should open");
     setup_stats_schema(&conn);
 
@@ -310,6 +344,20 @@ fn query_ai_usage_groups_daily_and_weekly_token_costs() {
     assert_eq!(
         alpha_sources,
         vec![AiUsageSourceTotals {
+            usage_source: "codex_log".to_string(),
+            pricing_source: "remem_static".to_string(),
+            calls: 3,
+            total_tokens: 1090,
+            estimated_cost_usd: 0.006,
+        }]
+    );
+
+    let alpha_breakdown = query_ai_usage_breakdown(&conn, Some(jan_05_2026), Some("alpha"), 10)?;
+    assert_eq!(
+        alpha_breakdown,
+        vec![AiUsageBreakdown {
+            project: Some("alpha".to_string()),
+            executor: "codex-cli".to_string(),
             usage_source: "codex_log".to_string(),
             pricing_source: "remem_static".to_string(),
             calls: 3,
@@ -377,4 +425,95 @@ fn query_ai_usage_groups_daily_and_weekly_token_costs() {
             },
         ]
     );
+    Ok(())
+}
+
+#[test]
+fn query_ai_usage_breakdown_exposes_project_executor_and_source() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory().expect("in-memory db should open");
+    setup_stats_schema(&conn);
+
+    let jan_05_2026 = 1_767_571_200;
+    insert_usage_with_source(
+        &conn,
+        Some("/Users/lifcc/.remem"),
+        jan_05_2026,
+        "cli",
+        900,
+        100,
+        0,
+        0,
+        0.003,
+        "text_estimate",
+        "remem_static",
+    );
+    insert_usage_with_source(
+        &conn,
+        Some("alpha"),
+        jan_05_2026 + 60,
+        "codex-cli",
+        100,
+        50,
+        0,
+        25,
+        0.001,
+        "codex_log",
+        "remem_static",
+    );
+    insert_usage_with_source(
+        &conn,
+        None,
+        jan_05_2026 + 120,
+        "http",
+        80,
+        20,
+        0,
+        0,
+        0.0005,
+        "anthropic_usage",
+        "remem_static",
+    );
+
+    let breakdown = query_ai_usage_breakdown(&conn, Some(jan_05_2026), None, 10)?;
+
+    assert_eq!(
+        breakdown,
+        vec![
+            AiUsageBreakdown {
+                project: Some("/Users/lifcc/.remem".to_string()),
+                executor: "cli".to_string(),
+                usage_source: "text_estimate".to_string(),
+                pricing_source: "remem_static".to_string(),
+                calls: 1,
+                total_tokens: 1000,
+                estimated_cost_usd: 0.003,
+            },
+            AiUsageBreakdown {
+                project: Some("alpha".to_string()),
+                executor: "codex-cli".to_string(),
+                usage_source: "codex_log".to_string(),
+                pricing_source: "remem_static".to_string(),
+                calls: 1,
+                total_tokens: 175,
+                estimated_cost_usd: 0.001,
+            },
+            AiUsageBreakdown {
+                project: None,
+                executor: "http".to_string(),
+                usage_source: "anthropic_usage".to_string(),
+                pricing_source: "remem_static".to_string(),
+                calls: 1,
+                total_tokens: 100,
+                estimated_cost_usd: 0.0005,
+            },
+        ]
+    );
+
+    let limited = query_ai_usage_breakdown(&conn, Some(jan_05_2026), None, 1)?;
+    assert_eq!(limited.len(), 1);
+    assert_eq!(limited[0].project.as_deref(), Some("/Users/lifcc/.remem"));
+
+    let empty = query_ai_usage_breakdown(&conn, Some(jan_05_2026), None, 0)?;
+    assert!(empty.is_empty());
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Add a top usage breakdown grouped by project, executor, usage source, and pricing source.
- Expand `remem usage` precision reporting so provider/log-derived usage and text-estimated usage are visibly separated by calls, tokens, and cost.
- Add explicit CLI warnings that `text_estimate` is prompt/output length only and does not include Claude Code host-side project memory, system context, or cache usage.

## Root cause

The usage table already stored `usage_source` and `pricing_source`, but the default report mostly presented aggregate totals. During the recursive Claude CLI incident, the suspicious shape was `project=/Users/lifcc/.remem` + `executor=cli` + `usage_source=text_estimate`; that required ad hoc SQL instead of being visible in `remem usage`.

This PR keeps the schema unchanged and makes that breakdown visible from existing historical `ai_usage_events` rows.

Fixes #263

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test query_ai_usage_breakdown_exposes_project_executor_and_source`
- `cargo test query_ai_usage_groups_daily_and_weekly_token_costs`
- `cargo test`
- `REMEM_DATA_DIR=/var/folders/3_/987z6jz91l9_t8mpvflf73xm0000gp/T/tmp.xD0KZjn8JF cargo run --quiet -- usage --days 1 --weeks 1`
