### PR TITLE
[codex] Guard Claude native memory sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.5"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.5"
+version = "0.4.7"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/context/claude_memory.rs
+++ b/src/context/claude_memory.rs
@@ -5,4 +5,9 @@ mod runtime;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use render::REMEM_FILE;
 pub use runtime::sync_to_claude_memory;
+pub(crate) use runtime::{
+    native_memory_max_bytes, native_memory_sync_disabled, DISABLE_NATIVE_MEMORY_SYNC_ENV,
+    NATIVE_MEMORY_MAX_BYTES_ENV,
+};

--- a/src/context/claude_memory/render.rs
+++ b/src/context/claude_memory/render.rs
@@ -2,7 +2,7 @@ const MAX_SESSIONS: usize = 10;
 const MAX_DECISIONS: usize = 8;
 const REQUEST_CHAR_LIMIT: usize = 120;
 const COMPLETED_CHAR_LIMIT: usize = 200;
-pub(super) const REMEM_FILE: &str = "remem_sessions.md";
+pub(crate) const REMEM_FILE: &str = "remem_sessions.md";
 
 pub(super) struct SessionRow {
     pub request: String,

--- a/src/context/claude_memory/runtime.rs
+++ b/src/context/claude_memory/runtime.rs
@@ -7,7 +7,25 @@ use crate::context::claude_memory::render::{
     max_sessions, render_memory_content, SessionRow, REMEM_FILE,
 };
 
+pub(crate) const DISABLE_NATIVE_MEMORY_SYNC_ENV: &str = "REMEM_DISABLE_NATIVE_MEMORY_SYNC";
+pub(crate) const NATIVE_MEMORY_MAX_BYTES_ENV: &str = "REMEM_NATIVE_MEMORY_MAX_BYTES";
+
+const DEFAULT_NATIVE_MEMORY_MAX_BYTES: usize = 16 * 1024;
+const TRUNCATION_NOTE: &str =
+    "\n\n---\n*Truncated by remem native memory guard; use `remem search` for full memory.*\n";
+
 pub fn sync_to_claude_memory(cwd: &str, project: &str) -> Result<()> {
+    if native_memory_sync_disabled() {
+        crate::log::info(
+            "claude-mem",
+            &format!(
+                "skip: native memory sync disabled by {} for {}",
+                DISABLE_NATIVE_MEMORY_SYNC_ENV, project
+            ),
+        );
+        return Ok(());
+    }
+
     let conn = crate::db::open_db()?;
     let memory_dir = claude_memory_dir(cwd);
 
@@ -23,6 +41,9 @@ pub fn sync_to_claude_memory(cwd: &str, project: &str) -> Result<()> {
     let Some(content) = render_memory_content(&sessions) else {
         return Ok(());
     };
+    let original_bytes = content.len();
+    let max_bytes = native_memory_max_bytes();
+    let (content, truncated) = enforce_native_memory_limit(&content, max_bytes);
 
     let file_path = memory_dir.join(REMEM_FILE);
     std::fs::write(&file_path, &content)?;
@@ -32,14 +53,92 @@ pub fn sync_to_claude_memory(cwd: &str, project: &str) -> Result<()> {
     crate::log::info(
         "claude-mem",
         &format!(
-            "synced {} sessions + {} decisions to {}",
+            "synced {} sessions + {} decisions to {} ({} bytes{})",
             sessions.len(),
             decisions_count,
-            file_path.display()
+            file_path.display(),
+            content.len(),
+            if truncated {
+                " after native memory size cap"
+            } else {
+                ""
+            }
         ),
     );
+    if truncated {
+        crate::log::warn(
+            "claude-mem",
+            &format!(
+                "native memory output for {} capped from {} to {} bytes by {}={}",
+                project,
+                original_bytes,
+                content.len(),
+                NATIVE_MEMORY_MAX_BYTES_ENV,
+                max_bytes
+            ),
+        );
+    }
 
     Ok(())
+}
+
+pub(crate) fn native_memory_sync_disabled() -> bool {
+    std::env::var(DISABLE_NATIVE_MEMORY_SYNC_ENV)
+        .ok()
+        .is_some_and(|value| env_value_enabled(&value))
+}
+
+pub(super) fn env_value_enabled(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+pub(crate) fn native_memory_max_bytes() -> usize {
+    std::env::var(NATIVE_MEMORY_MAX_BYTES_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_NATIVE_MEMORY_MAX_BYTES)
+}
+
+pub(super) fn enforce_native_memory_limit(content: &str, max_bytes: usize) -> (String, bool) {
+    if content.len() <= max_bytes {
+        return (content.to_string(), false);
+    }
+
+    if max_bytes == 0 {
+        return (String::new(), true);
+    }
+
+    if max_bytes <= TRUNCATION_NOTE.len() {
+        return (truncate_to_byte_limit(TRUNCATION_NOTE, max_bytes), true);
+    }
+
+    let content_budget = max_bytes - TRUNCATION_NOTE.len();
+    let mut capped = truncate_to_byte_limit(content, content_budget);
+    capped.push_str(TRUNCATION_NOTE);
+    while capped.len() > max_bytes {
+        capped.pop();
+    }
+    (capped, true)
+}
+
+fn truncate_to_byte_limit(content: &str, max_bytes: usize) -> String {
+    if content.len() <= max_bytes {
+        return content.to_string();
+    }
+
+    let mut end = 0;
+    for (idx, ch) in content.char_indices() {
+        let next = idx + ch.len_utf8();
+        if next > max_bytes {
+            break;
+        }
+        end = next;
+    }
+    content[..end].to_string()
 }
 
 fn load_recent_sessions(conn: &rusqlite::Connection, project: &str) -> Result<Vec<SessionRow>> {

--- a/src/context/claude_memory/tests.rs
+++ b/src/context/claude_memory/tests.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use super::index::ensure_memory_index;
 use super::paths::encode_project_path;
+use super::runtime::{enforce_native_memory_limit, env_value_enabled};
 
 fn unique_temp_dir(name: &str) -> PathBuf {
     let nanos = std::time::SystemTime::now()
@@ -54,4 +55,29 @@ fn ensure_memory_index_creates_new_file_when_missing() {
     assert!(content.contains("remem_sessions.md"));
 
     std::fs::remove_dir_all(&dir).expect("temp dir should clean up");
+}
+
+#[test]
+fn native_memory_limit_caps_output_without_breaking_utf8() {
+    let content = format!(
+        "---\nname: remem_sessions\n---\n\n{}\n",
+        "关键决策和最近会话摘要".repeat(80)
+    );
+
+    let (capped, truncated) = enforce_native_memory_limit(&content, 512);
+
+    assert!(truncated);
+    assert!(capped.len() <= 512, "capped length was {}", capped.len());
+    assert!(capped.is_char_boundary(capped.len()));
+    assert!(capped.contains("Truncated by remem native memory guard"));
+}
+
+#[test]
+fn native_memory_disable_env_accepts_explicit_truthy_values() {
+    for value in ["1", "true", "TRUE", "yes", "on"] {
+        assert!(env_value_enabled(value), "{value}");
+    }
+    for value in ["", "0", "false", "off", "disabled"] {
+        assert!(!env_value_enabled(value), "{value}");
+    }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,5 +1,6 @@
 mod database;
 mod environment;
+mod native_memory;
 mod report;
 mod schema;
 #[cfg(test)]

--- a/src/doctor/native_memory.rs
+++ b/src/doctor/native_memory.rs
@@ -1,0 +1,187 @@
+use std::path::{Path, PathBuf};
+
+use super::types::{Check, Status};
+
+const MAX_REPORTED_FILES: usize = 3;
+
+pub(super) fn check_native_memory_sync() -> Check {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let projects_dir = home.join(".claude").join("projects");
+    check_native_memory_sync_for(
+        &projects_dir,
+        crate::context::claude_memory::native_memory_max_bytes(),
+        crate::context::claude_memory::native_memory_sync_disabled(),
+    )
+}
+
+fn check_native_memory_sync_for(projects_dir: &Path, max_bytes: usize, disabled: bool) -> Check {
+    let mut files = match collect_remem_native_memory_files(projects_dir) {
+        Ok(files) => files,
+        Err(err) => {
+            return Check {
+                name: "Claude native memory",
+                status: Status::Warn,
+                detail: format!("cannot inspect {}: {}", projects_dir.display(), err),
+            };
+        }
+    };
+
+    if files.is_empty() {
+        return Check {
+            name: "Claude native memory",
+            status: Status::Ok,
+            detail: if disabled {
+                format!(
+                    "disabled by {}; no remem_sessions.md files found",
+                    crate::context::claude_memory::DISABLE_NATIVE_MEMORY_SYNC_ENV
+                )
+            } else {
+                "no remem_sessions.md files found".to_string()
+            },
+        };
+    }
+
+    files.sort_by(|a, b| b.bytes.cmp(&a.bytes).then_with(|| a.path.cmp(&b.path)));
+    let oversized = files
+        .iter()
+        .filter(|file| file.bytes > max_bytes as u64)
+        .collect::<Vec<_>>();
+    let largest = files.first().map(|file| file.bytes).unwrap_or(0);
+    let disabled_note = if disabled {
+        format!(
+            "; future sync disabled by {}",
+            crate::context::claude_memory::DISABLE_NATIVE_MEMORY_SYNC_ENV
+        )
+    } else {
+        String::new()
+    };
+
+    if oversized.is_empty() {
+        return Check {
+            name: "Claude native memory",
+            status: Status::Ok,
+            detail: format!(
+                "{} remem_sessions.md file(s), largest {} bytes, limit {}={} bytes{}",
+                files.len(),
+                largest,
+                crate::context::claude_memory::NATIVE_MEMORY_MAX_BYTES_ENV,
+                max_bytes,
+                disabled_note
+            ),
+        };
+    }
+
+    let examples = oversized
+        .iter()
+        .take(MAX_REPORTED_FILES)
+        .map(|file| format!("{} ({} bytes)", file.path.display(), file.bytes))
+        .collect::<Vec<_>>()
+        .join("; ");
+    Check {
+        name: "Claude native memory",
+        status: Status::Warn,
+        detail: format!(
+            "{} of {} remem_sessions.md file(s) exceed {} bytes{}; host-side Claude Code loads are not included in remem usage: {}",
+            oversized.len(),
+            files.len(),
+            max_bytes,
+            disabled_note,
+            examples
+        ),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct NativeMemoryFile {
+    path: PathBuf,
+    bytes: u64,
+}
+
+fn collect_remem_native_memory_files(
+    projects_dir: &Path,
+) -> std::io::Result<Vec<NativeMemoryFile>> {
+    if !projects_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(projects_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let file_path = entry
+            .path()
+            .join("memory")
+            .join(crate::context::claude_memory::REMEM_FILE);
+        if file_path.exists() {
+            let bytes = std::fs::metadata(&file_path)?.len();
+            files.push(NativeMemoryFile {
+                path: file_path,
+                bytes,
+            });
+        }
+    }
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doctor_temp_dir(name: &str) -> anyhow::Result<PathBuf> {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "remem-doctor-{name}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir)?;
+        Ok(dir)
+    }
+
+    #[test]
+    fn native_memory_check_warns_for_oversized_remem_sessions() -> anyhow::Result<()> {
+        let projects_dir = doctor_temp_dir("native-memory")?;
+        let memory_dir = projects_dir.join("project-a").join("memory");
+        std::fs::create_dir_all(&memory_dir)?;
+        std::fs::write(
+            memory_dir.join(crate::context::claude_memory::REMEM_FILE),
+            "x".repeat(32),
+        )?;
+
+        let check = check_native_memory_sync_for(&projects_dir, 16, false);
+
+        assert!(matches!(check.status, Status::Warn));
+        assert!(check.detail.contains("exceed 16 bytes"), "{}", check.detail);
+        assert!(
+            check.detail.contains("not included in remem usage"),
+            "{}",
+            check.detail
+        );
+
+        std::fs::remove_dir_all(projects_dir)?;
+        Ok(())
+    }
+
+    #[test]
+    fn native_memory_check_reports_disabled_state_without_files() -> anyhow::Result<()> {
+        let projects_dir = doctor_temp_dir("native-memory-disabled")?;
+
+        let check = check_native_memory_sync_for(&projects_dir, 16, true);
+
+        assert!(matches!(check.status, Status::Ok));
+        assert!(
+            check
+                .detail
+                .contains(crate::context::claude_memory::DISABLE_NATIVE_MEMORY_SYNC_ENV),
+            "{}",
+            check.detail
+        );
+
+        std::fs::remove_dir_all(projects_dir)?;
+        Ok(())
+    }
+}

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 
 use super::database::{check_database, check_disk_space, check_pending_queue, check_worker_daemon};
 use super::environment::{check_binary, check_hooks, check_mcp};
+use super::native_memory::check_native_memory_sync;
 use super::schema::check_schema_migration;
 use super::types::{Check, CheckJson, DoctorOutcome, ReportJson, Status, REPORT_SCHEMA_VERSION};
 
@@ -49,6 +50,7 @@ fn collect_checks() -> Vec<Check> {
     checks.extend(check_mcp());
     checks.push(check_worker_daemon());
     checks.push(check_pending_queue());
+    checks.push(check_native_memory_sync());
     checks.push(check_disk_space());
     checks
 }


### PR DESCRIPTION
## Summary

- Add `REMEM_DISABLE_NATIVE_MEMORY_SYNC=1` to skip future Claude native memory writes.
- Add `REMEM_NATIVE_MEMORY_MAX_BYTES` with a 16KB default cap for generated `remem_sessions.md` output.
- Add `remem doctor` visibility for existing Claude native `remem_sessions.md` files, including oversized-file warnings and a note that host-side Claude Code loads are outside remem usage accounting.

## Root cause

remem's own SessionStart context path has budgets, truncation, and gate behavior, but native Claude memory sync writes `remem_sessions.md` into Claude Code's per-project memory directory. Claude Code can later load those files into host session context/cache, and those costs are not visible in remem's `ai_usage_events` table.

This PR adds explicit guardrails around that boundary without changing the existing database schema.

Fixes #266

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test native_memory`
- `cargo test`
- `cargo run --quiet -- doctor --json` (exits 1 on this machine because existing pending queue warnings are present; output includes the new `Claude native memory` check)
