### PR TITLE
fix(context): suppress duplicate context injection after compact reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -9,6 +9,7 @@ use super::invocation::ContextInvocation;
 mod delta;
 
 const DEFAULT_GATE_HOSTS: &str = "codex-cli";
+const DEFAULT_SUPPRESSED_SOURCES: &str = "compact";
 const DEFAULT_FALLBACK_COOLDOWN_SECS: i64 = 900;
 const DEFAULT_RETENTION_DAYS: i64 = 30;
 
@@ -56,6 +57,13 @@ pub(super) fn apply_context_gate(
     let mode = resolve_gate_mode(invocation.gate_mode.as_deref());
     if mode == ContextGateMode::Off {
         return decision(output, ContextGateAction::Bypassed, "gate_off");
+    }
+    if source_is_suppressed(invocation.source.as_deref()) {
+        return decision(
+            String::new(),
+            ContextGateAction::Suppressed,
+            "suppressed_source",
+        );
     }
     if !has_trusted_gate_identity(invocation) {
         crate::log::warn(
@@ -271,8 +279,20 @@ fn host_is_gated(host: HostKind) -> bool {
 fn source_requires_fresh_emission(source: Option<&str>) -> bool {
     matches!(
         source.map(|value| value.trim().to_ascii_lowercase()),
-        Some(value) if value == "clear" || value == "compact"
+        Some(value) if value == "clear"
     )
+}
+
+fn source_is_suppressed(source: Option<&str>) -> bool {
+    let Some(source) = source.map(|value| value.trim().to_ascii_lowercase()) else {
+        return false;
+    };
+    let suppressed_sources = std::env::var("REMEM_CONTEXT_SUPPRESS_SOURCES")
+        .unwrap_or_else(|_| DEFAULT_SUPPRESSED_SOURCES.to_string());
+    suppressed_sources
+        .split(',')
+        .map(|candidate| candidate.trim().to_ascii_lowercase())
+        .any(|candidate| candidate == source)
 }
 
 fn has_trusted_gate_identity(invocation: &ContextInvocation) -> bool {
@@ -707,9 +727,30 @@ mod tests {
     #[test]
     fn restart_source_requires_fresh_emission() {
         assert!(source_requires_fresh_emission(Some("clear")));
-        assert!(source_requires_fresh_emission(Some("Compact")));
+        assert!(!source_requires_fresh_emission(Some("Compact")));
         assert!(!source_requires_fresh_emission(Some("startup")));
         assert!(!source_requires_fresh_emission(None));
+    }
+
+    #[test]
+    fn compact_source_is_suppressed_by_default() {
+        assert!(source_is_suppressed(Some("Compact")));
+        assert!(!source_is_suppressed(Some("clear")));
+        assert!(!source_is_suppressed(Some("startup")));
+        assert!(!source_is_suppressed(None));
+    }
+
+    #[test]
+    fn compact_source_suppresses_even_first_context() {
+        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-compact");
+        let mut invocation = invocation(Some("sess-compact"));
+        invocation.source = Some("compact".to_string());
+        let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+        let decision = apply_context_gate(&invocation, output);
+        assert_eq!(decision.action, ContextGateAction::Suppressed);
+        assert_eq!(decision.reason, "suppressed_source");
+        assert!(decision.output.is_empty());
     }
 
     #[test]

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -58,13 +58,6 @@ pub(super) fn apply_context_gate(
     if mode == ContextGateMode::Off {
         return decision(output, ContextGateAction::Bypassed, "gate_off");
     }
-    if source_is_suppressed(invocation.source.as_deref()) {
-        return decision(
-            String::new(),
-            ContextGateAction::Suppressed,
-            "suppressed_source",
-        );
-    }
     if !has_trusted_gate_identity(invocation) {
         crate::log::warn(
             "context-gate",
@@ -160,12 +153,18 @@ pub(super) fn apply_context_gate(
             Err(error) => fail_open(output, "gate_write", error),
         };
     }
+    let suppressed_source = source_is_suppressed(invocation.source.as_deref());
     if row.context_hash == hash {
-        if fallback_cooldown_allows_suppression(invocation, &row, now) {
+        if suppressed_source || fallback_cooldown_allows_suppression(invocation, &row, now) {
+            let reason = if suppressed_source {
+                "suppressed_source"
+            } else {
+                "same_hash"
+            };
             return match record_suppression(&conn, invocation, &key, now) {
                 Ok(()) => {
-                    log_gate("suppress", invocation, &key, "same_hash", &hash);
-                    decision(String::new(), ContextGateAction::Suppressed, "same_hash")
+                    log_gate("suppress", invocation, &key, reason, &hash);
+                    decision(String::new(), ContextGateAction::Suppressed, reason)
                 }
                 Err(error) => fail_open(output, "gate_write", error),
             };
@@ -567,253 +566,4 @@ fn log_gate(action: &str, invocation: &ContextInvocation, key: &str, reason: &st
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn setup_conn() -> rusqlite::Connection {
-        let conn = rusqlite::Connection::open_in_memory().unwrap();
-        conn.execute_batch(include_str!(
-            "../migrations/v016_context_injection_gate.sql"
-        ))
-        .unwrap();
-        conn
-    }
-
-    fn invocation(session_id: Option<&str>) -> ContextInvocation {
-        ContextInvocation {
-            cwd: "/tmp/remem".to_string(),
-            project: "/tmp/remem".to_string(),
-            session_id: session_id.map(str::to_string),
-            transcript_path: Some("/tmp/remem.jsonl".to_string()),
-            source: None,
-            host: HostKind::CodexCli,
-            use_colors: false,
-            debug: false,
-            force: false,
-            gate_mode: None,
-        }
-    }
-
-    #[test]
-    fn fingerprint_ignores_header_timestamp() {
-        let a = "# [/tmp/remem] context 2026-05-25 1:00pm\nBody\n";
-        let b = "# [/tmp/remem] context 2026-05-25 2:00pm\nBody\n";
-
-        assert_eq!(context_fingerprint(a), context_fingerprint(b));
-    }
-
-    #[test]
-    fn fingerprint_ignores_footer_totals_derived_from_header_width() {
-        let a = "# [/tmp/remem] context 2026-05-25 9:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n";
-        let b = "# [/tmp/remem] context 2026-05-25 10:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=101 chars/~26 tokens limit=12000 truncated=no\n";
-
-        assert_eq!(context_fingerprint(a), context_fingerprint(b));
-    }
-
-    #[test]
-    fn fingerprint_ignores_context_source_note() {
-        let normal =
-            "# [/tmp/remem] context now\nUse `search`/`get_observations` for details.\n\nBody\n";
-        let post_compact = "# [/tmp/remem] context now [REMEM POST-COMPACT RELOAD]\nUse `search`/`get_observations` for details.\nREMEM_CONTEXT_SOURCE=compact: Codex compact triggered this memory context reload.\n\nBody\n";
-
-        assert_eq!(
-            context_fingerprint(normal),
-            context_fingerprint(post_compact)
-        );
-    }
-
-    #[test]
-    fn fingerprint_keeps_non_footer_total_text() {
-        let a = "# [/tmp/remem] context now\nBody total=100 chars/~25 tokens\n";
-        let b = "# [/tmp/remem] context now\nBody total=101 chars/~26 tokens\n";
-
-        assert_ne!(context_fingerprint(a), context_fingerprint(b));
-    }
-
-    #[test]
-    fn first_same_session_context_emits_and_second_suppresses() -> Result<()> {
-        let conn = setup_conn();
-        let invocation = invocation(Some("sess-1"));
-        let key = injection_key(&invocation);
-        let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
-
-        assert!(load_gate_row(&conn, invocation.host.as_env_value(), &key)?.is_none());
-        upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
-        let row = load_gate_row(&conn, invocation.host.as_env_value(), &key)?
-            .ok_or_else(|| anyhow::anyhow!("missing context injection gate row"))?;
-        assert_eq!(row.context_hash, hash);
-
-        record_suppression(&conn, &invocation, &key, 101)?;
-        let suppress_count: i64 = conn.query_row(
-            "SELECT suppress_count FROM context_injections WHERE host = ?1 AND injection_key = ?2",
-            params![invocation.host.as_env_value(), key],
-            |row| row.get(0),
-        )?;
-        assert_eq!(suppress_count, 1);
-        Ok(())
-    }
-
-    #[test]
-    fn fallback_injection_key_canonicalizes_equivalent_cwd() -> Result<()> {
-        let cwd = std::env::current_dir()?;
-        let mut direct = invocation(None);
-        direct.transcript_path = None;
-        direct.cwd = cwd.to_string_lossy().to_string();
-
-        let mut dotted = direct.clone();
-        dotted.cwd = cwd.join(".").to_string_lossy().to_string();
-
-        assert_eq!(injection_key(&direct), injection_key(&dotted));
-        Ok(())
-    }
-
-    #[test]
-    fn transcript_fallback_injection_key_canonicalizes_equivalent_cwd() -> Result<()> {
-        let cwd = std::env::current_dir()?;
-        let mut direct = invocation(None);
-        direct.cwd = cwd.to_string_lossy().to_string();
-        direct.transcript_path = Some("/tmp/remem-transcript.jsonl".to_string());
-
-        let mut dotted = direct.clone();
-        dotted.cwd = cwd.join(".").to_string_lossy().to_string();
-
-        assert_eq!(injection_key(&direct), injection_key(&dotted));
-        Ok(())
-    }
-
-    #[test]
-    fn cwd_only_fallback_identity_fails_open_without_suppressing() {
-        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-cwd-only");
-        let mut invocation = invocation(None);
-        invocation.transcript_path = None;
-        let output = "# [/tmp/remem] context now\nBody\n".to_string();
-
-        let first = apply_context_gate(&invocation, output.clone());
-        assert_eq!(first.action, ContextGateAction::FailOpen);
-        assert_eq!(first.reason, "missing_session_identity");
-        assert_eq!(first.output, output);
-
-        let second = apply_context_gate(&invocation, output.clone());
-        assert_eq!(second.action, ContextGateAction::FailOpen);
-        assert_eq!(second.reason, "missing_session_identity");
-        assert_eq!(second.output, output);
-    }
-
-    #[test]
-    fn suppression_does_not_extend_fallback_cooldown() -> Result<()> {
-        let conn = setup_conn();
-        let invocation = invocation(None);
-        let key = injection_key(&invocation);
-        let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
-
-        upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
-        record_suppression(&conn, &invocation, &key, 150)?;
-
-        let (updated_at_epoch, last_emitted_epoch, suppress_count): (i64, i64, i64) = conn
-            .query_row(
-                "SELECT updated_at_epoch, last_emitted_epoch, suppress_count
-                 FROM context_injections
-                 WHERE host = ?1 AND injection_key = ?2",
-                params![invocation.host.as_env_value(), key],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-            )?;
-
-        assert_eq!(updated_at_epoch, 150);
-        assert_eq!(last_emitted_epoch, 100);
-        assert_eq!(suppress_count, 1);
-        Ok(())
-    }
-
-    #[test]
-    fn restart_source_requires_fresh_emission() {
-        assert!(source_requires_fresh_emission(Some("clear")));
-        assert!(!source_requires_fresh_emission(Some("Compact")));
-        assert!(!source_requires_fresh_emission(Some("startup")));
-        assert!(!source_requires_fresh_emission(None));
-    }
-
-    #[test]
-    fn compact_source_is_suppressed_by_default() {
-        assert!(source_is_suppressed(Some("Compact")));
-        assert!(!source_is_suppressed(Some("clear")));
-        assert!(!source_is_suppressed(Some("startup")));
-        assert!(!source_is_suppressed(None));
-    }
-
-    #[test]
-    fn compact_source_suppresses_even_first_context() {
-        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-compact");
-        let mut invocation = invocation(Some("sess-compact"));
-        invocation.source = Some("compact".to_string());
-        let output = "# [/tmp/remem] context now\nBody\n".to_string();
-
-        let decision = apply_context_gate(&invocation, output);
-        assert_eq!(decision.action, ContextGateAction::Suppressed);
-        assert_eq!(decision.reason, "suppressed_source");
-        assert!(decision.output.is_empty());
-    }
-
-    #[test]
-    fn restart_source_reemits_same_hash_context() {
-        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-restart");
-        let mut invocation = invocation(Some("sess-restart"));
-        let output = "# [/tmp/remem] context now\nBody\n".to_string();
-
-        let first = apply_context_gate(&invocation, output.clone());
-        assert_eq!(first.action, ContextGateAction::EmittedFull);
-
-        let second = apply_context_gate(&invocation, output.clone());
-        assert_eq!(second.action, ContextGateAction::Suppressed);
-
-        invocation.source = Some("clear".to_string());
-        let restart = apply_context_gate(&invocation, output.clone());
-        assert_eq!(restart.action, ContextGateAction::EmittedFull);
-        assert_eq!(restart.reason, "restart_source");
-        assert_eq!(restart.output, output);
-    }
-
-    #[test]
-    fn emit_and_suppress_persist_hook_source() -> Result<()> {
-        let conn = setup_conn();
-        let mut invocation = invocation(Some("sess-source"));
-        invocation.source = Some("startup".to_string());
-        let key = injection_key(&invocation);
-        let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
-
-        upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
-        invocation.source = Some("resume".to_string());
-        record_suppression(&conn, &invocation, &key, 101)?;
-
-        let hook_source: Option<String> = conn.query_row(
-            "SELECT hook_source FROM context_injections WHERE host = ?1 AND injection_key = ?2",
-            params![invocation.host.as_env_value(), key],
-            |row| row.get(0),
-        )?;
-
-        assert_eq!(hook_source.as_deref(), Some("resume"));
-        Ok(())
-    }
-
-    #[test]
-    fn fingerprint_keeps_user_debug_trace_heading() {
-        let a = "# [/tmp/remem] context now\nBody\n## Debug Trace\nUser note A\n";
-        let b = "# [/tmp/remem] context now\nBody\n## Debug Trace\nUser note B\n";
-
-        assert_ne!(context_fingerprint(a), context_fingerprint(b));
-    }
-
-    #[test]
-    fn fingerprint_ignores_generated_debug_trace() {
-        let base = "# [/tmp/remem] context now\nBody\n";
-        let a = format!(
-            "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=main session=sess-1\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n",
-            base
-        );
-        let b = format!(
-            "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=dev session=sess-2\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=dev total=120 chars/~30 tokens limit=12000 truncated=no\n",
-            base
-        );
-
-        assert_eq!(context_fingerprint(&a), context_fingerprint(&b));
-    }
-}
+mod tests;

--- a/src/context/injection_gate/tests.rs
+++ b/src/context/injection_gate/tests.rs
@@ -1,0 +1,317 @@
+use super::*;
+use rusqlite::params;
+
+fn setup_gate_conn() -> rusqlite::Connection {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch(include_str!(
+        "../../migrations/v016_context_injection_gate.sql"
+    ))
+    .unwrap();
+    conn
+}
+
+fn gate_invocation(session_id: Option<&str>) -> ContextInvocation {
+    ContextInvocation {
+        cwd: "/tmp/remem".to_string(),
+        project: "/tmp/remem".to_string(),
+        session_id: session_id.map(str::to_string),
+        transcript_path: Some("/tmp/remem.jsonl".to_string()),
+        source: None,
+        host: HostKind::CodexCli,
+        use_colors: false,
+        debug: false,
+        force: false,
+        gate_mode: None,
+    }
+}
+
+#[test]
+fn fingerprint_ignores_header_timestamp() {
+    let a = "# [/tmp/remem] context 2026-05-25 1:00pm\nBody\n";
+    let b = "# [/tmp/remem] context 2026-05-25 2:00pm\nBody\n";
+
+    assert_eq!(context_fingerprint(a), context_fingerprint(b));
+}
+
+#[test]
+fn fingerprint_ignores_footer_totals_derived_from_header_width() {
+    let a = "# [/tmp/remem] context 2026-05-25 9:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n";
+    let b = "# [/tmp/remem] context 2026-05-25 10:00am\nBody\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=101 chars/~26 tokens limit=12000 truncated=no\n";
+
+    assert_eq!(context_fingerprint(a), context_fingerprint(b));
+}
+
+#[test]
+fn fingerprint_ignores_context_source_note() {
+    let normal =
+        "# [/tmp/remem] context now\nUse `search`/`get_observations` for details.\n\nBody\n";
+    let post_compact = "# [/tmp/remem] context now [REMEM POST-COMPACT RELOAD]\nUse `search`/`get_observations` for details.\nREMEM_CONTEXT_SOURCE=compact: Codex compact triggered this memory context reload.\n\nBody\n";
+
+    assert_eq!(
+        context_fingerprint(normal),
+        context_fingerprint(post_compact)
+    );
+}
+
+#[test]
+fn fingerprint_keeps_non_footer_total_text() {
+    let a = "# [/tmp/remem] context now\nBody total=100 chars/~25 tokens\n";
+    let b = "# [/tmp/remem] context now\nBody total=101 chars/~26 tokens\n";
+
+    assert_ne!(context_fingerprint(a), context_fingerprint(b));
+}
+
+#[test]
+fn first_same_session_context_emits_and_second_suppresses() -> Result<()> {
+    let conn = setup_gate_conn();
+    let invocation = gate_invocation(Some("sess-1"));
+    let key = injection_key(&invocation);
+    let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
+
+    assert!(load_gate_row(&conn, invocation.host.as_env_value(), &key)?.is_none());
+    upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
+    let row = load_gate_row(&conn, invocation.host.as_env_value(), &key)?
+        .ok_or_else(|| anyhow::anyhow!("missing context injection gate row"))?;
+    assert_eq!(row.context_hash, hash);
+
+    record_suppression(&conn, &invocation, &key, 101)?;
+    let suppress_count: i64 = conn.query_row(
+        "SELECT suppress_count FROM context_injections WHERE host = ?1 AND injection_key = ?2",
+        params![invocation.host.as_env_value(), key],
+        |row| row.get(0),
+    )?;
+    assert_eq!(suppress_count, 1);
+    Ok(())
+}
+
+#[test]
+fn fallback_injection_key_canonicalizes_equivalent_cwd() -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let mut direct = gate_invocation(None);
+    direct.transcript_path = None;
+    direct.cwd = cwd.to_string_lossy().to_string();
+
+    let mut dotted = direct.clone();
+    dotted.cwd = cwd.join(".").to_string_lossy().to_string();
+
+    assert_eq!(injection_key(&direct), injection_key(&dotted));
+    Ok(())
+}
+
+#[test]
+fn transcript_fallback_injection_key_canonicalizes_equivalent_cwd() -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let mut direct = gate_invocation(None);
+    direct.cwd = cwd.to_string_lossy().to_string();
+    direct.transcript_path = Some("/tmp/remem-transcript.jsonl".to_string());
+
+    let mut dotted = direct.clone();
+    dotted.cwd = cwd.join(".").to_string_lossy().to_string();
+
+    assert_eq!(injection_key(&direct), injection_key(&dotted));
+    Ok(())
+}
+
+#[test]
+fn cwd_only_fallback_identity_fails_open_without_suppressing() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-cwd-only");
+    let mut invocation = gate_invocation(None);
+    invocation.transcript_path = None;
+    let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+    let first = apply_context_gate(&invocation, output.clone());
+    assert_eq!(first.action, ContextGateAction::FailOpen);
+    assert_eq!(first.reason, "missing_session_identity");
+    assert_eq!(first.output, output);
+
+    let second = apply_context_gate(&invocation, output.clone());
+    assert_eq!(second.action, ContextGateAction::FailOpen);
+    assert_eq!(second.reason, "missing_session_identity");
+    assert_eq!(second.output, output);
+}
+
+#[test]
+fn suppression_does_not_extend_fallback_cooldown() -> Result<()> {
+    let conn = setup_gate_conn();
+    let invocation = gate_invocation(None);
+    let key = injection_key(&invocation);
+    let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
+
+    upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
+    record_suppression(&conn, &invocation, &key, 150)?;
+
+    let (updated_at_epoch, last_emitted_epoch, suppress_count): (i64, i64, i64) = conn.query_row(
+        "SELECT updated_at_epoch, last_emitted_epoch, suppress_count
+             FROM context_injections
+             WHERE host = ?1 AND injection_key = ?2",
+        params![invocation.host.as_env_value(), key],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+
+    assert_eq!(updated_at_epoch, 150);
+    assert_eq!(last_emitted_epoch, 100);
+    assert_eq!(suppress_count, 1);
+    Ok(())
+}
+
+#[test]
+fn restart_source_requires_fresh_emission() {
+    assert!(source_requires_fresh_emission(Some("clear")));
+    assert!(!source_requires_fresh_emission(Some("Compact")));
+    assert!(!source_requires_fresh_emission(Some("startup")));
+    assert!(!source_requires_fresh_emission(None));
+}
+
+#[test]
+fn compact_source_is_suppressed_by_default() {
+    assert!(source_is_suppressed(Some("Compact")));
+    assert!(!source_is_suppressed(Some("clear")));
+    assert!(!source_is_suppressed(Some("startup")));
+    assert!(!source_is_suppressed(None));
+}
+
+#[test]
+fn compact_source_emits_first_context() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-compact-first");
+    let mut invocation = gate_invocation(Some("sess-compact-first"));
+    invocation.source = Some("compact".to_string());
+    let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+    let decision = apply_context_gate(&invocation, output.clone());
+    assert_eq!(decision.action, ContextGateAction::EmittedFull);
+    assert_eq!(decision.reason, "first_or_forced");
+    assert_eq!(decision.output, output);
+}
+
+#[test]
+fn compact_source_suppresses_same_hash_after_first_context() {
+    let _data_dir =
+        crate::db::test_support::ScopedTestDataDir::new("context-gate-compact-same-hash");
+    let mut invocation = gate_invocation(Some("sess-compact-same-hash"));
+    let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+    let first = apply_context_gate(&invocation, output.clone());
+    assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+    invocation.source = Some("compact".to_string());
+    let second = apply_context_gate(&invocation, output);
+    assert_eq!(second.action, ContextGateAction::Suppressed);
+    assert_eq!(second.reason, "suppressed_source");
+    assert!(second.output.is_empty());
+}
+
+#[test]
+fn compact_source_force_bypasses_suppression() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-compact-force");
+    let mut invocation = gate_invocation(Some("sess-compact-force"));
+    let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+    let first = apply_context_gate(&invocation, output.clone());
+    assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+    invocation.source = Some("compact".to_string());
+    invocation.force = true;
+    let forced = apply_context_gate(&invocation, output.clone());
+    assert_eq!(forced.action, ContextGateAction::EmittedFull);
+    assert_eq!(forced.reason, "first_or_forced");
+    assert_eq!(forced.output, output);
+}
+
+#[test]
+fn compact_source_missing_identity_fails_open() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-compact-no-id");
+    let mut invocation = gate_invocation(None);
+    invocation.transcript_path = None;
+    invocation.source = Some("compact".to_string());
+    let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+    let decision = apply_context_gate(&invocation, output.clone());
+    assert_eq!(decision.action, ContextGateAction::FailOpen);
+    assert_eq!(decision.reason, "missing_session_identity");
+    assert_eq!(decision.output, output);
+}
+
+#[test]
+fn compact_source_changed_hash_emits_delta() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-compact-changed");
+    let mut invocation = gate_invocation(Some("sess-compact-changed"));
+
+    let first = apply_context_gate(
+        &invocation,
+        "# [/tmp/remem] context now\nBody A\n".to_string(),
+    );
+    assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+    invocation.source = Some("compact".to_string());
+    let second = apply_context_gate(
+        &invocation,
+        "# [/tmp/remem] context now\nBody B\n".to_string(),
+    );
+    assert_eq!(second.action, ContextGateAction::EmittedDelta);
+    assert_eq!(second.reason, "changed_hash");
+    assert!(second.output.contains("context delta"));
+}
+
+#[test]
+fn restart_source_reemits_same_hash_context() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-restart");
+    let mut invocation = gate_invocation(Some("sess-restart"));
+    let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+    let first = apply_context_gate(&invocation, output.clone());
+    assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+    let second = apply_context_gate(&invocation, output.clone());
+    assert_eq!(second.action, ContextGateAction::Suppressed);
+
+    invocation.source = Some("clear".to_string());
+    let restart = apply_context_gate(&invocation, output.clone());
+    assert_eq!(restart.action, ContextGateAction::EmittedFull);
+    assert_eq!(restart.reason, "restart_source");
+    assert_eq!(restart.output, output);
+}
+
+#[test]
+fn emit_and_suppress_persist_hook_source() -> Result<()> {
+    let conn = setup_gate_conn();
+    let mut invocation = gate_invocation(Some("sess-source"));
+    invocation.source = Some("startup".to_string());
+    let key = injection_key(&invocation);
+    let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
+
+    upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
+    invocation.source = Some("resume".to_string());
+    record_suppression(&conn, &invocation, &key, 101)?;
+
+    let hook_source: Option<String> = conn.query_row(
+        "SELECT hook_source FROM context_injections WHERE host = ?1 AND injection_key = ?2",
+        params![invocation.host.as_env_value(), key],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(hook_source.as_deref(), Some("resume"));
+    Ok(())
+}
+
+#[test]
+fn fingerprint_keeps_user_debug_trace_heading() {
+    let a = "# [/tmp/remem] context now\nBody\n## Debug Trace\nUser note A\n";
+    let b = "# [/tmp/remem] context now\nBody\n## Debug Trace\nUser note B\n";
+
+    assert_ne!(context_fingerprint(a), context_fingerprint(b));
+}
+
+#[test]
+fn fingerprint_ignores_generated_debug_trace() {
+    let base = "# [/tmp/remem] context now\nBody\n";
+    let a = format!(
+        "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=main session=sess-1\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=100 chars/~25 tokens limit=12000 truncated=no\n",
+        base
+    );
+    let b = format!(
+        "{}\n## Debug Trace\n- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=dev session=sess-2\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=dev total=120 chars/~30 tokens limit=12000 truncated=no\n",
+        base
+    );
+
+    assert_eq!(context_fingerprint(&a), context_fingerprint(&b));
+}


### PR DESCRIPTION
## Summary

- suppress `remem context` emission when Codex `SessionStart` source is `compact`
- keep `source=clear` as the explicit re-emission path
- add `REMEM_CONTEXT_SUPPRESS_SOURCES` for configurable source suppression
- add regression coverage for compact suppression, including first-context compact reload

Closes #269.
Related to #228.

## Root cause

`src/context/injection_gate.rs` classified `source=compact` as a restart source. That bypassed same-hash suppression, so post-compact reloads could repeatedly inject the same full context block.

## Verification

```bash
git fetch origin main && git merge origin/main --no-edit
cargo fmt --all -- --check
git diff --check
cargo check
cargo test
```

Results:

- `origin/main` already up to date.
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.
- `cargo check` passed.
- `cargo test` passed: 626 lib tests, integration tests, benchmark tests, e2e eval, rate_limit tests, and doctests all green.
