### PR TITLE
Fix SQLCipher fail-closed database opens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions/import.rs
+++ b/src/cli/actions/import.rs
@@ -360,4 +360,23 @@ mod tests {
 
         cleanup_temp_db_files(&source_path);
     }
+
+    #[test]
+    fn backup_import_refuses_plaintext_target_without_override() {
+        let _data_dir = ScopedTestDataDir::new("import-fail-closed-target");
+        std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+        let source_path = unique_temp_db_path("runtime-import-fail-closed");
+        let source = create_source_db(&source_path);
+        drop(source);
+
+        let err = match run_import_backup(source_path.clone(), true) {
+            Ok(()) => panic!("import target must not open plaintext without explicit override"),
+            Err(err) => err,
+        };
+        let message = format!("{err:#}");
+        assert!(message.contains("open runtime database"), "got: {message}");
+        assert!(message.contains("SQLCipher key"), "got: {message}");
+
+        cleanup_temp_db_files(&source_path);
+    }
 }

--- a/src/cli/actions/maintenance.rs
+++ b/src/cli/actions/maintenance.rs
@@ -47,10 +47,20 @@ pub(in crate::cli) fn run_encrypt() -> Result<()> {
     println!("Key saved to {}", key_path.display());
 
     println!("Encrypting database (this may take a moment)...");
-    db::encrypt_database(&key)?;
+    if db::db_path().exists() {
+        db::encrypt_database(&key)?;
+    } else {
+        let _conn = db::open_db()?;
+        println!(
+            "Initialized encrypted database at {}",
+            db::db_path().display()
+        );
+    }
 
     println!("Done. Database is now encrypted with SQLCipher.");
-    println!("Backup saved as remem.db.bak");
+    if db::db_path().with_extension("db.bak").exists() {
+        println!("Backup saved as remem.db.bak");
+    }
     Ok(())
 }
 
@@ -230,12 +240,33 @@ mod tests {
     use serde_json::Value;
 
     use super::*;
+    use crate::db::test_support::ScopedTestDataDir;
     use crate::memory::governance::{GovernMemoryResult, GovernedMemory};
 
     #[test]
     fn parse_governance_id_text_accepts_commas_and_whitespace() -> Result<()> {
         let ids = parse_governance_id_text("1, 2\n3\t4")?;
         assert_eq!(ids, vec![1, 2, 3, 4]);
+        Ok(())
+    }
+
+    #[test]
+    fn run_encrypt_initializes_missing_database() -> Result<()> {
+        let test_dir = ScopedTestDataDir::new("encrypt-empty");
+        std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+
+        run_encrypt()?;
+
+        assert!(test_dir.path.join(".key").exists());
+        assert!(test_dir.db_path().exists());
+        let header = std::fs::read(test_dir.db_path())?;
+        assert_ne!(&header[..16], b"SQLite format 3\0");
+
+        let conn = rusqlite::Connection::open(test_dir.db_path())?;
+        crate::db::apply_cipher_key_if_available(&conn)?;
+        let count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sqlite_master", [], |row| row.get(0))?;
+        assert!(count > 0);
         Ok(())
     }
 

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -73,7 +73,7 @@ pub fn open_db() -> Result<Connection> {
 }
 
 pub(crate) fn open_configured_connection(path: &Path, key: Option<&str>) -> Result<Connection> {
-    let conn = Connection::open(&path)
+    let conn = Connection::open(path)
         .with_context(|| format!("Failed to open database: {}", path.display()))?;
 
     super::crypto::configure_cipher(&conn, key)?;

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use rusqlite::Connection;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn deterministic_hash(data: &[u8]) -> u64 {
     const FNV_OFFSET: u64 = 0xcbf29ce484222325;
@@ -52,6 +52,7 @@ pub fn db_path() -> PathBuf {
 
 pub fn open_db() -> Result<Connection> {
     let path = db_path();
+    let key = super::crypto::require_cipher_key_or_plaintext_override()?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
         #[cfg(unix)]
@@ -64,17 +65,22 @@ pub fn open_db() -> Result<Connection> {
         }
     }
 
+    let conn = open_configured_connection(&path, key.as_deref())?;
+    crate::retrieval::vector::load_vec_extension(&conn)?;
+    crate::migrate::run_migrations(&conn)?;
+    crate::retrieval::vector::ensure_vec_table(&conn)?;
+    Ok(conn)
+}
+
+pub(crate) fn open_configured_connection(path: &Path, key: Option<&str>) -> Result<Connection> {
     let conn = Connection::open(&path)
         .with_context(|| format!("Failed to open database: {}", path.display()))?;
 
-    super::crypto::apply_cipher_key_if_available(&conn)?;
+    super::crypto::configure_cipher(&conn, key)?;
 
     conn.execute_batch(
         "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
     )?;
-    crate::retrieval::vector::load_vec_extension(&conn)?;
-    crate::migrate::run_migrations(&conn)?;
-    crate::retrieval::vector::ensure_vec_table(&conn)?;
     Ok(conn)
 }
 

--- a/src/db/crypto.rs
+++ b/src/db/crypto.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
-pub(super) fn load_cipher_key() -> Option<String> {
+pub(crate) const ALLOW_PLAINTEXT_ENV: &str = "REMEM_ALLOW_PLAINTEXT_DB";
+
+pub(crate) fn load_cipher_key() -> Option<String> {
     if let Ok(key) = std::env::var("REMEM_CIPHER_KEY") {
         if !key.is_empty() {
             return Some(key);
@@ -18,6 +20,36 @@ pub(super) fn load_cipher_key() -> Option<String> {
         }
     }
     None
+}
+
+pub(crate) fn plaintext_db_allowed() -> bool {
+    std::env::var(ALLOW_PLAINTEXT_ENV).as_deref() == Ok("1")
+}
+
+pub(crate) fn require_cipher_key_or_plaintext_override() -> Result<Option<String>> {
+    let key = load_cipher_key();
+    if key.is_none() && !plaintext_db_allowed() {
+        anyhow::bail!(
+            "refusing to open remem database without a SQLCipher key; run `remem encrypt` to create a key and encrypted database, or set {ALLOW_PLAINTEXT_ENV}=1 to explicitly allow an unencrypted database"
+        );
+    }
+    Ok(key)
+}
+
+pub(crate) fn configure_cipher(conn: &Connection, key: Option<&str>) -> Result<bool> {
+    if let Some(key) = key {
+        conn.pragma_update(None, "key", key)?;
+        if !can_read_schema(conn) {
+            anyhow::bail!("SQLCipher key was applied but the database schema is unreadable");
+        }
+        return Ok(true);
+    }
+
+    crate::log::error(
+        "db",
+        &format!("opening unencrypted remem database because {ALLOW_PLAINTEXT_ENV}=1 is set"),
+    );
+    Ok(false)
 }
 
 pub(crate) fn apply_cipher_key_if_available(conn: &Connection) -> Result<bool> {
@@ -180,6 +212,45 @@ pub fn encrypt_database(key: &str) -> Result<()> {
 mod tests {
     use super::*;
     use crate::db::test_support::ScopedTestDataDir;
+
+    #[test]
+    fn open_db_refuses_plaintext_without_explicit_override() {
+        let test_dir = ScopedTestDataDir::new("cipher-fail-closed");
+        std::env::remove_var(ALLOW_PLAINTEXT_ENV);
+
+        let err = match crate::db::open_db() {
+            Ok(_) => panic!("open_db must fail closed without a cipher key"),
+            Err(err) => err,
+        };
+
+        let message = err.to_string();
+        assert!(message.contains("SQLCipher key"), "got: {message}");
+        assert!(
+            message.contains(ALLOW_PLAINTEXT_ENV),
+            "override must be explicit: {message}"
+        );
+        assert!(
+            !test_dir.db_path().exists(),
+            "fail-closed path must not create a plaintext database"
+        );
+    }
+
+    #[test]
+    fn open_db_allows_plaintext_only_with_explicit_override() -> Result<()> {
+        let test_dir = ScopedTestDataDir::new("cipher-plaintext-override");
+
+        let conn = crate::db::open_db()?;
+        let table_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sqlite_master", [], |row| row.get(0))?;
+        assert!(table_count > 0);
+        drop(conn);
+
+        let header = std::fs::read(test_dir.db_path())?;
+        assert_eq!(&header[..16], b"SQLite format 3\0");
+        let log = std::fs::read_to_string(test_dir.path.join("remem.log"))?;
+        assert!(log.contains("opening unencrypted remem database"));
+        Ok(())
+    }
 
     #[test]
     fn generate_cipher_key_writes_64_hex_chars() -> Result<()> {

--- a/src/db/test_support.rs
+++ b/src/db/test_support.rs
@@ -13,6 +13,7 @@ fn env_lock() -> &'static Mutex<()> {
 pub struct ScopedTestDataDir {
     _guard: MutexGuard<'static, ()>,
     previous: Option<OsString>,
+    previous_allow_plaintext: Option<OsString>,
     pub path: PathBuf,
 }
 
@@ -20,6 +21,7 @@ impl ScopedTestDataDir {
     pub fn new(label: &str) -> Self {
         let guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var_os("REMEM_DATA_DIR");
+        let previous_allow_plaintext = std::env::var_os("REMEM_ALLOW_PLAINTEXT_DB");
         let unique = format!(
             "remem-test-{}-{}-{}",
             label,
@@ -32,9 +34,11 @@ impl ScopedTestDataDir {
         let path = std::env::temp_dir().join(unique);
         let _ = std::fs::remove_dir_all(&path);
         std::env::set_var("REMEM_DATA_DIR", &path);
+        std::env::set_var("REMEM_ALLOW_PLAINTEXT_DB", "1");
         Self {
             _guard: guard,
             previous,
+            previous_allow_plaintext,
             path,
         }
     }
@@ -59,6 +63,11 @@ impl Drop for ScopedTestDataDir {
             std::env::set_var("REMEM_DATA_DIR", previous);
         } else {
             std::env::remove_var("REMEM_DATA_DIR");
+        }
+        if let Some(previous) = self.previous_allow_plaintext.as_ref() {
+            std::env::set_var("REMEM_ALLOW_PLAINTEXT_DB", previous);
+        } else {
+            std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
         }
         let _ = std::fs::remove_dir_all(&self.path);
     }

--- a/src/doctor/schema.rs
+++ b/src/doctor/schema.rs
@@ -11,7 +11,18 @@ pub(super) fn check_schema_migration() -> Check {
         };
     }
 
-    let real_conn = match rusqlite::Connection::open(&db_path) {
+    let key = match db::require_cipher_key_or_plaintext_override() {
+        Ok(key) => key,
+        Err(err) => {
+            return Check {
+                name: "Schema",
+                status: Status::Fail,
+                detail: format!("cannot open DB: {}", err),
+            };
+        }
+    };
+
+    let real_conn = match db::open_configured_connection(&db_path, key.as_deref()) {
         Ok(conn) => conn,
         Err(err) => {
             return Check {
@@ -21,14 +32,6 @@ pub(super) fn check_schema_migration() -> Check {
             };
         }
     };
-    if let Err(err) = real_conn.execute_batch("PRAGMA busy_timeout=5000;") {
-        return Check {
-            name: "Schema",
-            status: Status::Fail,
-            detail: format!("cannot set busy_timeout: {}", err),
-        };
-    }
-
     match crate::migrate::dry_run_pending(&real_conn) {
         Ok(result) => {
             if let Some(err) = result.error {

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -5,6 +5,7 @@ use crate::{db, memory};
 
 use super::database::{check_database, check_pending_queue, check_worker_daemon};
 use super::report::{run_doctor_with_writer, DoctorOptions};
+use super::schema::check_schema_migration;
 
 #[test]
 fn check_database_reports_shared_active_memory_count() {
@@ -116,6 +117,20 @@ fn check_pending_queue_reports_shared_counts() {
             stats.stuck_jobs,
         )
     );
+}
+
+#[test]
+fn check_schema_migration_reads_encrypted_database() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("doctor-encrypted-schema");
+    std::fs::create_dir_all(&test_dir.path)?;
+    std::fs::write(test_dir.path.join(".key"), "doctor-schema-key")?;
+    let conn = db::open_db()?;
+    drop(conn);
+
+    let check = check_schema_migration();
+    assert_eq!(check.icon(), "ok");
+    assert!(check.detail.contains("up to date"), "got: {}", check.detail);
+    Ok(())
 }
 
 #[test]

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -1,5 +1,9 @@
 use anyhow::{bail, ensure, Context, Result};
-use rusqlite::{backup::Backup, Connection};
+use rusqlite::{
+    backup::Backup,
+    types::{Type, ValueRef},
+    Connection,
+};
 use std::{
     fs::{self, OpenOptions},
     io::ErrorKind,
@@ -41,6 +45,15 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
             });
         }
     };
+    if let Some(key) = crate::db::load_cipher_key() {
+        if let Err(error) = crate::db::configure_cipher(&test_conn, Some(&key)) {
+            return Ok(DryRunResult {
+                current_version,
+                pending_count: applied_pending_count(&applied),
+                error: Some(format!("database clone: {}", error)),
+            });
+        }
+    }
     if let Err(error) = clone_database(real_conn, &mut test_conn) {
         return Ok(DryRunResult {
             current_version,
@@ -134,12 +147,32 @@ fn logical_current_version(raw_current_version: i64, applied: &[i64]) -> i64 {
 }
 
 fn clone_database(src: &Connection, dst: &mut Connection) -> Result<()> {
-    let page_size: i64 = src.query_row("PRAGMA page_size", [], |row| row.get(0))?;
+    let page_size = query_page_size(src)?;
     ensure!(page_size > 0, "source database page_size must be positive");
     dst.execute_batch(&format!("PRAGMA page_size = {page_size}"))?;
     let backup = Backup::new(src, dst)?;
     backup.run_to_completion(100, Duration::from_millis(1), None)?;
     Ok(())
+}
+
+fn query_page_size(conn: &Connection) -> Result<i64> {
+    conn.query_row("PRAGMA page_size", [], |row| match row.get_ref(0)? {
+        ValueRef::Integer(value) => Ok(value),
+        ValueRef::Text(bytes) => {
+            let text = std::str::from_utf8(bytes).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(0, Type::Text, Box::new(error))
+            })?;
+            text.parse::<i64>().map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(0, Type::Text, Box::new(error))
+            })
+        }
+        other => Err(rusqlite::Error::InvalidColumnType(
+            0,
+            "page_size".to_string(),
+            other.data_type(),
+        )),
+    })
+    .map_err(Into::into)
 }
 
 struct DryRunTempPath {

--- a/tests/e2e_eval.rs
+++ b/tests/e2e_eval.rs
@@ -15,6 +15,7 @@ fn eval_e2e_runs_in_sandbox_without_touching_parent_data_dir() {
     let output = Command::new(env!("CARGO_BIN_EXE_remem"))
         .args(["eval-e2e", "--json", "--k", "3"])
         .env("REMEM_DATA_DIR", &sentinel)
+        .env("REMEM_ALLOW_PLAINTEXT_DB", "1")
         .output()
         .expect("run remem eval-e2e");
 


### PR DESCRIPTION
## Summary
- fail closed when opening the runtime database without a SQLCipher key unless REMEM_ALLOW_PLAINTEXT_DB=1 is explicitly set
- apply the same keyed open path to doctor schema checks and migration dry-run clones
- let `remem encrypt` initialize an encrypted empty database and add security regression coverage for doctor/import/runtime opens
- bump remem-ai to 0.4.11

Closes #235

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo check
- cargo test plaintext -- --test-threads=1
- cargo test encrypted_database -- --test-threads=1
- cargo test run_encrypt_initializes_missing_database -- --test-threads=1
- cargo test dry_run_pending_clones_non_default_page_size_database -- --test-threads=1
- cargo test --test e2e_eval -- --test-threads=1
- cargo test -- --test-threads=1
- python3 scripts/ci/check_version_bump.py origin/main WORKTREE
- cargo publish --dry-run --locked

## Root cause
`open_db()` applied a cipher key only when one existed, discarded the returned false value when no key was present, and continued into migrations on a plaintext SQLite database. `doctor::schema` also bypassed the keyed runtime open path, so encrypted installs failed schema dry-run checks.