### PR TITLE
feat: add memory ownership schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -144,10 +144,7 @@ fn upsert_identity(
     now: i64,
 ) -> Result<IdentityIds> {
     let host_id = upsert_host(conn, normalize_host(input.host)?, now)?;
-    let root_path = input
-        .cwd
-        .map(|cwd| crate::db::canonical_project_path(cwd).display().to_string())
-        .unwrap_or_else(|| input.project.to_string());
+    let root_path = input.project.to_string();
     let git_branch = input.cwd.and_then(crate::db::detect_git_branch);
     let workspace_id = upsert_workspace(conn, &root_path, git_branch.as_deref(), now)?;
     let project_id = upsert_project(conn, workspace_id, input.project, now)?;

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -64,11 +64,11 @@ fn full_migration_on_empty_db() -> Result<()> {
     let applied = applied_versions(&conn)?;
     assert_eq!(
         applied,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 30);
+    assert_eq!(user_version, 31);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -325,7 +325,7 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 30);
+    assert_eq!(user_version, 31);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -365,7 +365,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 30);
+    assert_eq!(result.current_version, 31);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())
@@ -713,6 +713,190 @@ fn memory_cols_all_present_after_migration() -> Result<()> {
         conn2.prepare(&query2).is_ok(),
         "all MEMORY_COLS must be queryable after v10 upgrade: {:?}",
         expected_cols
+    );
+
+    Ok(())
+}
+
+#[test]
+fn memory_ownership_migration_backfills_legacy_rows() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+
+    for migration in MIGRATIONS.iter().filter(|migration| migration.version < 19) {
+        conn.execute_batch(migration.sql)?;
+    }
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_epoch INTEGER NOT NULL
+        );",
+    )?;
+    for migration in MIGRATIONS.iter().filter(|migration| migration.version < 19) {
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, ?2, ?3)",
+            params![migration.version, migration.name, 1_700_000_000_i64],
+        )?;
+    }
+
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope)
+         VALUES (1, 's1', '/repo', 'repo-fact', 'Repo fact', 'body', 'decision',
+          NULL, 100, 100, 'active', NULL, 'project')",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope)
+         VALUES (2, 's1', '/repo', 'global-pref', 'Global pref', 'body', 'preference',
+          NULL, 100, 100, 'active', NULL, 'global')",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO workstreams
+         (id, project, title, description, status, progress, next_action, blockers,
+          created_at_epoch, updated_at_epoch, completed_at_epoch)
+         VALUES (1, '/repo', 'Ship feature', NULL, 'active', NULL, NULL, NULL,
+          100, 100, NULL)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO workspaces(id, root_path, git_remote, git_branch, created_at_epoch, updated_at_epoch)
+         VALUES (1, '/repo', NULL, NULL, 100, 100)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO projects(id, workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
+         VALUES (1, 1, '/repo', 'repo', 100, 100)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO memory_candidates
+         (id, project_id, scope, memory_type, topic_key, text, evidence_event_ids,
+          confidence, risk_class, review_status, created_at_epoch, updated_at_epoch)
+         VALUES (1, 1, 'project', 'decision', 'candidate-fact', 'body', '[1]',
+          0.9, 'low', 'pending_review', 100, 100)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO session_summaries
+         (id, memory_session_id, project, request, completed, decisions, learned,
+          next_steps, preferences, prompt_number, created_at, created_at_epoch,
+          discovery_tokens, project_id)
+         VALUES (1, 'm1', '/legacy-repo', 'req', 'done', '[]', '[]',
+          '[]', '[]', 1, 'now', 100, 0, 1)",
+        [],
+    )?;
+
+    run_migrations(&conn)?;
+
+    let memory: (String, Option<String>, String, String, String) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key, context_class
+         FROM memories WHERE id = 1",
+        [],
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        },
+    )?;
+    assert_eq!(
+        memory,
+        (
+            "/repo".to_string(),
+            Some("/repo".to_string()),
+            "repo".to_string(),
+            "/repo".to_string(),
+            "startup_core".to_string()
+        )
+    );
+
+    let global: (String, Option<String>, String, String) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key
+         FROM memories WHERE id = 2",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    assert_eq!(
+        global,
+        (
+            "/repo".to_string(),
+            None,
+            "user".to_string(),
+            "user:default".to_string()
+        )
+    );
+
+    let candidate: (String, Option<String>, String, String) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key
+         FROM memory_candidates WHERE id = 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    assert_eq!(
+        candidate,
+        (
+            "/repo".to_string(),
+            Some("/repo".to_string()),
+            "repo".to_string(),
+            "/repo".to_string()
+        )
+    );
+
+    let workstream: (String, String, String, String) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key
+         FROM workstreams WHERE id = 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    assert_eq!(
+        workstream,
+        (
+            "/repo".to_string(),
+            "/repo".to_string(),
+            "repo".to_string(),
+            "/repo".to_string()
+        )
+    );
+
+    let summary: (
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        String,
+    ) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key, context_class
+         FROM session_summaries WHERE id = 1",
+        [],
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        },
+    )?;
+    assert_eq!(
+        summary,
+        (
+            "/repo".to_string(),
+            None,
+            None,
+            None,
+            "search_only".to_string()
+        )
     );
 
     Ok(())

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -95,6 +95,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "commit_session_links",
         sql: include_str!("../migrations/v018_commit_session_links.sql"),
     },
+    Migration {
+        version: 19,
+        name: "memory_ownership",
+        sql: include_str!("../migrations/v019_memory_ownership.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v019_memory_ownership.sql
+++ b/src/migrations/v019_memory_ownership.sql
@@ -1,0 +1,131 @@
+-- v019_memory_ownership: explicit ownership/routing metadata for memory
+-- governance. Fields are nullable during the compatibility period; future
+-- routing/promotion work will enforce them for new active rows.
+
+ALTER TABLE memories ADD COLUMN source_project TEXT;
+ALTER TABLE memories ADD COLUMN target_project TEXT;
+ALTER TABLE memories ADD COLUMN owner_scope TEXT;
+ALTER TABLE memories ADD COLUMN owner_key TEXT;
+ALTER TABLE memories ADD COLUMN topic_domain TEXT;
+ALTER TABLE memories ADD COLUMN routing_confidence REAL;
+ALTER TABLE memories ADD COLUMN routing_reason TEXT;
+ALTER TABLE memories ADD COLUMN context_class TEXT;
+ALTER TABLE memories ADD COLUMN expires_at_epoch INTEGER;
+ALTER TABLE memories ADD COLUMN valid_from_epoch INTEGER;
+ALTER TABLE memories ADD COLUMN valid_to_epoch INTEGER;
+
+UPDATE memories
+SET source_project = COALESCE(source_project, project),
+    target_project = CASE
+        WHEN COALESCE(scope, 'project') = 'global' THEN NULL
+        ELSE COALESCE(target_project, project)
+    END,
+    owner_scope = COALESCE(
+        owner_scope,
+        CASE
+            WHEN COALESCE(scope, 'project') = 'global' THEN 'user'
+            ELSE 'repo'
+        END
+    ),
+    owner_key = COALESCE(
+        owner_key,
+        CASE
+            WHEN COALESCE(scope, 'project') = 'global' THEN 'user:default'
+            ELSE project
+        END
+    ),
+    context_class = COALESCE(context_class, 'startup_core');
+
+ALTER TABLE memory_candidates ADD COLUMN source_project TEXT;
+ALTER TABLE memory_candidates ADD COLUMN target_project TEXT;
+ALTER TABLE memory_candidates ADD COLUMN owner_scope TEXT;
+ALTER TABLE memory_candidates ADD COLUMN owner_key TEXT;
+ALTER TABLE memory_candidates ADD COLUMN topic_domain TEXT;
+ALTER TABLE memory_candidates ADD COLUMN routing_confidence REAL;
+ALTER TABLE memory_candidates ADD COLUMN routing_reason TEXT;
+ALTER TABLE memory_candidates ADD COLUMN context_class TEXT;
+ALTER TABLE memory_candidates ADD COLUMN expires_at_epoch INTEGER;
+ALTER TABLE memory_candidates ADD COLUMN valid_from_epoch INTEGER;
+ALTER TABLE memory_candidates ADD COLUMN valid_to_epoch INTEGER;
+
+UPDATE memory_candidates
+SET source_project = COALESCE(
+        source_project,
+        (SELECT p.project_path FROM projects p WHERE p.id = memory_candidates.project_id)
+    ),
+    target_project = CASE
+        WHEN scope = 'global' THEN NULL
+        ELSE COALESCE(
+            target_project,
+            (SELECT p.project_path FROM projects p WHERE p.id = memory_candidates.project_id)
+        )
+    END,
+    owner_scope = COALESCE(
+        owner_scope,
+        CASE
+            WHEN scope = 'global' THEN 'user'
+            WHEN project_id IS NOT NULL THEN 'repo'
+            ELSE NULL
+        END
+    ),
+    owner_key = COALESCE(
+        owner_key,
+        CASE
+            WHEN scope = 'global' THEN 'user:default'
+            ELSE (SELECT p.project_path FROM projects p WHERE p.id = memory_candidates.project_id)
+        END
+    );
+
+ALTER TABLE workstreams ADD COLUMN source_project TEXT;
+ALTER TABLE workstreams ADD COLUMN target_project TEXT;
+ALTER TABLE workstreams ADD COLUMN owner_scope TEXT;
+ALTER TABLE workstreams ADD COLUMN owner_key TEXT;
+ALTER TABLE workstreams ADD COLUMN topic_domain TEXT;
+ALTER TABLE workstreams ADD COLUMN routing_confidence REAL;
+ALTER TABLE workstreams ADD COLUMN routing_reason TEXT;
+ALTER TABLE workstreams ADD COLUMN context_class TEXT;
+ALTER TABLE workstreams ADD COLUMN expires_at_epoch INTEGER;
+ALTER TABLE workstreams ADD COLUMN valid_from_epoch INTEGER;
+ALTER TABLE workstreams ADD COLUMN valid_to_epoch INTEGER;
+
+UPDATE workstreams
+SET source_project = COALESCE(source_project, project),
+    target_project = COALESCE(target_project, project),
+    owner_scope = COALESCE(owner_scope, 'repo'),
+    owner_key = COALESCE(owner_key, project),
+    context_class = COALESCE(context_class, 'startup_core');
+
+ALTER TABLE session_summaries ADD COLUMN source_project TEXT;
+ALTER TABLE session_summaries ADD COLUMN target_project TEXT;
+ALTER TABLE session_summaries ADD COLUMN owner_scope TEXT;
+ALTER TABLE session_summaries ADD COLUMN owner_key TEXT;
+ALTER TABLE session_summaries ADD COLUMN topic_domain TEXT;
+ALTER TABLE session_summaries ADD COLUMN routing_confidence REAL;
+ALTER TABLE session_summaries ADD COLUMN routing_reason TEXT;
+ALTER TABLE session_summaries ADD COLUMN context_class TEXT;
+ALTER TABLE session_summaries ADD COLUMN expires_at_epoch INTEGER;
+ALTER TABLE session_summaries ADD COLUMN valid_from_epoch INTEGER;
+ALTER TABLE session_summaries ADD COLUMN valid_to_epoch INTEGER;
+
+UPDATE session_summaries
+SET source_project = COALESCE(
+        source_project,
+        (SELECT p.project_path FROM projects p WHERE p.id = session_summaries.project_id),
+        project
+    ),
+    context_class = COALESCE(context_class, 'search_only');
+
+CREATE INDEX IF NOT EXISTS idx_memories_owner_status
+    ON memories(owner_scope, owner_key, status, updated_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_memories_source_project
+    ON memories(source_project, updated_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_memories_target_project_status
+    ON memories(target_project, status, updated_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_memory_candidates_owner_review
+    ON memory_candidates(owner_scope, owner_key, review_status, updated_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_workstreams_owner_status
+    ON workstreams(owner_scope, owner_key, status, updated_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_session_summaries_owner_created
+    ON session_summaries(owner_scope, owner_key, created_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_session_summaries_source_project
+    ON session_summaries(source_project, created_at_epoch DESC);

--- a/src/project_id.rs
+++ b/src/project_id.rs
@@ -19,10 +19,21 @@ pub fn canonical_project_path(cwd: &str) -> PathBuf {
     })
 }
 
+/// Canonical project identity path.
+///
+/// Prefer the git worktree root when `cwd` is inside a repository so nested
+/// directories in the same repo share one durable project. Fall back to the
+/// canonical cwd for non-git directories and missing paths.
+pub fn canonical_project_root(cwd: &str) -> PathBuf {
+    let canonical_cwd = canonical_project_path(cwd);
+    crate::git_util::resolve_toplevel(&canonical_cwd)
+        .map(|root| std::fs::canonicalize(&root).unwrap_or(root))
+        .unwrap_or(canonical_cwd)
+}
+
 /// Canonical project identity (single source of truth).
-/// This intentionally uses full canonical path to avoid cross-repo key collisions.
 pub fn project_from_cwd(cwd: &str) -> String {
-    canonical_project_path(cwd).to_string_lossy().to_string()
+    canonical_project_root(cwd).to_string_lossy().to_string()
 }
 
 /// Push exact project filter SQL and parameter.
@@ -39,4 +50,62 @@ pub fn push_project_filter(
 
 pub fn project_matches(value: Option<&str>, project: &str) -> bool {
     value.is_some_and(|v| v == project)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn unique_temp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "remem-project-id-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time before unix epoch")
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn project_from_cwd_falls_back_to_canonical_cwd_outside_git() {
+        let root = unique_temp_path("outside-git");
+        let nested = root.join("nested");
+        std::fs::create_dir_all(&nested).expect("create temp dir");
+
+        let expected = nested.canonicalize().expect("canonicalize temp dir");
+        assert_eq!(
+            project_from_cwd(nested.to_str().unwrap()),
+            expected.display().to_string()
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn project_from_cwd_prefers_git_toplevel_for_nested_cwd() {
+        let root = unique_temp_path("git-root");
+        let nested = root.join("crates").join("member").join("src");
+        std::fs::create_dir_all(&nested).expect("create nested temp dir");
+        let status = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&root)
+            .status()
+            .expect("spawn git init");
+        assert!(status.success(), "git init should succeed");
+
+        let expected = root.canonicalize().expect("canonicalize git root");
+        assert_eq!(
+            project_from_cwd(nested.to_str().unwrap()),
+            expected.display().to_string()
+        );
+        assert_eq!(
+            canonical_project_path(nested.to_str().unwrap()),
+            nested.canonicalize().expect("canonicalize nested cwd"),
+            "canonical cwd helper must remain a cwd path, not a project identity"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
 }


### PR DESCRIPTION
## Summary
- closes #220
- add v019 ownership/routing lifecycle metadata to memories, memory_candidates, workstreams, and session_summaries
- backfill legacy rows into repo/user owner scopes while keeping the compatibility period nullable
- make project identity prefer the git worktree root, and keep Claude memory path canonicalization cwd-based
- align capture workspace identity with the normalized project root

## Verification
- cargo fmt --check
- git diff --check
- cargo check
- cargo test project_id::tests -- --nocapture
- cargo test memory_ownership_migration_backfills_legacy_rows -- --nocapture
- cargo test full_migration_on_empty_db -- --nocapture
- cargo test db::capture -- --nocapture
- cargo test migrate::tests -- --nocapture
- cargo test project_key_is_stable_and_collision_resistant -- --nocapture
- cargo test

## Notes
- This PR intentionally only adds the compatibility schema/backfill and stable repo-root identity. Candidate routing enforcement and owner-aware context filtering are handled by #221 and #222.