### PR TITLE
Route memory candidates before promotion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -8,11 +8,17 @@ use crate::db;
 use crate::memory::format::{xml_escape_attr, xml_escape_text};
 use crate::memory::MemoryType;
 
+mod apply;
 mod parse;
 pub(crate) mod review;
+mod route;
 
+use apply::{
+    promote_candidate_to_memory_with_route, update_candidate_after_lifecycle, CandidateApplyOutcome,
+};
 use parse::{normalize_memory_type, normalize_scope, normalize_topic_key};
 use parse::{parse_defer_reason, parse_memory_candidates};
+pub(super) use route::{route_candidate, CandidateRoute};
 
 const MEMORY_CANDIDATE_SYSTEM: &str = "\
 Generate durable memory candidates from extracted observations.
@@ -236,17 +242,26 @@ fn persist_candidates(
             continue;
         }
 
-        let review_status = if should_auto_promote(candidate, batch) {
-            "auto_promoted"
-        } else {
-            "pending_review"
-        };
+        let observation_texts = batch
+            .observations
+            .iter()
+            .map(|observation| observation.text.as_str());
+        let route = route_candidate(
+            &task.project,
+            task.session_id.as_deref(),
+            candidate,
+            observation_texts,
+        );
+        let review_status = "pending_review";
         let now = chrono::Utc::now().timestamp();
         tx.execute(
             "INSERT INTO memory_candidates
              (project_id, scope, memory_type, topic_key, text, evidence_event_ids,
-              confidence, risk_class, review_status, created_at_epoch, updated_at_epoch)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10)",
+              confidence, risk_class, review_status, created_at_epoch, updated_at_epoch,
+              source_project, target_project, owner_scope, owner_key, topic_domain,
+              routing_confidence, routing_reason, context_class)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10,
+                     ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
             params![
                 task.project_id,
                 candidate.scope,
@@ -257,15 +272,33 @@ fn persist_candidates(
                 candidate.confidence,
                 candidate.risk_class,
                 review_status,
-                now
+                now,
+                task.project,
+                route.target_project.as_deref(),
+                route.owner_scope,
+                route.owner_key,
+                route.topic_domain.as_deref(),
+                route.routing_confidence,
+                route.routing_reason,
+                route.context_class
             ],
         )?;
         let candidate_id = tx.last_insert_rowid();
         summary.candidates += 1;
 
-        if review_status == "auto_promoted" {
-            promote_task_candidate(&tx, task, candidate_id, candidate, &evidence_json)?;
-            summary.promoted += 1;
+        if should_auto_promote(candidate, batch, &route, &evidence_json) {
+            let outcome =
+                promote_task_candidate(&tx, task, candidate_id, candidate, &evidence_json, &route)?;
+            update_candidate_after_lifecycle(
+                &tx,
+                candidate_id,
+                candidate,
+                &route,
+                outcome.review_status_for("auto_promoted"),
+            )?;
+            if outcome.promoted {
+                summary.promoted += 1;
+            }
         } else {
             summary.pending_review += 1;
         }
@@ -314,78 +347,38 @@ fn promote_task_candidate(
     candidate_id: i64,
     candidate: &ParsedMemoryCandidate,
     evidence_json: &str,
-) -> Result<()> {
-    promote_candidate_to_memory(
+    route: &CandidateRoute,
+) -> Result<CandidateApplyOutcome> {
+    promote_candidate_to_memory_with_route(
         conn,
         task.session_id.as_deref(),
         &task.project,
         candidate_id,
         candidate,
         evidence_json,
-    )?;
-    Ok(())
+        route,
+    )
 }
 
-pub(super) fn promote_candidate_to_memory(
-    conn: &Connection,
-    session_id: Option<&str>,
-    project: &str,
-    candidate_id: i64,
+fn should_auto_promote(
     candidate: &ParsedMemoryCandidate,
+    batch: &ObservationBatch,
+    route: &CandidateRoute,
     evidence_json: &str,
-) -> Result<i64> {
-    let title = candidate_title(candidate);
-    let memory_id = if candidate.memory_type == "lesson" {
-        crate::memory::lesson::save_lesson(
-            conn,
-            &crate::memory::lesson::SaveLessonRequest {
-                session_id,
-                project,
-                topic_key: Some(&candidate.topic_key),
-                title: &title,
-                content: &candidate.text,
-                confidence: candidate.confidence,
-                source_evidence: Some(evidence_json),
-                files: None,
-                branch: None,
-                scope: &candidate.scope,
-                created_at_epoch: None,
-                stale_after_epoch: None,
-            },
-        )?
-    } else {
-        crate::memory::insert_memory_full(
-            conn,
-            session_id,
-            project,
-            Some(&candidate.topic_key),
-            &title,
-            &candidate.text,
-            &candidate.memory_type,
-            None,
-            None,
-            &candidate.scope,
-            None,
-        )?
-    };
-    conn.execute(
-        "UPDATE memories
-         SET evidence_event_ids = ?1,
-             source_candidate_id = ?2,
-             confidence = ?3
-        WHERE id = ?4",
-        params![evidence_json, candidate_id, candidate.confidence, memory_id],
-    )?;
-    Ok(memory_id)
-}
-
-fn should_auto_promote(candidate: &ParsedMemoryCandidate, batch: &ObservationBatch) -> bool {
+) -> bool {
     candidate.scope == "project"
         && candidate.risk_class == "low"
         && candidate.confidence >= AUTO_PROMOTE_MIN_CONFIDENCE
+        && route.is_repo_owned()
+        && route.routing_confidence >= AUTO_PROMOTE_MIN_CONFIDENCE
+        && has_evidence_ids(evidence_json)
         && MemoryType::parse(&candidate.memory_type).is_some_and(MemoryType::auto_promote)
         && !contains_auto_promote_unsafe_marker(&candidate.text)
         && is_supported_by_source_observation(candidate, batch)
+}
+
+fn has_evidence_ids(evidence_json: &str) -> bool {
+    serde_json::from_str::<Vec<i64>>(evidence_json).is_ok_and(|ids| !ids.is_empty())
 }
 
 fn is_supported_by_source_observation(

--- a/src/memory_candidate/apply.rs
+++ b/src/memory_candidate/apply.rs
@@ -1,0 +1,270 @@
+use anyhow::{bail, Result};
+use rusqlite::{params, Connection};
+
+use super::{candidate_title, normalize_evidence_text, CandidateRoute, ParsedMemoryCandidate};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CandidateApplyOutcome {
+    pub memory_id: Option<i64>,
+    pub promoted: bool,
+    pub noop: bool,
+    pub superseded: usize,
+}
+
+impl CandidateApplyOutcome {
+    pub(super) fn review_status_for<'a>(&self, promoted_status: &'a str) -> &'a str {
+        if self.noop {
+            "noop"
+        } else {
+            promoted_status
+        }
+    }
+}
+
+pub(super) fn promote_candidate_to_memory_with_route(
+    conn: &Connection,
+    session_id: Option<&str>,
+    source_project: &str,
+    candidate_id: i64,
+    candidate: &ParsedMemoryCandidate,
+    evidence_json: &str,
+    route: &CandidateRoute,
+) -> Result<CandidateApplyOutcome> {
+    let title = candidate_title(candidate);
+    let memory_project = route.memory_project(source_project);
+    let memory_scope = route.memory_scope();
+    let active = find_active_same_topic(conn, candidate, route)?;
+    if let Some(existing) = active.iter().find(|row| {
+        normalize_evidence_text(&row.content) == normalize_evidence_text(&candidate.text)
+    }) {
+        return Ok(CandidateApplyOutcome {
+            memory_id: Some(existing.id),
+            promoted: false,
+            noop: true,
+            superseded: 0,
+        });
+    }
+
+    let memory_id = insert_routed_memory(
+        conn,
+        session_id,
+        source_project,
+        &memory_project,
+        candidate_id,
+        candidate,
+        route,
+        &title,
+        evidence_json,
+        memory_scope,
+    )?;
+    let superseded_ids = active.iter().map(|row| row.id).collect::<Vec<_>>();
+    let superseded = soft_supersede_routed(conn, &superseded_ids, Some(memory_id))?;
+    Ok(CandidateApplyOutcome {
+        memory_id: Some(memory_id),
+        promoted: true,
+        noop: false,
+        superseded,
+    })
+}
+
+pub(super) fn update_candidate_after_lifecycle(
+    conn: &Connection,
+    candidate_id: i64,
+    candidate: &ParsedMemoryCandidate,
+    route: &CandidateRoute,
+    review_status: &str,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "UPDATE memory_candidates
+         SET scope = ?1,
+             memory_type = ?2,
+             topic_key = ?3,
+             text = ?4,
+             review_status = ?5,
+             updated_at_epoch = ?6,
+             target_project = ?7,
+             owner_scope = ?8,
+             owner_key = ?9,
+             topic_domain = ?10,
+             routing_confidence = ?11,
+             routing_reason = ?12,
+             context_class = ?13
+         WHERE id = ?14",
+        params![
+            candidate.scope,
+            candidate.memory_type,
+            candidate.topic_key,
+            candidate.text,
+            review_status,
+            now,
+            route.target_project.as_deref(),
+            route.owner_scope,
+            route.owner_key,
+            route.topic_domain.as_deref(),
+            route.routing_confidence,
+            route.routing_reason,
+            route.context_class,
+            candidate_id
+        ],
+    )?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ActiveTopicMemory {
+    id: i64,
+    content: String,
+}
+
+fn find_active_same_topic(
+    conn: &Connection,
+    candidate: &ParsedMemoryCandidate,
+    route: &CandidateRoute,
+) -> Result<Vec<ActiveTopicMemory>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, content
+         FROM memories
+         WHERE status = 'active'
+           AND memory_type = ?1
+           AND topic_key = ?2
+           AND COALESCE(
+                owner_scope,
+                CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
+           ) = ?3
+           AND COALESCE(
+                owner_key,
+                CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user:default' ELSE project END
+           ) = ?4
+         ORDER BY updated_at_epoch DESC, id DESC",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            candidate.memory_type,
+            candidate.topic_key,
+            route.owner_scope,
+            route.owner_key
+        ],
+        |row| {
+            Ok(ActiveTopicMemory {
+                id: row.get(0)?,
+                content: row.get(1)?,
+            })
+        },
+    )?;
+    crate::db::query::collect_rows(rows)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_routed_memory(
+    conn: &Connection,
+    session_id: Option<&str>,
+    source_project: &str,
+    memory_project: &str,
+    candidate_id: i64,
+    candidate: &ParsedMemoryCandidate,
+    route: &CandidateRoute,
+    title: &str,
+    evidence_json: &str,
+    scope: &str,
+) -> Result<i64> {
+    let now = chrono::Utc::now().timestamp();
+    let search_context = crate::memory::search_context::build_search_context(
+        &candidate.memory_type,
+        Some(&candidate.topic_key),
+        &candidate.text,
+        None,
+    );
+    conn.execute(
+        "INSERT INTO memories
+         (session_id, project, topic_key, title, content, memory_type, files, search_context,
+          created_at_epoch, updated_at_epoch, status, branch, scope,
+          evidence_event_ids, source_candidate_id, confidence,
+          source_project, target_project, owner_scope, owner_key, topic_domain,
+          routing_confidence, routing_reason, context_class)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7,
+                 ?8, ?8, 'active', NULL, ?9,
+                 ?10, ?11, ?12,
+                 ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
+        params![
+            session_id,
+            memory_project,
+            candidate.topic_key,
+            title,
+            candidate.text,
+            candidate.memory_type,
+            search_context,
+            now,
+            scope,
+            evidence_json,
+            candidate_id,
+            candidate.confidence,
+            source_project,
+            route.target_project.as_deref(),
+            route.owner_scope,
+            route.owner_key,
+            route.topic_domain.as_deref(),
+            route.routing_confidence,
+            route.routing_reason,
+            route.context_class
+        ],
+    )?;
+    let memory_id = conn.last_insert_rowid();
+    if candidate.memory_type == "lesson" {
+        insert_lesson_metadata(conn, memory_id, candidate, evidence_json, now)?;
+    }
+    refresh_memory_entities(conn, memory_id, title, &candidate.text);
+    Ok(memory_id)
+}
+
+fn insert_lesson_metadata(
+    conn: &Connection,
+    memory_id: i64,
+    candidate: &ParsedMemoryCandidate,
+    evidence_json: &str,
+    now: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO memory_lessons
+         (memory_id, confidence, reinforcement_count, source_evidence,
+          last_reinforced_at_epoch, stale_after_epoch)
+         VALUES (?1, ?2, 1, ?3, ?4, NULL)",
+        params![memory_id, candidate.confidence, evidence_json, now],
+    )?;
+    Ok(())
+}
+
+fn refresh_memory_entities(conn: &Connection, id: i64, title: &str, content: &str) {
+    let entities = crate::retrieval::entity::extract_entities(title, content);
+    if entities.is_empty() {
+        return;
+    }
+    if let Err(e) = crate::retrieval::entity::link_entities(conn, id, &entities) {
+        crate::log::warn("memory", &format!("entity link failed for id={id}: {e}"));
+    }
+}
+
+fn soft_supersede_routed(
+    conn: &Connection,
+    memory_ids: &[i64],
+    replacement_id: Option<i64>,
+) -> Result<usize> {
+    let mut seen = std::collections::HashSet::with_capacity(memory_ids.len());
+    let targets = memory_ids
+        .iter()
+        .copied()
+        .filter(|id| Some(*id) != replacement_id && seen.insert(*id))
+        .collect::<Vec<_>>();
+    let mut changed = 0usize;
+    for id in targets {
+        let updated = conn.execute(
+            "UPDATE memories SET status = 'stale' WHERE id = ?1",
+            params![id],
+        )?;
+        if updated != 1 {
+            bail!("failed to mark superseded memory stale: id={id}");
+        }
+        changed += updated;
+    }
+    Ok(changed)
+}

--- a/src/memory_candidate/review.rs
+++ b/src/memory_candidate/review.rs
@@ -2,8 +2,9 @@ use anyhow::{bail, Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 
 use super::{
-    normalize_memory_type, normalize_scope, normalize_topic_key, promote_candidate_to_memory,
-    ParsedMemoryCandidate,
+    normalize_memory_type, normalize_scope, normalize_topic_key,
+    promote_candidate_to_memory_with_route, route_candidate, update_candidate_after_lifecycle,
+    CandidateRoute, ParsedMemoryCandidate,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -33,6 +34,14 @@ pub(crate) struct CandidateEdit {
 struct CandidateRow {
     id: i64,
     project: Option<String>,
+    source_project: Option<String>,
+    target_project: Option<String>,
+    owner_scope: Option<String>,
+    owner_key: Option<String>,
+    topic_domain: Option<String>,
+    routing_confidence: Option<f64>,
+    routing_reason: Option<String>,
+    context_class: Option<String>,
     scope: String,
     memory_type: String,
     topic_key: String,
@@ -54,7 +63,9 @@ pub(crate) fn list_pending(
         let mut stmt = conn.prepare(
             "SELECT c.id, p.project_path, c.scope, c.memory_type, c.topic_key,
                     c.text, c.evidence_event_ids, c.confidence, c.risk_class,
-                    c.review_status, c.created_at_epoch
+                    c.review_status, c.created_at_epoch, c.source_project,
+                    c.target_project, c.owner_scope, c.owner_key, c.topic_domain,
+                    c.routing_confidence, c.routing_reason, c.context_class
              FROM memory_candidates c
              LEFT JOIN projects p ON p.id = c.project_id
              WHERE c.review_status = 'pending_review'
@@ -70,7 +81,9 @@ pub(crate) fn list_pending(
         let mut stmt = conn.prepare(
             "SELECT c.id, p.project_path, c.scope, c.memory_type, c.topic_key,
                     c.text, c.evidence_event_ids, c.confidence, c.risk_class,
-                    c.review_status, c.created_at_epoch
+                    c.review_status, c.created_at_epoch, c.source_project,
+                    c.target_project, c.owner_scope, c.owner_key, c.topic_domain,
+                    c.routing_confidence, c.routing_reason, c.context_class
              FROM memory_candidates c
              LEFT JOIN projects p ON p.id = c.project_id
              WHERE c.review_status = 'pending_review'
@@ -162,6 +175,14 @@ impl CandidateRow {
             risk_class: row.get(8)?,
             review_status: row.get(9)?,
             created_at_epoch: row.get(10)?,
+            source_project: row.get(11)?,
+            target_project: row.get(12)?,
+            owner_scope: row.get(13)?,
+            owner_key: row.get(14)?,
+            topic_domain: row.get(15)?,
+            routing_confidence: row.get(16)?,
+            routing_reason: row.get(17)?,
+            context_class: row.get(18)?,
         })
     }
 
@@ -211,13 +232,49 @@ impl CandidateRow {
             risk_class: self.risk_class.clone(),
         })
     }
+
+    fn route_for(&self, candidate: &ParsedMemoryCandidate) -> CandidateRoute {
+        match (
+            self.owner_scope.as_ref(),
+            self.owner_key.as_ref(),
+            self.routing_confidence,
+            self.routing_reason.as_ref(),
+            self.context_class.as_ref(),
+        ) {
+            (
+                Some(owner_scope),
+                Some(owner_key),
+                Some(routing_confidence),
+                Some(routing_reason),
+                Some(context_class),
+            ) => CandidateRoute {
+                owner_scope: owner_scope.clone(),
+                owner_key: owner_key.clone(),
+                target_project: self.target_project.clone(),
+                topic_domain: self.topic_domain.clone(),
+                routing_confidence,
+                routing_reason: routing_reason.clone(),
+                context_class: context_class.clone(),
+            },
+            _ => {
+                let project = self
+                    .source_project
+                    .as_deref()
+                    .or(self.project.as_deref())
+                    .unwrap_or("<unknown>");
+                route_candidate(project, None, candidate, std::iter::empty())
+            }
+        }
+    }
 }
 
 fn load_candidate(conn: &Connection, id: i64) -> Result<Option<CandidateRow>> {
     conn.query_row(
         "SELECT c.id, p.project_path, c.scope, c.memory_type, c.topic_key,
                 c.text, c.evidence_event_ids, c.confidence, c.risk_class,
-                c.review_status, c.created_at_epoch
+                c.review_status, c.created_at_epoch, c.source_project,
+                c.target_project, c.owner_scope, c.owner_key, c.topic_domain,
+                c.routing_confidence, c.routing_reason, c.context_class
          FROM memory_candidates c
          LEFT JOIN projects p ON p.id = c.project_id
          WHERE c.id = ?1",
@@ -246,39 +303,35 @@ fn promote_row(
     edited: Option<&ParsedMemoryCandidate>,
 ) -> Result<i64> {
     let project = row
-        .project
+        .source_project
         .as_deref()
-        .context("candidate is missing project path")?;
+        .or(row.project.as_deref())
+        .context("candidate is missing source project path")?;
     let candidate = edited.cloned().unwrap_or_else(|| row.as_candidate());
-    let memory_id = promote_candidate_to_memory(
+    let route = if edited.is_some() {
+        route_candidate(project, None, &candidate, std::iter::empty())
+    } else {
+        row.route_for(&candidate)
+    };
+    let outcome = promote_candidate_to_memory_with_route(
         conn,
         None,
         project,
         row.id,
         &candidate,
         &row.evidence_event_ids,
+        &route,
     )?;
+    let status = outcome.review_status_for(review_status);
     let now = chrono::Utc::now().timestamp();
+    update_candidate_after_lifecycle(conn, row.id, &candidate, &route, status)?;
     conn.execute(
-        "UPDATE memory_candidates
-         SET scope = ?1,
-             memory_type = ?2,
-             topic_key = ?3,
-             text = ?4,
-             review_status = ?5,
-             updated_at_epoch = ?6
-         WHERE id = ?7",
-        params![
-            candidate.scope,
-            candidate.memory_type,
-            candidate.topic_key,
-            candidate.text,
-            review_status,
-            now,
-            row.id
-        ],
+        "UPDATE memory_candidates SET updated_at_epoch = ?1 WHERE id = ?2",
+        params![now, row.id],
     )?;
-    Ok(memory_id)
+    outcome
+        .memory_id
+        .context("candidate promotion produced no memory id")
 }
 
 fn evidence_preview(conn: &Connection, evidence_json: &str) -> Result<Vec<String>> {
@@ -446,6 +499,58 @@ mod tests {
     }
 
     #[test]
+    fn review_approve_lesson_candidate_supersedes_old_lesson() -> Result<()> {
+        let mut conn = setup_conn();
+        let old_id = crate::memory::lesson::save_lesson(
+            &conn,
+            &crate::memory::lesson::SaveLessonRequest {
+                session_id: None,
+                project: "/tmp/remem",
+                topic_key: Some("review-lesson-update"),
+                title: "Old lesson",
+                content: "Old lesson content",
+                confidence: 0.8,
+                source_evidence: None,
+                files: None,
+                branch: None,
+                scope: "project",
+                created_at_epoch: None,
+                stale_after_epoch: None,
+            },
+        )?;
+        let id = insert_pending_candidate_with_scope_and_type(
+            &mut conn,
+            "review-lesson-update",
+            "Updated lesson content",
+            "project",
+            "lesson",
+        )?;
+
+        let new_id = approve_candidate(&mut conn, id)?.expect("candidate should approve");
+
+        let old_status: String = conn.query_row(
+            "SELECT status FROM memories WHERE id = ?1",
+            params![old_id],
+            |row| row.get(0),
+        )?;
+        let (content, metadata_count): (String, i64) = conn.query_row(
+            "SELECT m.content, COUNT(l.memory_id)
+             FROM memories m
+             LEFT JOIN memory_lessons l ON l.memory_id = m.id
+             WHERE m.id = ?1",
+            params![new_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let memory_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+        assert_eq!(old_status, "stale");
+        assert_eq!(content, "Updated lesson content");
+        assert_eq!(metadata_count, 1);
+        assert_eq!(memory_count, 2);
+        Ok(())
+    }
+
+    #[test]
     fn review_discard_marks_candidate_without_deleting_evidence() -> Result<()> {
         let mut conn = setup_conn();
         let id = insert_pending_candidate(&mut conn, "review-discard", "Discard this memory")?;
@@ -514,9 +619,9 @@ mod tests {
     }
 
     #[test]
-    fn review_approve_updates_duplicate_topic_memory() -> Result<()> {
+    fn review_approve_supersedes_duplicate_topic_memory() -> Result<()> {
         let mut conn = setup_conn();
-        crate::memory::insert_memory_full(
+        let old_id = crate::memory::insert_memory_full(
             &conn,
             None,
             "/tmp/remem",
@@ -535,13 +640,22 @@ mod tests {
 
         let memory_count: i64 =
             conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
-        let content: String = conn.query_row(
-            "SELECT content FROM memories WHERE topic_key = 'review-dup'",
+        let (content, owner_scope, owner_key): (String, String, String) = conn.query_row(
+            "SELECT content, owner_scope, owner_key FROM memories
+             WHERE topic_key = 'review-dup' AND status = 'active'",
             [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        let old_status: String = conn.query_row(
+            "SELECT status FROM memories WHERE id = ?1",
+            params![old_id],
             |row| row.get(0),
         )?;
-        assert_eq!(memory_count, 1);
+        assert_eq!(memory_count, 2);
         assert_eq!(content, "Updated memory");
+        assert_eq!(old_status, "stale");
+        assert_eq!(owner_scope, "repo");
+        assert_eq!(owner_key, "/tmp/remem");
         Ok(())
     }
 

--- a/src/memory_candidate/route.rs
+++ b/src/memory_candidate/route.rs
@@ -1,0 +1,254 @@
+use super::ParsedMemoryCandidate;
+
+const ROUTE_CONFIDENCE_HIGH: f64 = 0.95;
+const ROUTE_CONFIDENCE_DEFAULT_REPO: f64 = 0.88;
+const ROUTE_CONFIDENCE_CONFLICT: f64 = 0.45;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CandidateRoute {
+    pub owner_scope: String,
+    pub owner_key: String,
+    pub target_project: Option<String>,
+    pub topic_domain: Option<String>,
+    pub routing_confidence: f64,
+    pub routing_reason: String,
+    pub context_class: String,
+}
+
+impl CandidateRoute {
+    pub(crate) fn memory_project(&self, source_project: &str) -> String {
+        match self.owner_scope.as_str() {
+            "repo" => self
+                .target_project
+                .clone()
+                .unwrap_or_else(|| source_project.to_string()),
+            "user" => source_project.to_string(),
+            "tool" | "domain" | "workstream" | "session" | "workspace" => {
+                format!("{}:{}", self.owner_scope, self.owner_key)
+            }
+            _ => source_project.to_string(),
+        }
+    }
+
+    pub(crate) fn memory_scope(&self) -> &'static str {
+        if self.owner_scope == "user" {
+            "global"
+        } else {
+            "project"
+        }
+    }
+
+    pub(crate) fn is_repo_owned(&self) -> bool {
+        self.owner_scope == "repo"
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RouteKind {
+    Repo,
+    CodexCli,
+    ClaudeCode,
+    GhCli,
+    GrokApi,
+    Macos,
+    UserPreference,
+}
+
+pub(crate) fn route_candidate<'a>(
+    source_project: &str,
+    session_id: Option<&str>,
+    candidate: &ParsedMemoryCandidate,
+    observation_texts: impl IntoIterator<Item = &'a str>,
+) -> CandidateRoute {
+    let mut haystack = format!(
+        "{} {} {} {}",
+        candidate.scope, candidate.memory_type, candidate.topic_key, candidate.text
+    );
+    for text in observation_texts {
+        haystack.push(' ');
+        haystack.push_str(text);
+    }
+    let haystack = haystack.to_ascii_lowercase();
+
+    let mut matches = Vec::new();
+    if candidate.scope == "global" {
+        matches.push(RouteKind::UserPreference);
+    }
+    if has_any(
+        &haystack,
+        &[
+            "codex",
+            "codex-cli",
+            "approval policy",
+            "sandbox",
+            "mcp server",
+            "mcp config",
+        ],
+    ) {
+        matches.push(RouteKind::CodexCli);
+    }
+    if has_any(
+        &haystack,
+        &[
+            "claude code",
+            "claude-code",
+            "claude hooks",
+            "claude desktop",
+        ],
+    ) {
+        matches.push(RouteKind::ClaudeCode);
+    }
+    if has_any(
+        &haystack,
+        &[
+            "gh cli",
+            "github cli",
+            "github actions",
+            "pull request workflow",
+        ],
+    ) {
+        matches.push(RouteKind::GhCli);
+    }
+    if has_any(&haystack, &["grok", "xai", "x.ai", "xai api", "grok api"]) {
+        matches.push(RouteKind::GrokApi);
+    }
+    if has_any(
+        &haystack,
+        &["macos", "tcc", "app bundle", "sparkle", "warp", "launchd"],
+    ) {
+        matches.push(RouteKind::Macos);
+    }
+
+    if matches.is_empty() && candidate.scope == "project" {
+        matches.push(RouteKind::Repo);
+    }
+
+    let non_repo_matches = matches
+        .iter()
+        .copied()
+        .filter(|route| *route != RouteKind::Repo)
+        .collect::<Vec<_>>();
+    if non_repo_matches.len() > 1 {
+        return CandidateRoute {
+            owner_scope: "session".to_string(),
+            owner_key: session_id
+                .map(|id| format!("session:{id}"))
+                .unwrap_or_else(|| "session:unknown".to_string()),
+            target_project: None,
+            topic_domain: Some("ambiguous".to_string()),
+            routing_confidence: ROUTE_CONFIDENCE_CONFLICT,
+            routing_reason: "conflicting deterministic route signals".to_string(),
+            context_class: "never_inject".to_string(),
+        };
+    }
+
+    match matches.first().copied().unwrap_or(RouteKind::Repo) {
+        RouteKind::UserPreference => CandidateRoute {
+            owner_scope: "user".to_string(),
+            owner_key: "user:default".to_string(),
+            target_project: None,
+            topic_domain: Some("user-preference".to_string()),
+            routing_confidence: ROUTE_CONFIDENCE_HIGH,
+            routing_reason: "global candidate route".to_string(),
+            context_class: "startup_core".to_string(),
+        },
+        RouteKind::CodexCli => tool_route("codex-cli", "codex-cli", "Codex CLI tool signal"),
+        RouteKind::ClaudeCode => tool_route(
+            "claude-code",
+            "claude-code",
+            "Claude Code tool/runtime signal",
+        ),
+        RouteKind::GhCli => tool_route("gh-cli", "github-workflow", "GitHub CLI/workflow signal"),
+        RouteKind::GrokApi => domain_route("grok-api", "grok-api", "Grok/xAI API signal"),
+        RouteKind::Macos => domain_route("macos", "macos", "macOS/Warp system signal"),
+        RouteKind::Repo => CandidateRoute {
+            owner_scope: "repo".to_string(),
+            owner_key: source_project.to_string(),
+            target_project: Some(source_project.to_string()),
+            topic_domain: repo_domain(source_project),
+            routing_confidence: ROUTE_CONFIDENCE_DEFAULT_REPO,
+            routing_reason: "default project-scoped candidate route".to_string(),
+            context_class: "startup_core".to_string(),
+        },
+    }
+}
+
+fn has_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+fn tool_route(owner_key: &str, domain: &str, reason: &str) -> CandidateRoute {
+    CandidateRoute {
+        owner_scope: "tool".to_string(),
+        owner_key: owner_key.to_string(),
+        target_project: None,
+        topic_domain: Some(domain.to_string()),
+        routing_confidence: ROUTE_CONFIDENCE_HIGH,
+        routing_reason: reason.to_string(),
+        context_class: "search_only".to_string(),
+    }
+}
+
+fn domain_route(owner_key: &str, domain: &str, reason: &str) -> CandidateRoute {
+    CandidateRoute {
+        owner_scope: "domain".to_string(),
+        owner_key: owner_key.to_string(),
+        target_project: None,
+        topic_domain: Some(domain.to_string()),
+        routing_confidence: ROUTE_CONFIDENCE_HIGH,
+        routing_reason: reason.to_string(),
+        context_class: "search_only".to_string(),
+    }
+}
+
+fn repo_domain(source_project: &str) -> Option<String> {
+    source_project
+        .rsplit('/')
+        .find(|part| !part.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(text: &str) -> ParsedMemoryCandidate {
+        ParsedMemoryCandidate {
+            scope: "project".to_string(),
+            memory_type: "decision".to_string(),
+            topic_key: "topic".to_string(),
+            text: text.to_string(),
+            confidence: 0.9,
+            risk_class: "low".to_string(),
+        }
+    }
+
+    #[test]
+    fn routes_codex_sandbox_to_tool_owner() {
+        let route = route_candidate(
+            "/repo/stash",
+            Some("s1"),
+            &candidate("Codex CLI sandbox approval mode must stay workspace-write."),
+            std::iter::empty(),
+        );
+
+        assert_eq!(route.owner_scope, "tool");
+        assert_eq!(route.owner_key, "codex-cli");
+        assert_eq!(route.memory_project("/repo/stash"), "tool:codex-cli");
+        assert_eq!(route.context_class, "search_only");
+    }
+
+    #[test]
+    fn routes_project_candidate_to_repo_owner() {
+        let route = route_candidate(
+            "/repo/stash",
+            Some("s1"),
+            &candidate("Stash drag and drop keeps item ordering in the project UI."),
+            std::iter::empty(),
+        );
+
+        assert_eq!(route.owner_scope, "repo");
+        assert_eq!(route.owner_key, "/repo/stash");
+        assert_eq!(route.target_project.as_deref(), Some("/repo/stash"));
+    }
+}

--- a/src/memory_candidate/tests.rs
+++ b/src/memory_candidate/tests.rs
@@ -12,12 +12,20 @@ fn setup_conn() -> Connection {
 }
 
 fn setup_task(conn: &mut Connection, session_id: &str) -> Result<db::ExtractionTask> {
+    setup_task_with_project(conn, session_id, "/tmp/remem")
+}
+
+fn setup_task_with_project(
+    conn: &mut Connection,
+    session_id: &str,
+    project: &str,
+) -> Result<db::ExtractionTask> {
     record_captured_event(
         conn,
         &CaptureEventInput {
             host: "codex-cli",
             session_id,
-            project: "/tmp/remem",
+            project,
             cwd: None,
             event_type: "tool_result",
             role: None,
@@ -152,20 +160,44 @@ async fn memory_candidate_auto_promotes_low_risk_project_candidate() -> Result<(
             pending_review: 0
         }
     );
-    let (candidate_id, review_status): (i64, String) = conn.query_row(
-        "SELECT id, review_status FROM memory_candidates",
+    let (candidate_id, review_status, owner_scope, owner_key, target_project, context_class): (
+        i64,
+        String,
+        String,
+        String,
+        String,
+        String,
+    ) = conn.query_row(
+        "SELECT id, review_status, owner_scope, owner_key, target_project, context_class
+         FROM memory_candidates",
         [],
-        |row| Ok((row.get(0)?, row.get(1)?)),
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+            ))
+        },
     )?;
     assert_eq!(review_status, "auto_promoted");
-    let (memory_type, topic_key, evidence, source_candidate_id, confidence): (
-        String,
-        String,
-        String,
-        i64,
-        f64,
-    ) = conn.query_row(
-        "SELECT memory_type, topic_key, evidence_event_ids, source_candidate_id, confidence
+    assert_eq!(owner_scope, "repo");
+    assert_eq!(owner_key, "/tmp/remem");
+    assert_eq!(target_project, "/tmp/remem");
+    assert_eq!(context_class, "startup_core");
+    let (
+        memory_type,
+        topic_key,
+        evidence,
+        source_candidate_id,
+        confidence,
+        memory_owner_scope,
+        memory_owner_key,
+    ): (String, String, String, i64, f64, String, String) = conn.query_row(
+        "SELECT memory_type, topic_key, evidence_event_ids, source_candidate_id, confidence,
+                owner_scope, owner_key
          FROM memories WHERE source_candidate_id = ?1",
         params![candidate_id],
         |row| {
@@ -175,6 +207,8 @@ async fn memory_candidate_auto_promotes_low_risk_project_candidate() -> Result<(
                 row.get(2)?,
                 row.get(3)?,
                 row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
             ))
         },
     )?;
@@ -183,6 +217,313 @@ async fn memory_candidate_auto_promotes_low_risk_project_candidate() -> Result<(
     assert_eq!(source_candidate_id, candidate_id);
     assert!(evidence.contains('1'));
     assert_eq!(confidence, 0.92);
+    assert_eq!(memory_owner_scope, "repo");
+    assert_eq!(memory_owner_key, "/tmp/remem");
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_routes_stash_repo_fact_to_repo_owner() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task_with_project(&mut conn, "sess-candidate-stash", "/tmp/stash")?;
+    let text = "Stash keeps sidebar drag and drop ordering in the project UI.";
+    insert_source_observation(&conn, &task, text)?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok(format!(
+            "<memory_candidate>\
+                <scope>project</scope>\
+                <type>decision</type>\
+                <topic_key>stash-sidebar-dnd</topic_key>\
+                <risk_class>low</risk_class>\
+                <confidence>0.92</confidence>\
+                <text>{text}</text>\
+             </memory_candidate>"
+        ))
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0
+        }
+    );
+    let (project, owner_scope, owner_key): (String, String, String) = conn.query_row(
+        "SELECT project, owner_scope, owner_key FROM memories",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    assert_eq!(project, "/tmp/stash");
+    assert_eq!(owner_scope, "repo");
+    assert_eq!(owner_key, "/tmp/stash");
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_routes_codex_sandbox_fact_to_tool_review() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task_with_project(&mut conn, "sess-candidate-codex", "/tmp/stash")?;
+    let text = "Codex CLI sandbox approvals must use workspace-write for local repo edits.";
+    insert_source_observation(&conn, &task, text)?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok(format!(
+            "<memory_candidate>\
+                <scope>project</scope>\
+                <type>decision</type>\
+                <topic_key>codex-sandbox-approval</topic_key>\
+                <risk_class>low</risk_class>\
+                <confidence>0.94</confidence>\
+                <text>{text}</text>\
+             </memory_candidate>"
+        ))
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1
+        }
+    );
+    let (review_status, owner_scope, owner_key, context_class): (String, String, String, String) =
+        conn.query_row(
+            "SELECT review_status, owner_scope, owner_key, context_class FROM memory_candidates",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    assert_eq!(review_status, "pending_review");
+    assert_eq!(owner_scope, "tool");
+    assert_eq!(owner_key, "codex-cli");
+    assert_eq!(context_class, "search_only");
+    assert_eq!(memory_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_routes_domain_and_user_facts_without_auto_promote() -> Result<()> {
+    let mut conn = setup_conn();
+    let grok_task = setup_task_with_project(&mut conn, "sess-candidate-grok", "/tmp/stash")?;
+    let grok_text = "Grok API streaming responses require xAI-compatible retry handling.";
+    insert_source_observation(&conn, &grok_task, grok_text)?;
+    process_with_generator(&mut conn, &grok_task, |_prompt| async {
+        Ok(format!(
+            "<memory_candidate>\
+                <scope>project</scope>\
+                <type>decision</type>\
+                <topic_key>grok-api-streaming</topic_key>\
+                <risk_class>low</risk_class>\
+                <confidence>0.93</confidence>\
+                <text>{grok_text}</text>\
+             </memory_candidate>"
+        ))
+    })
+    .await?;
+
+    let macos_task = setup_task_with_project(&mut conn, "sess-candidate-macos", "/tmp/stash")?;
+    let macos_text = "Warp on macOS may need TCC reset when the app bundle identity changes.";
+    insert_source_observation(&conn, &macos_task, macos_text)?;
+    process_with_generator(&mut conn, &macos_task, |_prompt| async {
+        Ok(format!(
+            "<memory_candidate>\
+                <scope>project</scope>\
+                <type>decision</type>\
+                <topic_key>warp-macos-tcc</topic_key>\
+                <risk_class>low</risk_class>\
+                <confidence>0.93</confidence>\
+                <text>{macos_text}</text>\
+             </memory_candidate>"
+        ))
+    })
+    .await?;
+
+    let pref_task = setup_task_with_project(&mut conn, "sess-candidate-pref", "/tmp/stash")?;
+    let pref_text = "User prefers concise Chinese progress updates during long-running work.";
+    insert_source_observation(&conn, &pref_task, pref_text)?;
+    process_with_generator(&mut conn, &pref_task, |_prompt| async {
+        Ok(format!(
+            "<memory_candidate>\
+                <scope>global</scope>\
+                <type>preference</type>\
+                <topic_key>concise-chinese-progress</topic_key>\
+                <risk_class>medium</risk_class>\
+                <confidence>0.91</confidence>\
+                <text>{pref_text}</text>\
+             </memory_candidate>"
+        ))
+    })
+    .await?;
+
+    let routes = conn
+        .prepare(
+            "SELECT topic_key, owner_scope, owner_key, review_status
+             FROM memory_candidates
+             ORDER BY id ASC",
+        )?
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    assert_eq!(
+        routes,
+        vec![
+            (
+                "grok-api-streaming".to_string(),
+                "domain".to_string(),
+                "grok-api".to_string(),
+                "pending_review".to_string()
+            ),
+            (
+                "warp-macos-tcc".to_string(),
+                "domain".to_string(),
+                "macos".to_string(),
+                "pending_review".to_string()
+            ),
+            (
+                "concise-chinese-progress".to_string(),
+                "user".to_string(),
+                "user:default".to_string(),
+                "pending_review".to_string()
+            )
+        ]
+    );
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    assert_eq!(memory_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_existing_same_topic_same_text_becomes_noop() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-noop")?;
+    let text = "Use the worker loop to process extraction tasks after observation extraction.";
+    insert_source_observation(&conn, &task, text)?;
+    crate::memory::insert_memory_full(
+        &conn,
+        None,
+        "/tmp/remem",
+        Some("decision-worker-loop"),
+        "Existing worker loop",
+        text,
+        "decision",
+        None,
+        None,
+        "project",
+        None,
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok(low_risk_candidate_xml())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 0
+        }
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    assert_eq!(review_status, "noop");
+    assert_eq!(memory_count, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_newer_same_topic_supersedes_old_memory() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-update")?;
+    let text =
+        "Use the async worker loop to process extraction tasks after observation extraction.";
+    insert_source_observation(&conn, &task, text)?;
+    let old_id = crate::memory::insert_memory_full(
+        &conn,
+        None,
+        "/tmp/remem",
+        Some("decision-worker-loop"),
+        "Old worker loop",
+        "Use the synchronous worker loop to process extraction tasks after observation extraction.",
+        "decision",
+        None,
+        None,
+        "project",
+        None,
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok(format!(
+            "<memory_candidate>\
+                <scope>project</scope>\
+                <type>decision</type>\
+                <topic_key>decision-worker-loop</topic_key>\
+                <risk_class>low</risk_class>\
+                <confidence>0.92</confidence>\
+                <text>{text}</text>\
+             </memory_candidate>"
+        ))
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0
+        }
+    );
+    let old_status: String = conn.query_row(
+        "SELECT status FROM memories WHERE id = ?1",
+        params![old_id],
+        |row| row.get(0),
+    )?;
+    let active_text: String = conn.query_row(
+        "SELECT content FROM memories
+         WHERE topic_key = 'decision-worker-loop' AND status = 'active'",
+        [],
+        |row| row.get(0),
+    )?;
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    assert_eq!(old_status, "stale");
+    assert_eq!(active_text, text);
+    assert_eq!(memory_count, 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_auto_promote_requires_route_and_evidence() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-no-evidence")?;
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok(low_risk_candidate_xml())
+    })
+    .await?;
+
+    assert_eq!(result, MemoryCandidateResult::EmptyRange);
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    assert_eq!(memory_count, 0);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #221.

Summary:
- Adds deterministic candidate routing for repo, tool, domain, user, and ambiguous session owners, then persists route metadata on candidates and promoted memories.
- Restricts auto-promotion to high-confidence repo-owned candidates with source evidence; tool, domain, user, and ambiguous routes stay pending review.
- Applies lifecycle on promotion: identical same-topic active memory becomes noop; newer same-topic content inserts a replacement and marks the old memory stale.
- Keeps lesson candidates in the same lifecycle while preserving memory_lessons metadata.
- Adds realistic sandbox tests for Stash repo facts, Codex sandbox facts, Grok API facts, macOS/Warp facts, user preferences, no evidence, noop, and update/supersede.
- Bumps remem-ai to 0.4.13 for the binary-impacting change.

Verification:
- cargo fmt --check
- git diff --check
- cargo check
- cargo test memory_candidate::review::tests -- --nocapture
- cargo test memory_candidate -- --nocapture
- cargo test