### PR TITLE
Route summary memories through candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/SPEC-benchmark.md
+++ b/SPEC-benchmark.md
@@ -48,8 +48,8 @@ Project A 存入 global preference → Project B 查询 → 验证 global scope 
 ### Scenario 6: Time Decay Ranking
 插入新旧两组相同相关度记忆 → 搜索 → 验证新记忆排名高于旧记忆。
 
-### Scenario 7: Summary Parse & Promotion
-输入 AI 生成的 summary XML → parse_summary → promote_summary_to_memories → 验证 decisions/discoveries/preferences 被正确提取为独立记忆。
+### Scenario 7: Summary Parse & Candidate Promotion
+输入 AI 生成的 summary XML → parse_summary → promote_summary_to_memory_candidates → 验证 decisions/discoveries/preferences 被正确提取为待审候选，不直接写入 active memories。
 
 ### Scenario 8: Search Filter By Type
 插入不同 memory type → 按 type 搜索 → 验证过滤语义和排序稳定。

--- a/docs/memory-lifecycle.md
+++ b/docs/memory-lifecycle.md
@@ -33,6 +33,11 @@ Candidate review state is separate from memory state:
 | `discarded` | Candidate was rejected after review. |
 | `defer` outcome | No candidate row is created; the extraction task keeps the reason in `last_error` and retries later. |
 
+Session summaries are not a shortcut to active memories. Durable decisions,
+learned facts, and preferences derived from summaries must be written as
+`pending_review` memory candidates with source event evidence, then promoted
+through the same routing and lifecycle path as observation-derived candidates.
+
 ## Provenance Rules
 
 Every promoted memory should keep enough provenance to explain why it exists:

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -18,7 +18,7 @@ pub use crate::retrieval::memory_search::{
     search_memories_fts, search_memories_fts_filtered, search_memories_like,
     search_memories_like_filtered,
 };
-pub use promote::{promote_summary_to_memories, slugify_for_topic};
+pub use promote::{promote_summary_to_memory_candidates, slugify_for_topic};
 
 pub use events::*;
 pub use store::*;

--- a/src/memory/promote.rs
+++ b/src/memory/promote.rs
@@ -5,4 +5,4 @@ mod summary;
 mod tests;
 
 pub use slug::slugify_for_topic;
-pub use summary::promote_summary_to_memories;
+pub use summary::promote_summary_to_memory_candidates;

--- a/src/memory/promote/format.rs
+++ b/src/memory/promote/format.rs
@@ -1,6 +1,8 @@
 pub(crate) const MIN_DECISION_LEN: usize = 30;
+#[cfg(test)]
 const MAX_TITLE_LEN: usize = 120;
 
+#[cfg(test)]
 pub(crate) fn build_title(content: &str, request: &str, label: &str) -> String {
     let source = if content.len() >= 20 {
         content
@@ -11,11 +13,6 @@ pub(crate) fn build_title(content: &str, request: &str, label: &str) -> String {
         return format!("Session {label}");
     }
     let truncated = truncate_at_boundary(source, MAX_TITLE_LEN - label.len() - 5);
-    format!("{truncated} — {label}")
-}
-
-pub(crate) fn build_item_title(item: &str, label: &str, _index: usize) -> String {
-    let truncated = truncate_at_boundary(item, MAX_TITLE_LEN - label.len() - 5);
     format!("{truncated} — {label}")
 }
 

--- a/src/memory/promote/summary.rs
+++ b/src/memory/promote/summary.rs
@@ -1,19 +1,19 @@
-use anyhow::Result;
-use rusqlite::Connection;
+use anyhow::{bail, Result};
+use rusqlite::{params, Connection, OptionalExtension};
 
-use crate::memory::lesson::{is_lesson_candidate, save_lesson, SaveLessonRequest};
-use crate::memory::{insert_memory, insert_memory_full};
+use crate::memory::lesson::is_lesson_candidate;
+use crate::memory_candidate::{persist_summary_candidates, ParsedMemoryCandidate};
 
-use super::format::{
-    build_content, build_item_title, build_title, split_into_items, MIN_DECISION_LEN,
-};
+use super::format::{build_content, split_into_items, MIN_DECISION_LEN};
 use super::slug::content_hash;
 
 const MIN_LEARNED_LEN: usize = 30;
 const MIN_PREFERENCE_LEN: usize = 10;
+const SUMMARY_CANDIDATE_CONFIDENCE: f64 = 0.74;
+const SUMMARY_CANDIDATE_RISK: &str = "medium";
 
-pub fn promote_summary_to_memories(
-    conn: &Connection,
+pub fn promote_summary_to_memory_candidates(
+    conn: &mut Connection,
     session_id: &str,
     project: &str,
     request: Option<&str>,
@@ -21,73 +21,82 @@ pub fn promote_summary_to_memories(
     learned: Option<&str>,
     preferences: Option<&str>,
 ) -> Result<usize> {
+    let candidates = summary_memory_candidates(request, decisions, learned, preferences);
+    if candidates.is_empty() {
+        return Ok(0);
+    }
+
+    let source = summary_candidate_source(conn, session_id, project)?;
+    let summary = persist_summary_candidates(
+        conn,
+        session_id,
+        source.project_id,
+        project,
+        &source.evidence_event_ids,
+        &candidates,
+    )?;
+
+    if summary.candidates > 0 {
+        crate::log::info(
+            "promote",
+            &format!(
+                "created {} memory candidate(s) from summary project={}",
+                summary.candidates, project
+            ),
+        );
+    }
+    Ok(summary.candidates)
+}
+
+fn summary_memory_candidates(
+    request: Option<&str>,
+    decisions: Option<&str>,
+    learned: Option<&str>,
+    preferences: Option<&str>,
+) -> Vec<ParsedMemoryCandidate> {
     let request_text = request.unwrap_or("").trim();
-    let mut count = 0;
+    let mut candidates = Vec::new();
 
     if let Some(text) = decisions {
-        count += promote_standard_items(
-            conn,
-            session_id,
-            project,
+        append_standard_candidates(
+            &mut candidates,
             request_text,
             text,
             MIN_DECISION_LEN,
             "decision",
-            "decisions",
             "decision",
-            "decision",
-        )?;
+        );
     }
 
     if let Some(text) = learned {
-        count += promote_learned_items(conn, session_id, project, request_text, text)?;
+        append_learned_candidates(&mut candidates, request_text, text);
     }
 
     if let Some(text) = preferences {
         let text = text.trim();
         if text.len() >= MIN_PREFERENCE_LEN {
-            let title = build_title(text, "", "preference");
-            let topic_key = format!("preference-{}", content_hash(text));
-            insert_memory_full(
-                conn,
-                Some(session_id),
-                project,
-                Some(&topic_key),
-                &title,
-                text,
-                "preference",
-                None,
-                None,
-                "project",
-                None,
-            )?;
-            count += 1;
+            candidates.push(ParsedMemoryCandidate {
+                scope: "project".to_string(),
+                memory_type: "preference".to_string(),
+                topic_key: format!("preference-{}", content_hash(text)),
+                text: text.to_string(),
+                confidence: SUMMARY_CANDIDATE_CONFIDENCE,
+                risk_class: SUMMARY_CANDIDATE_RISK.to_string(),
+            });
         }
     }
 
-    if count > 0 {
-        crate::log::info(
-            "promote",
-            &format!(
-                "promoted {} memories from summary project={}",
-                count, project
-            ),
-        );
-    }
-
-    Ok(count)
+    candidates
 }
 
-fn promote_learned_items(
-    conn: &Connection,
-    session_id: &str,
-    project: &str,
+fn append_learned_candidates(
+    candidates: &mut Vec<ParsedMemoryCandidate>,
     request_text: &str,
     text: &str,
-) -> Result<usize> {
+) {
     let text = text.trim();
     if text.len() < MIN_LEARNED_LEN {
-        return Ok(0);
+        return;
     }
 
     let split_items = split_into_items(text);
@@ -101,54 +110,28 @@ fn promote_learned_items(
         vec![text]
     };
 
-    let mut count = 0;
-    for (index, item) in items.iter().enumerate() {
+    for item in items {
         let content = build_content(item, request_text);
         if is_lesson_candidate(item) {
-            let title = if items.len() > 1 {
-                build_item_title(item, "lesson", index)
-            } else {
-                build_title(item, request_text, "lesson")
-            };
-            let topic_key = format!("lesson-{}", content_hash(item));
-            save_lesson(
-                conn,
-                &SaveLessonRequest {
-                    session_id: Some(session_id),
-                    project,
-                    topic_key: Some(&topic_key),
-                    title: &title,
-                    content: &content,
-                    confidence: lesson_confidence(item),
-                    source_evidence: (!request_text.is_empty()).then_some(request_text),
-                    files: None,
-                    branch: None,
-                    scope: "project",
-                    created_at_epoch: None,
-                    stale_after_epoch: None,
-                },
-            )?;
+            candidates.push(ParsedMemoryCandidate {
+                scope: "project".to_string(),
+                memory_type: "lesson".to_string(),
+                topic_key: format!("lesson-{}", content_hash(item)),
+                text: content,
+                confidence: lesson_confidence(item),
+                risk_class: SUMMARY_CANDIDATE_RISK.to_string(),
+            });
         } else {
-            let title = if items.len() > 1 {
-                build_item_title(item, "learned", index)
-            } else {
-                build_title(item, request_text, "learned")
-            };
-            let topic_key = format!("discovery-{}", content_hash(item));
-            insert_memory(
-                conn,
-                Some(session_id),
-                project,
-                Some(&topic_key),
-                &title,
-                &content,
-                "discovery",
-                None,
-            )?;
+            candidates.push(ParsedMemoryCandidate {
+                scope: "project".to_string(),
+                memory_type: "discovery".to_string(),
+                topic_key: format!("discovery-{}", content_hash(item)),
+                text: content,
+                confidence: SUMMARY_CANDIDATE_CONFIDENCE,
+                risk_class: SUMMARY_CANDIDATE_RISK.to_string(),
+            });
         }
-        count += 1;
     }
-    Ok(count)
 }
 
 fn lesson_confidence(item: &str) -> f64 {
@@ -162,60 +145,106 @@ fn lesson_confidence(item: &str) -> f64 {
     }
 }
 
-fn promote_standard_items(
-    conn: &Connection,
-    session_id: &str,
-    project: &str,
+fn append_standard_candidates(
+    candidates: &mut Vec<ParsedMemoryCandidate>,
     request_text: &str,
     text: &str,
     min_len: usize,
-    item_label: &str,
-    single_label: &str,
     topic_prefix: &str,
     memory_type: &str,
-) -> Result<usize> {
+) {
     let text = text.trim();
     if text.len() < min_len {
-        return Ok(0);
+        return;
     }
 
     let items = split_into_items(text);
     if items.len() > 1 {
-        let mut count = 0;
-        for (index, item) in items.iter().enumerate() {
-            if item.len() < min_len {
-                continue;
-            }
-            let title = build_item_title(item, item_label, index);
-            let content = build_content(item, request_text);
-            let topic_key = format!("{}-{}", topic_prefix, content_hash(item));
-            insert_memory(
-                conn,
-                Some(session_id),
-                project,
-                Some(&topic_key),
-                &title,
-                &content,
-                memory_type,
-                None,
-            )?;
-            count += 1;
+        for item in items.iter().filter(|item| item.len() >= min_len) {
+            candidates.push(ParsedMemoryCandidate {
+                scope: "project".to_string(),
+                memory_type: memory_type.to_string(),
+                topic_key: format!("{}-{}", topic_prefix, content_hash(item)),
+                text: build_content(item, request_text),
+                confidence: SUMMARY_CANDIDATE_CONFIDENCE,
+                risk_class: SUMMARY_CANDIDATE_RISK.to_string(),
+            });
         }
-        Ok(count)
     } else {
-        let title = build_title(text, request_text, single_label);
-        let content = build_content(text, request_text);
-        let topic_key = format!("{}-{}", topic_prefix, content_hash(text));
-        insert_memory(
-            conn,
-            Some(session_id),
-            project,
-            Some(&topic_key),
-            &title,
-            &content,
-            memory_type,
-            None,
-        )?;
-        Ok(1)
+        candidates.push(ParsedMemoryCandidate {
+            scope: "project".to_string(),
+            memory_type: memory_type.to_string(),
+            topic_key: format!("{}-{}", topic_prefix, content_hash(text)),
+            text: build_content(text, request_text),
+            confidence: SUMMARY_CANDIDATE_CONFIDENCE,
+            risk_class: SUMMARY_CANDIDATE_RISK.to_string(),
+        });
+    }
+}
+
+#[derive(Debug)]
+struct SummaryCandidateSource {
+    project_id: i64,
+    evidence_event_ids: Vec<i64>,
+}
+
+fn summary_candidate_source(
+    conn: &Connection,
+    session_id: &str,
+    project: &str,
+) -> Result<SummaryCandidateSource> {
+    let row = match latest_captured_event(conn, session_id, project, Some("session_stop"))? {
+        Some(row) => Some(row),
+        None => latest_captured_event(conn, session_id, project, None)?,
+    };
+    let Some((project_id, event_id)) = row else {
+        bail!(
+            "summary candidate extraction missing captured evidence session={} project={}",
+            session_id,
+            project
+        );
+    };
+    Ok(SummaryCandidateSource {
+        project_id,
+        evidence_event_ids: vec![event_id],
+    })
+}
+
+fn latest_captured_event(
+    conn: &Connection,
+    session_id: &str,
+    project: &str,
+    event_type: Option<&str>,
+) -> Result<Option<(i64, i64)>> {
+    match event_type {
+        Some(event_type) => conn
+            .query_row(
+                "SELECT e.project_id, e.id
+                 FROM captured_events e
+                 JOIN projects p ON p.id = e.project_id
+                 WHERE e.session_id = ?1
+                   AND p.project_path = ?2
+                   AND e.event_type = ?3
+                 ORDER BY e.id DESC
+                 LIMIT 1",
+                params![session_id, project, event_type],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+            .map_err(Into::into),
+        None => conn
+            .query_row(
+                "SELECT e.project_id, e.id
+                 FROM captured_events e
+                 JOIN projects p ON p.id = e.project_id
+                 WHERE e.session_id = ?1
+                   AND p.project_path = ?2
+                 ORDER BY e.id DESC
+                 LIMIT 1",
+                params![session_id, project],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+            .map_err(Into::into),
     }
 }

--- a/src/memory/promote/tests/promote.rs
+++ b/src/memory/promote/tests/promote.rs
@@ -1,185 +1,247 @@
-use super::super::promote_summary_to_memories;
+use anyhow::Result;
+use rusqlite::Connection;
+
+use super::super::promote_summary_to_memory_candidates;
 use super::super::slug::content_hash;
-use crate::memory::tests_helper::setup_memory_schema;
+use crate::db;
+
+fn setup_conn() -> Result<Connection> {
+    let conn = Connection::open_in_memory()?;
+    crate::migrate::run_migrations(&conn)?;
+    Ok(conn)
+}
+
+fn record_summary_evidence(conn: &Connection, session_id: &str, project: &str) -> Result<i64> {
+    let outcome = db::record_captured_event(
+        conn,
+        &db::CaptureEventInput {
+            host: "codex-cli",
+            session_id,
+            project,
+            cwd: Some(project),
+            event_type: "session_stop",
+            role: None,
+            tool_name: None,
+            content: "summary source payload",
+            task_kind: Some(db::ExtractionTaskKind::SessionRollup),
+        },
+    )?;
+    Ok(outcome.event_row_id)
+}
 
 #[test]
-fn test_promote_multi_decisions() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    setup_memory_schema(&conn);
+fn test_summary_candidates_multi_decisions_do_not_create_memories() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-decisions";
+    let project = "test/proj";
+    let evidence_id = record_summary_evidence(&conn, session_id, project)?;
 
     let decisions = "• Use RwLock instead of Mutex for concurrent read support\n\
                      • Switch to trigram tokenizer for CJK text search\n\
                      • Set compression threshold to 100 observations";
-    let count = promote_summary_to_memories(
-        &conn,
-        "session-1",
-        "test/proj",
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
         Some("Optimize search and concurrency"),
         Some(decisions),
         None,
         None,
-    )
-    .unwrap();
+    )?;
     assert_eq!(count, 3);
 
-    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
-    let titles: Vec<&str> = memories
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    let candidate_rows = conn
+        .prepare(
+            "SELECT memory_type, review_status, evidence_event_ids
+             FROM memory_candidates
+             ORDER BY id ASC",
+        )?
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let evidence_json = serde_json::to_string(&vec![evidence_id])?;
+
+    assert_eq!(memory_count, 0);
+    assert_eq!(candidate_rows.len(), 3);
+    assert!(candidate_rows
         .iter()
-        .map(|memory| memory.title.as_str())
-        .collect();
-    assert!(
-        titles.iter().any(|title| title.contains("RwLock")),
-        "title should contain keyword from content: {:?}",
-        titles
-    );
-    assert!(
-        titles.iter().any(|title| title.contains("trigram")),
-        "title should contain keyword from content: {:?}",
-        titles
-    );
+        .all(|row| row.0 == "decision" && row.1 == "pending_review" && row.2 == evidence_json));
+    Ok(())
 }
 
 #[test]
-fn test_promote_multi_learned() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    setup_memory_schema(&conn);
+fn test_summary_candidates_learned_lesson_and_discovery() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-learned";
+    let project = "test/proj";
+    record_summary_evidence(&conn, session_id, project)?;
 
     let learned = "- FTS5 trigram tokenizer handles CJK without word boundaries\n\
-                   - WAL mode allows concurrent reads with single writer";
-    let count = promote_summary_to_memories(
-        &conn,
-        "session-1",
-        "test/proj",
+                   - Root cause: warning-only fallback hid missing data; avoid silent degradation.";
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
         Some("Research storage"),
         None,
         Some(learned),
         None,
-    )
-    .unwrap();
+    )?;
     assert_eq!(count, 2);
 
-    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
-    assert!(memories
-        .iter()
-        .all(|memory| memory.memory_type == "discovery"));
+    let rows = conn
+        .prepare(
+            "SELECT memory_type, confidence, review_status
+             FROM memory_candidates
+             ORDER BY memory_type ASC",
+        )?
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, f64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].0, "discovery");
+    assert_eq!(rows[0].2, "pending_review");
+    assert_eq!(rows[1].0, "lesson");
+    assert!(rows[1].1 >= 0.8);
+    assert_eq!(rows[1].2, "pending_review");
+    Ok(())
 }
 
 #[test]
-fn test_promote_actionable_learned_as_lesson() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    setup_memory_schema(&conn);
+fn test_summary_candidate_duplicate_output_is_idempotent() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-dup";
+    let project = "test/proj";
+    record_summary_evidence(&conn, session_id, project)?;
 
-    let learned = "Root cause: warning-only fallback hid missing data; avoid silent degradation.";
-    let count = promote_summary_to_memories(
-        &conn,
-        "session-1",
-        "test/proj",
-        Some("Fix missing memory output"),
+    let decision = "Use FTS5 trigram tokenizer for CJK text search support";
+    let first = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Optimize search"),
+        Some(decision),
         None,
-        Some(learned),
         None,
-    )
-    .unwrap();
-    assert_eq!(count, 1);
+    )?;
+    let second = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Optimize search"),
+        Some(decision),
+        None,
+        None,
+    )?;
 
-    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
-    assert_eq!(memories.len(), 1);
-    assert_eq!(memories[0].memory_type, "lesson");
-    let metadata = crate::memory::lesson::get_lesson_metadata(&conn, memories[0].id)
-        .unwrap()
-        .expect("lesson metadata should exist");
-    assert_eq!(metadata.reinforcement_count, 1);
-    assert!(metadata.confidence >= 0.8);
+    let candidate_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(first, 1);
+    assert_eq!(second, 0);
+    assert_eq!(candidate_count, 1);
+    Ok(())
 }
 
 #[test]
-fn test_promote_duplicate_lesson_reinforces_existing() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    setup_memory_schema(&conn);
+fn test_summary_preference_candidate_defaults_to_project_scope() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-preference";
+    let project = "test/proj";
+    record_summary_evidence(&conn, session_id, project)?;
 
-    let learned = "Lesson: after three failed fixes, stop and challenge the hypothesis.";
-    promote_summary_to_memories(
-        &conn,
-        "session-1",
-        "test/proj",
-        Some("Fix build loop"),
-        None,
-        Some(learned),
-        None,
-    )
-    .unwrap();
-    promote_summary_to_memories(
-        &conn,
-        "session-2",
-        "test/proj",
-        Some("Fix build loop again"),
-        None,
-        Some(learned),
-        None,
-    )
-    .unwrap();
-
-    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
-    assert_eq!(memories.len(), 1);
-    assert_eq!(memories[0].memory_type, "lesson");
-    let metadata = crate::memory::lesson::get_lesson_metadata(&conn, memories[0].id)
-        .unwrap()
-        .expect("lesson metadata should exist");
-    assert_eq!(metadata.reinforcement_count, 2);
-}
-
-#[test]
-fn test_promote_preference_defaults_to_project_scope() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    setup_memory_schema(&conn);
-
-    let count = promote_summary_to_memories(
-        &conn,
-        "session-1",
-        "test/proj",
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
         Some("Capture local preference"),
         None,
         None,
         Some("Always run project-specific smoke tests"),
-    )
-    .unwrap();
+    )?;
     assert_eq!(count, 1);
 
-    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
-    assert_eq!(memories.len(), 1);
-    assert_eq!(memories[0].memory_type, "preference");
-    assert_eq!(memories[0].scope, "project");
+    let (scope, memory_type, owner_scope, owner_key): (String, String, String, String) = conn
+        .query_row(
+            "SELECT scope, memory_type, owner_scope, owner_key FROM memory_candidates",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+    assert_eq!(scope, "project");
+    assert_eq!(memory_type, "preference");
+    assert_eq!(owner_scope, "repo");
+    assert_eq!(owner_key, project);
+    Ok(())
 }
 
 #[test]
-fn test_promote_content_format() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    setup_memory_schema(&conn);
+fn test_summary_candidates_missing_evidence_fails_closed() -> Result<()> {
+    let mut conn = setup_conn()?;
 
-    let decisions = "Switched from unicode61 to trigram tokenizer for better CJK support";
-    promote_summary_to_memories(
-        &conn,
-        "session-1",
+    let err = promote_summary_to_memory_candidates(
+        &mut conn,
+        "missing-evidence",
         "test/proj",
-        Some("Fix search"),
-        Some(decisions),
+        Some("Optimize search"),
+        Some("Use FTS5 trigram tokenizer for CJK text search support"),
         None,
         None,
     )
-    .unwrap();
+    .expect_err("missing captured evidence should fail closed");
 
-    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
-    assert_eq!(memories.len(), 1);
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    let candidate_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    assert!(err.to_string().contains("missing captured evidence"));
+    assert_eq!(memory_count, 0);
+    assert_eq!(candidate_count, 0);
+    Ok(())
+}
+
+#[test]
+fn test_summary_candidate_content_keeps_compact_context() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-content";
+    let project = "test/proj";
+    record_summary_evidence(&conn, session_id, project)?;
+
+    promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Fix search"),
+        Some("Switched from unicode61 to trigram tokenizer for better CJK support"),
+        None,
+        None,
+    )?;
+
+    let text: String =
+        conn.query_row("SELECT text FROM memory_candidates", [], |row| row.get(0))?;
     assert!(
-        !memories[0].text.contains("**Request**"),
-        "content should not have boilerplate: {}",
-        memories[0].text
+        !text.contains("**Request**"),
+        "content should not have boilerplate: {text}"
     );
     assert!(
-        memories[0].text.contains("[Context:"),
-        "content should have compact context: {}",
-        memories[0].text
+        text.contains("[Context:"),
+        "content should have compact context: {text}"
     );
+    Ok(())
 }
 
 #[test]
@@ -190,40 +252,4 @@ fn test_content_hash_dedup() {
 
     let hash3 = content_hash("Switch to WAL mode for concurrent reads");
     assert_ne!(hash1, hash3);
-}
-
-#[test]
-fn test_cross_session_dedup() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    setup_memory_schema(&conn);
-
-    let decision = "Use FTS5 trigram tokenizer for CJK text search support";
-    promote_summary_to_memories(
-        &conn,
-        "session-1",
-        "test/proj",
-        Some("Optimize search"),
-        Some(decision),
-        None,
-        None,
-    )
-    .unwrap();
-
-    promote_summary_to_memories(
-        &conn,
-        "session-2",
-        "test/proj",
-        Some("Database performance tuning"),
-        Some(decision),
-        None,
-        None,
-    )
-    .unwrap();
-
-    let memories = crate::memory::get_recent_memories(&conn, "test/proj", 10).unwrap();
-    assert_eq!(
-        memories.len(),
-        1,
-        "same decision should dedup across sessions"
-    );
 }

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -78,13 +78,20 @@ struct ObservationBatch {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(super) struct ParsedMemoryCandidate {
-    pub(super) scope: String,
-    pub(super) memory_type: String,
-    pub(super) topic_key: String,
-    pub(super) text: String,
-    pub(super) confidence: f64,
-    pub(super) risk_class: String,
+pub(crate) struct ParsedMemoryCandidate {
+    pub(crate) scope: String,
+    pub(crate) memory_type: String,
+    pub(crate) topic_key: String,
+    pub(crate) text: String,
+    pub(crate) confidence: f64,
+    pub(crate) risk_class: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct CandidatePersistSummary {
+    pub(crate) candidates: usize,
+    pub(crate) promoted: usize,
+    pub(crate) pending_review: usize,
 }
 
 pub(crate) async fn process(task: &db::ExtractionTask) -> Result<MemoryCandidateResult> {
@@ -233,24 +240,79 @@ fn persist_candidates(
     task: &db::ExtractionTask,
     batch: &ObservationBatch,
     candidates: &[ParsedMemoryCandidate],
-) -> Result<PersistSummary> {
-    let evidence_json = serde_json::to_string(&batch.evidence_event_ids)?;
+) -> Result<CandidatePersistSummary> {
+    let route_texts = batch
+        .observations
+        .iter()
+        .map(|observation| observation.text.as_str())
+        .collect::<Vec<_>>();
+    persist_candidate_rows(
+        conn,
+        CandidatePersistSource {
+            project_id: task.project_id,
+            project: &task.project,
+            session_id: task.session_id.as_deref(),
+            evidence_event_ids: &batch.evidence_event_ids,
+            route_texts,
+        },
+        candidates,
+        Some(batch),
+    )
+}
+
+pub(crate) fn persist_summary_candidates(
+    conn: &mut Connection,
+    session_id: &str,
+    project_id: i64,
+    project: &str,
+    evidence_event_ids: &[i64],
+    candidates: &[ParsedMemoryCandidate],
+) -> Result<CandidatePersistSummary> {
+    let route_texts = candidates
+        .iter()
+        .map(|candidate| candidate.text.as_str())
+        .collect::<Vec<_>>();
+    persist_candidate_rows(
+        conn,
+        CandidatePersistSource {
+            project_id,
+            project,
+            session_id: Some(session_id),
+            evidence_event_ids,
+            route_texts,
+        },
+        candidates,
+        None,
+    )
+}
+
+struct CandidatePersistSource<'a> {
+    project_id: i64,
+    project: &'a str,
+    session_id: Option<&'a str>,
+    evidence_event_ids: &'a [i64],
+    route_texts: Vec<&'a str>,
+}
+
+fn persist_candidate_rows(
+    conn: &mut Connection,
+    source: CandidatePersistSource<'_>,
+    candidates: &[ParsedMemoryCandidate],
+    auto_promote_batch: Option<&ObservationBatch>,
+) -> Result<CandidatePersistSummary> {
+    let evidence_json = serde_json::to_string(source.evidence_event_ids)?;
     let tx = conn.transaction()?;
-    let mut summary = PersistSummary::default();
+    let mut summary = CandidatePersistSummary::default();
     for candidate in candidates {
-        if candidate_exists(&tx, task.project_id, candidate)? {
+        if candidate_exists(&tx, source.project_id, candidate)? {
             continue;
         }
 
-        let observation_texts = batch
-            .observations
-            .iter()
-            .map(|observation| observation.text.as_str());
         let route = route_candidate(
-            &task.project,
-            task.session_id.as_deref(),
+            source.project,
+            source.session_id,
             candidate,
-            observation_texts,
+            source.route_texts.iter().copied(),
         );
         let review_status = "pending_review";
         let now = chrono::Utc::now().timestamp();
@@ -263,7 +325,7 @@ fn persist_candidates(
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10,
                      ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
             params![
-                task.project_id,
+                source.project_id,
                 candidate.scope,
                 candidate.memory_type,
                 candidate.topic_key,
@@ -273,7 +335,7 @@ fn persist_candidates(
                 candidate.risk_class,
                 review_status,
                 now,
-                task.project,
+                source.project,
                 route.target_project.as_deref(),
                 route.owner_scope,
                 route.owner_key,
@@ -286,9 +348,18 @@ fn persist_candidates(
         let candidate_id = tx.last_insert_rowid();
         summary.candidates += 1;
 
-        if should_auto_promote(candidate, batch, &route, &evidence_json) {
-            let outcome =
-                promote_task_candidate(&tx, task, candidate_id, candidate, &evidence_json, &route)?;
+        if auto_promote_batch
+            .is_some_and(|batch| should_auto_promote(candidate, batch, &route, &evidence_json))
+        {
+            let outcome = promote_source_candidate(
+                &tx,
+                source.session_id,
+                source.project,
+                candidate_id,
+                candidate,
+                &evidence_json,
+                &route,
+            )?;
             update_candidate_after_lifecycle(
                 &tx,
                 candidate_id,
@@ -305,13 +376,6 @@ fn persist_candidates(
     }
     tx.commit()?;
     Ok(summary)
-}
-
-#[derive(Default)]
-struct PersistSummary {
-    candidates: usize,
-    promoted: usize,
-    pending_review: usize,
 }
 
 fn candidate_exists(
@@ -341,9 +405,10 @@ fn candidate_exists(
     Ok(existing.is_some())
 }
 
-fn promote_task_candidate(
+fn promote_source_candidate(
     conn: &Connection,
-    task: &db::ExtractionTask,
+    session_id: Option<&str>,
+    project: &str,
     candidate_id: i64,
     candidate: &ParsedMemoryCandidate,
     evidence_json: &str,
@@ -351,8 +416,8 @@ fn promote_task_candidate(
 ) -> Result<CandidateApplyOutcome> {
     promote_candidate_to_memory_with_route(
         conn,
-        task.session_id.as_deref(),
-        &task.project,
+        session_id,
+        project,
         candidate_id,
         candidate,
         evidence_json,

--- a/src/summarize/summary_job/persist.rs
+++ b/src/summarize/summary_job/persist.rs
@@ -117,7 +117,7 @@ pub(super) fn finalize_summary(
         }
     }
 
-    if let Err(err) = crate::memory::promote_summary_to_memories(
+    if let Err(err) = crate::memory::promote_summary_to_memory_candidates(
         conn,
         session_id,
         project,
@@ -126,10 +126,13 @@ pub(super) fn finalize_summary(
         summary.learned.as_deref(),
         summary.preferences.as_deref(),
     ) {
-        crate::log::warn("summary-job", &format!("memory promotion failed: {}", err));
+        crate::log::warn(
+            "summary-job",
+            &format!("memory candidate promotion failed: {}", err),
+        );
         db::clear_summarize_cooldown_for_message(conn, project, msg_hash)
-            .context("failed to clear summary retry marker after memory promotion failure")?;
-        return Err(err).context("memory promotion failed");
+            .context("failed to clear summary retry marker after memory candidate failure")?;
+        return Err(err).context("memory candidate promotion failed");
     }
     Ok(())
 }
@@ -247,17 +250,34 @@ mod tests {
         Ok(conn)
     }
 
+    fn record_summary_evidence(conn: &Connection, session_id: &str, project: &str) -> Result<i64> {
+        let outcome = db::record_captured_event(
+            conn,
+            &db::CaptureEventInput {
+                host: "codex-cli",
+                session_id,
+                project,
+                cwd: Some(project),
+                event_type: "session_stop",
+                role: None,
+                tool_name: None,
+                content: "summary source payload",
+                task_kind: Some(db::ExtractionTaskKind::SessionRollup),
+            },
+        )?;
+        Ok(outcome.event_row_id)
+    }
+
     #[test]
-    fn promotion_failure_releases_lock_and_clears_retry_marker() -> Result<()> {
+    fn candidate_failure_releases_lock_and_clears_retry_marker() -> Result<()> {
         let mut conn = setup_conn()?;
 
-        let project = "proj/promotion-failure";
+        let project = "proj/candidate-failure";
         let session_id = "content-session-1";
         let memory_sid = "memory-session-1";
         let msg_hash = "message-hash-1";
 
         assert!(db::try_acquire_summarize_lock(&mut conn, project, 60)?);
-        conn.execute_batch("DROP TABLE memories;")?;
 
         let err = finalize_summary(
             &mut conn,
@@ -281,10 +301,11 @@ mod tests {
                 workstream_blockers: None,
             },
         )
-        .expect_err("promotion failure should surface to the worker");
+        .expect_err("missing candidate evidence should surface to the worker");
 
         assert!(
-            err.to_string().contains("memory promotion failed"),
+            err.to_string()
+                .contains("memory candidate promotion failed"),
             "unexpected error: {err:#}"
         );
 
@@ -303,6 +324,136 @@ mod tests {
             !db::is_duplicate_message(&conn, project, msg_hash)?,
             "duplicate marker should not suppress retry after promotion failure"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn finalize_summary_creates_candidates_without_active_memories() -> Result<()> {
+        let mut conn = setup_conn()?;
+        let project = "test/proj";
+        let session_id = "summary-candidate-session";
+        let memory_sid = "mem-summary-candidate";
+        let evidence_id = record_summary_evidence(&conn, session_id, project)?;
+
+        finalize_summary(
+            &mut conn,
+            session_id,
+            memory_sid,
+            project,
+            "hash-summary-candidate",
+            ParsedSummary {
+                request: Some("Repair summary memory governance".to_string()),
+                completed: Some("Saved summary row".to_string()),
+                decisions: Some(
+                    "Use memory candidates for summary-derived durable decisions".to_string(),
+                ),
+                learned: Some(
+                    "FTS5 trigram tokenizer handles CJK search without word boundaries".to_string(),
+                ),
+                next_steps: None,
+                preferences: Some(
+                    "Always review summary-derived preferences before activation".to_string(),
+                ),
+                workstream: None,
+                workstream_progress: None,
+                workstream_next: None,
+                workstream_blockers: None,
+            },
+        )?;
+
+        let memory_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+        let candidate_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(memory_count, 0);
+        assert_eq!(candidate_count, 3);
+
+        let rows = conn
+            .prepare(
+                "SELECT memory_type, review_status, evidence_event_ids,
+                        source_project, owner_scope, owner_key
+                 FROM memory_candidates
+                 ORDER BY id ASC",
+            )?
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        let evidence_json = serde_json::to_string(&vec![evidence_id])?;
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "decision".to_string(),
+                    "pending_review".to_string(),
+                    evidence_json.clone(),
+                    project.to_string(),
+                    "repo".to_string(),
+                    project.to_string()
+                ),
+                (
+                    "discovery".to_string(),
+                    "pending_review".to_string(),
+                    evidence_json.clone(),
+                    project.to_string(),
+                    "repo".to_string(),
+                    project.to_string()
+                ),
+                (
+                    "preference".to_string(),
+                    "pending_review".to_string(),
+                    evidence_json,
+                    project.to_string(),
+                    "repo".to_string(),
+                    project.to_string()
+                )
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn finalize_summary_with_no_durable_candidates_does_not_require_evidence() -> Result<()> {
+        let mut conn = setup_conn()?;
+
+        finalize_summary(
+            &mut conn,
+            "summary-no-candidates",
+            "mem-summary-no-candidates",
+            "test/proj",
+            "hash-summary-no-candidates",
+            ParsedSummary {
+                request: Some("Tiny update".to_string()),
+                completed: Some("Done".to_string()),
+                decisions: Some("Short".to_string()),
+                learned: Some("Also short".to_string()),
+                next_steps: None,
+                preferences: None,
+                workstream: None,
+                workstream_progress: None,
+                workstream_next: None,
+                workstream_blockers: None,
+            },
+        )?;
+
+        let memory_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+        let candidate_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(memory_count, 0);
+        assert_eq!(candidate_count, 0);
         Ok(())
     }
 

--- a/tests/bench_fixtures.rs
+++ b/tests/bench_fixtures.rs
@@ -31,6 +31,76 @@ pub fn setup_full_schema(conn: &Connection) -> Result<()> {
             created_at_epoch INTEGER NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS hosts (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            created_at_epoch INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS workspaces (
+            id INTEGER PRIMARY KEY,
+            root_path TEXT NOT NULL UNIQUE,
+            git_remote TEXT,
+            git_branch TEXT,
+            created_at_epoch INTEGER NOT NULL,
+            updated_at_epoch INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS projects (
+            id INTEGER PRIMARY KEY,
+            workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+            project_path TEXT NOT NULL,
+            project_key TEXT NOT NULL,
+            created_at_epoch INTEGER NOT NULL,
+            updated_at_epoch INTEGER NOT NULL,
+            UNIQUE(workspace_id, project_path)
+        );
+
+        CREATE TABLE IF NOT EXISTS sessions (
+            id INTEGER PRIMARY KEY,
+            host_id INTEGER NOT NULL REFERENCES hosts(id),
+            workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+            project_id INTEGER NOT NULL REFERENCES projects(id),
+            session_id TEXT NOT NULL,
+            started_at_epoch INTEGER,
+            last_seen_at_epoch INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            UNIQUE(host_id, project_id, session_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS event_blobs (
+            id INTEGER PRIMARY KEY,
+            content_hash TEXT NOT NULL UNIQUE,
+            content_encoding TEXT NOT NULL,
+            content_bytes BLOB NOT NULL,
+            original_bytes INTEGER NOT NULL,
+            stored_bytes INTEGER NOT NULL,
+            created_at_epoch INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS captured_events (
+            id INTEGER PRIMARY KEY,
+            host_id INTEGER NOT NULL REFERENCES hosts(id),
+            workspace_id INTEGER NOT NULL REFERENCES workspaces(id),
+            project_id INTEGER NOT NULL REFERENCES projects(id),
+            session_row_id INTEGER NOT NULL REFERENCES sessions(id),
+            session_id TEXT NOT NULL,
+            turn_id TEXT,
+            event_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            role TEXT,
+            tool_name TEXT,
+            content_text TEXT,
+            content_blob_id INTEGER REFERENCES event_blobs(id),
+            content_hash TEXT NOT NULL,
+            token_estimate INTEGER NOT NULL DEFAULT 0,
+            retention_class TEXT NOT NULL,
+            created_at_epoch INTEGER NOT NULL,
+            inserted_at_epoch INTEGER NOT NULL,
+            UNIQUE(host_id, session_id, event_id)
+        );
+
         CREATE TABLE IF NOT EXISTS memories (
             id INTEGER PRIMARY KEY,
             session_id TEXT,
@@ -154,6 +224,34 @@ pub fn setup_full_schema(conn: &Connection) -> Result<()> {
             lease_owner TEXT,
             lease_expires_epoch INTEGER
         );
+
+        CREATE TABLE IF NOT EXISTS memory_candidates (
+            id INTEGER PRIMARY KEY,
+            project_id INTEGER REFERENCES projects(id),
+            scope TEXT NOT NULL,
+            memory_type TEXT NOT NULL,
+            topic_key TEXT NOT NULL,
+            text TEXT NOT NULL,
+            evidence_event_ids TEXT NOT NULL,
+            confidence REAL NOT NULL,
+            risk_class TEXT NOT NULL,
+            review_status TEXT NOT NULL,
+            created_at_epoch INTEGER NOT NULL,
+            updated_at_epoch INTEGER NOT NULL,
+            source_project TEXT,
+            target_project TEXT,
+            owner_scope TEXT,
+            owner_key TEXT,
+            topic_domain TEXT,
+            routing_confidence REAL,
+            routing_reason TEXT,
+            context_class TEXT,
+            expires_at_epoch INTEGER,
+            valid_from_epoch INTEGER,
+            valid_to_epoch INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_memory_candidates_dedupe
+            ON memory_candidates(project_id, scope, memory_type, topic_key, text);
 
         CREATE TABLE IF NOT EXISTS workstreams (
             id INTEGER PRIMARY KEY,

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -8,10 +8,10 @@
 mod bench_fixtures;
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::Connection;
 
 use remem::{
-    memory,
+    db, memory,
     retrieval::{entity, search, search_multihop},
     summarize,
 };
@@ -76,8 +76,8 @@ fn bench_memory_capture_rate() -> Result<()> {
             if event.event_type == "file_edit" && event.detail.is_some() {
                 total_meaningful += 1;
 
-                // Simulate promotion: insert as memory (in production this is done
-                // by summary → promote_summary_to_memories)
+                // Simulate active memory after review. Summary-derived facts now
+                // enter the candidate lifecycle before activation.
                 memory::insert_memory(
                     &conn,
                     Some(&session.session_id),
@@ -691,23 +691,31 @@ fn bench_summary_parse_partial() -> Result<()> {
 }
 
 #[test]
-fn bench_summary_promote_creates_memories() -> Result<()> {
-    let conn = Connection::open_in_memory()?;
+fn bench_summary_promote_creates_candidates() -> Result<()> {
+    let mut conn = Connection::open_in_memory()?;
     setup_full_schema(&conn)?;
 
     let session_id = "promote-test-001";
     let project = "tools/remem";
 
-    // Register session
-    conn.execute(
-        "INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at_epoch) \
-         VALUES (?1, ?1, ?2, ?3)",
-        params![session_id, project, chrono::Utc::now().timestamp()],
+    db::record_captured_event(
+        &conn,
+        &db::CaptureEventInput {
+            host: "codex-cli",
+            session_id,
+            project,
+            cwd: Some(project),
+            event_type: "session_stop",
+            role: None,
+            tool_name: None,
+            content: "summary source payload",
+            task_kind: None,
+        },
     )?;
 
-    // Promote fields to memories
-    memory::promote_summary_to_memories(
-        &conn,
+    // Summary-derived durable facts become reviewable candidates, not active memories.
+    memory::promote_summary_to_memory_candidates(
+        &mut conn,
         session_id,
         project,
         Some("Implement benchmark framework"),
@@ -716,53 +724,50 @@ fn bench_summary_promote_creates_memories() -> Result<()> {
         Some("Always run cargo check before cargo test"),
     )?;
 
-    // Verify memories were created
-    let all = memory::get_recent_memories(&conn, project, 50)?;
-
-    let decisions: Vec<_> = all.iter().filter(|m| m.memory_type == "decision").collect();
-    let discoveries: Vec<_> = all
-        .iter()
-        .filter(|m| m.memory_type == "discovery")
-        .collect();
-    let preferences: Vec<_> = all
-        .iter()
-        .filter(|m| m.memory_type == "preference")
-        .collect();
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    let decisions: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_candidates WHERE memory_type = 'decision'",
+        [],
+        |row| row.get(0),
+    )?;
+    let discoveries: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_candidates WHERE memory_type = 'discovery'",
+        [],
+        |row| row.get(0),
+    )?;
+    let preferences: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_candidates WHERE memory_type = 'preference'",
+        [],
+        |row| row.get(0),
+    )?;
 
     eprintln!(
-        "[Promote] total={} decisions={} discoveries={} preferences={}",
-        all.len(),
-        decisions.len(),
-        discoveries.len(),
-        preferences.len(),
+        "[Promote] active_memories={} decisions={} discoveries={} preferences={}",
+        memory_count, decisions, discoveries, preferences,
     );
 
+    assert_eq!(memory_count, 0, "Summaries must not write active memories");
     assert!(
-        !decisions.is_empty(),
-        "Decisions should be promoted to memories"
+        decisions > 0,
+        "Decisions should be promoted to memory candidates"
     );
     assert!(
-        !discoveries.is_empty(),
-        "Discoveries should be promoted to memories"
+        discoveries > 0,
+        "Discoveries should be promoted to memory candidates"
     );
-    assert!(
-        !preferences.is_empty(),
-        "Preferences should be promoted to memories"
-    );
+    assert!(preferences > 0, "Preferences should become candidates");
 
-    // Verify promoted preferences follow the current project-scope default.
-    let project_prefs: Vec<_> = preferences
-        .iter()
-        .filter(|m| m.scope == "project")
-        .collect();
-    eprintln!(
-        "[Promote] project preferences: {}/{}",
-        project_prefs.len(),
-        preferences.len()
-    );
+    let project_prefs: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_candidates
+         WHERE memory_type = 'preference' AND scope = 'project'",
+        [],
+        |row| row.get(0),
+    )?;
+    eprintln!("[Promote] project preference candidates: {project_prefs}/{preferences}");
     assert!(
-        !project_prefs.is_empty(),
-        "Promoted preferences should default to project scope"
+        project_prefs > 0,
+        "Preference candidates should default to project scope"
     );
 
     Ok(())


### PR DESCRIPTION
Closes #272.

## Summary
- Stop summary-derived durable facts from writing directly into active `memories`.
- Convert summary decisions, learned facts, lessons, and preferences into `pending_review` `memory_candidates` with source event evidence and owner routing metadata.
- Fail closed when a summary contains durable candidate material but has no captured evidence, while clearing the retry marker so the worker can retry.
- Keep non-durable summary/workstream persistence compatible when no candidate-worthy content exists.
- Update the benchmark scenario and lifecycle docs for summary candidate promotion.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo test memory::promote -- --nocapture`
- `cargo test summarize::summary_job::persist::tests -- --nocapture`
- `cargo test bench_summary_promote_creates_candidates -- --nocapture`
- `cargo test memory_candidate -- --nocapture`
- `cargo test`
