### PR TITLE
fix(memory): address P0/P1 audit regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.14"
+version = "0.4.15"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/db/crypto.rs
+++ b/src/db/crypto.rs
@@ -184,7 +184,10 @@ pub fn encrypt_database(key: &str) -> Result<()> {
         );
     }
     let conn = Connection::open(&db_file)?;
-    conn.execute_batch("PRAGMA busy_timeout=5000;")?;
+    // Enforce foreign keys so ON DELETE CASCADE / SET NULL behave during the
+    // sqlcipher_export copy; foreign_keys defaults to OFF on every new
+    // connection (#244).
+    conn.execute_batch("PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;")?;
     conn.execute(
         &format!(
             "ATTACH DATABASE '{}' AS encrypted KEY '{}'",

--- a/src/memory/raw_archive.rs
+++ b/src/memory/raw_archive.rs
@@ -33,13 +33,15 @@ fn exact_content_hash(content: &str) -> String {
     format!("{:016x}", crate::db::deterministic_hash(content.as_bytes()))
 }
 
-/// Insert one raw message. UNIQUE(project, role, content_hash) makes this
-/// idempotent across repeated Stop-hook drains of the same transcript.
+/// Insert one raw message. UNIQUE(project, session_id, role, content_hash)
+/// makes this idempotent across repeated Stop-hook drains of the same
+/// transcript while still preserving identical text spoken in different
+/// sessions (issue #237).
 /// Returns the row id of the existing or newly inserted message, or None
 /// when the content is empty.
 /// Outcome of a raw-message insert attempt.
 ///
-/// `inserted == false` means a row with the same `(project, role,
+/// `inserted == false` means a row with the same `(project, session_id, role,
 /// content_hash)` already existed and `id` points at the pre-existing row
 /// rather than a newly created one.
 #[derive(Debug, Clone, Copy)]
@@ -69,7 +71,7 @@ pub fn insert_raw_message(
         "INSERT INTO raw_messages \
          (session_id, project, role, content, content_hash, source, branch, cwd, created_at_epoch) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) \
-         ON CONFLICT(project, role, content_hash) DO NOTHING",
+         ON CONFLICT(project, session_id, role, content_hash) DO NOTHING",
         params![session_id, project, role, trimmed, hash, source, branch, cwd, now],
     )?;
 
@@ -80,8 +82,9 @@ pub fn insert_raw_message(
         }))
     } else {
         let existing: i64 = conn.query_row(
-            "SELECT id FROM raw_messages WHERE project = ?1 AND role = ?2 AND content_hash = ?3",
-            params![project, role, hash],
+            "SELECT id FROM raw_messages \
+             WHERE project = ?1 AND session_id = ?2 AND role = ?3 AND content_hash = ?4",
+            params![project, session_id, role, hash],
             |row| row.get(0),
         )?;
         Ok(Some(RawInsertOutcome {
@@ -270,7 +273,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_is_idempotent_per_project_role_content() {
+    fn insert_is_idempotent_per_session_role_content() {
         let conn = setup_conn();
         let id1 = insert_raw_message(
             &conn,
@@ -284,9 +287,10 @@ mod tests {
         )
         .unwrap()
         .expect("first insert returns Some");
+        // Same session + same text => deduped onto the existing row.
         let id2 = insert_raw_message(
             &conn,
-            "s2",
+            "s1",
             "/proj",
             ROLE_USER,
             "hello world",
@@ -303,6 +307,47 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    /// Regression for #237: the same text spoken in two different sessions must
+    /// keep BOTH turns. The old UNIQUE(project, role, content_hash) globally
+    /// deduped across sessions and silently dropped the second turn.
+    #[test]
+    fn identical_text_across_sessions_keeps_both_turns() {
+        let conn = setup_conn();
+        let id1 = insert_raw_message(
+            &conn,
+            "s1",
+            "/proj",
+            ROLE_USER,
+            "let's deploy the service",
+            SOURCE_HOOK,
+            None,
+            None,
+        )
+        .unwrap()
+        .expect("first insert returns Some");
+        let id2 = insert_raw_message(
+            &conn,
+            "s2",
+            "/proj",
+            ROLE_USER,
+            "let's deploy the service",
+            SOURCE_HOOK,
+            None,
+            None,
+        )
+        .unwrap()
+        .expect("second insert returns Some");
+
+        assert!(id1.inserted, "first session turn must be inserted");
+        assert!(id2.inserted, "second session turn must also be inserted");
+        assert_ne!(id1.id, id2.id, "the two sessions must keep distinct rows");
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "both session turns must be preserved");
     }
 
     #[test]

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -86,7 +86,7 @@ pub fn insert_memory_full(
                 conn.execute(
                     "UPDATE memories SET session_id = ?1, title = ?2, content = ?3, \
                      memory_type = ?4, files = ?5, updated_at_epoch = ?6, branch = ?7, \
-                     scope = ?8, search_context = ?9 WHERE id = ?10",
+                     scope = ?8, search_context = ?9, status = 'active' WHERE id = ?10",
                     params![
                         session_id,
                         title,

--- a/src/memory/store/write/tests.rs
+++ b/src/memory/store/write/tests.rs
@@ -38,6 +38,110 @@ fn test_topic_key_upsert() {
 }
 
 #[test]
+fn test_topic_key_upsert_reactivates_stale_row() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    let id1 = insert_memory(
+        &conn,
+        Some("s1"),
+        "test/proj",
+        Some("deploy-runbook"),
+        "Deploy runbook v1",
+        "Old steps.",
+        "procedure",
+        None,
+    )
+    .unwrap();
+
+    // Simulate the row aging out (e.g. via cleanup) into a non-active state.
+    conn.execute(
+        "UPDATE memories SET status = 'stale' WHERE id = ?1",
+        params![id1],
+    )
+    .unwrap();
+
+    // The same topic_key is upserted with fresh content.
+    let id2 = insert_memory(
+        &conn,
+        Some("s2"),
+        "test/proj",
+        Some("deploy-runbook"),
+        "Deploy runbook v2",
+        "New steps after fix.",
+        "procedure",
+        None,
+    )
+    .unwrap();
+    assert_eq!(id1, id2);
+
+    // The row must be reactivated so the updated content is visible again.
+    let status: String = conn
+        .query_row(
+            "SELECT status FROM memories WHERE id = ?1",
+            params![id1],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "active");
+
+    let memories = get_recent_memories(&conn, "test/proj", 10).unwrap();
+    assert_eq!(memories.len(), 1);
+    assert_eq!(memories[0].title, "Deploy runbook v2");
+    assert_eq!(memories[0].text, "New steps after fix.");
+}
+
+#[test]
+fn test_topic_key_upsert_reactivates_archived_row() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    let id1 = insert_memory(
+        &conn,
+        Some("s1"),
+        "test/proj",
+        Some("api-token-rotation"),
+        "Token rotation v1",
+        "Original notes.",
+        "decision",
+        None,
+    )
+    .unwrap();
+
+    conn.execute(
+        "UPDATE memories SET status = 'archived' WHERE id = ?1",
+        params![id1],
+    )
+    .unwrap();
+
+    let id2 = insert_memory(
+        &conn,
+        Some("s2"),
+        "test/proj",
+        Some("api-token-rotation"),
+        "Token rotation v2",
+        "Rotation now automated.",
+        "decision",
+        None,
+    )
+    .unwrap();
+    assert_eq!(id1, id2);
+
+    let status: String = conn
+        .query_row(
+            "SELECT status FROM memories WHERE id = ?1",
+            params![id1],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "active");
+
+    let memories = get_recent_memories(&conn, "test/proj", 10).unwrap();
+    assert_eq!(memories.len(), 1);
+    assert_eq!(memories[0].title, "Token rotation v2");
+}
+
+#[test]
 fn test_created_at_override() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -104,6 +104,39 @@ impl MemoryType {
             .copied()
             .find(|memory_type| memory_type.as_str() == value)
     }
+
+    /// Map a raw observation_type (the legal observation vocabulary lives in
+    /// `crate::db::models::OBSERVATION_TYPES`: bugfix/feature/refactor/discovery/
+    /// decision/change) onto the candidate `MemoryType` it can support.
+    ///
+    /// The candidate vocabulary and the observation vocabulary are different
+    /// word lists, so a raw string-equality comparison between them is wrong:
+    /// `architecture` is a valid candidate type but never a valid observation
+    /// type, so an architecture candidate could never be matched and could
+    /// never auto-promote. `feature`/`refactor`/`change` observations all
+    /// describe project discoveries, so they collapse onto `Discovery`.
+    pub fn from_observation_type(observation_type: &str) -> Option<Self> {
+        match observation_type.trim().to_ascii_lowercase().as_str() {
+            "bugfix" => Some(Self::Bugfix),
+            "decision" => Some(Self::Decision),
+            "discovery" | "feature" | "refactor" | "change" => Some(Self::Discovery),
+            _ => None,
+        }
+    }
+
+    /// Whether an observation of `observation_type` can serve as supporting
+    /// evidence for a candidate of `self`. Auto-promotable candidate types are
+    /// matched to their observation equivalent; `Architecture` candidates have
+    /// no observation equivalent, so they accept `Discovery`-class evidence
+    /// (the closest project-knowledge observation class).
+    pub fn supports_observation_type(self, observation_type: &str) -> bool {
+        match Self::from_observation_type(observation_type) {
+            Some(mapped) => {
+                mapped == self || (self == Self::Architecture && mapped == Self::Discovery)
+            }
+            None => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -215,6 +248,36 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(MEMORY_TYPES, canonical.as_slice());
+    }
+
+    #[test]
+    fn architecture_candidate_accepts_discovery_class_observations() {
+        // architecture is a valid candidate type but never a valid observation
+        // type; it must accept discovery-class observation evidence.
+        assert!(MemoryType::Architecture.supports_observation_type("discovery"));
+        assert!(MemoryType::Architecture.supports_observation_type("feature"));
+        assert!(MemoryType::Architecture.supports_observation_type("refactor"));
+        assert!(MemoryType::Architecture.supports_observation_type("change"));
+        // but not unrelated classes
+        assert!(!MemoryType::Architecture.supports_observation_type("bugfix"));
+        assert!(!MemoryType::Architecture.supports_observation_type("decision"));
+    }
+
+    #[test]
+    fn auto_promote_types_match_their_observation_equivalents() {
+        assert!(MemoryType::Bugfix.supports_observation_type("bugfix"));
+        assert!(MemoryType::Decision.supports_observation_type("decision"));
+        assert!(MemoryType::Discovery.supports_observation_type("discovery"));
+        // feature/refactor/change all collapse onto discovery
+        assert!(MemoryType::Discovery.supports_observation_type("feature"));
+        assert!(MemoryType::Discovery.supports_observation_type("refactor"));
+        assert!(MemoryType::Discovery.supports_observation_type("change"));
+        // mismatches stay false
+        assert!(!MemoryType::Bugfix.supports_observation_type("decision"));
+        assert!(!MemoryType::Decision.supports_observation_type("discovery"));
+        // unknown observation type maps to nothing
+        assert!(MemoryType::from_observation_type("architecture").is_none());
+        assert!(MemoryType::from_observation_type("nonsense").is_none());
     }
 
     #[test]

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -371,6 +371,18 @@ fn persist_candidate_rows(
                 summary.promoted += 1;
             }
         } else {
+            crate::log::warn(
+                "memory-candidate",
+                &format!(
+                    "candidate routed to pending_review: id={} type={} scope={} risk={} confidence={:.2} reason={}",
+                    candidate_id,
+                    candidate.memory_type,
+                    candidate.scope,
+                    candidate.risk_class,
+                    candidate.confidence,
+                    auto_promote_block_reason(candidate, auto_promote_batch, &route, &evidence_json)
+                ),
+            );
             summary.pending_review += 1;
         }
     }
@@ -446,6 +458,48 @@ fn has_evidence_ids(evidence_json: &str) -> bool {
     serde_json::from_str::<Vec<i64>>(evidence_json).is_ok_and(|ids| !ids.is_empty())
 }
 
+/// Explain why a candidate did not auto-promote, mirroring the checks in
+/// `should_auto_promote`. Used for observability when a candidate is routed to
+/// pending_review (U-29: a downgrade with user-visible effect must be logged).
+fn auto_promote_block_reason(
+    candidate: &ParsedMemoryCandidate,
+    batch: Option<&ObservationBatch>,
+    route: &CandidateRoute,
+    evidence_json: &str,
+) -> &'static str {
+    if candidate.scope != "project" {
+        return "scope_not_project";
+    }
+    if candidate.risk_class != "low" {
+        return "risk_class_not_low";
+    }
+    if candidate.confidence < AUTO_PROMOTE_MIN_CONFIDENCE {
+        return "confidence_below_threshold";
+    }
+    if !route.is_repo_owned() {
+        return "route_not_repo_owned";
+    }
+    if route.routing_confidence < AUTO_PROMOTE_MIN_CONFIDENCE {
+        return "routing_confidence_below_threshold";
+    }
+    if !has_evidence_ids(evidence_json) {
+        return "missing_evidence_ids";
+    }
+    if !MemoryType::parse(&candidate.memory_type).is_some_and(MemoryType::auto_promote) {
+        return "memory_type_not_auto_promotable";
+    }
+    if contains_auto_promote_unsafe_marker(&candidate.text) {
+        return "contains_unsafe_marker";
+    }
+    let Some(batch) = batch else {
+        return "missing_source_observation_batch";
+    };
+    if !is_supported_by_source_observation(candidate, batch) {
+        return "no_supporting_source_observation";
+    }
+    "unknown"
+}
+
 fn is_supported_by_source_observation(
     candidate: &ParsedMemoryCandidate,
     batch: &ObservationBatch,
@@ -454,9 +508,12 @@ fn is_supported_by_source_observation(
     if candidate_text.chars().count() < 24 {
         return false;
     }
+    let Some(candidate_type) = MemoryType::parse(&candidate.memory_type) else {
+        return false;
+    };
     batch.observations.iter().any(|observation| {
         observation.confidence >= AUTO_PROMOTE_MIN_OBSERVATION_CONFIDENCE
-            && observation.observation_type == candidate.memory_type
+            && candidate_type.supports_observation_type(&observation.observation_type)
             && normalize_evidence_text(&observation.text).contains(&candidate_text)
     })
 }
@@ -515,4 +572,6 @@ fn build_candidate_prompt(task: &db::ExtractionTask, batch: &ObservationBatch) -
 }
 
 #[cfg(test)]
-mod tests;
+pub(super) mod tests;
+#[cfg(test)]
+mod tests_autopromote;

--- a/src/memory_candidate/tests.rs
+++ b/src/memory_candidate/tests.rs
@@ -5,13 +5,13 @@ use crate::db::{self, record_captured_event, CaptureEventInput, ExtractionTaskKi
 
 use super::{process_with_generator, MemoryCandidateResult};
 
-fn setup_conn() -> Connection {
+pub(super) fn setup_conn() -> Connection {
     let conn = Connection::open_in_memory().expect("in-memory db should open");
     crate::migrate::run_migrations(&conn).expect("migrations should run");
     conn
 }
 
-fn setup_task(conn: &mut Connection, session_id: &str) -> Result<db::ExtractionTask> {
+pub(super) fn setup_task(conn: &mut Connection, session_id: &str) -> Result<db::ExtractionTask> {
     setup_task_with_project(conn, session_id, "/tmp/remem")
 }
 

--- a/src/memory_candidate/tests_autopromote.rs
+++ b/src/memory_candidate/tests_autopromote.rs
@@ -1,0 +1,156 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use crate::db;
+
+use super::tests::{setup_conn, setup_task};
+use super::{process_with_generator, MemoryCandidateResult};
+
+fn insert_source_observation_typed(
+    conn: &Connection,
+    task: &db::ExtractionTask,
+    observation_type: &str,
+    text: &str,
+) -> Result<()> {
+    let obs_id = db::insert_observation_with_branch(
+        conn,
+        "capture-observation-test",
+        &task.project,
+        observation_type,
+        Some("Typed observation"),
+        None,
+        Some(text),
+        None,
+        None,
+        None,
+        None,
+        None,
+        12,
+        None,
+        None,
+    )?;
+    let event_id = task.high_watermark_event_id.unwrap_or(1);
+    conn.execute(
+        "UPDATE observations
+         SET host_id = ?1,
+             project_id = ?2,
+             session_row_id = ?3,
+             observation_type = ?4,
+             text = ?5,
+             evidence_event_ids = ?6,
+             confidence = ?7
+         WHERE id = ?8",
+        params![
+            task.host_id,
+            task.project_id,
+            task.session_row_id,
+            observation_type,
+            text,
+            serde_json::to_string(&vec![event_id])?,
+            0.91,
+            obs_id
+        ],
+    )?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_auto_promotes_architecture_from_discovery_observation() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-architecture")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "discovery",
+        "The extraction worker uses a single-writer SQLite connection per process.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>architecture</type><topic_key>architecture-worker-db</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>The extraction worker uses a single-writer SQLite connection per process.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0
+        }
+    );
+    let (memory_type, review_status): (String, String) = conn.query_row(
+        "SELECT memory_type, review_status FROM memory_candidates",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(memory_type, "architecture");
+    assert_eq!(review_status, "auto_promoted");
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    assert_eq!(memory_count, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_auto_promotes_discovery_from_feature_observation() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-feature")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "Added a structured retrieval gate that scores candidates before promotion.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>discovery</type><topic_key>discovery-retrieval-gate</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>Added a structured retrieval gate that scores candidates before promotion.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0
+        }
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(review_status, "auto_promoted");
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_keeps_architecture_unsupported_by_bugfix_pending() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-architecture-bugfix")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "bugfix",
+        "The extraction worker uses a single-writer SQLite connection per process.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>architecture</type><topic_key>architecture-worker-db</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>The extraction worker uses a single-writer SQLite connection per process.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1
+        }
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(review_status, "pending_review");
+    Ok(())
+}

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -5,6 +5,8 @@ mod state;
 mod tests;
 #[cfg(test)]
 mod tests_convergence;
+#[cfg(test)]
+mod tests_schema;
 mod transition;
 mod types;
 

--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -19,9 +19,18 @@ pub(crate) fn run_migrations(conn: &Connection) -> Result<()> {
         }
         Err(error) => {
             if let Err(rollback_error) = conn.execute_batch("ROLLBACK") {
-                crate::log::warn(
+                // A failed rollback can leave the database in a partially-migrated
+                // state, so this is never a benign warning (U-29). Surface it at
+                // error level and keep both error chains.
+                crate::log::error(
                     "migrate",
-                    &format!("rollback failed after migration error: {rollback_error}"),
+                    &format!(
+                        "rollback failed after migration error: {rollback_error}; \
+                         original migration error: {error:#}"
+                    ),
+                );
+                return Err(
+                    error.context(format!("migration rollback also failed: {rollback_error}"))
                 );
             }
             Err(error)
@@ -63,11 +72,19 @@ fn run_migrations_locked(conn: &Connection) -> Result<()> {
         );
     }
 
-    let latest = super::latest_schema_version();
+    // Keep PRAGMA user_version consistent with what `_schema_migrations`
+    // actually records: derive it from the highest applied migration, not from
+    // the binary's latest known version. Using the binary version here would
+    // claim a schema level the database may not have reached if a later
+    // migration was never applied (#244).
+    let max_applied = applied_versions(conn)?
+        .into_iter()
+        .max()
+        .unwrap_or(OLD_BASELINE_VERSION);
     let current_user_version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap_or(0);
-    let user_version = current_user_version.max(OLD_BASELINE_VERSION - 1 + latest);
+    let user_version = current_user_version.max(OLD_BASELINE_VERSION - 1 + max_applied);
     conn.execute_batch(&format!("PRAGMA user_version = {}", user_version))?;
     Ok(())
 }

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -64,11 +64,11 @@ fn full_migration_on_empty_db() -> Result<()> {
     let applied = applied_versions(&conn)?;
     assert_eq!(
         applied,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,]
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 31);
+    assert_eq!(user_version, 33);
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -325,7 +325,7 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 31);
+    assert_eq!(user_version, 33);
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -365,7 +365,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 31);
+    assert_eq!(result.current_version, 33);
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())
@@ -715,257 +715,5 @@ fn memory_cols_all_present_after_migration() -> Result<()> {
         expected_cols
     );
 
-    Ok(())
-}
-
-#[test]
-fn memory_ownership_migration_backfills_legacy_rows() -> Result<()> {
-    let conn = Connection::open_in_memory()?;
-    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
-
-    for migration in MIGRATIONS.iter().filter(|migration| migration.version < 19) {
-        conn.execute_batch(migration.sql)?;
-    }
-    conn.execute_batch(
-        "CREATE TABLE _schema_migrations (
-            version INTEGER PRIMARY KEY,
-            name TEXT NOT NULL,
-            applied_at_epoch INTEGER NOT NULL
-        );",
-    )?;
-    for migration in MIGRATIONS.iter().filter(|migration| migration.version < 19) {
-        conn.execute(
-            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
-             VALUES (?1, ?2, ?3)",
-            params![migration.version, migration.name, 1_700_000_000_i64],
-        )?;
-    }
-
-    conn.execute(
-        "INSERT INTO memories
-         (id, session_id, project, topic_key, title, content, memory_type, files,
-          created_at_epoch, updated_at_epoch, status, branch, scope)
-         VALUES (1, 's1', '/repo', 'repo-fact', 'Repo fact', 'body', 'decision',
-          NULL, 100, 100, 'active', NULL, 'project')",
-        [],
-    )?;
-    conn.execute(
-        "INSERT INTO memories
-         (id, session_id, project, topic_key, title, content, memory_type, files,
-          created_at_epoch, updated_at_epoch, status, branch, scope)
-         VALUES (2, 's1', '/repo', 'global-pref', 'Global pref', 'body', 'preference',
-          NULL, 100, 100, 'active', NULL, 'global')",
-        [],
-    )?;
-    conn.execute(
-        "INSERT INTO workstreams
-         (id, project, title, description, status, progress, next_action, blockers,
-          created_at_epoch, updated_at_epoch, completed_at_epoch)
-         VALUES (1, '/repo', 'Ship feature', NULL, 'active', NULL, NULL, NULL,
-          100, 100, NULL)",
-        [],
-    )?;
-    conn.execute(
-        "INSERT INTO workspaces(id, root_path, git_remote, git_branch, created_at_epoch, updated_at_epoch)
-         VALUES (1, '/repo', NULL, NULL, 100, 100)",
-        [],
-    )?;
-    conn.execute(
-        "INSERT INTO projects(id, workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
-         VALUES (1, 1, '/repo', 'repo', 100, 100)",
-        [],
-    )?;
-    conn.execute(
-        "INSERT INTO memory_candidates
-         (id, project_id, scope, memory_type, topic_key, text, evidence_event_ids,
-          confidence, risk_class, review_status, created_at_epoch, updated_at_epoch)
-         VALUES (1, 1, 'project', 'decision', 'candidate-fact', 'body', '[1]',
-          0.9, 'low', 'pending_review', 100, 100)",
-        [],
-    )?;
-    conn.execute(
-        "INSERT INTO session_summaries
-         (id, memory_session_id, project, request, completed, decisions, learned,
-          next_steps, preferences, prompt_number, created_at, created_at_epoch,
-          discovery_tokens, project_id)
-         VALUES (1, 'm1', '/legacy-repo', 'req', 'done', '[]', '[]',
-          '[]', '[]', 1, 'now', 100, 0, 1)",
-        [],
-    )?;
-
-    run_migrations(&conn)?;
-
-    let memory: (String, Option<String>, String, String, String) = conn.query_row(
-        "SELECT source_project, target_project, owner_scope, owner_key, context_class
-         FROM memories WHERE id = 1",
-        [],
-        |row| {
-            Ok((
-                row.get(0)?,
-                row.get(1)?,
-                row.get(2)?,
-                row.get(3)?,
-                row.get(4)?,
-            ))
-        },
-    )?;
-    assert_eq!(
-        memory,
-        (
-            "/repo".to_string(),
-            Some("/repo".to_string()),
-            "repo".to_string(),
-            "/repo".to_string(),
-            "startup_core".to_string()
-        )
-    );
-
-    let global: (String, Option<String>, String, String) = conn.query_row(
-        "SELECT source_project, target_project, owner_scope, owner_key
-         FROM memories WHERE id = 2",
-        [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-    )?;
-    assert_eq!(
-        global,
-        (
-            "/repo".to_string(),
-            None,
-            "user".to_string(),
-            "user:default".to_string()
-        )
-    );
-
-    let candidate: (String, Option<String>, String, String) = conn.query_row(
-        "SELECT source_project, target_project, owner_scope, owner_key
-         FROM memory_candidates WHERE id = 1",
-        [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-    )?;
-    assert_eq!(
-        candidate,
-        (
-            "/repo".to_string(),
-            Some("/repo".to_string()),
-            "repo".to_string(),
-            "/repo".to_string()
-        )
-    );
-
-    let workstream: (String, String, String, String) = conn.query_row(
-        "SELECT source_project, target_project, owner_scope, owner_key
-         FROM workstreams WHERE id = 1",
-        [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-    )?;
-    assert_eq!(
-        workstream,
-        (
-            "/repo".to_string(),
-            "/repo".to_string(),
-            "repo".to_string(),
-            "/repo".to_string()
-        )
-    );
-
-    let summary: (
-        String,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        String,
-    ) = conn.query_row(
-        "SELECT source_project, target_project, owner_scope, owner_key, context_class
-         FROM session_summaries WHERE id = 1",
-        [],
-        |row| {
-            Ok((
-                row.get(0)?,
-                row.get(1)?,
-                row.get(2)?,
-                row.get(3)?,
-                row.get(4)?,
-            ))
-        },
-    )?;
-    assert_eq!(
-        summary,
-        (
-            "/repo".to_string(),
-            None,
-            None,
-            None,
-            "search_only".to_string()
-        )
-    );
-
-    Ok(())
-}
-
-#[test]
-fn memories_fts_active_filter_ignores_non_active_delete_and_update() -> Result<()> {
-    let conn = Connection::open_in_memory()?;
-    run_migrations(&conn)?;
-
-    conn.execute(
-        "INSERT INTO memories(id, project, title, content, memory_type, created_at_epoch,
-            updated_at_epoch, status)
-         VALUES (1, 'proj', 'stale title', 'stale body needle', 'discovery', 100, 100, 'stale')",
-        [],
-    )?;
-    conn.execute("DELETE FROM memories WHERE id = 1", [])?;
-
-    conn.execute(
-        "INSERT INTO memories(id, project, title, content, memory_type, created_at_epoch,
-            updated_at_epoch, status)
-         VALUES (2, 'proj', 'promoted title', 'promoted body needle', 'discovery', 100, 100, 'stale')",
-        [],
-    )?;
-    conn.execute(
-        "UPDATE memories SET status = 'active', updated_at_epoch = 200 WHERE id = 2",
-        [],
-    )?;
-    let active_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM memories_fts WHERE memories_fts MATCH 'promoted'",
-        [],
-        |row| row.get(0),
-    )?;
-    assert_eq!(active_count, 1);
-
-    conn.execute(
-        "UPDATE memories SET status = 'stale', updated_at_epoch = 300 WHERE id = 2",
-        [],
-    )?;
-    let stale_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM memories_fts WHERE memories_fts MATCH 'promoted'",
-        [],
-        |row| row.get(0),
-    )?;
-    assert_eq!(stale_count, 0);
-
-    Ok(())
-}
-
-#[test]
-fn run_migrations_rejects_db_newer_than_binary() -> Result<()> {
-    let conn = Connection::open_in_memory()?;
-    run_migrations(&conn)?;
-
-    // Simulate a future binary having recorded a v99 migration into this DB.
-    let now = chrono::Utc::now().timestamp();
-    conn.execute(
-        "INSERT INTO _schema_migrations (version, name, applied_at_epoch) VALUES (?1, ?2, ?3)",
-        rusqlite::params![99i64, "future_feature", now],
-    )?;
-
-    let err = run_migrations(&conn).expect_err("re-running on a newer DB must fail");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("v99")
-            && msg.contains(&format!("schema v{}", super::latest_schema_version()))
-            && msg.contains("remem --version")
-            && msg.contains("upgrade"),
-        "error should mention the newer schema, binary schema, and verification command: {msg}"
-    );
     Ok(())
 }

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -289,3 +289,58 @@ fn real_queries_work_on_upgraded_db() -> Result<()> {
 
     Ok(())
 }
+
+/// #244: PRAGMA user_version must stay consistent with the highest version
+/// recorded in _schema_migrations. Both a fresh DB and an upgraded legacy DB
+/// must report user_version == OLD_BASELINE_VERSION - 1 + max_applied.
+#[test]
+fn user_version_tracks_max_applied_migration() -> Result<()> {
+    let expected = super::types::OLD_BASELINE_VERSION - 1 + super::latest_schema_version();
+
+    for conn in [make_fresh_db()?, make_upgraded_v10_db()?] {
+        let max_applied = super::state::applied_versions(&conn)?
+            .into_iter()
+            .max()
+            .expect("at least one migration applied");
+        let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+
+        assert_eq!(
+            max_applied,
+            super::latest_schema_version(),
+            "all migrations must be recorded in _schema_migrations"
+        );
+        assert_eq!(
+            user_version, expected,
+            "user_version must equal OLD_BASELINE_VERSION-1 + max applied version"
+        );
+    }
+    Ok(())
+}
+
+/// #244: all known migrations must end up recorded in _schema_migrations after
+/// a legacy upgrade, so PRAGMA user_version (derived from the max applied
+/// version) cannot drift ahead of what was actually applied.
+#[test]
+fn legacy_upgrade_records_every_migration() -> Result<()> {
+    let conn = make_upgraded_v10_db()?;
+    let applied = super::state::applied_versions(&conn)?;
+    for migration in super::types::MIGRATIONS {
+        assert!(
+            applied.contains(&migration.version),
+            "migration v{} must be recorded after upgrade: {applied:?}",
+            migration.version
+        );
+    }
+    Ok(())
+}
+
+/// #244: foreign_keys must be ON for the runtime connection so ON DELETE
+/// CASCADE / SET NULL actually fire.
+#[test]
+fn open_db_enables_foreign_keys() -> Result<()> {
+    let _guard = crate::db::test_support::ScopedTestDataDir::new("fk-pragma");
+    let conn = crate::db::open_db()?;
+    let fk_on: i64 = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
+    assert_eq!(fk_on, 1, "open_db must enable PRAGMA foreign_keys");
+    Ok(())
+}

--- a/src/migrate/tests_schema.rs
+++ b/src/migrate/tests_schema.rs
@@ -1,0 +1,259 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use super::{run_migrations, MIGRATIONS};
+
+#[test]
+fn memory_ownership_migration_backfills_legacy_rows() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+
+    for migration in MIGRATIONS.iter().filter(|migration| migration.version < 19) {
+        conn.execute_batch(migration.sql)?;
+    }
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_epoch INTEGER NOT NULL
+        );",
+    )?;
+    for migration in MIGRATIONS.iter().filter(|migration| migration.version < 19) {
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, ?2, ?3)",
+            params![migration.version, migration.name, 1_700_000_000_i64],
+        )?;
+    }
+
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope)
+         VALUES (1, 's1', '/repo', 'repo-fact', 'Repo fact', 'body', 'decision',
+          NULL, 100, 100, 'active', NULL, 'project')",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope)
+         VALUES (2, 's1', '/repo', 'global-pref', 'Global pref', 'body', 'preference',
+          NULL, 100, 100, 'active', NULL, 'global')",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO workstreams
+         (id, project, title, description, status, progress, next_action, blockers,
+          created_at_epoch, updated_at_epoch, completed_at_epoch)
+         VALUES (1, '/repo', 'Ship feature', NULL, 'active', NULL, NULL, NULL,
+          100, 100, NULL)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO workspaces(id, root_path, git_remote, git_branch, created_at_epoch, updated_at_epoch)
+         VALUES (1, '/repo', NULL, NULL, 100, 100)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO projects(id, workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
+         VALUES (1, 1, '/repo', 'repo', 100, 100)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO memory_candidates
+         (id, project_id, scope, memory_type, topic_key, text, evidence_event_ids,
+          confidence, risk_class, review_status, created_at_epoch, updated_at_epoch)
+         VALUES (1, 1, 'project', 'decision', 'candidate-fact', 'body', '[1]',
+          0.9, 'low', 'pending_review', 100, 100)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO session_summaries
+         (id, memory_session_id, project, request, completed, decisions, learned,
+          next_steps, preferences, prompt_number, created_at, created_at_epoch,
+          discovery_tokens, project_id)
+         VALUES (1, 'm1', '/legacy-repo', 'req', 'done', '[]', '[]',
+          '[]', '[]', 1, 'now', 100, 0, 1)",
+        [],
+    )?;
+
+    run_migrations(&conn)?;
+
+    let memory: (String, Option<String>, String, String, String) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key, context_class
+         FROM memories WHERE id = 1",
+        [],
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        },
+    )?;
+    assert_eq!(
+        memory,
+        (
+            "/repo".to_string(),
+            Some("/repo".to_string()),
+            "repo".to_string(),
+            "/repo".to_string(),
+            "startup_core".to_string()
+        )
+    );
+
+    let global: (String, Option<String>, String, String) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key
+         FROM memories WHERE id = 2",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    assert_eq!(
+        global,
+        (
+            "/repo".to_string(),
+            None,
+            "user".to_string(),
+            "user:default".to_string()
+        )
+    );
+
+    let candidate: (String, Option<String>, String, String) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key
+         FROM memory_candidates WHERE id = 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    assert_eq!(
+        candidate,
+        (
+            "/repo".to_string(),
+            Some("/repo".to_string()),
+            "repo".to_string(),
+            "/repo".to_string()
+        )
+    );
+
+    let workstream: (String, String, String, String) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key
+         FROM workstreams WHERE id = 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    assert_eq!(
+        workstream,
+        (
+            "/repo".to_string(),
+            "/repo".to_string(),
+            "repo".to_string(),
+            "/repo".to_string()
+        )
+    );
+
+    let summary: (
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        String,
+    ) = conn.query_row(
+        "SELECT source_project, target_project, owner_scope, owner_key, context_class
+         FROM session_summaries WHERE id = 1",
+        [],
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        },
+    )?;
+    assert_eq!(
+        summary,
+        (
+            "/repo".to_string(),
+            None,
+            None,
+            None,
+            "search_only".to_string()
+        )
+    );
+
+    Ok(())
+}
+
+/// After v020 (#236) memories_fts indexes EVERY row regardless of status: the
+/// index-layer `WHERE status='active'` filter is gone, and visibility is now
+/// enforced only by the post-JOIN `m.status` predicate in fts.rs.
+#[test]
+fn memories_fts_indexes_all_statuses_after_v020() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    run_migrations(&conn)?;
+
+    conn.execute(
+        "INSERT INTO memories(id, project, title, content, memory_type, created_at_epoch,
+            updated_at_epoch, status)
+         VALUES (1, 'proj', 'stale title', 'stale body needle', 'discovery', 100, 100, 'stale')",
+        [],
+    )?;
+    let count_match = |needle: &str| -> Result<i64> {
+        Ok(conn.query_row(
+            "SELECT COUNT(*) FROM memories_fts WHERE memories_fts MATCH ?1",
+            [needle],
+            |row| row.get(0),
+        )?)
+    };
+    assert_eq!(
+        count_match("needle")?,
+        1,
+        "stale rows must enter memories_fts"
+    );
+
+    conn.execute(
+        "UPDATE memories SET status = 'active', updated_at_epoch = 200 WHERE id = 1",
+        [],
+    )?;
+    assert_eq!(count_match("needle")?, 1);
+    conn.execute(
+        "UPDATE memories SET status = 'archived', updated_at_epoch = 300 WHERE id = 1",
+        [],
+    )?;
+    assert_eq!(
+        count_match("needle")?,
+        1,
+        "archived rows stay indexed; visibility is a query-layer concern now"
+    );
+
+    conn.execute("DELETE FROM memories WHERE id = 1", [])?;
+    assert_eq!(count_match("needle")?, 0, "delete must remove the FTS row");
+
+    Ok(())
+}
+
+#[test]
+fn run_migrations_rejects_db_newer_than_binary() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    run_migrations(&conn)?;
+
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "INSERT INTO _schema_migrations (version, name, applied_at_epoch) VALUES (?1, ?2, ?3)",
+        params![99i64, "future_feature", now],
+    )?;
+
+    let err = run_migrations(&conn).expect_err("re-running on a newer DB must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("v99")
+            && msg.contains(&format!("schema v{}", super::latest_schema_version()))
+            && msg.contains("remem --version")
+            && msg.contains("upgrade"),
+        "error should mention the newer schema, binary schema, and verification command: {msg}"
+    );
+    Ok(())
+}

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -100,6 +100,16 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "memory_ownership",
         sql: include_str!("../migrations/v019_memory_ownership.sql"),
     },
+    Migration {
+        version: 20,
+        name: "memory_fts_all_status",
+        sql: include_str!("../migrations/v020_memory_fts_all_status.sql"),
+    },
+    Migration {
+        version: 21,
+        name: "raw_messages_session_dedup",
+        sql: include_str!("../migrations/v021_raw_messages_session_dedup.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v020_memory_fts_all_status.sql
+++ b/src/migrations/v020_memory_fts_all_status.sql
@@ -1,0 +1,43 @@
+-- v020_memory_fts_all_status: index ALL memory rows in memories_fts regardless of status.
+--
+-- Issue #236. The v012 triggers (inherited from v005, issue #70) only inserted rows
+-- WHERE status = 'active'. But fts.rs queries with `m.status IN ('active','stale','archived')`
+-- when include_inactive=true, so stale/archived rows never entered memories_fts and the
+-- JOIN dropped them — include_inactive searches on the bm25 path silently returned empty.
+--
+-- Fix: rebuild the triggers WITHOUT the status filter so every row is indexed. Visibility
+-- is now enforced purely by the post-JOIN `m.status` predicate in fts.rs
+-- (memory_status_filter_sql), which is the single source of truth for what callers see.
+
+DROP TRIGGER IF EXISTS memories_ai;
+DROP TRIGGER IF EXISTS memories_ad;
+DROP TRIGGER IF EXISTS memories_au;
+DROP TABLE IF EXISTS memories_fts;
+
+CREATE VIRTUAL TABLE memories_fts USING fts5(
+    title, content, search_context,
+    content='memories',
+    content_rowid='id',
+    tokenize='trigram'
+);
+
+CREATE TRIGGER memories_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, title, content, search_context)
+    VALUES (new.id, new.title, new.content, COALESCE(new.search_context, ''));
+END;
+
+CREATE TRIGGER memories_ad AFTER DELETE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, title, content, search_context)
+    VALUES ('delete', old.id, old.title, old.content, COALESCE(old.search_context, ''));
+END;
+
+CREATE TRIGGER memories_au AFTER UPDATE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, title, content, search_context)
+    VALUES ('delete', old.id, old.title, old.content, COALESCE(old.search_context, ''));
+    INSERT INTO memories_fts(rowid, title, content, search_context)
+    VALUES (new.id, new.title, new.content, COALESCE(new.search_context, ''));
+END;
+
+INSERT INTO memories_fts(rowid, title, content, search_context)
+SELECT id, title, content, COALESCE(search_context, '')
+FROM memories;

--- a/src/migrations/v021_raw_messages_session_dedup.sql
+++ b/src/migrations/v021_raw_messages_session_dedup.sql
@@ -1,0 +1,77 @@
+-- v021_raw_messages_session_dedup: add session_id to the raw_messages dedup key.
+--
+-- Issue #237. v002 declared UNIQUE(project, role, content_hash) — missing session_id.
+-- raw_archive.rs uses ON CONFLICT(project, role, content_hash) DO NOTHING, so the same
+-- text drained from two different sessions was globally deduped and the second session's
+-- turn was silently dropped. Raw archive must preserve every turn per session.
+--
+-- Fix: (1) collapse pre-existing duplicates down to the earliest row per
+-- (project, session_id, role, content_hash); (2) rebuild raw_messages with
+-- UNIQUE(project, session_id, role, content_hash). SQLite cannot alter a UNIQUE
+-- constraint in place, so the table is recreated and rows are copied over.
+
+-- (1) Delete duplicates that would survive global dedup but are distinct under the
+-- session-scoped key. Keep the earliest (smallest id) row in each session-scoped group.
+DELETE FROM raw_messages
+WHERE id NOT IN (
+    SELECT MIN(id)
+    FROM raw_messages
+    GROUP BY project, session_id, role, content_hash
+);
+
+-- (2) Rebuild the table with the corrected UNIQUE constraint.
+-- Drop FTS triggers first so the bulk copy does not double-fire them; the FTS table
+-- is rebuilt from the final row set below.
+DROP TRIGGER IF EXISTS raw_messages_ai;
+DROP TRIGGER IF EXISTS raw_messages_ad;
+DROP TRIGGER IF EXISTS raw_messages_au;
+
+ALTER TABLE raw_messages RENAME TO raw_messages_old;
+
+CREATE TABLE raw_messages (
+    id INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    project TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    source TEXT NOT NULL,
+    branch TEXT,
+    cwd TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    UNIQUE(project, session_id, role, content_hash)
+);
+
+INSERT INTO raw_messages
+    (id, session_id, project, role, content, content_hash, source, branch, cwd, created_at_epoch)
+SELECT id, session_id, project, role, content, content_hash, source, branch, cwd, created_at_epoch
+FROM raw_messages_old;
+
+DROP TABLE raw_messages_old;
+
+CREATE INDEX IF NOT EXISTS idx_raw_messages_project_created
+    ON raw_messages(project, created_at_epoch DESC);
+
+CREATE INDEX IF NOT EXISTS idx_raw_messages_session
+    ON raw_messages(session_id, created_at_epoch);
+
+-- Recreate FTS triggers (same bodies as v002).
+CREATE TRIGGER raw_messages_ai AFTER INSERT ON raw_messages BEGIN
+    INSERT INTO raw_messages_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+CREATE TRIGGER raw_messages_ad AFTER DELETE ON raw_messages BEGIN
+    INSERT INTO raw_messages_fts(raw_messages_fts, rowid, content)
+    VALUES ('delete', old.id, old.content);
+END;
+
+CREATE TRIGGER raw_messages_au AFTER UPDATE ON raw_messages BEGIN
+    INSERT INTO raw_messages_fts(raw_messages_fts, rowid, content)
+    VALUES ('delete', old.id, old.content);
+    INSERT INTO raw_messages_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+-- Rebuild the FTS index from the final row set.
+INSERT INTO raw_messages_fts(raw_messages_fts) VALUES ('delete-all');
+INSERT INTO raw_messages_fts(rowid, content)
+SELECT id, content FROM raw_messages;

--- a/src/retrieval/memory_search/fts.rs
+++ b/src/retrieval/memory_search/fts.rs
@@ -80,3 +80,73 @@ pub fn search_memories_fts_filtered(
     let rows = stmt.query_map(refs.as_slice(), map_memory_row_pub)?;
     crate::db::query::collect_rows(rows)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::migrate::run_migrations(&conn).unwrap();
+        conn
+    }
+
+    fn insert_memory(conn: &Connection, id: i64, body: &str, status: &str) {
+        conn.execute(
+            "INSERT INTO memories(id, project, title, content, memory_type, created_at_epoch,
+                updated_at_epoch, status)
+             VALUES (?1, 'proj', 'title', ?2, 'decision', 100, 100, ?3)",
+            rusqlite::params![id, body, status],
+        )
+        .unwrap();
+    }
+
+    /// Reproduction for #236: before v019 a stale row never entered memories_fts,
+    /// so the JOIN dropped it and include_inactive bm25 search returned empty.
+    #[test]
+    fn include_inactive_finds_stale_rows() {
+        let conn = setup_conn();
+        insert_memory(&conn, 1, "deprecated zookeeper approach", "stale");
+
+        // active-only search must hide the stale row
+        let active_only = search_memories_fts_filtered(
+            &conn,
+            "zookeeper",
+            Some("proj"),
+            None,
+            10,
+            0,
+            false,
+            None,
+        )
+        .unwrap();
+        assert!(
+            active_only.is_empty(),
+            "active-only search must hide stale rows: {active_only:?}"
+        );
+
+        // include_inactive must surface the stale row via the bm25 path
+        let with_inactive =
+            search_memories_fts_filtered(&conn, "zookeeper", Some("proj"), None, 10, 0, true, None)
+                .unwrap();
+        assert_eq!(
+            with_inactive.len(),
+            1,
+            "include_inactive must retrieve stale"
+        );
+        assert_eq!(with_inactive[0].status, "stale");
+    }
+
+    /// Active rows must remain retrievable on the default (active-only) path.
+    #[test]
+    fn active_path_still_finds_active_rows() {
+        let conn = setup_conn();
+        insert_memory(&conn, 1, "current kafka pipeline", "active");
+
+        let hits =
+            search_memories_fts_filtered(&conn, "kafka", Some("proj"), None, 10, 0, false, None)
+                .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].status, "active");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes five P0/P1 audit findings across memory persistence, search visibility, candidate promotion, and schema integrity:

- Closes #236: rebuilds `memories_fts` triggers so stale/archived rows are indexed; visibility stays enforced by query-layer status filters.
- Closes #237: changes raw archive dedupe from global `(project, role, content_hash)` to session-scoped `(project, session_id, role, content_hash)`.
- Closes #238: maps observation vocabulary to memory candidate vocabulary so architecture candidates can be supported by discovery-class observations.
- Closes #241: reactivates stale/archived rows when a topic-key upsert writes fresh content.
- Closes #244: keeps `_schema_migrations` and `PRAGMA user_version` consistent with the highest actually-applied migration, and preserves FK enforcement during encryption export.

Also bumps the crate version to `0.4.19` after merging latest `origin/main`, because the CI version gate requires binary-impacting PRs to increase `Cargo.toml` package.version.

## Notes

This branch has been merged with latest `origin/main` after the ownership/routing/governance eval work landed. The audit migrations now follow that work as:

- `v019_memory_ownership` from `main`
- `v020_memory_fts_all_status`
- `v021_raw_messages_session_dedup`

I did not change the legacy transition behavior that skips the old baseline. In this codebase that path intentionally applies remaining migrations after the partial baseline; the actual #244 consistency bug is fixed in `run_migrations()` by deriving `user_version` from max applied migration.

## Validation

- `git diff --check`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`

Latest local `cargo test` result: lib 697 passed / 0 failed, plus integration, benchmark, rate_limit, and doc tests all passed.
