### PR TITLE
Make startup context owner-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.14"
+version = "0.4.15"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@
 │  search              │  │  1. flush (batch→obs, ≤15/batch)  │
 │  get_observations    │  │  2. compress (>100→auto merge)     │
 │  timeline            │  │  3. summarize (session summary)    │
-│  timeline_report     │  │  4. promote (summary→memory)       │
+│  timeline_report     │  │  4. candidate (summary→review)      │
 │  save_memory         │  │                                    │
 │  workstreams         │  │  Timeout: 180s global limit        │
 │  update_workstream   │  │                                    │
@@ -269,7 +269,7 @@ Short-lived process model (each hook = independent process) cannot dedup via in-
 - **Model mapping**: `REMEM_MODEL=haiku` → `claude-haiku-4-5-20251001` (HTTP uses full ID, CLI uses short name)
 - **Codex model**: `REMEM_CODEX_MODEL` defaults to `gpt-5.2`; set `auto` to omit `--model` and use the Codex CLI default
 - **Timeouts**: Single AI call 90s, entire worker 180s
-- **4 prompts**: observation (capture), summary (session summary), compress (long-term compression), promote (summary→memory)
+- **4 prompts**: observation (capture), summary (session summary), compress (long-term compression), candidate extraction (summary→reviewable memory candidates)
 - **Usage ledger**: `ai_usage_events` stores model, operation, token breakdown, usage source, pricing source, and estimated USD cost
 - **Precision levels**: provider/log usage (`anthropic_usage`, `codex_log`) is preferred; `text_estimate` is kept only as a fallback and marked in reports
 
@@ -304,13 +304,13 @@ Memories have a `scope` field: `project` (default) or `global`.
 | `global` | All projects | Explicit opt-in only |
 
 **How it works automatically:**
-- When a session summary is promoted to memories, `preference` type defaults to `scope=project`
-- When Claude calls `save_memory(type="preference")`, scope defaults to `project`
-- All memory types stay project-scoped unless the caller explicitly requests `scope=global`
-- General memory retrieval still uses the overlay query `WHERE (project = ? OR scope = 'global')`
-- SessionStart preference rendering uses project preferences by default; global preference injection is disabled unless `REMEM_CONTEXT_PREFERENCE_GLOBAL_LIMIT` is set above `0`
+- Summary-derived durable facts become `memory_candidates`; they do not directly write active `memories`.
+- New active memory writes populate `source_project`, `target_project`, `owner_scope`, and `owner_key`.
+- SessionStart context uses owner-aware startup filters: repo-owned rows for the current repo, user-owned preferences, and legacy project rows only as a compatibility fallback.
+- Tool/domain-owned memories are excluded from startup context unless later task-aware retrieval explicitly asks for that owner class.
+- The context footer reports owner counts (`repo`, `user`, `tool`, `domain`, etc.), and `--debug` shows inclusion/exclusion reasons.
 
-Global preferences require deliberate action. Preferences learned in project A do not automatically appear in project B's SessionStart context.
+User preferences require explicit user/global ownership. Project preferences learned in project A do not automatically appear in project B's repo context.
 
 The `save_memory` MCP tool accepts an optional `scope` parameter for explicit control. The CLI supports `remem preferences add --global "text"` for manual global preferences.
 

--- a/docs/context-budget-design-2026-04-29.md
+++ b/docs/context-budget-design-2026-04-29.md
@@ -83,7 +83,7 @@ struct ContextLimits {
     session_limit: usize,               // default 5
     self_diagnostic_limit: usize,       // default 2
     preference_project_limit: usize,    // default 20
-    preference_global_limit: usize,     // default 0
+    preference_global_limit: usize,     // default 5 for owner_scope=user
     preference_char_limit: usize,       // default 1500
 }
 ```

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,6 +4,7 @@ mod host;
 mod injection_gate;
 mod invocation;
 mod memory_traits;
+mod ownership;
 mod policy;
 mod query;
 mod render;

--- a/src/context/ownership.rs
+++ b/src/context/ownership.rs
@@ -1,0 +1,170 @@
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct OwnerCounts {
+    pub repo: usize,
+    pub user: usize,
+    pub workspace: usize,
+    pub tool: usize,
+    pub domain: usize,
+    pub workstream: usize,
+    pub session: usize,
+    pub legacy: usize,
+    pub unknown: usize,
+}
+
+impl OwnerCounts {
+    pub(super) fn add_scope(&mut self, scope: Option<&str>) {
+        match scope.map(str::trim).filter(|scope| !scope.is_empty()) {
+            Some("repo") => self.repo += 1,
+            Some("user") => self.user += 1,
+            Some("workspace") => self.workspace += 1,
+            Some("tool") => self.tool += 1,
+            Some("domain") => self.domain += 1,
+            Some("workstream") => self.workstream += 1,
+            Some("session") => self.session += 1,
+            None => self.legacy += 1,
+            Some(_) => self.unknown += 1,
+        }
+    }
+
+    pub(super) fn add_repo(&mut self, count: usize) {
+        self.repo += count;
+    }
+
+    pub(super) fn add_user(&mut self, count: usize) {
+        self.user += count;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct OwnerMetadata {
+    pub source_project: Option<String>,
+    pub target_project: Option<String>,
+    pub owner_scope: Option<String>,
+    pub owner_key: Option<String>,
+    pub topic_domain: Option<String>,
+    pub context_class: Option<String>,
+}
+
+impl OwnerMetadata {
+    pub(super) fn from_memory_row(
+        row: &rusqlite::Row<'_>,
+        offset: usize,
+    ) -> rusqlite::Result<Self> {
+        Ok(Self {
+            source_project: row.get(offset)?,
+            target_project: row.get(offset + 1)?,
+            owner_scope: row.get(offset + 2)?,
+            owner_key: row.get(offset + 3)?,
+            topic_domain: row.get(offset + 4)?,
+            context_class: row.get(offset + 5)?,
+        })
+    }
+
+    fn scope(&self) -> Option<&str> {
+        self.owner_scope.as_deref()
+    }
+
+    fn key(&self) -> Option<&str> {
+        self.owner_key.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct OwnerTrace {
+    pub object_kind: &'static str,
+    pub id: i64,
+    pub title: String,
+    pub source_project: Option<String>,
+    pub target_project: Option<String>,
+    pub owner_scope: Option<String>,
+    pub owner_key: Option<String>,
+    pub topic_domain: Option<String>,
+    pub context_class: Option<String>,
+    pub included: bool,
+    pub reason: &'static str,
+}
+
+impl OwnerTrace {
+    pub(super) fn memory(
+        id: i64,
+        title: &str,
+        owner: &OwnerMetadata,
+        included: bool,
+        reason: &'static str,
+    ) -> Self {
+        Self {
+            object_kind: "memory",
+            id,
+            title: title.to_string(),
+            source_project: owner.source_project.clone(),
+            target_project: owner.target_project.clone(),
+            owner_scope: owner.owner_scope.clone(),
+            owner_key: owner.owner_key.clone(),
+            topic_domain: owner.topic_domain.clone(),
+            context_class: owner.context_class.clone(),
+            included,
+            reason,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct OwnerDecision {
+    pub included: bool,
+    pub reason: &'static str,
+}
+
+pub(super) fn startup_memory_owner_decision(
+    current_project: &str,
+    memory_project: &str,
+    memory_scope: &str,
+    owner: &OwnerMetadata,
+) -> OwnerDecision {
+    match owner.scope() {
+        Some("repo")
+            if owner.key() == Some(current_project)
+                || owner.target_project.as_deref() == Some(current_project) =>
+        {
+            OwnerDecision {
+                included: true,
+                reason: "repo_owner_match",
+            }
+        }
+        Some("workspace") => OwnerDecision {
+            included: false,
+            reason: "workspace_owner_not_enabled_for_startup",
+        },
+        Some("user") => OwnerDecision {
+            included: false,
+            reason: "user_memory_loaded_by_preference_layer",
+        },
+        Some("tool") => OwnerDecision {
+            included: false,
+            reason: "tool_not_relevant_to_startup",
+        },
+        Some("domain") => OwnerDecision {
+            included: false,
+            reason: "domain_not_relevant_to_startup",
+        },
+        Some("workstream") => OwnerDecision {
+            included: false,
+            reason: "workstream_memory_not_linked_to_startup",
+        },
+        Some("session") => OwnerDecision {
+            included: false,
+            reason: "session_memory_not_startup_durable",
+        },
+        Some(_) => OwnerDecision {
+            included: false,
+            reason: "unknown_owner_scope",
+        },
+        None if memory_project == current_project && memory_scope != "global" => OwnerDecision {
+            included: true,
+            reason: "legacy_project_fallback",
+        },
+        None => OwnerDecision {
+            included: false,
+            reason: "legacy_project_mismatch",
+        },
+    }
+}

--- a/src/context/policy.rs
+++ b/src/context/policy.rs
@@ -49,7 +49,7 @@ impl Default for ContextLimits {
             session_limit: 5,
             self_diagnostic_limit: 2,
             preference_project_limit: 20,
-            preference_global_limit: 0,
+            preference_global_limit: 5,
             preference_char_limit: 1_500,
             lesson_limit: 4,
             lesson_char_limit: 1_200,

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -6,6 +6,7 @@ use rusqlite::Connection;
 use crate::memory::{self, Memory};
 
 use super::memory_traits::{is_memory_self_diagnostic, is_self_diagnostic_text};
+use super::ownership::{startup_memory_owner_decision, OwnerCounts, OwnerMetadata, OwnerTrace};
 use super::policy::{ContextPolicy, SectionKind};
 use super::types::{LoadedContext, SessionSummaryBrief};
 
@@ -30,7 +31,8 @@ pub(super) fn load_context_data_with_policy(
     current_branch: Option<&str>,
     policy: &ContextPolicy,
 ) -> LoadedContext {
-    let mut memories = load_project_memories(conn, project, current_branch, policy);
+    let memory_selection = load_project_memories(conn, project, current_branch, policy);
+    let mut memories = memory_selection.memories;
     sort_memories_by_branch(&mut memories, current_branch);
     let lessons = memory::lesson::list_lessons_for_context(
         conn,
@@ -68,7 +70,20 @@ pub(super) fn load_context_data_with_policy(
         lessons,
         summaries,
         workstreams,
+        owner_traces: memory_selection.owner_traces,
+        owner_counts: memory_selection.owner_counts,
     }
+}
+
+struct ContextMemorySelection {
+    memories: Vec<Memory>,
+    owner_traces: Vec<OwnerTrace>,
+    owner_counts: OwnerCounts,
+}
+
+struct ContextMemoryRow {
+    memory: Memory,
+    owner: OwnerMetadata,
 }
 
 fn load_project_memories(
@@ -76,17 +91,19 @@ fn load_project_memories(
     project: &str,
     current_branch: Option<&str>,
     policy: &ContextPolicy,
-) -> Vec<Memory> {
+) -> ContextMemorySelection {
     let mut memories = Vec::new();
+    let mut traces = Vec::new();
     let mut seen_ids = HashSet::new();
 
     let excluded_types = policy
         .section(SectionKind::MemoryIndex)
         .map(|section| section.exclude_types.as_slice())
         .unwrap_or(&[]);
-    let recent = memory::get_recent_project_memories_excluding_types(
+    let recent = query_owner_included_memory_rows(
         conn,
         project,
+        None,
         excluded_types,
         policy.limits.candidate_fetch_limit as i64,
     )
@@ -97,24 +114,24 @@ fn load_project_memories(
         );
         Vec::new()
     });
-    for memory in recent {
-        if seen_ids.insert(memory.id) {
-            memories.push(memory);
+    for row in recent {
+        if seen_ids.insert(row.memory.id) {
+            memories.push(row.memory);
         }
     }
 
     let project_query = project.rsplit('/').next().unwrap_or(project);
-    match memory::search_project_memories_excluding_types(
+    match query_owner_included_memory_rows(
         conn,
         project,
-        project_query,
+        Some(project_query),
         excluded_types,
         BASENAME_SEARCH_LIMIT,
     ) {
         Ok(searched) => {
-            for memory in searched {
-                if seen_ids.insert(memory.id) {
-                    memories.push(memory);
+            for row in searched {
+                if seen_ids.insert(row.memory.id) {
+                    memories.push(row.memory);
                 }
             }
         }
@@ -131,7 +148,272 @@ fn load_project_memories(
         policy.limits.self_diagnostic_limit,
     );
     sort_memories_by_branch(&mut selected, current_branch);
-    selected
+
+    let selected_ids = selected
+        .iter()
+        .map(|memory| memory.id)
+        .collect::<HashSet<_>>();
+    let selected_rows = query_owner_traces_for_ids(conn, &selected_ids).unwrap_or_else(|e| {
+        crate::log::error(
+            "context",
+            &format!("failed to load owner trace rows for {project}: {e}"),
+        );
+        Vec::new()
+    });
+    let mut owner_counts = OwnerCounts::default();
+    for row in selected_rows {
+        let decision = startup_memory_owner_decision(
+            project,
+            &row.memory.project,
+            &row.memory.scope,
+            &row.owner,
+        );
+        owner_counts.add_scope(row.owner.owner_scope.as_deref());
+        traces.push(OwnerTrace::memory(
+            row.memory.id,
+            &row.memory.title,
+            &row.owner,
+            true,
+            decision.reason,
+        ));
+    }
+
+    let excluded =
+        query_owner_exclusion_traces(conn, project, excluded_types, 30).unwrap_or_else(|e| {
+            crate::log::error(
+                "context",
+                &format!("failed to load owner exclusion trace rows for {project}: {e}"),
+            );
+            Vec::new()
+        });
+    traces.extend(excluded);
+
+    ContextMemorySelection {
+        memories: selected,
+        owner_traces: traces,
+        owner_counts,
+    }
+}
+
+fn query_owner_included_memory_rows(
+    conn: &Connection,
+    project: &str,
+    query: Option<&str>,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<ContextMemoryRow>> {
+    if limit <= 0 || query.is_some_and(|value| value.trim().is_empty()) {
+        return Ok(vec![]);
+    }
+
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    push_owner_included_filter(project, &mut idx, &mut conditions, &mut params);
+    conditions.push(crate::memory::memory_status_filter_sql("status", false));
+
+    if let Some(query) = query {
+        let like_pattern = format!("%{query}%");
+        conditions.push(format!("(title LIKE ?{idx} OR content LIKE ?{idx})"));
+        params.push(Box::new(like_pattern));
+        idx += 1;
+    }
+
+    push_excluded_type_filter(excluded_types, &mut idx, &mut conditions, &mut params);
+    params.push(Box::new(limit));
+    let sql = format!(
+        "SELECT {}, {} FROM memories \
+         WHERE {} \
+         ORDER BY updated_at_epoch DESC LIMIT ?{}",
+        memory::MEMORY_COLS,
+        MEMORY_OWNER_COLS,
+        conditions.join(" AND "),
+        idx,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), map_context_memory_row)?;
+    crate::db::query::collect_rows(rows)
+}
+
+fn query_owner_traces_for_ids(
+    conn: &Connection,
+    selected_ids: &HashSet<i64>,
+) -> Result<Vec<ContextMemoryRow>> {
+    if selected_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut ids = selected_ids.iter().copied().collect::<Vec<_>>();
+    ids.sort_unstable();
+    let placeholders = (1..=ids.len())
+        .map(|idx| format!("?{idx}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "SELECT {}, {} FROM memories WHERE id IN ({}) ORDER BY updated_at_epoch DESC",
+        memory::MEMORY_COLS,
+        MEMORY_OWNER_COLS,
+        placeholders
+    );
+    let params = ids
+        .into_iter()
+        .map(|id| Box::new(id) as Box<dyn rusqlite::types::ToSql>)
+        .collect::<Vec<_>>();
+    let refs = crate::db::to_sql_refs(&params);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), map_context_memory_row)?;
+    crate::db::query::collect_rows(rows)
+}
+
+fn query_owner_exclusion_traces(
+    conn: &Connection,
+    project: &str,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<OwnerTrace>> {
+    if limit <= 0 {
+        return Ok(vec![]);
+    }
+
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    push_context_related_filter(project, &mut idx, &mut conditions, &mut params);
+    push_owner_excluded_filter(project, &mut idx, &mut conditions, &mut params);
+    conditions.push(crate::memory::memory_status_filter_sql("status", false));
+    push_excluded_type_filter(excluded_types, &mut idx, &mut conditions, &mut params);
+    params.push(Box::new(limit));
+
+    let sql = format!(
+        "SELECT {}, {} FROM memories \
+         WHERE {} \
+         ORDER BY updated_at_epoch DESC LIMIT ?{}",
+        memory::MEMORY_COLS,
+        MEMORY_OWNER_COLS,
+        conditions.join(" AND "),
+        idx,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        let context_row = map_context_memory_row(row)?;
+        let decision = startup_memory_owner_decision(
+            project,
+            &context_row.memory.project,
+            &context_row.memory.scope,
+            &context_row.owner,
+        );
+        Ok(OwnerTrace::memory(
+            context_row.memory.id,
+            &context_row.memory.title,
+            &context_row.owner,
+            false,
+            decision.reason,
+        ))
+    })?;
+    crate::db::query::collect_rows(rows)
+}
+
+const MEMORY_OWNER_COLS: &str = "source_project, target_project, owner_scope, owner_key, \
+                                topic_domain, context_class";
+
+fn map_context_memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ContextMemoryRow> {
+    Ok(ContextMemoryRow {
+        memory: memory::map_memory_row_pub(row)?,
+        owner: OwnerMetadata::from_memory_row(row, 13)?,
+    })
+}
+
+fn push_owner_included_filter(
+    project: &str,
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    let owner_key_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let target_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let legacy_project_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    conditions.push(format!(
+        "((owner_scope = 'repo' AND owner_key = ?{owner_key_idx}) \
+          OR (owner_scope = 'repo' AND target_project = ?{target_idx}) \
+          OR (owner_scope IS NULL AND project = ?{legacy_project_idx} \
+              AND COALESCE(scope, 'project') != 'global'))"
+    ));
+}
+
+fn push_owner_excluded_filter(
+    project: &str,
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    let owner_key_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let target_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let legacy_project_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    conditions.push(format!(
+        "NOT ((owner_scope = 'repo' AND owner_key = ?{owner_key_idx}) \
+              OR (owner_scope = 'repo' AND target_project = ?{target_idx}) \
+              OR (owner_scope IS NULL AND project = ?{legacy_project_idx} \
+                  AND COALESCE(scope, 'project') != 'global'))"
+    ));
+}
+
+fn push_context_related_filter(
+    project: &str,
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    let project_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let source_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let target_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let owner_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    conditions.push(format!(
+        "(project = ?{project_idx} OR source_project = ?{source_idx} \
+          OR target_project = ?{target_idx} OR owner_key = ?{owner_idx})"
+    ));
+}
+
+fn push_excluded_type_filter(
+    excluded_types: &[&str],
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    if excluded_types.is_empty() {
+        return;
+    }
+    let placeholders: Vec<String> = excluded_types
+        .iter()
+        .map(|memory_type| {
+            let placeholder = format!("?{idx}");
+            params.push(Box::new((*memory_type).to_string()));
+            *idx += 1;
+            placeholder
+        })
+        .collect();
+    conditions.push(format!("memory_type NOT IN ({})", placeholders.join(", ")));
 }
 
 fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {
@@ -408,7 +690,10 @@ fn query_summary_batch(
     let mut stmt = conn.prepare(
         "SELECT request, completed, created_at_epoch \
          FROM session_summaries \
-         WHERE project = ?1 AND request IS NOT NULL AND request != '' \
+         WHERE request IS NOT NULL AND request != '' \
+           AND ((owner_scope = 'repo' AND owner_key = ?1) \
+                OR (owner_scope = 'repo' AND target_project = ?1) \
+                OR (owner_scope IS NULL AND project = ?1)) \
          ORDER BY created_at_epoch DESC LIMIT ?2 OFFSET ?3",
     )?;
     let rows = stmt.query_map(

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -8,6 +8,7 @@ use super::injection_gate::{apply_context_gate, ContextGateAction, ContextGateDe
 use super::invocation::{
     direct_context_invocation, resolve_context_invocation, ContextCliOptions, ContextInvocation,
 };
+use super::ownership::OwnerCounts;
 use super::policy::{ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
@@ -172,6 +173,12 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
         memories_loaded: loaded.memories.len() + loaded.lessons.len(),
         project_preferences: preference_summary.project_rendered,
         global_preferences: preference_summary.global_rendered,
+        owner_counts: {
+            let mut counts = loaded.owner_counts.clone();
+            counts.add_repo(preference_summary.project_rendered);
+            counts.add_user(preference_summary.global_rendered);
+            counts
+        },
         ..ContextRenderStats::default()
     };
 
@@ -336,6 +343,7 @@ pub(in crate::context) struct ContextRenderStats {
     pub global_preferences: usize,
     pub sessions: SectionRenderStats,
     pub workstreams: SectionRenderStats,
+    pub owner_counts: OwnerCounts,
     pub core_ids: Vec<i64>,
     pub output_chars: usize,
     pub truncated: bool,
@@ -346,7 +354,7 @@ pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats)
     let source = context_source_footer(stats.hook_source.as_deref());
     let estimated_tokens = estimate_tokens(stats.output_chars);
     format!(
-        "{} context memories loaded. {} core ({} chars). {} lessons ({} chars). {} indexed ({} chars). {} preferences (project:{} global:{}, {} chars). {} sessions ({} chars). host={} source={} branch={} total={} chars/~{} tokens limit={} truncated={}\n",
+        "{} context memories loaded. {} core ({} chars). {} lessons ({} chars). {} indexed ({} chars). {} preferences (project:{} global:{}, {} chars). {} sessions ({} chars). owners repo={} user={} workspace={} tool={} domain={} workstream={} session={} legacy={} unknown={}. host={} source={} branch={} total={} chars/~{} tokens limit={} truncated={}\n",
         stats.memories_loaded,
         stats.core.count,
         stats.core.chars,
@@ -360,6 +368,15 @@ pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats)
         stats.preferences.chars,
         stats.sessions.count,
         stats.sessions.chars,
+        stats.owner_counts.repo,
+        stats.owner_counts.user,
+        stats.owner_counts.workspace,
+        stats.owner_counts.tool,
+        stats.owner_counts.domain,
+        stats.owner_counts.workstream,
+        stats.owner_counts.session,
+        stats.owner_counts.legacy,
+        stats.owner_counts.unknown,
         stats.host,
         source,
         branch,
@@ -370,7 +387,7 @@ pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats)
     )
 }
 
-fn build_context_debug_trace(
+pub(in crate::context) fn build_context_debug_trace(
     request: &ContextRequest,
     policy: &ContextPolicy,
     loaded: &super::types::LoadedContext,
@@ -413,6 +430,44 @@ fn build_context_debug_trace(
         "- preferences project_rendered={} global_rendered={} reason=scope_limits_then_claude_md_dedup\n",
         stats.project_preferences, stats.global_preferences
     ));
+    trace.push_str(&format!(
+        "- owner counts repo={} user={} workspace={} tool={} domain={} workstream={} session={} legacy={} unknown={}\n",
+        stats.owner_counts.repo,
+        stats.owner_counts.user,
+        stats.owner_counts.workspace,
+        stats.owner_counts.tool,
+        stats.owner_counts.domain,
+        stats.owner_counts.workstream,
+        stats.owner_counts.session,
+        stats.owner_counts.legacy,
+        stats.owner_counts.unknown
+    ));
+    for trace_row in loaded.owner_traces.iter().take(60) {
+        trace.push_str(&format!(
+            "- owner {} id={} scope={} key={} source_project={} target_project={} domain={} context_class={} {} reason={} title={}\n",
+            trace_row.object_kind,
+            trace_row.id,
+            trace_row.owner_scope.as_deref().unwrap_or("-"),
+            trace_row.owner_key.as_deref().unwrap_or("-"),
+            trace_row.source_project.as_deref().unwrap_or("-"),
+            trace_row.target_project.as_deref().unwrap_or("-"),
+            trace_row.topic_domain.as_deref().unwrap_or("-"),
+            trace_row.context_class.as_deref().unwrap_or("-"),
+            if trace_row.included {
+                "included"
+            } else {
+                "excluded"
+            },
+            trace_row.reason,
+            truncate_chars_with_ellipsis(&trace_row.title, 120)
+        ));
+    }
+    if loaded.owner_traces.len() > 60 {
+        trace.push_str(&format!(
+            "- owner trace truncated: {} additional rows omitted\n",
+            loaded.owner_traces.len() - 60
+        ));
+    }
     for (rank, lesson) in loaded.lessons.iter().enumerate() {
         trace.push_str(&format!(
             "- lesson rank={} id={} confidence={:.2} reinforced={} scope={} topic={} title={}\n",

--- a/src/context/tests/mod.rs
+++ b/src/context/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::workstream::{WorkStream, WorkStreamStatus};
 use rusqlite::{params, Connection};
 
 mod load;
+mod ownership;
 mod render;
 mod sessions;
 
@@ -102,6 +103,48 @@ pub(super) fn insert_memory_with_branch(
     .unwrap();
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(super) fn insert_owned_memory(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    topic_key: Option<&str>,
+    memory_type: &str,
+    title: &str,
+    content: &str,
+    updated_at_epoch: i64,
+    owner_scope: &str,
+    owner_key: &str,
+    target_project: Option<&str>,
+    topic_domain: Option<&str>,
+) {
+    insert_memory(
+        conn,
+        id,
+        project,
+        topic_key,
+        memory_type,
+        title,
+        content,
+        updated_at_epoch,
+    );
+    conn.execute(
+        "UPDATE memories
+         SET source_project = ?1, target_project = ?2, owner_scope = ?3,
+             owner_key = ?4, topic_domain = ?5, context_class = 'startup_core'
+         WHERE id = ?6",
+        params![
+            project,
+            target_project,
+            owner_scope,
+            owner_key,
+            topic_domain,
+            id
+        ],
+    )
+    .unwrap();
+}
+
 pub(super) fn insert_global_memory(
     conn: &Connection,
     id: i64,
@@ -151,7 +194,18 @@ pub(super) fn create_session_summary_schema(conn: &Connection) {
             project TEXT,
             request TEXT,
             completed TEXT,
-            created_at_epoch INTEGER
+            created_at_epoch INTEGER,
+            source_project TEXT,
+            target_project TEXT,
+            owner_scope TEXT,
+            owner_key TEXT,
+            topic_domain TEXT,
+            routing_confidence REAL,
+            routing_reason TEXT,
+            context_class TEXT,
+            expires_at_epoch INTEGER,
+            valid_from_epoch INTEGER,
+            valid_to_epoch INTEGER
         );",
     )
     .unwrap();

--- a/src/context/tests/ownership.rs
+++ b/src/context/tests/ownership.rs
@@ -1,0 +1,191 @@
+use rusqlite::Connection;
+
+use crate::memory::types::tests_helper::setup_memory_schema;
+
+use super::super::host::HostKind;
+use super::super::policy::{ContextLimits, ContextPolicy};
+use super::super::query::load_context_data_with_policy;
+use super::super::render::{build_context_debug_trace, build_context_stats_footer};
+use super::super::render::{ContextRenderStats, SectionRenderStats};
+use super::super::types::ContextRequest;
+use super::{insert_memory, insert_owned_memory};
+
+#[test]
+fn startup_context_excludes_unrelated_tool_and_domain_memories() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let stash = "/Users/lifcc/Desktop/code/AI/tool/stash";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_owned_memory(
+        &conn,
+        1,
+        stash,
+        Some("stash-dnd-decision"),
+        "decision",
+        "Stash DnD uses pointer sensors",
+        "The Stash UI uses pointer sensors for drag and drop behavior.",
+        now,
+        "repo",
+        stash,
+        Some(stash),
+        Some("stash-ui"),
+    );
+    insert_owned_memory(
+        &conn,
+        2,
+        stash,
+        Some("codex-sandbox"),
+        "decision",
+        "Codex approval mode uses workspace-write",
+        "Codex CLI sandbox and approval policy are tool-level facts.",
+        now + 1,
+        "tool",
+        "codex-cli",
+        None,
+        Some("codex-sandbox"),
+    );
+    insert_owned_memory(
+        &conn,
+        3,
+        stash,
+        Some("grok-api"),
+        "discovery",
+        "Grok API supports image references",
+        "The xAI Grok API wrapper accepts image reference payloads.",
+        now + 2,
+        "domain",
+        "grok-api",
+        None,
+        Some("grok-api"),
+    );
+    insert_owned_memory(
+        &conn,
+        4,
+        stash,
+        Some("warp-startup"),
+        "discovery",
+        "Warp launch state is macOS domain context",
+        "Warp terminal launch behavior is not Stash repository context.",
+        now + 3,
+        "domain",
+        "macos",
+        None,
+        Some("macos"),
+    );
+    insert_memory(
+        &conn,
+        5,
+        stash,
+        Some("legacy-stash-fallback"),
+        "bugfix",
+        "Legacy Stash memory remains compatible",
+        "Rows without owner metadata still load through project fallback.",
+        now - 1,
+    );
+
+    let loaded = load_context_data_with_policy(
+        &conn,
+        stash,
+        None,
+        &ContextPolicy::from_limits(ContextLimits {
+            candidate_fetch_limit: 2,
+            memory_index_limit: 10,
+            core_item_limit: 10,
+            ..ContextLimits::default()
+        }),
+    );
+    let titles = loaded
+        .memories
+        .iter()
+        .map(|memory| memory.title.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(titles.contains(&"Stash DnD uses pointer sensors"));
+    assert!(titles.contains(&"Legacy Stash memory remains compatible"));
+    assert!(!titles.contains(&"Codex approval mode uses workspace-write"));
+    assert!(!titles.contains(&"Grok API supports image references"));
+    assert!(!titles.contains(&"Warp launch state is macOS domain context"));
+    assert_eq!(loaded.owner_counts.repo, 1);
+    assert_eq!(loaded.owner_counts.legacy, 1);
+    assert!(loaded.owner_traces.iter().any(|trace| !trace.included
+        && trace.owner_scope.as_deref() == Some("tool")
+        && trace.reason == "tool_not_relevant_to_startup"));
+    assert!(loaded.owner_traces.iter().any(|trace| !trace.included
+        && trace.owner_scope.as_deref() == Some("domain")
+        && trace.reason == "domain_not_relevant_to_startup"));
+}
+
+#[test]
+fn debug_trace_and_footer_report_owner_reasons_and_counts() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    let stash = "/Users/lifcc/Desktop/code/AI/tool/stash";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_owned_memory(
+        &conn,
+        1,
+        stash,
+        Some("stash-repo"),
+        "decision",
+        "Stash repo context",
+        "Stash repository context should load at startup.",
+        now,
+        "repo",
+        stash,
+        Some(stash),
+        Some("stash-ui"),
+    );
+    insert_owned_memory(
+        &conn,
+        2,
+        stash,
+        Some("codex-tool"),
+        "decision",
+        "Codex sandbox context",
+        "Codex sandbox context should stay out of Stash startup.",
+        now + 1,
+        "tool",
+        "codex-cli",
+        None,
+        Some("codex-sandbox"),
+    );
+
+    let loaded = load_context_data_with_policy(
+        &conn,
+        stash,
+        None,
+        &ContextPolicy::from_limits(ContextLimits::default()),
+    );
+    let stats = ContextRenderStats {
+        host: "codex-cli".to_string(),
+        memories_loaded: loaded.memories.len(),
+        core: SectionRenderStats {
+            count: loaded.memories.len(),
+            chars: 128,
+        },
+        owner_counts: loaded.owner_counts.clone(),
+        ..ContextRenderStats::default()
+    };
+    let request = ContextRequest {
+        cwd: stash.to_string(),
+        project: stash.to_string(),
+        session_id: Some("sess-owner".to_string()),
+        hook_source: None,
+        current_branch: None,
+        host: HostKind::CodexCli,
+        use_colors: false,
+    };
+
+    let debug = build_context_debug_trace(&request, &ContextPolicy::from_env(), &loaded, &stats);
+    assert!(debug.contains("owner counts repo=1"));
+    assert!(debug.contains("owner memory id=1 scope=repo"));
+    assert!(debug.contains("included reason=repo_owner_match"));
+    assert!(debug.contains("owner memory id=2 scope=tool"));
+    assert!(debug.contains("excluded reason=tool_not_relevant_to_startup"));
+
+    let footer = build_context_stats_footer(&stats);
+    assert!(footer.contains("owners repo=1 user=0"));
+    assert!(footer.contains("tool=0 domain=0"));
+}

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -404,6 +404,7 @@ fn context_stats_footer_reports_budget_scope_and_truncation() {
             count: 1,
             chars: 80,
         },
+        owner_counts: Default::default(),
         core_ids: vec![1, 2],
         output_chars: 3_200,
         truncated: true,

--- a/src/context/tests/sessions.rs
+++ b/src/context/tests/sessions.rs
@@ -186,3 +186,79 @@ fn query_recent_summaries_allows_normal_summary_after_low_signal_same_cluster() 
         Some("Validated current runtime hook behavior")
     );
 }
+
+#[test]
+fn query_recent_summaries_excludes_tool_and_domain_owned_rows() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_session_summary_schema(&conn);
+    let project = "/tmp/stash";
+
+    insert_session_summary(
+        &conn,
+        project,
+        "Legacy Stash session",
+        Some("Legacy project rows remain compatible"),
+        300,
+    );
+    insert_owned_summary(
+        &conn,
+        project,
+        "Repo Stash session",
+        "repo",
+        project,
+        Some(project),
+        301,
+    );
+    insert_owned_summary(
+        &conn,
+        project,
+        "Codex sandbox session",
+        "tool",
+        "codex-cli",
+        None,
+        302,
+    );
+    insert_owned_summary(
+        &conn,
+        project,
+        "Grok API session",
+        "domain",
+        "grok-api",
+        None,
+        303,
+    );
+
+    let summaries = query_recent_summaries(&conn, project, 10).unwrap();
+    let requests = summaries
+        .iter()
+        .map(|summary| summary.request.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(requests, vec!["Repo Stash session", "Legacy Stash session"]);
+}
+
+fn insert_owned_summary(
+    conn: &Connection,
+    project: &str,
+    request: &str,
+    owner_scope: &str,
+    owner_key: &str,
+    target_project: Option<&str>,
+    created_at_epoch: i64,
+) {
+    conn.execute(
+        "INSERT INTO session_summaries
+         (project, request, completed, created_at_epoch, source_project,
+          target_project, owner_scope, owner_key)
+         VALUES (?1, ?2, 'done', ?3, ?1, ?4, ?5, ?6)",
+        rusqlite::params![
+            project,
+            request,
+            created_at_epoch,
+            target_project,
+            owner_scope,
+            owner_key
+        ],
+    )
+    .unwrap();
+}

--- a/src/context/types.rs
+++ b/src/context/types.rs
@@ -3,6 +3,7 @@ use crate::memory::Memory;
 use crate::workstream::WorkStream;
 
 use super::host::HostKind;
+use super::ownership::{OwnerCounts, OwnerTrace};
 
 #[derive(Debug, Clone)]
 pub(super) struct ContextRequest {
@@ -28,4 +29,6 @@ pub(super) struct LoadedContext {
     pub lessons: Vec<LessonMemory>,
     pub summaries: Vec<SessionSummaryBrief>,
     pub workstreams: Vec<WorkStream>,
+    pub owner_traces: Vec<OwnerTrace>,
+    pub owner_counts: OwnerCounts,
 }

--- a/src/memory/lesson.rs
+++ b/src/memory/lesson.rs
@@ -149,7 +149,10 @@ pub fn list_lessons_for_context(
          JOIN memory_lessons l ON l.memory_id = m.id
          WHERE m.memory_type = 'lesson'
            AND m.status = 'active'
-           AND (m.project = ?1 OR m.scope = 'global')
+           AND ((m.owner_scope = 'repo' AND m.owner_key = ?1)
+                OR (m.owner_scope = 'repo' AND m.target_project = ?1)
+                OR (m.owner_scope = 'user' AND m.owner_key = 'user:default')
+                OR (m.owner_scope IS NULL AND (m.project = ?1 OR m.scope = 'global')))
            AND l.confidence >= ?2
            AND (l.stale_after_epoch IS NULL OR l.stale_after_epoch > ?3)
            AND (?4 IS NULL OR m.branch = ?4 OR m.branch IS NULL)

--- a/src/memory/preference/query.rs
+++ b/src/memory/preference/query.rs
@@ -15,7 +15,9 @@ pub fn query_project_preferences(
     let sql = format!(
         "SELECT {} FROM memories \
          WHERE memory_type = 'preference' AND status = 'active' \
-         AND project = ?1 AND (scope IS NULL OR scope = 'project') \
+         AND ((owner_scope = 'repo' AND owner_key = ?1) \
+              OR (owner_scope = 'repo' AND target_project = ?1) \
+              OR (owner_scope IS NULL AND project = ?1 AND (scope IS NULL OR scope = 'project'))) \
          GROUP BY COALESCE(topic_key, id) \
          ORDER BY MAX(updated_at_epoch) DESC LIMIT ?2",
         memory::MEMORY_COLS,
@@ -33,7 +35,8 @@ pub fn query_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<M
     let sql = format!(
         "SELECT {} FROM memories \
          WHERE memory_type = 'preference' AND status = 'active' \
-         AND scope = 'global' \
+         AND ((owner_scope = 'user' AND owner_key = 'user:default') \
+              OR (owner_scope IS NULL AND scope = 'global')) \
          GROUP BY COALESCE(topic_key, id) \
          ORDER BY MAX(updated_at_epoch) DESC LIMIT ?1",
         memory::MEMORY_COLS,

--- a/src/memory/preference/tests.rs
+++ b/src/memory/preference/tests.rs
@@ -84,6 +84,79 @@ fn test_project_preferences_exclude_global_overlay() -> Result<()> {
 }
 
 #[test]
+fn test_project_preferences_exclude_tool_owned_rows_from_same_project() -> Result<()> {
+    let conn = setup_test_db();
+    let repo_pref = memory::insert_memory(
+        &conn,
+        None,
+        "test/proj",
+        Some("local-pref"),
+        "Preference: Local workflow",
+        "Use the local project workflow",
+        "preference",
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET source_project = project, target_project = project,
+             owner_scope = 'repo', owner_key = project
+         WHERE id = ?1",
+        [repo_pref],
+    )?;
+    let tool_pref = memory::insert_memory(
+        &conn,
+        None,
+        "test/proj",
+        Some("codex-pref"),
+        "Preference: Codex approvals",
+        "Use Codex workspace-write approval mode",
+        "preference",
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET source_project = project, target_project = NULL,
+             owner_scope = 'tool', owner_key = 'codex-cli'
+         WHERE id = ?1",
+        [tool_pref],
+    )?;
+
+    let prefs = query_project_preferences(&conn, "test/proj", 20)?;
+    assert_eq!(prefs.len(), 1);
+    assert_eq!(prefs[0].text, "Use the local project workflow");
+    Ok(())
+}
+
+#[test]
+fn test_user_owner_preferences_are_global_core_preferences() -> Result<()> {
+    let conn = setup_test_db();
+    let id = memory::insert_memory_full(
+        &conn,
+        None,
+        "other/proj",
+        Some("user-style"),
+        "Preference: User style",
+        "Keep answers concise",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET owner_scope = 'user', owner_key = 'user:default'
+         WHERE id = ?1",
+        [id],
+    )?;
+
+    let prefs = query_global_preferences(&conn, 10)?;
+    assert_eq!(prefs.len(), 1);
+    assert_eq!(prefs[0].text, "Keep answers concise");
+    Ok(())
+}
+
+#[test]
 fn test_render_preferences_global_limit_zero_does_not_leak_global() -> Result<()> {
     let conn = setup_test_db();
     memory::insert_memory_full(

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -69,6 +69,7 @@ pub fn insert_memory_full(
     let now = chrono::Utc::now().timestamp();
     let created_at = created_at_override.unwrap_or(now);
     let search_context = build_search_context(memory_type, topic_key, content, files);
+    let ownership = default_ownership(project, scope);
 
     if let Some(topic_key) = topic_key {
         if !topic_key.is_empty() {
@@ -86,7 +87,13 @@ pub fn insert_memory_full(
                 conn.execute(
                     "UPDATE memories SET session_id = ?1, title = ?2, content = ?3, \
                      memory_type = ?4, files = ?5, updated_at_epoch = ?6, branch = ?7, \
-                     scope = ?8, search_context = ?9 WHERE id = ?10",
+                     scope = ?8, search_context = ?9, \
+                     source_project = COALESCE(source_project, ?10), \
+                     target_project = COALESCE(target_project, ?11), \
+                     owner_scope = COALESCE(owner_scope, ?12), \
+                     owner_key = COALESCE(owner_key, ?13), \
+                     context_class = COALESCE(context_class, ?14) \
+                     WHERE id = ?15",
                     params![
                         session_id,
                         title,
@@ -97,6 +104,11 @@ pub fn insert_memory_full(
                         branch,
                         scope,
                         search_context,
+                        ownership.source_project,
+                        ownership.target_project,
+                        ownership.owner_scope,
+                        ownership.owner_key,
+                        ownership.context_class,
                         id
                     ],
                 )?;
@@ -109,8 +121,10 @@ pub fn insert_memory_full(
     conn.execute(
         "INSERT INTO memories \
          (session_id, project, topic_key, title, content, memory_type, files, search_context, \
-          created_at_epoch, updated_at_epoch, status, branch, scope) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'active', ?11, ?12)",
+          created_at_epoch, updated_at_epoch, status, branch, scope, \
+          source_project, target_project, owner_scope, owner_key, context_class) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'active', ?11, ?12, \
+                 ?13, ?14, ?15, ?16, ?17)",
         params![
             session_id,
             project,
@@ -123,12 +137,45 @@ pub fn insert_memory_full(
             created_at,
             now,
             branch,
-            scope
+            scope,
+            ownership.source_project,
+            ownership.target_project,
+            ownership.owner_scope,
+            ownership.owner_key,
+            ownership.context_class
         ],
     )?;
     let id = conn.last_insert_rowid();
     refresh_memory_entities(conn, id, title, content, "entity link failed");
     Ok(id)
+}
+
+struct DefaultOwnership<'a> {
+    source_project: &'a str,
+    target_project: Option<&'a str>,
+    owner_scope: &'static str,
+    owner_key: &'a str,
+    context_class: &'static str,
+}
+
+fn default_ownership<'a>(project: &'a str, scope: &str) -> DefaultOwnership<'a> {
+    if scope == "global" {
+        DefaultOwnership {
+            source_project: project,
+            target_project: None,
+            owner_scope: "user",
+            owner_key: "user:default",
+            context_class: "startup_core",
+        }
+    } else {
+        DefaultOwnership {
+            source_project: project,
+            target_project: Some(project),
+            owner_scope: "repo",
+            owner_key: project,
+            context_class: "startup_core",
+        }
+    }
 }
 
 fn refresh_memory_entities(conn: &Connection, id: i64, title: &str, content: &str, message: &str) {

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -251,7 +251,18 @@ pub mod tests_helper {
                 updated_at_epoch INTEGER NOT NULL,
                 status TEXT NOT NULL DEFAULT 'active',
                 branch TEXT,
-                scope TEXT DEFAULT 'project'
+                scope TEXT DEFAULT 'project',
+                source_project TEXT,
+                target_project TEXT,
+                owner_scope TEXT,
+                owner_key TEXT,
+                topic_domain TEXT,
+                routing_confidence REAL,
+                routing_reason TEXT,
+                context_class TEXT,
+                expires_at_epoch INTEGER,
+                valid_from_epoch INTEGER,
+                valid_to_epoch INTEGER
             );
             CREATE VIRTUAL TABLE memories_fts USING fts5(
                 title, content, search_context,

--- a/src/workstream/matcher.rs
+++ b/src/workstream/matcher.rs
@@ -13,7 +13,10 @@ pub fn find_matching_workstream(
             "SELECT id, project, title, description, status, progress, next_action, blockers,
                     created_at_epoch, updated_at_epoch, completed_at_epoch
              FROM workstreams
-             WHERE project = ?1 AND title = ?2 AND status IN ('active', 'paused')",
+             WHERE title = ?2 AND status IN ('active', 'paused')
+               AND ((owner_scope = 'repo' AND owner_key = ?1)
+                    OR (owner_scope = 'repo' AND target_project = ?1)
+                    OR (owner_scope IS NULL AND project = ?1))",
             params![project, title],
             map_workstream_row,
         )
@@ -27,7 +30,10 @@ pub fn find_matching_workstream(
         "SELECT id, project, title, description, status, progress, next_action, blockers,
                 created_at_epoch, updated_at_epoch, completed_at_epoch
          FROM workstreams
-         WHERE project = ?1 AND status IN ('active', 'paused')
+         WHERE status IN ('active', 'paused')
+           AND ((owner_scope = 'repo' AND owner_key = ?1)
+                OR (owner_scope = 'repo' AND target_project = ?1)
+                OR (owner_scope IS NULL AND project = ?1))
          ORDER BY updated_at_epoch DESC",
     )?;
     let rows = stmt.query_map(params![project], map_workstream_row)?;

--- a/src/workstream/query.rs
+++ b/src/workstream/query.rs
@@ -10,7 +10,11 @@ const SELECT_FIELDS: &str =
 
 pub fn query_active_workstreams(conn: &Connection, project: &str) -> Result<Vec<WorkStream>> {
     let sql = format!(
-        "{} WHERE project = ?1 AND status IN ('active', 'paused') ORDER BY updated_at_epoch DESC",
+        "{} WHERE status IN ('active', 'paused')
+              AND ((owner_scope = 'repo' AND owner_key = ?1)
+                   OR (owner_scope = 'repo' AND target_project = ?1)
+                   OR (owner_scope IS NULL AND project = ?1))
+              ORDER BY updated_at_epoch DESC",
         SELECT_FIELDS
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -26,7 +30,11 @@ pub fn query_workstreams(
     let (sql, filter_val) = if let Some(status) = status_filter {
         (
             format!(
-                "{} WHERE project = ?1 AND status = ?2 ORDER BY updated_at_epoch DESC",
+                "{} WHERE status = ?2
+                      AND ((owner_scope = 'repo' AND owner_key = ?1)
+                           OR (owner_scope = 'repo' AND target_project = ?1)
+                           OR (owner_scope IS NULL AND project = ?1))
+                      ORDER BY updated_at_epoch DESC",
                 SELECT_FIELDS
             ),
             Some(status.to_string()),
@@ -34,7 +42,10 @@ pub fn query_workstreams(
     } else {
         (
             format!(
-                "{} WHERE project = ?1 ORDER BY updated_at_epoch DESC",
+                "{} WHERE ((owner_scope = 'repo' AND owner_key = ?1)
+                           OR (owner_scope = 'repo' AND target_project = ?1)
+                           OR (owner_scope IS NULL AND project = ?1))
+                      ORDER BY updated_at_epoch DESC",
                 SELECT_FIELDS
             ),
             None,

--- a/src/workstream/tests/query.rs
+++ b/src/workstream/tests/query.rs
@@ -141,3 +141,30 @@ fn test_completed_status() {
     assert_eq!(completed[0].status, WorkStreamStatus::Completed);
     assert!(completed[0].completed_at_epoch.is_some());
 }
+
+#[test]
+fn test_query_active_workstreams_excludes_tool_domain_owned_rows() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_workstream_schema(&conn);
+    let now = chrono::Utc::now().timestamp();
+
+    conn.execute(
+        "INSERT INTO workstreams
+         (project, title, status, created_at_epoch, updated_at_epoch,
+          source_project, target_project, owner_scope, owner_key)
+         VALUES
+         ('test/proj', 'Repo Task', 'active', ?1, ?1, 'test/proj', 'test/proj', 'repo', 'test/proj'),
+         ('test/proj', 'Codex Task', 'active', ?1, ?1, 'test/proj', NULL, 'tool', 'codex-cli'),
+         ('test/proj', 'Grok Task', 'paused', ?1, ?1, 'test/proj', NULL, 'domain', 'grok-api')",
+        params![now],
+    )
+    .unwrap();
+
+    let workstreams = query_active_workstreams(&conn, "test/proj").unwrap();
+    let titles = workstreams
+        .iter()
+        .map(|workstream| workstream.title.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(titles, vec!["Repo Task"]);
+}

--- a/src/workstream/tests/support.rs
+++ b/src/workstream/tests/support.rs
@@ -13,7 +13,18 @@ pub(super) fn setup_workstream_schema(conn: &Connection) {
             blockers TEXT,
             created_at_epoch INTEGER NOT NULL,
             updated_at_epoch INTEGER NOT NULL,
-            completed_at_epoch INTEGER
+            completed_at_epoch INTEGER,
+            source_project TEXT,
+            target_project TEXT,
+            owner_scope TEXT,
+            owner_key TEXT,
+            topic_domain TEXT,
+            routing_confidence REAL,
+            routing_reason TEXT,
+            context_class TEXT,
+            expires_at_epoch INTEGER,
+            valid_from_epoch INTEGER,
+            valid_to_epoch INTEGER
         );
         CREATE TABLE workstream_sessions (
             id INTEGER PRIMARY KEY,

--- a/src/workstream/write.rs
+++ b/src/workstream/write.rs
@@ -25,7 +25,12 @@ pub fn upsert_workstream(
         conn.execute(
             "UPDATE workstreams
              SET title = ?1, status = ?2, progress = ?3, next_action = ?4, blockers = ?5,
-                 updated_at_epoch = ?6, completed_at_epoch = COALESCE(?7, completed_at_epoch)
+                 updated_at_epoch = ?6, completed_at_epoch = COALESCE(?7, completed_at_epoch),
+                 source_project = COALESCE(source_project, ?9),
+                 target_project = COALESCE(target_project, ?9),
+                 owner_scope = COALESCE(owner_scope, 'repo'),
+                 owner_key = COALESCE(owner_key, ?9),
+                 context_class = COALESCE(context_class, 'startup_core')
              WHERE id = ?8",
             params![
                 title,
@@ -36,6 +41,7 @@ pub fn upsert_workstream(
                 now,
                 completed_at,
                 existing.id,
+                project,
             ],
         )?;
         existing.id
@@ -43,8 +49,9 @@ pub fn upsert_workstream(
         conn.execute(
             "INSERT INTO workstreams
              (project, title, status, progress, next_action, blockers,
-              created_at_epoch, updated_at_epoch, completed_at_epoch)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8)",
+              created_at_epoch, updated_at_epoch, completed_at_epoch,
+              source_project, target_project, owner_scope, owner_key, context_class)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8, ?1, ?1, 'repo', ?1, 'startup_core')",
             params![
                 project,
                 title,

--- a/tests/bench_fixtures.rs
+++ b/tests/bench_fixtures.rs
@@ -115,7 +115,18 @@ pub fn setup_full_schema(conn: &Connection) -> Result<()> {
             updated_at_epoch INTEGER NOT NULL,
             status TEXT NOT NULL DEFAULT 'active',
             branch TEXT,
-            scope TEXT DEFAULT 'project'
+            scope TEXT DEFAULT 'project',
+            source_project TEXT,
+            target_project TEXT,
+            owner_scope TEXT,
+            owner_key TEXT,
+            topic_domain TEXT,
+            routing_confidence REAL,
+            routing_reason TEXT,
+            context_class TEXT,
+            expires_at_epoch INTEGER,
+            valid_from_epoch INTEGER,
+            valid_to_epoch INTEGER
         );
 
         CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
@@ -204,7 +215,18 @@ pub fn setup_full_schema(conn: &Connection) -> Result<()> {
             preferences TEXT,
             branch TEXT,
             created_at_epoch INTEGER NOT NULL,
-            usage_tokens INTEGER DEFAULT 0
+            usage_tokens INTEGER DEFAULT 0,
+            source_project TEXT,
+            target_project TEXT,
+            owner_scope TEXT,
+            owner_key TEXT,
+            topic_domain TEXT,
+            routing_confidence REAL,
+            routing_reason TEXT,
+            context_class TEXT,
+            expires_at_epoch INTEGER,
+            valid_from_epoch INTEGER,
+            valid_to_epoch INTEGER
         );
 
         CREATE TABLE IF NOT EXISTS pending_observations (
@@ -261,7 +283,18 @@ pub fn setup_full_schema(conn: &Connection) -> Result<()> {
             next_action TEXT,
             blockers TEXT,
             created_at_epoch INTEGER NOT NULL,
-            updated_at_epoch INTEGER NOT NULL
+            updated_at_epoch INTEGER NOT NULL,
+            source_project TEXT,
+            target_project TEXT,
+            owner_scope TEXT,
+            owner_key TEXT,
+            topic_domain TEXT,
+            routing_confidence REAL,
+            routing_reason TEXT,
+            context_class TEXT,
+            expires_at_epoch INTEGER,
+            valid_from_epoch INTEGER,
+            valid_to_epoch INTEGER
         );
         CREATE TABLE IF NOT EXISTS entities (
             id INTEGER PRIMARY KEY,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -79,7 +79,18 @@ pub fn setup_memory_schema(conn: &Connection) -> Result<()> {
             updated_at_epoch INTEGER NOT NULL,
             status TEXT NOT NULL DEFAULT 'active',
             branch TEXT,
-            scope TEXT DEFAULT 'project'
+            scope TEXT DEFAULT 'project',
+            source_project TEXT,
+            target_project TEXT,
+            owner_scope TEXT,
+            owner_key TEXT,
+            topic_domain TEXT,
+            routing_confidence REAL,
+            routing_reason TEXT,
+            context_class TEXT,
+            expires_at_epoch INTEGER,
+            valid_from_epoch INTEGER,
+            valid_to_epoch INTEGER
         );
 
         CREATE VIRTUAL TABLE memories_fts USING fts5(


### PR DESCRIPTION
Closes #222.

## Summary
- Add owner-aware startup context filtering for memories: current repo-owned rows are included, legacy project rows remain a compatibility fallback, and tool/domain/session/workstream-owned rows are excluded by default.
- Add debug owner traces and footer owner counts (`repo`, `user`, `tool`, `domain`, etc.).
- Apply owner-aware filters to recent sessions, lessons, preferences, workstream matching/querying, and default active memory/workstream writes.
- Enable owner/user preference rendering through the context policy default (`preference_global_limit=5`) while preserving explicit `0` as no global/user overlay.
- Update docs and sandbox schemas/fixtures for the ownership columns.

## Tests
- Mixed Stash/Codex/Grok/Warp-style startup context fixture asserts only Stash repo + legacy context loads.
- Debug trace/owner footer tests assert inclusion and exclusion reasons.
- Session summary, preference, and workstream tests assert tool/domain-owned rows do not enter startup/project layers.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo test context:: --lib -- --nocapture`
- `cargo test memory::preference --lib -- --nocapture`
- `cargo test workstream::tests --lib -- --nocapture`
- `cargo test memory::lesson --lib -- --nocapture`
- `cargo test memory::store::write --lib -- --nocapture`
- `cargo test memory_candidate --lib -- --nocapture`
- `cargo test bench_summary_promote_creates_candidates -- --nocapture`
- `REMEM_ALLOW_PLAINTEXT_DB=1 cargo run --quiet -- context --cwd /Users/lifcc/Desktop/code/AI/tools/stash --host codex-cli --debug --force --gate off | rg "owner counts|context memories loaded"`
  - Footer/debug showed `tool=0 domain=0`.
  - The issue's old `/AI/tool/stash` path does not exist locally; smoke used `/AI/tools/stash`.
- `cargo test`

## Notes
The live smoke applied the existing v019 ownership migration to the local plaintext remem DB before rendering context.
