### PR TITLE
Add currentness TTL lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/docs/memory-lifecycle.md
+++ b/docs/memory-lifecycle.md
@@ -24,6 +24,17 @@ soft state transition to preserve provenance and debugging history.
 memories remain in the database as historical evidence but should not rank as
 current facts unless a caller explicitly asks to include stale entries.
 
+Current operational facts can also carry `expires_at_epoch`. Default retrieval
+treats an expired active row as non-current even before cleanup runs. Cleanup
+then marks expired active rows `stale` and keeps the row for provenance.
+
+Default TTLs:
+
+- local service/port/URL health and PR/CI/review state: 24 hours
+- git branch divergence snapshots: 7 days
+- product, architecture, verified bugfix, lesson, procedure, and user
+  preference memories: no TTL unless explicitly superseded
+
 Candidate review state is separate from memory state:
 
 | Candidate state | Meaning |

--- a/docs/workstream-design.md
+++ b/docs/workstream-design.md
@@ -150,7 +150,7 @@ CREATE TABLE workstream_sessions (
 
 3. 关闭：
    - AI 判断 session 完成了该任务 → completed
-   - 超过 7 天无活动 → paused（自动）
+   - 超过 14 天无活动 → paused（自动）
    - 超过 30 天无活动 → abandoned（自动）
 
 4. 恢复：新 session 的 request 匹配到 paused workstream → 重新激活
@@ -212,7 +212,7 @@ update_workstream(id, status?, next_action?, blockers?) → 手动更新
 | 创建时机 | Stop hook（复用 summary AI 调用） | 不增加额外 AI 调用成本 |
 | 匹配策略 | FTS5 语义匹配已有 workstream | 避免重复创建；允许跨 session 关联 |
 | 关联粒度 | 1 workstream : N sessions | 一个任务可能跨多个 session |
-| 自动关闭 | 7d→paused, 30d→abandoned | 避免 stale workstream 堆积 |
+| 自动关闭 | 14d→paused, 30d→abandoned | 避免 stale workstream 堆积 |
 | 存储位置 | 同一个 remem.db | 不引入新的存储依赖 |
 
 ## 参考资料

--- a/src/cli/actions/maintenance.rs
+++ b/src/cli/actions/maintenance.rs
@@ -66,9 +66,25 @@ pub(in crate::cli) fn run_encrypt() -> Result<()> {
 
 pub(in crate::cli) fn run_cleanup() -> Result<()> {
     let conn = db::open_db()?;
+    let expired_memories =
+        memory::lifecycle::expire_active_memories(&conn, chrono::Utc::now().timestamp())?;
+    let workstreams_paused = crate::workstream::auto_pause_all_inactive(
+        &conn,
+        crate::workstream::DEFAULT_AUTO_PAUSE_DAYS,
+    )?;
+    let workstreams_abandoned = crate::workstream::auto_abandon_all_inactive(
+        &conn,
+        crate::workstream::DEFAULT_AUTO_ABANDON_DAYS,
+    )?;
     let events_deleted = memory::cleanup_old_events(&conn, 30)?;
     let memories_archived = memory::archive_stale_memories(&conn, 180)?;
     println!("Cleanup complete:");
+    println!("  Expired memories marked stale: {}", expired_memories);
+    println!("  Inactive workstreams paused: {}", workstreams_paused);
+    println!(
+        "  Long-paused workstreams abandoned: {}",
+        workstreams_abandoned
+    );
     println!("  Old events deleted (>30 days): {}", events_deleted);
     println!(
         "  Stale memories archived (>180 days): {}",

--- a/src/cli/actions/query/tests.rs
+++ b/src/cli/actions/query/tests.rs
@@ -287,13 +287,20 @@ fn cli_why_render_distinguishes_visibility_from_query_scoring() {
         last_emitted_epoch: 0,
     };
 
-    let output = render_why_memory(&sample_memory(), Some("proj"), Some("main"), Some(&gate));
+    let output = render_why_memory(
+        &sample_memory(),
+        Some("proj"),
+        Some("main"),
+        Some(&gate),
+        None,
+    );
 
     assert!(output.contains("Memory #1"));
     assert!(output.contains("project match: exact proj"));
     assert!(output.contains("branch match: branchless; visible in branch-scoped search for main"));
     assert!(output.contains("type: core memory type"));
     assert!(output.contains("status: active; default search can include it"));
+    assert!(output.contains("currentness: no TTL/currentness metadata available"));
     assert!(output.contains("query scoring: query-specific"));
     assert!(output.contains("context visibility: memory index candidate and core candidate"));
     assert!(output.contains("context gate: latest codex-cli output for proj: mode=suppressed"));

--- a/src/cli/actions/query/why.rs
+++ b/src/cli/actions/query/why.rs
@@ -19,6 +19,14 @@ pub(super) struct ContextGateSummary {
     pub(super) last_emitted_epoch: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MemoryCurrentness {
+    pub(super) expires_at_epoch: Option<i64>,
+    pub(super) valid_from_epoch: Option<i64>,
+    pub(super) valid_to_epoch: Option<i64>,
+    pub(super) now_epoch: i64,
+}
+
 pub(in crate::cli) fn run_why(id: i64, project: Option<&str>, branch: Option<&str>) -> Result<()> {
     let conn = db::open_db()?;
     let memories = memory::get_memories_by_ids(&conn, &[id], None)?;
@@ -32,6 +40,7 @@ pub(in crate::cli) fn run_why(id: i64, project: Option<&str>, branch: Option<&st
     let current_branch = resolve_current_branch(branch)?;
     let gate_project = context_gate_project(memory, current_project.as_deref());
     let gate = load_latest_context_gate_summary(&conn, gate_project)?;
+    let currentness = load_memory_currentness(&conn, memory.id)?;
 
     print!(
         "{}",
@@ -39,7 +48,8 @@ pub(in crate::cli) fn run_why(id: i64, project: Option<&str>, branch: Option<&st
             memory,
             current_project.as_deref(),
             current_branch.as_deref(),
-            gate.as_ref()
+            gate.as_ref(),
+            currentness.as_ref()
         )
     );
     Ok(())
@@ -98,11 +108,35 @@ fn load_latest_context_gate_summary(
     .map_err(Into::into)
 }
 
+fn load_memory_currentness(
+    conn: &rusqlite::Connection,
+    id: i64,
+) -> Result<Option<MemoryCurrentness>> {
+    let now_epoch = chrono::Utc::now().timestamp();
+    conn.query_row(
+        "SELECT expires_at_epoch, valid_from_epoch, valid_to_epoch
+         FROM memories
+         WHERE id = ?1",
+        [id],
+        |row| {
+            Ok(MemoryCurrentness {
+                expires_at_epoch: row.get(0)?,
+                valid_from_epoch: row.get(1)?,
+                valid_to_epoch: row.get(2)?,
+                now_epoch,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
 pub(super) fn render_why_memory(
     memory: &Memory,
     current_project: Option<&str>,
     current_branch: Option<&str>,
     gate: Option<&ContextGateSummary>,
+    currentness: Option<&MemoryCurrentness>,
 ) -> String {
     let mut output = String::new();
     output.push_str(&format!("Memory #{}\n", memory.id));
@@ -122,7 +156,11 @@ pub(super) fn render_why_memory(
     ));
     output.push_str(&format!(
         "  status: {}\n",
-        status_visibility(&memory.status)
+        status_visibility(&memory.status, currentness)
+    ));
+    output.push_str(&format!(
+        "  currentness: {}\n",
+        currentness_visibility(currentness)
     ));
     output.push_str(&format!(
         "  recency: updated {}\n",
@@ -133,7 +171,7 @@ pub(super) fn render_why_memory(
     );
     output.push_str(&format!(
         "  context visibility: {}\n",
-        context_visibility(&memory.memory_type, &memory.status)
+        context_visibility(&memory.memory_type, &memory.status, currentness)
     ));
     output.push_str(&format!(
         "  context gate: {}\n",
@@ -197,7 +235,24 @@ fn type_visibility(memory_type: &str) -> String {
     .to_string()
 }
 
-fn status_visibility(status: &str) -> String {
+fn status_visibility(status: &str, currentness: Option<&MemoryCurrentness>) -> String {
+    if let Some(currentness) = currentness {
+        if status == "active" {
+            if let Some(expires_at) = currentness.expires_at_epoch {
+                if expires_at <= currentness.now_epoch {
+                    return format!(
+                        "active but expired at {}; hidden by default current retrieval until cleanup marks it stale",
+                        format_memory_timestamp(expires_at)
+                    );
+                }
+                return format!(
+                    "active; default current retrieval can include it until {}",
+                    format_memory_timestamp(expires_at)
+                );
+            }
+        }
+    }
+
     match status {
         "active" => "active; default search can include it".to_string(),
         "stale" | "archived" => {
@@ -207,9 +262,42 @@ fn status_visibility(status: &str) -> String {
     }
 }
 
-fn context_visibility(memory_type: &str, status: &str) -> String {
+fn currentness_visibility(currentness: Option<&MemoryCurrentness>) -> String {
+    let Some(currentness) = currentness else {
+        return "no TTL/currentness metadata available".to_string();
+    };
+
+    let expires = currentness
+        .expires_at_epoch
+        .map(format_memory_timestamp)
+        .unwrap_or_else(|| "none".to_string());
+    let valid_from = currentness
+        .valid_from_epoch
+        .map(format_memory_timestamp)
+        .unwrap_or_else(|| "none".to_string());
+    let valid_to = currentness
+        .valid_to_epoch
+        .map(format_memory_timestamp)
+        .unwrap_or_else(|| "none".to_string());
+    format!("expires={expires}; valid_from={valid_from}; valid_to={valid_to}")
+}
+
+fn context_visibility(
+    memory_type: &str,
+    status: &str,
+    currentness: Option<&MemoryCurrentness>,
+) -> String {
     if status != "active" {
         return format!("not context-eligible by default because status={status}");
+    }
+    if let Some(currentness) = currentness {
+        if currentness
+            .expires_at_epoch
+            .is_some_and(|expires_at| expires_at <= currentness.now_epoch)
+        {
+            return "not context-eligible by default because the current fact is expired"
+                .to_string();
+        }
     }
 
     match memory_type {

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -210,7 +210,11 @@ fn query_owner_included_memory_rows(
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
     let mut idx = 1;
     push_owner_included_filter(project, &mut idx, &mut conditions, &mut params);
-    conditions.push(crate::memory::memory_status_filter_sql("status", false));
+    conditions.push(crate::memory::memory_current_filter_sql(
+        "status",
+        "expires_at_epoch",
+        false,
+    ));
 
     if let Some(query) = query {
         let like_pattern = format!("%{query}%");
@@ -281,7 +285,11 @@ fn query_owner_exclusion_traces(
     let mut idx = 1;
     push_context_related_filter(project, &mut idx, &mut conditions, &mut params);
     push_owner_excluded_filter(project, &mut idx, &mut conditions, &mut params);
-    conditions.push(crate::memory::memory_status_filter_sql("status", false));
+    conditions.push(crate::memory::memory_current_filter_sql(
+        "status",
+        "expires_at_epoch",
+        false,
+    ));
     push_excluded_type_filter(excluded_types, &mut idx, &mut conditions, &mut params);
     params.push(Box::new(limit));
 

--- a/src/eval/local/project_leak.rs
+++ b/src/eval/local/project_leak.rs
@@ -95,6 +95,7 @@ mod tests {
                 status TEXT NOT NULL DEFAULT 'active',
                 scope TEXT NOT NULL DEFAULT 'project',
                 branch TEXT,
+                expires_at_epoch INTEGER,
                 updated_at_epoch INTEGER NOT NULL DEFAULT 0
             );
             CREATE TABLE entities (

--- a/src/memory/events/cleanup.rs
+++ b/src/memory/events/cleanup.rs
@@ -13,7 +13,7 @@ pub fn archive_stale_memories(conn: &Connection, days: i64) -> Result<usize> {
     let cutoff = chrono::Utc::now().timestamp() - (days * 86400);
     Ok(conn.execute(
         "UPDATE memories SET status = 'archived' \
-         WHERE status = 'active' AND updated_at_epoch < ?1",
+         WHERE status = 'stale' AND updated_at_epoch < ?1",
         params![cutoff],
     )?)
 }

--- a/src/memory/events/tests.rs
+++ b/src/memory/events/tests.rs
@@ -120,7 +120,7 @@ fn test_archive_stale_memories() {
     conn.execute(
         "INSERT INTO memories (session_id, project, title, content, memory_type, \
          created_at_epoch, updated_at_epoch, status)
-         VALUES ('s1', 'proj', 'old', 'old content', 'decision', ?1, ?1, 'active')",
+         VALUES ('s1', 'proj', 'old', 'old content', 'decision', ?1, ?1, 'stale')",
         params![old],
     )
     .unwrap();
@@ -133,6 +133,14 @@ fn test_archive_stale_memories() {
     .unwrap();
 
     assert_eq!(archive_stale_memories(&conn, 180).unwrap(), 1);
+    let archived: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE status = 'archived'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(archived, 1);
     let active: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM memories WHERE status = 'active'",
@@ -141,4 +149,25 @@ fn test_archive_stale_memories() {
         )
         .unwrap();
     assert_eq!(active, 1);
+}
+
+#[test]
+fn test_archive_stale_memories_does_not_archive_old_active_durable_memory() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+
+    let old = chrono::Utc::now().timestamp() - (365 * 86400);
+    conn.execute(
+        "INSERT INTO memories (session_id, project, title, content, memory_type, \
+         created_at_epoch, updated_at_epoch, status)
+         VALUES ('s1', 'proj', 'old decision', 'keep durable decision', 'architecture', ?1, ?1, 'active')",
+        params![old],
+    )
+    .unwrap();
+
+    assert_eq!(archive_stale_memories(&conn, 180).unwrap(), 0);
+    let status: String = conn
+        .query_row("SELECT status FROM memories", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(status, "active");
 }

--- a/src/memory/lesson.rs
+++ b/src/memory/lesson.rs
@@ -148,7 +148,7 @@ pub fn list_lessons_for_context(
          FROM memories m
          JOIN memory_lessons l ON l.memory_id = m.id
          WHERE m.memory_type = 'lesson'
-           AND m.status = 'active'
+           AND {current_filter}
            AND ((m.owner_scope = 'repo' AND m.owner_key = ?1)
                 OR (m.owner_scope = 'repo' AND m.target_project = ?1)
                 OR (m.owner_scope = 'user' AND m.owner_key = 'user:default')
@@ -162,7 +162,9 @@ pub fn list_lessons_for_context(
            l.reinforcement_count DESC,
            l.last_reinforced_at_epoch DESC
          LIMIT ?5",
-        cols = prefixed_memory_cols("m")
+        cols = prefixed_memory_cols("m"),
+        current_filter =
+            crate::memory::memory_current_filter_sql("m.status", "m.expires_at_epoch", false),
     ))?;
     let rows = stmt.query_map(
         params![

--- a/src/memory/lifecycle.rs
+++ b/src/memory/lifecycle.rs
@@ -1,6 +1,9 @@
 use anyhow::{anyhow, Result};
 use rusqlite::{params, Connection};
 
+pub const SHORT_CURRENT_TTL_SECONDS: i64 = 24 * 60 * 60;
+pub const BRANCH_SNAPSHOT_TTL_SECONDS: i64 = 7 * 24 * 60 * 60;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryLifecycleOp {
     Add,
@@ -83,20 +86,21 @@ pub fn apply_update(
     superseded_ids: &[i64],
 ) -> Result<LifecycleOutcome> {
     let tx = conn.unchecked_transaction()?;
-    let memory_id = crate::memory::insert_memory_full(
+    let mut superseded_targets = superseded_ids.to_vec();
+    superseded_targets.extend(find_active_same_state_key(&tx, project, topic_key, scope)?);
+    let memory_id = insert_replacement_memory(
         &tx,
         session_id,
         project,
-        Some(topic_key),
+        topic_key,
         title,
         content,
         memory_type,
         files,
         branch,
         scope,
-        None,
     )?;
-    let superseded = soft_supersede(&tx, project, superseded_ids, Some(memory_id))?;
+    let superseded = soft_supersede(&tx, project, &superseded_targets, Some(memory_id))?;
     tx.commit()?;
     Ok(LifecycleOutcome {
         op: MemoryLifecycleOp::Update,
@@ -127,6 +131,83 @@ pub fn apply_invalidate(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
+fn insert_replacement_memory(
+    conn: &Connection,
+    session_id: Option<&str>,
+    project: &str,
+    topic_key: &str,
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    files: Option<&str>,
+    branch: Option<&str>,
+    scope: &str,
+) -> Result<i64> {
+    let now = chrono::Utc::now().timestamp();
+    let (expires_at_epoch, valid_from_epoch) =
+        ttl_metadata(memory_type, Some(topic_key), content, now);
+    let search_context = crate::memory::search_context::build_search_context(
+        memory_type,
+        Some(topic_key),
+        content,
+        files,
+    );
+    let (target_project, owner_scope, owner_key) = if scope == "global" {
+        (None, "user", "user:default")
+    } else {
+        (Some(project), "repo", project)
+    };
+    conn.execute(
+        "INSERT INTO memories
+         (session_id, project, topic_key, title, content, memory_type, files, search_context,
+          created_at_epoch, updated_at_epoch, status, branch, scope,
+          source_project, target_project, owner_scope, owner_key, context_class,
+          expires_at_epoch, valid_from_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8,
+                 ?9, ?9, 'active', ?10, ?11,
+                 ?12, ?13, ?14, ?15, 'startup_core',
+                 ?16, ?17)",
+        params![
+            session_id,
+            project,
+            topic_key,
+            title,
+            content,
+            memory_type,
+            files,
+            search_context,
+            now,
+            branch,
+            scope,
+            project,
+            target_project,
+            owner_scope,
+            owner_key,
+            expires_at_epoch,
+            valid_from_epoch
+        ],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn find_active_same_state_key(
+    conn: &Connection,
+    project: &str,
+    topic_key: &str,
+    scope: &str,
+) -> Result<Vec<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT id FROM memories
+         WHERE project = ?1
+           AND topic_key = ?2
+           AND COALESCE(scope, 'project') = ?3
+           AND status = 'active'",
+    )?;
+    let rows = stmt.query_map(params![project, topic_key, scope], |row| row.get(0))?;
+    crate::db::query::collect_rows(rows)
+}
+
 pub fn noop(reason: impl Into<String>) -> LifecycleOutcome {
     LifecycleOutcome {
         op: MemoryLifecycleOp::Noop,
@@ -147,6 +228,70 @@ pub fn defer(reason: impl Into<String>) -> LifecycleOutcome {
         deferred: true,
         reason: Some(reason.into()),
     }
+}
+
+pub fn default_ttl_seconds(
+    memory_type: &str,
+    topic_key: Option<&str>,
+    content: &str,
+) -> Option<i64> {
+    let topic_key = topic_key.unwrap_or_default().to_ascii_lowercase();
+    let content = content.to_ascii_lowercase();
+
+    if has_any(&topic_key, short_current_needles()) {
+        return Some(SHORT_CURRENT_TTL_SECONDS);
+    }
+
+    if has_any(&topic_key, branch_snapshot_needles()) {
+        return Some(BRANCH_SNAPSHOT_TTL_SECONDS);
+    }
+
+    if durable_type_has_no_content_ttl(memory_type) {
+        return None;
+    }
+
+    if has_any(&content, short_current_needles()) {
+        return Some(SHORT_CURRENT_TTL_SECONDS);
+    }
+
+    if has_any(&content, branch_snapshot_needles()) {
+        return Some(BRANCH_SNAPSHOT_TTL_SECONDS);
+    }
+
+    None
+}
+
+pub fn expires_at_epoch(
+    memory_type: &str,
+    topic_key: Option<&str>,
+    content: &str,
+    now_epoch: i64,
+) -> Option<i64> {
+    default_ttl_seconds(memory_type, topic_key, content).map(|ttl| now_epoch + ttl)
+}
+
+pub fn ttl_metadata(
+    memory_type: &str,
+    topic_key: Option<&str>,
+    content: &str,
+    now_epoch: i64,
+) -> (Option<i64>, Option<i64>) {
+    let expires_at_epoch = expires_at_epoch(memory_type, topic_key, content, now_epoch);
+    let valid_from_epoch = expires_at_epoch.map(|_| now_epoch);
+    (expires_at_epoch, valid_from_epoch)
+}
+
+pub fn expire_active_memories(conn: &Connection, now_epoch: i64) -> Result<usize> {
+    Ok(conn.execute(
+        "UPDATE memories
+         SET status = 'stale',
+             valid_to_epoch = COALESCE(valid_to_epoch, ?1),
+             updated_at_epoch = ?1
+         WHERE status = 'active'
+           AND expires_at_epoch IS NOT NULL
+           AND expires_at_epoch <= ?1",
+        params![now_epoch],
+    )?)
 }
 
 pub fn soft_supersede(
@@ -177,10 +322,14 @@ pub fn soft_supersede(
     }
 
     let mut changed = 0usize;
+    let now = chrono::Utc::now().timestamp();
     for id in targets {
         let updated = conn.execute(
-            "UPDATE memories SET status = 'stale' WHERE id = ?1 AND project = ?2",
-            params![id, project],
+            "UPDATE memories
+             SET status = 'stale',
+                 valid_to_epoch = COALESCE(valid_to_epoch, ?3)
+             WHERE id = ?1 AND project = ?2",
+            params![id, project, now],
         )?;
         if updated != 1 {
             return Err(anyhow!(
@@ -193,6 +342,61 @@ pub fn soft_supersede(
     }
     Ok(changed)
 }
+
+fn has_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+fn short_current_needles() -> &'static [&'static str] {
+    &[
+        "dev-server",
+        "dev server",
+        "localhost",
+        "127.0.0.1",
+        "port occupied",
+        "port is occupied",
+        "currently running",
+        "server running",
+        "local url",
+        "url healthy",
+        "healthy at",
+        "mergeability",
+        "mergeable",
+        "review status",
+        "review-status",
+        "ci state",
+        "ci status",
+        "ci-status",
+        "github actions",
+        "pull request",
+        "pull-request",
+        "pr #",
+    ]
+}
+
+fn branch_snapshot_needles() -> &'static [&'static str] {
+    &[
+        "git-divergence",
+        "branch-divergence",
+        "branch divergence",
+        "current branch",
+        "git status",
+        "ahead of",
+        "behind origin",
+        "diverged",
+        "dirty worktree",
+    ]
+}
+
+fn durable_type_has_no_content_ttl(memory_type: &str) -> bool {
+    matches!(
+        memory_type,
+        "architecture" | "bugfix" | "lesson" | "preference" | "procedure"
+    )
+}
+
+#[cfg(test)]
+mod ttl_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/memory/lifecycle/ttl_tests.rs
+++ b/src/memory/lifecycle/ttl_tests.rs
@@ -1,0 +1,267 @@
+use anyhow::Result;
+use rusqlite::Connection;
+
+use super::*;
+use crate::memory::insert_memory;
+use crate::memory::tests_helper::setup_memory_schema;
+use crate::retrieval::search::search_with_branch;
+
+#[test]
+fn ttl_classifier_assigns_current_fact_windows_only() {
+    assert_eq!(
+        default_ttl_seconds(
+            "discovery",
+            Some("repo:/tmp/app:dev-server"),
+            "Local dev server is currently running on the current branch at localhost:3000.",
+        ),
+        Some(SHORT_CURRENT_TTL_SECONDS)
+    );
+    assert_eq!(
+        default_ttl_seconds(
+            "discovery",
+            Some("repo:/tmp/app:git-divergence"),
+            "Current branch is ahead of origin/main by two commits.",
+        ),
+        Some(BRANCH_SNAPSHOT_TTL_SECONDS)
+    );
+    assert_eq!(
+        default_ttl_seconds(
+            "architecture",
+            Some("repo:/tmp/app:storage-design"),
+            "Use SQLite WAL for concurrent readers.",
+        ),
+        None
+    );
+    assert_eq!(
+        default_ttl_seconds(
+            "architecture",
+            Some("repo:/tmp/app:storage-design"),
+            "The architecture decision mentions localhost examples and pull request checks.",
+        ),
+        None
+    );
+    assert_eq!(
+        default_ttl_seconds(
+            "procedure",
+            Some("repo:/tmp/app:release-procedure"),
+            "When reviewing pull requests, run CI status checks before merge.",
+        ),
+        None
+    );
+    assert_eq!(
+        default_ttl_seconds(
+            "preference",
+            Some("user:default:communication-style"),
+            "User prefers concise Chinese progress updates.",
+        ),
+        None
+    );
+}
+
+#[test]
+fn apply_add_assigns_ttl_to_current_operational_fact() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let project = "test-lifecycle";
+    let before = chrono::Utc::now().timestamp();
+
+    let outcome = apply_add(
+        &conn,
+        Some("s1"),
+        project,
+        Some("repo:test-lifecycle:dev-server"),
+        "Dev server",
+        "Local dev server is currently running at localhost:3000.",
+        "discovery",
+        None,
+        None,
+        "project",
+    )?;
+    let memory_id = outcome.memory_id.expect("memory id");
+    let (expires_at, valid_from): (i64, i64) = conn.query_row(
+        "SELECT expires_at_epoch, valid_from_epoch FROM memories WHERE id = ?1",
+        [memory_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+
+    let min_expected = before + SHORT_CURRENT_TTL_SECONDS;
+    let max_expected = chrono::Utc::now().timestamp() + SHORT_CURRENT_TTL_SECONDS;
+    assert!((min_expected..=max_expected).contains(&expires_at));
+    assert!(valid_from >= before);
+    Ok(())
+}
+
+#[test]
+fn ttl_expiry_marks_current_fact_stale_without_deleting_it() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let project = "test-lifecycle";
+    let id = insert_memory(
+        &conn,
+        Some("s1"),
+        project,
+        Some("repo:test-lifecycle:dev-server"),
+        "Dev server",
+        "Local dev server is currently running at localhost:3000.",
+        "discovery",
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET expires_at_epoch = ?1, valid_from_epoch = ?2
+         WHERE id = ?3",
+        rusqlite::params![100, 50, id],
+    )?;
+
+    let changed = expire_active_memories(&conn, 101)?;
+    assert_eq!(changed, 1);
+    let (status, valid_to, content): (String, Option<i64>, String) = conn.query_row(
+        "SELECT status, valid_to_epoch, content FROM memories WHERE id = ?1",
+        [id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    assert_eq!(status, "stale");
+    assert_eq!(valid_to, Some(101));
+    assert_eq!(
+        content,
+        "Local dev server is currently running at localhost:3000."
+    );
+    Ok(())
+}
+
+#[test]
+fn default_search_excludes_expired_active_memory_but_debug_lookup_can_inspect_it() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let project = "test-lifecycle";
+    let expired_id = insert_memory(
+        &conn,
+        Some("s1"),
+        project,
+        Some("repo:test-lifecycle:dev-server"),
+        "Expired dev server",
+        "localhost server old-state-needle is currently running at port 3000.",
+        "discovery",
+        None,
+    )?;
+    let fresh_id = insert_memory(
+        &conn,
+        Some("s2"),
+        project,
+        Some("repo:test-lifecycle:server-policy"),
+        "Durable server policy",
+        "server policy old-state-needle uses fixed configuration.",
+        "architecture",
+        None,
+    )?;
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "UPDATE memories SET expires_at_epoch = ?1 WHERE id = ?2",
+        rusqlite::params![now - 1, expired_id],
+    )?;
+
+    let current = search_with_branch(
+        &conn,
+        Some("old-state-needle"),
+        Some(project),
+        None,
+        10,
+        0,
+        false,
+        None,
+    )?;
+    assert_eq!(
+        current.iter().map(|memory| memory.id).collect::<Vec<_>>(),
+        vec![fresh_id]
+    );
+
+    let debug = crate::memory::get_memories_by_ids(&conn, &[expired_id], Some(project))?;
+    assert_eq!(debug.len(), 1);
+    assert_eq!(debug[0].status, "active");
+    Ok(())
+}
+
+#[test]
+fn durable_memory_without_ttl_survives_expiry_job() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let project = "test-lifecycle";
+    let id = insert_memory(
+        &conn,
+        Some("s1"),
+        project,
+        Some("repo:test-lifecycle:storage-design"),
+        "Storage design",
+        "Use SQLite WAL for concurrent readers.",
+        "architecture",
+        None,
+    )?;
+
+    assert_eq!(expire_active_memories(&conn, i64::MAX)?, 0);
+    let status: String =
+        conn.query_row("SELECT status FROM memories WHERE id = ?1", [id], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(status, "active");
+    Ok(())
+}
+
+#[test]
+fn state_key_update_inserts_replacement_and_stales_old_fact() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let project = "test-lifecycle";
+    let state_key = "repo:test-lifecycle:dev-server";
+    let old_id = insert_memory(
+        &conn,
+        Some("s1"),
+        project,
+        Some(state_key),
+        "Dev server old",
+        "Dev server is running on port 3000.",
+        "discovery",
+        None,
+    )?;
+
+    let outcome = apply_update(
+        &conn,
+        Some("s2"),
+        project,
+        state_key,
+        "Dev server current",
+        "Dev server is running on port 5173.",
+        "discovery",
+        None,
+        None,
+        "project",
+        &[],
+    )?;
+    let new_id = outcome.memory_id.expect("replacement id");
+
+    assert_ne!(old_id, new_id);
+    assert_eq!(outcome.superseded, 1);
+    let rows = conn
+        .prepare(
+            "SELECT id, status, topic_key, content, expires_at_epoch, valid_from_epoch
+             FROM memories
+             WHERE topic_key = ?1 ORDER BY id ASC",
+        )?
+        .query_map([state_key], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<i64>>(4)?,
+                row.get::<_, Option<i64>>(5)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].1, "stale");
+    assert_eq!(rows[1].1, "active");
+    assert_eq!(rows[1].3, "Dev server is running on port 5173.");
+    assert!(rows[1].4.is_some());
+    assert!(rows[1].5.is_some());
+    Ok(())
+}

--- a/src/memory/preference/query.rs
+++ b/src/memory/preference/query.rs
@@ -14,13 +14,14 @@ pub fn query_project_preferences(
 
     let sql = format!(
         "SELECT {} FROM memories \
-         WHERE memory_type = 'preference' AND status = 'active' \
+         WHERE memory_type = 'preference' AND {} \
          AND ((owner_scope = 'repo' AND owner_key = ?1) \
               OR (owner_scope = 'repo' AND target_project = ?1) \
               OR (owner_scope IS NULL AND project = ?1 AND (scope IS NULL OR scope = 'project'))) \
          GROUP BY COALESCE(topic_key, id) \
          ORDER BY MAX(updated_at_epoch) DESC LIMIT ?2",
         memory::MEMORY_COLS,
+        memory::memory_current_filter_sql("status", "expires_at_epoch", false),
     );
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params![project, limit as i64], memory::map_memory_row_pub)?;
@@ -34,12 +35,13 @@ pub fn query_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<M
 
     let sql = format!(
         "SELECT {} FROM memories \
-         WHERE memory_type = 'preference' AND status = 'active' \
+         WHERE memory_type = 'preference' AND {} \
          AND ((owner_scope = 'user' AND owner_key = 'user:default') \
               OR (owner_scope IS NULL AND scope = 'global')) \
          GROUP BY COALESCE(topic_key, id) \
          ORDER BY MAX(updated_at_epoch) DESC LIMIT ?1",
         memory::MEMORY_COLS,
+        memory::memory_current_filter_sql("status", "expires_at_epoch", false),
     );
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params![limit as i64], memory::map_memory_row_pub)?;

--- a/src/memory/store/read.rs
+++ b/src/memory/store/read.rs
@@ -18,7 +18,11 @@ pub fn get_recent_memories_excluding_types(
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
     let mut idx = 1;
     idx = push_project_filter_required("project", project, idx, &mut conditions, &mut params);
-    conditions.push(crate::memory::memory_status_filter_sql("status", false));
+    conditions.push(crate::memory::memory_current_filter_sql(
+        "status",
+        "expires_at_epoch",
+        false,
+    ));
 
     if !excluded_types.is_empty() {
         let placeholders: Vec<String> = excluded_types
@@ -61,7 +65,11 @@ pub fn get_recent_project_memories_excluding_types(
     params.push(Box::new(project.to_string()));
     idx += 1;
     conditions.push("COALESCE(scope, 'project') != 'global'".to_string());
-    conditions.push(crate::memory::memory_status_filter_sql("status", false));
+    conditions.push(crate::memory::memory_current_filter_sql(
+        "status",
+        "expires_at_epoch",
+        false,
+    ));
 
     if !excluded_types.is_empty() {
         let placeholders: Vec<String> = excluded_types
@@ -109,7 +117,11 @@ pub fn search_project_memories_excluding_types(
     params.push(Box::new(project.to_string()));
     idx += 1;
     conditions.push("COALESCE(scope, 'project') != 'global'".to_string());
-    conditions.push(crate::memory::memory_status_filter_sql("status", false));
+    conditions.push(crate::memory::memory_current_filter_sql(
+        "status",
+        "expires_at_epoch",
+        false,
+    ));
 
     let like_pattern = format!("%{query}%");
     conditions.push(format!("(title LIKE ?{idx} OR content LIKE ?{idx})"));
@@ -167,8 +179,9 @@ pub fn list_memories(
     let mut idx = 1;
     idx = push_project_filter_required("project", project, idx, &mut conditions, &mut params);
 
-    conditions.push(crate::memory::memory_status_filter_sql(
+    conditions.push(crate::memory::memory_current_filter_sql(
         "status",
+        "expires_at_epoch",
         include_inactive,
     ));
     if let Some(memory_type) = memory_type {

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -68,6 +68,8 @@ pub fn insert_memory_full(
 ) -> Result<i64> {
     let now = chrono::Utc::now().timestamp();
     let created_at = created_at_override.unwrap_or(now);
+    let (expires_at_epoch, valid_from_epoch) =
+        crate::memory::lifecycle::ttl_metadata(memory_type, topic_key, content, now);
     let search_context = build_search_context(memory_type, topic_key, content, files);
     let ownership = default_ownership(project, scope);
 
@@ -88,12 +90,14 @@ pub fn insert_memory_full(
                     "UPDATE memories SET session_id = ?1, title = ?2, content = ?3, \
                      memory_type = ?4, files = ?5, updated_at_epoch = ?6, branch = ?7, \
                      scope = ?8, search_context = ?9, \
-                     source_project = COALESCE(source_project, ?10), \
-                     target_project = COALESCE(target_project, ?11), \
-                     owner_scope = COALESCE(owner_scope, ?12), \
-                     owner_key = COALESCE(owner_key, ?13), \
-                     context_class = COALESCE(context_class, ?14) \
-                     WHERE id = ?15",
+                     status = 'active', valid_to_epoch = NULL, \
+                     expires_at_epoch = ?10, valid_from_epoch = ?11, \
+                     source_project = COALESCE(source_project, ?12), \
+                     target_project = COALESCE(target_project, ?13), \
+                     owner_scope = COALESCE(owner_scope, ?14), \
+                     owner_key = COALESCE(owner_key, ?15), \
+                     context_class = COALESCE(context_class, ?16) \
+                     WHERE id = ?17",
                     params![
                         session_id,
                         title,
@@ -104,6 +108,8 @@ pub fn insert_memory_full(
                         branch,
                         scope,
                         search_context,
+                        expires_at_epoch,
+                        valid_from_epoch,
                         ownership.source_project,
                         ownership.target_project,
                         ownership.owner_scope,
@@ -122,9 +128,10 @@ pub fn insert_memory_full(
         "INSERT INTO memories \
          (session_id, project, topic_key, title, content, memory_type, files, search_context, \
           created_at_epoch, updated_at_epoch, status, branch, scope, \
-          source_project, target_project, owner_scope, owner_key, context_class) \
+          source_project, target_project, owner_scope, owner_key, context_class, \
+          expires_at_epoch, valid_from_epoch) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'active', ?11, ?12, \
-                 ?13, ?14, ?15, ?16, ?17)",
+                 ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
         params![
             session_id,
             project,
@@ -142,7 +149,9 @@ pub fn insert_memory_full(
             ownership.target_project,
             ownership.owner_scope,
             ownership.owner_key,
-            ownership.context_class
+            ownership.context_class,
+            expires_at_epoch,
+            valid_from_epoch
         ],
     )?;
     let id = conn.last_insert_rowid();

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -164,6 +164,21 @@ pub fn memory_status_filter_sql(column: &str, include_inactive: bool) -> String 
     }
 }
 
+pub fn memory_current_filter_sql(
+    status_column: &str,
+    expires_column: &str,
+    include_inactive: bool,
+) -> String {
+    if include_inactive {
+        memory_status_filter_sql(status_column, true)
+    } else {
+        format!(
+            "{status_column} = 'active' AND \
+             ({expires_column} IS NULL OR {expires_column} > CAST(strftime('%s', 'now') AS INTEGER))"
+        )
+    }
+}
+
 pub fn map_memory_row_pub(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
     map_memory_row(row)
 }

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -304,7 +304,20 @@ fn persist_candidate_rows(
     let tx = conn.transaction()?;
     let mut summary = CandidatePersistSummary::default();
     for candidate in candidates {
-        if candidate_exists(&tx, source.project_id, candidate)? {
+        let now = chrono::Utc::now().timestamp();
+        let (expires_at_epoch, valid_from_epoch) = crate::memory::lifecycle::ttl_metadata(
+            &candidate.memory_type,
+            Some(&candidate.topic_key),
+            &candidate.text,
+            now,
+        );
+        if candidate_exists(
+            &tx,
+            source.project_id,
+            candidate,
+            expires_at_epoch.is_some(),
+            now,
+        )? {
             continue;
         }
 
@@ -315,15 +328,15 @@ fn persist_candidate_rows(
             source.route_texts.iter().copied(),
         );
         let review_status = "pending_review";
-        let now = chrono::Utc::now().timestamp();
         tx.execute(
             "INSERT INTO memory_candidates
              (project_id, scope, memory_type, topic_key, text, evidence_event_ids,
               confidence, risk_class, review_status, created_at_epoch, updated_at_epoch,
               source_project, target_project, owner_scope, owner_key, topic_domain,
-              routing_confidence, routing_reason, context_class)
+              routing_confidence, routing_reason, context_class, expires_at_epoch,
+              valid_from_epoch)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10,
-                     ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+                     ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
             params![
                 source.project_id,
                 candidate.scope,
@@ -342,7 +355,9 @@ fn persist_candidate_rows(
                 route.topic_domain.as_deref(),
                 route.routing_confidence,
                 route.routing_reason,
-                route.context_class
+                route.context_class,
+                expires_at_epoch,
+                valid_from_epoch
             ],
         )?;
         let candidate_id = tx.last_insert_rowid();
@@ -382,6 +397,8 @@ fn candidate_exists(
     conn: &Connection,
     project_id: i64,
     candidate: &ParsedMemoryCandidate,
+    candidate_has_ttl: bool,
+    now_epoch: i64,
 ) -> Result<bool> {
     let existing: Option<i64> = conn
         .query_row(
@@ -391,13 +408,19 @@ fn candidate_exists(
                AND memory_type = ?3
                AND topic_key = ?4
                AND text = ?5
+               AND (
+                    ?6 = 0
+                    OR (expires_at_epoch IS NOT NULL AND expires_at_epoch > ?7)
+               )
              LIMIT 1",
             params![
                 project_id,
                 candidate.scope,
                 candidate.memory_type,
                 candidate.topic_key,
-                candidate.text
+                candidate.text,
+                if candidate_has_ttl { 1_i64 } else { 0_i64 },
+                now_epoch
             ],
             |row| row.get(0),
         )

--- a/src/memory_candidate/apply.rs
+++ b/src/memory_candidate/apply.rs
@@ -33,8 +33,15 @@ pub(super) fn promote_candidate_to_memory_with_route(
     let title = candidate_title(candidate);
     let memory_project = route.memory_project(source_project);
     let memory_scope = route.memory_scope();
-    let active = find_active_same_topic(conn, candidate, route)?;
-    if let Some(existing) = active.iter().find(|row| {
+    let now = chrono::Utc::now().timestamp();
+    let candidate_has_ttl = crate::memory::lifecycle::default_ttl_seconds(
+        &candidate.memory_type,
+        Some(&candidate.topic_key),
+        &candidate.text,
+    )
+    .is_some();
+    let active = find_active_same_topic(conn, candidate, route, now, candidate_has_ttl)?;
+    if let Some(existing) = active.iter().filter(|row| row.is_current).find(|row| {
         normalize_evidence_text(&row.content) == normalize_evidence_text(&candidate.text)
     }) {
         return Ok(CandidateApplyOutcome {
@@ -75,6 +82,12 @@ pub(super) fn update_candidate_after_lifecycle(
     review_status: &str,
 ) -> Result<()> {
     let now = chrono::Utc::now().timestamp();
+    let (expires_at_epoch, valid_from_epoch) = crate::memory::lifecycle::ttl_metadata(
+        &candidate.memory_type,
+        Some(&candidate.topic_key),
+        &candidate.text,
+        now,
+    );
     conn.execute(
         "UPDATE memory_candidates
          SET scope = ?1,
@@ -89,8 +102,10 @@ pub(super) fn update_candidate_after_lifecycle(
              topic_domain = ?10,
              routing_confidence = ?11,
              routing_reason = ?12,
-             context_class = ?13
-         WHERE id = ?14",
+             context_class = ?13,
+             expires_at_epoch = ?14,
+             valid_from_epoch = ?15
+         WHERE id = ?16",
         params![
             candidate.scope,
             candidate.memory_type,
@@ -105,6 +120,8 @@ pub(super) fn update_candidate_after_lifecycle(
             route.routing_confidence,
             route.routing_reason,
             route.context_class,
+            expires_at_epoch,
+            valid_from_epoch,
             candidate_id
         ],
     )?;
@@ -115,15 +132,27 @@ pub(super) fn update_candidate_after_lifecycle(
 struct ActiveTopicMemory {
     id: i64,
     content: String,
+    is_current: bool,
 }
 
 fn find_active_same_topic(
     conn: &Connection,
     candidate: &ParsedMemoryCandidate,
     route: &CandidateRoute,
+    now_epoch: i64,
+    candidate_has_ttl: bool,
 ) -> Result<Vec<ActiveTopicMemory>> {
     let mut stmt = conn.prepare(
-        "SELECT id, content
+        "SELECT id, content,
+                CASE
+                    WHEN ?5 = 1 THEN
+                        CASE
+                            WHEN expires_at_epoch IS NOT NULL AND expires_at_epoch > ?6 THEN 1
+                            ELSE 0
+                        END
+                    WHEN expires_at_epoch IS NULL OR expires_at_epoch > ?6 THEN 1
+                    ELSE 0
+                END AS is_current
          FROM memories
          WHERE status = 'active'
            AND memory_type = ?1
@@ -143,12 +172,15 @@ fn find_active_same_topic(
             candidate.memory_type,
             candidate.topic_key,
             route.owner_scope,
-            route.owner_key
+            route.owner_key,
+            if candidate_has_ttl { 1_i64 } else { 0_i64 },
+            now_epoch
         ],
         |row| {
             Ok(ActiveTopicMemory {
                 id: row.get(0)?,
                 content: row.get(1)?,
+                is_current: row.get::<_, i64>(2)? == 1,
             })
         },
     )?;
@@ -169,6 +201,12 @@ fn insert_routed_memory(
     scope: &str,
 ) -> Result<i64> {
     let now = chrono::Utc::now().timestamp();
+    let (expires_at_epoch, valid_from_epoch) = crate::memory::lifecycle::ttl_metadata(
+        &candidate.memory_type,
+        Some(&candidate.topic_key),
+        &candidate.text,
+        now,
+    );
     let search_context = crate::memory::search_context::build_search_context(
         &candidate.memory_type,
         Some(&candidate.topic_key),
@@ -181,11 +219,12 @@ fn insert_routed_memory(
           created_at_epoch, updated_at_epoch, status, branch, scope,
           evidence_event_ids, source_candidate_id, confidence,
           source_project, target_project, owner_scope, owner_key, topic_domain,
-          routing_confidence, routing_reason, context_class)
+          routing_confidence, routing_reason, context_class, expires_at_epoch,
+          valid_from_epoch)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7,
                  ?8, ?8, 'active', NULL, ?9,
                  ?10, ?11, ?12,
-                 ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
+                 ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)",
         params![
             session_id,
             memory_project,
@@ -206,7 +245,9 @@ fn insert_routed_memory(
             route.topic_domain.as_deref(),
             route.routing_confidence,
             route.routing_reason,
-            route.context_class
+            route.context_class,
+            expires_at_epoch,
+            valid_from_epoch
         ],
     )?;
     let memory_id = conn.last_insert_rowid();
@@ -258,8 +299,11 @@ fn soft_supersede_routed(
     let mut changed = 0usize;
     for id in targets {
         let updated = conn.execute(
-            "UPDATE memories SET status = 'stale' WHERE id = ?1",
-            params![id],
+            "UPDATE memories
+             SET status = 'stale',
+                 valid_to_epoch = COALESCE(valid_to_epoch, ?2)
+             WHERE id = ?1",
+            params![id, chrono::Utc::now().timestamp()],
         )?;
         if updated != 1 {
             bail!("failed to mark superseded memory stale: id={id}");

--- a/src/memory_candidate/tests.rs
+++ b/src/memory_candidate/tests.rs
@@ -5,6 +5,8 @@ use crate::db::{self, record_captured_event, CaptureEventInput, ExtractionTaskKi
 
 use super::{process_with_generator, MemoryCandidateResult};
 
+mod ttl;
+
 fn setup_conn() -> Connection {
     let conn = Connection::open_in_memory().expect("in-memory db should open");
     crate::migrate::run_migrations(&conn).expect("migrations should run");

--- a/src/memory_candidate/tests/ttl.rs
+++ b/src/memory_candidate/tests/ttl.rs
@@ -1,0 +1,121 @@
+use anyhow::Result;
+use rusqlite::params;
+
+use super::*;
+
+#[tokio::test]
+async fn memory_candidate_assigns_ttl_to_current_operational_state() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-ttl")?;
+    let text = "Local dev server is currently running at localhost:3000 for remem.";
+    insert_source_observation(&conn, &task, text)?;
+    let before = chrono::Utc::now().timestamp();
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok(format!(
+            "<memory_candidate>\
+                <scope>project</scope>\
+                <type>decision</type>\
+                <topic_key>repo:/tmp/remem:dev-server</topic_key>\
+                <risk_class>low</risk_class>\
+                <confidence>0.92</confidence>\
+                <text>{text}</text>\
+             </memory_candidate>"
+        ))
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0
+        }
+    );
+    let (candidate_expires, memory_expires, memory_valid_from): (i64, i64, i64) = conn.query_row(
+        "SELECT c.expires_at_epoch, m.expires_at_epoch, m.valid_from_epoch
+         FROM memory_candidates c
+         JOIN memories m ON m.source_candidate_id = c.id",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    let min_expected = before + crate::memory::lifecycle::SHORT_CURRENT_TTL_SECONDS;
+    let max_expected =
+        chrono::Utc::now().timestamp() + crate::memory::lifecycle::SHORT_CURRENT_TTL_SECONDS;
+    assert!((min_expected..=max_expected).contains(&candidate_expires));
+    assert!((min_expected..=max_expected).contains(&memory_expires));
+    assert!(memory_valid_from >= before);
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_refreshes_legacy_current_state_without_ttl() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-refresh-ttl")?;
+    let text = "Local dev server is currently running at localhost:3000 for remem.";
+    let topic_key = "repo-tmp-remem-dev-server";
+    insert_source_observation(&conn, &task, text)?;
+    let old_epoch = chrono::Utc::now().timestamp() - 3600;
+
+    conn.execute(
+        "INSERT INTO memory_candidates
+         (project_id, scope, memory_type, topic_key, text, evidence_event_ids,
+          confidence, risk_class, review_status, created_at_epoch, updated_at_epoch,
+          source_project, target_project, owner_scope, owner_key, context_class)
+         VALUES (?1, 'project', 'decision', ?2, ?3, '[]',
+                 0.92, 'low', 'auto_promoted', ?4, ?4,
+                 ?5, ?5, 'repo', ?5, 'startup_core')",
+        params![task.project_id, topic_key, text, old_epoch, task.project],
+    )?;
+    conn.execute(
+        "INSERT INTO memories
+         (session_id, project, topic_key, title, content, memory_type,
+          created_at_epoch, updated_at_epoch, status, scope,
+          source_project, target_project, owner_scope, owner_key, context_class)
+         VALUES ('legacy-current', ?1, ?2, 'Dev server', ?3, 'decision',
+                 ?4, ?4, 'active', 'project',
+                 ?1, ?1, 'repo', ?1, 'startup_core')",
+        params![task.project, topic_key, text, old_epoch],
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok(format!(
+            "<memory_candidate>\
+                <scope>project</scope>\
+                <type>decision</type>\
+                <topic_key>{topic_key}</topic_key>\
+                <risk_class>low</risk_class>\
+                <confidence>0.92</confidence>\
+                <text>{text}</text>\
+             </memory_candidate>"
+        ))
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0
+        }
+    );
+    let rows = conn
+        .prepare(
+            "SELECT status, expires_at_epoch
+             FROM memories
+             WHERE topic_key = ?1
+             ORDER BY id ASC",
+        )?
+        .query_map([topic_key], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].0, "stale");
+    assert_eq!(rows[0].1, None);
+    assert_eq!(rows[1].0, "active");
+    assert!(rows[1].1.is_some());
+    Ok(())
+}

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -246,17 +246,20 @@ fn indexes_match_after_upgrade() -> Result<()> {
 /// This catches columns referenced in code but missing from both baseline and backfill.
 #[test]
 fn real_queries_work_on_upgraded_db() -> Result<()> {
-    use crate::memory::types::MEMORY_COLS;
+    use crate::memory::{memory_current_filter_sql, MEMORY_COLS};
 
     let conn = make_upgraded_v10_db()?;
+    let current_filter = memory_current_filter_sql("m.status", "m.expires_at_epoch", false);
 
     // FTS search query (from memory_search/fts.rs)
     let fts_query = format!(
         "SELECT m.{} FROM memories m \
          JOIN memories_fts ON memories_fts.rowid = m.id \
          WHERE memories_fts MATCH 'test' \
+           AND {} \
          ORDER BY bm25(memories_fts, 10.0, 1.0, 3.0) LIMIT 10",
-        MEMORY_COLS.replace(", ", ", m.")
+        MEMORY_COLS.replace(", ", ", m."),
+        current_filter
     );
     assert!(
         conn.prepare(&fts_query).is_ok(),
@@ -264,11 +267,14 @@ fn real_queries_work_on_upgraded_db() -> Result<()> {
     );
 
     // LIKE fallback query (from memory_search/like.rs)
+    let current_filter = memory_current_filter_sql("m.status", "m.expires_at_epoch", false);
     let like_query = format!(
         "SELECT m.{} FROM memories m \
          WHERE m.content LIKE '%test%' \
+           AND {} \
          ORDER BY m.updated_at_epoch DESC LIMIT 10",
-        MEMORY_COLS.replace(", ", ", m.")
+        MEMORY_COLS.replace(", ", ", m."),
+        current_filter
     );
     assert!(
         conn.prepare(&like_query).is_ok(),
@@ -276,11 +282,12 @@ fn real_queries_work_on_upgraded_db() -> Result<()> {
     );
 
     // Scope-aware read query (from memory/store/read.rs)
+    let current_filter = memory_current_filter_sql("status", "expires_at_epoch", false);
     let scope_query = format!(
         "SELECT {} FROM memories \
-         WHERE (project = 'test' OR scope = 'global') AND status = 'active' \
+         WHERE (project = 'test' OR scope = 'global') AND {} \
          ORDER BY updated_at_epoch DESC LIMIT 10",
-        MEMORY_COLS
+        MEMORY_COLS, current_filter
     );
     assert!(
         conn.prepare(&scope_query).is_ok(),

--- a/src/observe/flush/context/tests.rs
+++ b/src/observe/flush/context/tests.rs
@@ -49,7 +49,8 @@ fn setup_existing_context_schema(conn: &Connection) -> Result<()> {
             updated_at_epoch INTEGER NOT NULL,
             status TEXT NOT NULL DEFAULT 'active',
             branch TEXT,
-            scope TEXT DEFAULT 'project'
+            scope TEXT DEFAULT 'project',
+            expires_at_epoch INTEGER
         );",
     )?;
     Ok(())

--- a/src/retrieval/entity/graph/sql.rs
+++ b/src/retrieval/entity/graph/sql.rs
@@ -71,5 +71,5 @@ fn branch_filter_sql(param_idx: usize) -> String {
 }
 
 fn status_filter_sql(include_inactive: bool) -> String {
-    crate::memory::memory_status_filter_sql("m.status", include_inactive)
+    crate::memory::memory_current_filter_sql("m.status", "m.expires_at_epoch", include_inactive)
 }

--- a/src/retrieval/entity/search/sql.rs
+++ b/src/retrieval/entity/search/sql.rs
@@ -7,5 +7,5 @@ pub(super) fn branch_filter_sql(param_idx: usize) -> String {
 }
 
 pub(super) fn status_filter_sql(include_inactive: bool) -> String {
-    crate::memory::memory_status_filter_sql("m.status", include_inactive)
+    crate::memory::memory_current_filter_sql("m.status", "m.expires_at_epoch", include_inactive)
 }

--- a/src/retrieval/entity/tests/support.rs
+++ b/src/retrieval/entity/tests/support.rs
@@ -11,6 +11,7 @@ pub(super) fn setup_entity_schema(conn: &Connection) {
             branch TEXT,
             status TEXT NOT NULL DEFAULT 'active',
             scope TEXT NOT NULL DEFAULT 'project',
+            expires_at_epoch INTEGER,
             updated_at_epoch INTEGER NOT NULL DEFAULT 0
         );
         CREATE TABLE entities (

--- a/src/retrieval/memory_search/fts.rs
+++ b/src/retrieval/memory_search/fts.rs
@@ -40,8 +40,9 @@ pub fn search_memories_fts_filtered(
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(query.to_string())];
 
     let mut idx = 2;
-    conditions.push(crate::memory::memory_status_filter_sql(
+    conditions.push(crate::memory::memory_current_filter_sql(
         "m.status",
+        "m.expires_at_epoch",
         include_inactive,
     ));
 

--- a/src/retrieval/memory_search/like.rs
+++ b/src/retrieval/memory_search/like.rs
@@ -44,8 +44,9 @@ pub fn search_memories_like_filtered(
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
     let mut idx = 1;
 
-    conditions.push(crate::memory::memory_status_filter_sql(
+    conditions.push(crate::memory::memory_current_filter_sql(
         "m.status",
+        "m.expires_at_epoch",
         include_inactive,
     ));
 

--- a/src/retrieval/temporal/search.rs
+++ b/src/retrieval/temporal/search.rs
@@ -30,8 +30,9 @@ pub fn search_by_time_filtered(
     ];
     let mut idx = 3;
 
-    conditions.push(crate::memory::memory_status_filter_sql(
+    conditions.push(crate::memory::memory_current_filter_sql(
         "status",
+        "expires_at_epoch",
         include_inactive,
     ));
     if let Some(project) = project {

--- a/src/retrieval/temporal/tests.rs
+++ b/src/retrieval/temporal/tests.rs
@@ -7,6 +7,8 @@ fn setup_conn() -> Connection {
     let conn = Connection::open_in_memory().expect("in-memory db should open");
     conn.execute_batch(MIGRATIONS[0].sql)
         .expect("baseline schema should load");
+    conn.execute_batch("ALTER TABLE memories ADD COLUMN expires_at_epoch INTEGER;")
+        .expect("expires column should load");
     conn
 }
 

--- a/src/workstream.rs
+++ b/src/workstream.rs
@@ -6,7 +6,10 @@ mod tests;
 mod types;
 mod write;
 
-pub use lifecycle::{auto_abandon_inactive, auto_pause_inactive};
+pub use lifecycle::{
+    auto_abandon_all_inactive, auto_abandon_inactive, auto_pause_all_inactive, auto_pause_inactive,
+    DEFAULT_AUTO_ABANDON_DAYS, DEFAULT_AUTO_PAUSE_DAYS,
+};
 pub use matcher::find_matching_workstream;
 pub use query::{query_active_workstreams, query_workstreams};
 pub use types::{ParsedWorkStream, WorkStream, WorkStreamStatus};

--- a/src/workstream/lifecycle.rs
+++ b/src/workstream/lifecycle.rs
@@ -1,13 +1,30 @@
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
+pub const DEFAULT_AUTO_PAUSE_DAYS: i64 = 14;
+pub const DEFAULT_AUTO_ABANDON_DAYS: i64 = 30;
+
 pub fn auto_pause_inactive(conn: &Connection, project: &str, days: i64) -> Result<usize> {
-    let now = chrono::Utc::now().timestamp();
-    let cutoff = now - (days * 86400);
+    let cutoff = chrono::Utc::now().timestamp() - (days * 86400);
     let count = conn.execute(
-        "UPDATE workstreams SET status = 'paused', updated_at_epoch = ?1
-         WHERE project = ?2 AND status = 'active' AND updated_at_epoch < ?3",
-        params![now, project, cutoff],
+        "UPDATE workstreams SET status = 'paused'
+         WHERE status = 'active'
+           AND updated_at_epoch < ?2
+           AND ((owner_scope = 'repo' AND owner_key = ?1)
+                OR (owner_scope = 'repo' AND target_project = ?1)
+                OR (owner_scope = 'workstream' AND target_project = ?1)
+                OR (owner_scope IS NULL AND project = ?1))",
+        params![project, cutoff],
+    )?;
+    Ok(count)
+}
+
+pub fn auto_pause_all_inactive(conn: &Connection, days: i64) -> Result<usize> {
+    let cutoff = chrono::Utc::now().timestamp() - (days * 86400);
+    let count = conn.execute(
+        "UPDATE workstreams SET status = 'paused'
+         WHERE status = 'active' AND updated_at_epoch < ?1",
+        params![cutoff],
     )?;
     Ok(count)
 }
@@ -17,8 +34,24 @@ pub fn auto_abandon_inactive(conn: &Connection, project: &str, days: i64) -> Res
     let cutoff = now - (days * 86400);
     let count = conn.execute(
         "UPDATE workstreams SET status = 'abandoned', updated_at_epoch = ?1
-         WHERE project = ?2 AND status = 'paused' AND updated_at_epoch < ?3",
+         WHERE status = 'paused'
+           AND updated_at_epoch < ?3
+           AND ((owner_scope = 'repo' AND owner_key = ?2)
+                OR (owner_scope = 'repo' AND target_project = ?2)
+                OR (owner_scope = 'workstream' AND target_project = ?2)
+                OR (owner_scope IS NULL AND project = ?2))",
         params![now, project, cutoff],
+    )?;
+    Ok(count)
+}
+
+pub fn auto_abandon_all_inactive(conn: &Connection, days: i64) -> Result<usize> {
+    let now = chrono::Utc::now().timestamp();
+    let cutoff = now - (days * 86400);
+    let count = conn.execute(
+        "UPDATE workstreams SET status = 'abandoned', updated_at_epoch = ?1
+         WHERE status = 'paused' AND updated_at_epoch < ?2",
+        params![now, cutoff],
     )?;
     Ok(count)
 }

--- a/src/workstream/matcher.rs
+++ b/src/workstream/matcher.rs
@@ -16,6 +16,7 @@ pub fn find_matching_workstream(
              WHERE title = ?2 AND status IN ('active', 'paused')
                AND ((owner_scope = 'repo' AND owner_key = ?1)
                     OR (owner_scope = 'repo' AND target_project = ?1)
+                    OR (owner_scope = 'workstream' AND target_project = ?1)
                     OR (owner_scope IS NULL AND project = ?1))",
             params![project, title],
             map_workstream_row,
@@ -33,6 +34,7 @@ pub fn find_matching_workstream(
          WHERE status IN ('active', 'paused')
            AND ((owner_scope = 'repo' AND owner_key = ?1)
                 OR (owner_scope = 'repo' AND target_project = ?1)
+                OR (owner_scope = 'workstream' AND target_project = ?1)
                 OR (owner_scope IS NULL AND project = ?1))
          ORDER BY updated_at_epoch DESC",
     )?;

--- a/src/workstream/query.rs
+++ b/src/workstream/query.rs
@@ -10,9 +10,10 @@ const SELECT_FIELDS: &str =
 
 pub fn query_active_workstreams(conn: &Connection, project: &str) -> Result<Vec<WorkStream>> {
     let sql = format!(
-        "{} WHERE status IN ('active', 'paused')
+        "{} WHERE status = 'active'
               AND ((owner_scope = 'repo' AND owner_key = ?1)
                    OR (owner_scope = 'repo' AND target_project = ?1)
+                   OR (owner_scope = 'workstream' AND target_project = ?1)
                    OR (owner_scope IS NULL AND project = ?1))
               ORDER BY updated_at_epoch DESC",
         SELECT_FIELDS
@@ -33,6 +34,7 @@ pub fn query_workstreams(
                 "{} WHERE status = ?2
                       AND ((owner_scope = 'repo' AND owner_key = ?1)
                            OR (owner_scope = 'repo' AND target_project = ?1)
+                           OR (owner_scope = 'workstream' AND target_project = ?1)
                            OR (owner_scope IS NULL AND project = ?1))
                       ORDER BY updated_at_epoch DESC",
                 SELECT_FIELDS
@@ -44,6 +46,7 @@ pub fn query_workstreams(
             format!(
                 "{} WHERE ((owner_scope = 'repo' AND owner_key = ?1)
                            OR (owner_scope = 'repo' AND target_project = ?1)
+                           OR (owner_scope = 'workstream' AND target_project = ?1)
                            OR (owner_scope IS NULL AND project = ?1))
                       ORDER BY updated_at_epoch DESC",
                 SELECT_FIELDS

--- a/src/workstream/tests/lifecycle.rs
+++ b/src/workstream/tests/lifecycle.rs
@@ -1,14 +1,16 @@
 use rusqlite::{params, Connection};
 
 use super::support::setup_workstream_schema;
-use crate::workstream::{auto_abandon_inactive, auto_pause_inactive, query_workstreams};
+use crate::workstream::{
+    auto_abandon_inactive, auto_pause_inactive, query_workstreams, DEFAULT_AUTO_PAUSE_DAYS,
+};
 
 #[test]
-fn test_auto_pause_after_7_days() {
+fn test_auto_pause_after_14_days() {
     let conn = Connection::open_in_memory().unwrap();
     setup_workstream_schema(&conn);
 
-    let old_epoch = chrono::Utc::now().timestamp() - (8 * 86400);
+    let old_epoch = chrono::Utc::now().timestamp() - ((DEFAULT_AUTO_PAUSE_DAYS + 1) * 86400);
     conn.execute(
         "INSERT INTO workstreams (project, title, status, created_at_epoch, updated_at_epoch)
          VALUES ('test/proj', 'Stale Task', 'active', ?1, ?1)",
@@ -16,7 +18,7 @@ fn test_auto_pause_after_7_days() {
     )
     .unwrap();
 
-    let paused = auto_pause_inactive(&conn, "test/proj", 7).unwrap();
+    let paused = auto_pause_inactive(&conn, "test/proj", DEFAULT_AUTO_PAUSE_DAYS).unwrap();
     assert_eq!(paused, 1);
 
     let workstreams = query_workstreams(&conn, "test/proj", Some("paused")).unwrap();
@@ -48,7 +50,7 @@ fn test_auto_pause_skips_recent() {
     let conn = Connection::open_in_memory().unwrap();
     setup_workstream_schema(&conn);
 
-    let recent = chrono::Utc::now().timestamp() - (3 * 86400);
+    let recent = chrono::Utc::now().timestamp() - ((DEFAULT_AUTO_PAUSE_DAYS - 1) * 86400);
     conn.execute(
         "INSERT INTO workstreams (project, title, status, created_at_epoch, updated_at_epoch)
          VALUES ('test/proj', 'Recent Task', 'active', ?1, ?1)",
@@ -56,8 +58,70 @@ fn test_auto_pause_skips_recent() {
     )
     .unwrap();
 
-    let paused = auto_pause_inactive(&conn, "test/proj", 7).unwrap();
+    let paused = auto_pause_inactive(&conn, "test/proj", DEFAULT_AUTO_PAUSE_DAYS).unwrap();
     assert_eq!(paused, 0);
+}
+
+#[test]
+fn test_auto_pause_uses_repo_owner_metadata() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_workstream_schema(&conn);
+
+    let old_epoch = chrono::Utc::now().timestamp() - ((DEFAULT_AUTO_PAUSE_DAYS + 1) * 86400);
+    conn.execute(
+        "INSERT INTO workstreams
+         (project, title, status, created_at_epoch, updated_at_epoch,
+          owner_scope, owner_key, target_project)
+         VALUES ('legacy/path', 'Owned Task', 'active', ?1, ?1,
+                 'repo', 'test/proj', 'test/proj')",
+        params![old_epoch],
+    )
+    .unwrap();
+
+    let paused = auto_pause_inactive(&conn, "test/proj", DEFAULT_AUTO_PAUSE_DAYS).unwrap();
+    assert_eq!(paused, 1);
+}
+
+#[test]
+fn test_auto_pause_uses_workstream_owner_target_project() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_workstream_schema(&conn);
+
+    let old_epoch = chrono::Utc::now().timestamp() - ((DEFAULT_AUTO_PAUSE_DAYS + 1) * 86400);
+    conn.execute(
+        "INSERT INTO workstreams
+         (project, title, status, created_at_epoch, updated_at_epoch,
+          owner_scope, owner_key, target_project)
+         VALUES ('legacy/path', 'Owned Workstream', 'active', ?1, ?1,
+                 'workstream', 'ws-123', 'test/proj')",
+        params![old_epoch],
+    )
+    .unwrap();
+
+    let paused = auto_pause_inactive(&conn, "test/proj", DEFAULT_AUTO_PAUSE_DAYS).unwrap();
+    assert_eq!(paused, 1);
+}
+
+#[test]
+fn test_cleanup_sequence_can_abandon_more_than_30_days_inactive() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_workstream_schema(&conn);
+
+    let old_epoch = chrono::Utc::now().timestamp() - (45 * 86400);
+    conn.execute(
+        "INSERT INTO workstreams (project, title, status, created_at_epoch, updated_at_epoch)
+         VALUES ('test/proj', 'Very Old Active', 'active', ?1, ?1)",
+        params![old_epoch],
+    )
+    .unwrap();
+
+    let paused = auto_pause_inactive(&conn, "test/proj", DEFAULT_AUTO_PAUSE_DAYS).unwrap();
+    assert_eq!(paused, 1);
+    let abandoned = auto_abandon_inactive(&conn, "test/proj", 30).unwrap();
+    assert_eq!(abandoned, 1);
+
+    let workstreams = query_workstreams(&conn, "test/proj", Some("abandoned")).unwrap();
+    assert_eq!(workstreams.len(), 1);
 }
 
 #[test]

--- a/src/workstream/tests/query.rs
+++ b/src/workstream/tests/query.rs
@@ -143,6 +143,26 @@ fn test_completed_status() {
 }
 
 #[test]
+fn test_query_active_workstreams_excludes_paused_repo_rows() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_workstream_schema(&conn);
+    let now = chrono::Utc::now().timestamp();
+
+    conn.execute(
+        "INSERT INTO workstreams (project, title, status, created_at_epoch, updated_at_epoch)
+         VALUES
+         ('test/proj', 'Active Task', 'active', ?1, ?1),
+         ('test/proj', 'Paused Task', 'paused', ?1, ?1)",
+        params![now],
+    )
+    .unwrap();
+
+    let active = query_active_workstreams(&conn, "test/proj").unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].title, "Active Task");
+}
+
+#[test]
 fn test_query_active_workstreams_excludes_tool_domain_owned_rows() {
     let conn = Connection::open_in_memory().unwrap();
     setup_workstream_schema(&conn);


### PR DESCRIPTION
Closes #223.

Summary:
- Add TTL/currentness metadata for operational memories and candidates, with default filters excluding expired active rows before cleanup.
- Refresh legacy or expired current-state candidates instead of treating them as durable duplicates/noops.
- Mark expired active memories stale during cleanup, preserve durable no-TTL memories, and keep paused workstreams out of default startup context.
- Add diagnostics for TTL/currentness in `remem why` and coverage for TTL, stale preservation, workstream pause, and migration query guards.

Verification:
- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo test`