### PR TITLE
Add memory governance eval suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -11,7 +11,7 @@ mod shared;
 mod usage;
 
 pub(super) use admin::run_admin;
-pub(super) use eval::{run_eval, run_eval_e2e, run_eval_local};
+pub(super) use eval::{run_eval, run_eval_e2e, run_eval_governance, run_eval_local};
 pub(super) use import::run_import;
 pub(super) use maintenance::{
     run_cleanup, run_dream, run_encrypt, run_governance, GovernanceCliRequest,

--- a/src/cli/actions/eval.rs
+++ b/src/cli/actions/eval.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 
 use crate::db;
 
@@ -24,6 +24,21 @@ pub(in crate::cli) async fn run_eval_e2e(k: usize, json: bool, keep_data_dir: bo
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         print!("{}", report);
+    }
+    Ok(())
+}
+
+pub(in crate::cli) fn run_eval_governance(k: usize, json: bool) -> Result<()> {
+    let report = crate::eval::governance::run_sandbox_eval(
+        crate::eval::governance::GovernanceEvalOptions { k },
+    )?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", report);
+    }
+    if !report.metrics.all_checks_passed {
+        bail!("eval-governance checks failed");
     }
     Ok(())
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -4,9 +4,10 @@ use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 
 use super::actions::{
     run_admin, run_archive, run_audit_scope, run_backfill_entities, run_cleanup, run_commit,
-    run_dream, run_encrypt, run_eval, run_eval_e2e, run_eval_local, run_governance, run_import,
-    run_merge_preferences, run_pending, run_preferences, run_reroute, run_review, run_search,
-    run_show, run_status, run_usage, run_why, GovernanceCliRequest, RerouteCliRequest,
+    run_dream, run_encrypt, run_eval, run_eval_e2e, run_eval_governance, run_eval_local,
+    run_governance, run_import, run_merge_preferences, run_pending, run_preferences, run_reroute,
+    run_review, run_search, run_show, run_status, run_usage, run_why, GovernanceCliRequest,
+    RerouteCliRequest,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands};
@@ -188,6 +189,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             json,
             keep_data_dir,
         } => run_eval_e2e(k, json, keep_data_dir).await?,
+        Commands::EvalGovernance { k, json } => run_eval_governance(k, json)?,
         Commands::EvalLocal => run_eval_local()?,
         Commands::BackfillEntities => run_backfill_entities()?,
         Commands::Encrypt => run_encrypt()?,

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -558,6 +558,19 @@ fn cli_parses_eval_e2e_options() {
 }
 
 #[test]
+fn cli_parses_eval_governance_options() {
+    let cli = Cli::parse_from(["remem", "eval-governance", "--json", "-k", "4"]);
+
+    match cli.command {
+        Commands::EvalGovernance { k, json } => {
+            assert_eq!(k, 4);
+            assert!(json);
+        }
+        _ => panic!("expected eval-governance command"),
+    }
+}
+
+#[test]
 fn cli_parses_pending_short_aliases() {
     let list = Cli::parse_from(["remem", "pending", "list", "--limit", "3"]);
     match list.command {

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -338,6 +338,15 @@ pub(super) enum Commands {
         #[arg(long)]
         keep_data_dir: bool,
     },
+    /// Run sandboxed memory governance quality evaluation.
+    EvalGovernance {
+        /// Number of results to evaluate per query.
+        #[arg(long, short = 'k', default_value = "5")]
+        k: usize,
+        /// Emit the evaluation report as JSON.
+        #[arg(long)]
+        json: bool,
+    },
     /// Run local retrieval diagnostics.
     EvalLocal,
     /// Backfill entity records for existing memories.

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,4 +14,5 @@ mod sections;
 mod tests;
 mod types;
 
+pub(crate) use render::governance_eval_snapshot;
 pub use render::{generate_context, generate_context_from_cli};

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::Result;
 
 use crate::db;
@@ -9,7 +11,7 @@ use super::invocation::{
     direct_context_invocation, resolve_context_invocation, ContextCliOptions, ContextInvocation,
 };
 use super::ownership::OwnerCounts;
-use super::policy::{ContextPolicy, SectionKind};
+use super::policy::{ContextLimits, ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
     empty_state_output, render_core_memory_with_limits, render_lessons_with_limit,
@@ -21,6 +23,110 @@ use super::types::ContextRequest;
 struct RenderedContext {
     output: String,
     stats: ContextRenderStats,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ContextEvalSnapshot {
+    pub memory_topic_keys: Vec<String>,
+    pub memory_titles: Vec<String>,
+    pub rendered_output: String,
+    pub total_included: usize,
+    pub safe_owner_included: usize,
+    pub unsafe_owner_included: usize,
+    pub excluded_owner_titles: Vec<String>,
+}
+
+pub(crate) fn governance_eval_snapshot(
+    conn: &rusqlite::Connection,
+    project: &str,
+    current_branch: Option<&str>,
+) -> Result<ContextEvalSnapshot> {
+    let policy = ContextPolicy::from_limits(ContextLimits::default());
+    let loaded = load_context_data_with_policy(conn, project, current_branch, &policy);
+    let rendered_output = render_loaded_context_for_eval(conn, project, &policy, &loaded)?;
+    let rendered_memories = loaded
+        .memories
+        .iter()
+        .filter(|memory| rendered_output.contains(&memory.title))
+        .collect::<Vec<_>>();
+    let memory_topic_keys = rendered_memories
+        .iter()
+        .filter_map(|memory| memory.topic_key.clone())
+        .collect::<Vec<_>>();
+    let memory_titles = rendered_memories
+        .iter()
+        .map(|memory| memory.title.clone())
+        .collect::<Vec<_>>();
+    let unsafe_owner_included = loaded
+        .owner_traces
+        .iter()
+        .filter(|trace| trace.included)
+        .filter(|trace| !matches!(trace.owner_scope.as_deref(), Some("repo") | None))
+        .count();
+    let excluded_owner_titles = loaded
+        .owner_traces
+        .iter()
+        .filter(|trace| !trace.included)
+        .map(|trace| trace.title.clone())
+        .collect::<Vec<_>>();
+    let total_included = loaded.memories.len();
+
+    Ok(ContextEvalSnapshot {
+        memory_topic_keys,
+        memory_titles,
+        rendered_output,
+        total_included,
+        safe_owner_included: total_included.saturating_sub(unsafe_owner_included),
+        unsafe_owner_included,
+        excluded_owner_titles,
+    })
+}
+
+fn render_loaded_context_for_eval(
+    conn: &rusqlite::Connection,
+    project: &str,
+    policy: &ContextPolicy,
+    loaded: &super::types::LoadedContext,
+) -> Result<String> {
+    let (preference_output, _) = render_preferences_to_buffer(conn, project, project, policy)?;
+    let mut output = preference_output;
+
+    if !loaded.lessons.is_empty() {
+        render_lessons_with_limit(
+            &mut output,
+            &loaded.lessons,
+            policy.section_item_limit(SectionKind::Lessons, policy.limits.lesson_limit),
+            policy.section_char_limit(SectionKind::Lessons, policy.limits.lesson_char_limit),
+        );
+    }
+    if !loaded.memories.is_empty() {
+        let render_limits = section_render_limits(policy);
+        let core_summary =
+            render_core_memory_with_limits(&mut output, &loaded.memories, &render_limits);
+        let core_ids: HashSet<i64> = core_summary.ids.into_iter().collect();
+        render_memory_index_with_limits_excluding(
+            &mut output,
+            &loaded.memories,
+            &render_limits,
+            &core_ids,
+        );
+    }
+    if !loaded.workstreams.is_empty() {
+        render_workstreams_with_limits(
+            &mut output,
+            &loaded.workstreams,
+            policy.section_item_limit(SectionKind::Workstreams, 5),
+            policy.section_char_limit(SectionKind::Workstreams, 1_200),
+        );
+    }
+    if !loaded.summaries.is_empty() {
+        render_recent_sessions_with_limit(
+            &mut output,
+            &loaded.summaries,
+            policy.section_char_limit(SectionKind::Sessions, 2_200),
+        );
+    }
+    Ok(output)
 }
 
 pub fn generate_context(

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -1,6 +1,17 @@
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+
 use anyhow::{Context, Result};
 use rusqlite::Connection;
-use std::path::{Path, PathBuf};
+
+thread_local! {
+    static DATA_DIR_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn with_data_dir<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
+    let _guard = DataDirOverrideGuard::set(dir.to_path_buf());
+    f()
+}
 
 pub fn deterministic_hash(data: &[u8]) -> u64 {
     const FNV_OFFSET: u64 = 0xcbf29ce484222325;
@@ -37,6 +48,9 @@ pub fn project_from_cwd(cwd: &str) -> String {
 }
 
 pub fn data_dir() -> PathBuf {
+    if let Some(path) = DATA_DIR_OVERRIDE.with(|slot| slot.borrow().clone()) {
+        return path;
+    }
     std::env::var("REMEM_DATA_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
@@ -100,6 +114,26 @@ pub fn detect_git_branch(cwd: &str) -> Option<String> {
         None
     } else {
         Some(branch)
+    }
+}
+
+struct DataDirOverrideGuard {
+    previous: Option<PathBuf>,
+}
+
+impl DataDirOverrideGuard {
+    fn set(path: PathBuf) -> Self {
+        let previous = DATA_DIR_OVERRIDE.with(|slot| slot.replace(Some(path)));
+        Self { previous }
+    }
+}
+
+impl Drop for DataDirOverrideGuard {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        DATA_DIR_OVERRIDE.with(|slot| {
+            slot.replace(previous);
+        });
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,4 +1,5 @@
 pub mod e2e;
 pub mod golden;
+pub mod governance;
 pub mod local;
 pub mod metrics;

--- a/src/eval/governance.rs
+++ b/src/eval/governance.rs
@@ -1,0 +1,13 @@
+mod fixture;
+mod run;
+mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use run::run_sandbox_eval;
+pub use types::{
+    CandidateSummary, ContextReport, GovernanceEvalMetadata, GovernanceEvalOptions,
+    GovernanceEvalReport, GovernanceMetricSummary, LifecycleCounts, OwnerCheckReport, QueryReport,
+    RateMetric,
+};

--- a/src/eval/governance/fixture.rs
+++ b/src/eval/governance/fixture.rs
@@ -1,0 +1,661 @@
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::db::{self, CaptureEventInput};
+use crate::memory::{self, Memory};
+
+use super::types::{LifecycleCounts, OwnerCheckReport};
+
+pub(super) const CORPUS_NAME: &str = "builtin-memory-governance-v1";
+pub(super) const PROJECT: &str = "/tmp/remem-governance/repo";
+pub(super) const NESTED_SRC_PROJECT: &str = "/tmp/remem-governance/repo/src";
+pub(super) const NESTED_CRATE_PROJECT: &str = "/tmp/remem-governance/repo/crates/agent";
+pub(super) const EXPECTED_SUMMARY_CANDIDATES: usize = 7;
+const SUMMARY_SESSION: &str = "governance-summary-session";
+
+#[derive(Clone, Copy)]
+pub(super) struct ExpectedOwner {
+    topic_key: &'static str,
+    owner_scope: &'static str,
+    owner_key: &'static str,
+    target_project: Option<&'static str>,
+}
+
+pub(super) struct ExpectedCandidateOwner {
+    text_contains: &'static str,
+    owner_scope: &'static str,
+    owner_key: &'static str,
+    target_project: Option<&'static str>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct SearchScenario {
+    pub id: &'static str,
+    pub category: &'static str,
+    pub query: &'static str,
+    pub project: &'static str,
+    pub memory_type: Option<&'static str>,
+    pub branch: Option<&'static str>,
+    pub expected_topic_keys: &'static [&'static str],
+    pub allowed_topic_keys: &'static [&'static str],
+    pub forbidden_title_contains: &'static [&'static str],
+}
+
+pub(super) const SEARCH_SCENARIOS: &[SearchScenario] = &[
+    SearchScenario {
+        id: "nested-repo-cwd",
+        category: "owner_retrieval",
+        query: "drag drop pointer sensors",
+        project: NESTED_SRC_PROJECT,
+        memory_type: None,
+        branch: None,
+        expected_topic_keys: &["repo-dnd-pointer"],
+        allowed_topic_keys: &["repo-dnd-pointer"],
+        forbidden_title_contains: &[],
+    },
+    SearchScenario {
+        id: "repo-mentioning-codex",
+        category: "owner_retrieval",
+        query: "approval_panel.rs",
+        project: PROJECT,
+        memory_type: None,
+        branch: Some("main"),
+        expected_topic_keys: &["repo-codex-file-exception"],
+        allowed_topic_keys: &["repo-codex-file-exception"],
+        forbidden_title_contains: &["Codex approval mode"],
+    },
+    SearchScenario {
+        id: "updated-current-fact",
+        category: "active_current",
+        query: "emerald toolbar theme",
+        project: PROJECT,
+        memory_type: None,
+        branch: Some("main"),
+        expected_topic_keys: &["repo-toolbar-color"],
+        allowed_topic_keys: &["repo-toolbar-color"],
+        forbidden_title_contains: &["Toolbar color was blue"],
+    },
+    SearchScenario {
+        id: "false-premise-stale-state",
+        category: "stale_exclusion",
+        query: "blue v1",
+        project: PROJECT,
+        memory_type: None,
+        branch: Some("main"),
+        expected_topic_keys: &[],
+        allowed_topic_keys: &[],
+        forbidden_title_contains: &["Toolbar color was blue"],
+    },
+    SearchScenario {
+        id: "branch-mismatch",
+        category: "stale_exclusion",
+        query: "wasm snapshot",
+        project: PROJECT,
+        memory_type: None,
+        branch: Some("main"),
+        expected_topic_keys: &[],
+        allowed_topic_keys: &[],
+        forbidden_title_contains: &["Feature branch wasm snapshot"],
+    },
+    SearchScenario {
+        id: "branch-current",
+        category: "active_current",
+        query: "main branch build cache policy",
+        project: PROJECT,
+        memory_type: Some("decision"),
+        branch: Some("main"),
+        expected_topic_keys: &["decision-1111111111111111"],
+        allowed_topic_keys: &["decision-1111111111111111"],
+        forbidden_title_contains: &["Feature branch wasm snapshot"],
+    },
+];
+
+pub(super) struct FixtureSeed {
+    pub expected_owners: Vec<ExpectedOwner>,
+    pub expected_candidate_owners: Vec<ExpectedCandidateOwner>,
+    pub lifecycle_counts: LifecycleCounts,
+}
+
+pub(super) fn seed_fixture(conn: &mut Connection) -> Result<FixtureSeed> {
+    let mut expected_owners = Vec::new();
+    let mut lifecycle_counts = LifecycleCounts::default();
+
+    insert_repo_fixtures(conn, &mut expected_owners)?;
+    insert_pollution_fixtures(conn, &mut expected_owners)?;
+    insert_lifecycle_fixtures(conn, &mut expected_owners, &mut lifecycle_counts)?;
+    insert_branch_fixtures(conn, &mut expected_owners)?;
+    let mut expected_candidate_owners = Vec::new();
+    record_summary_evidence(conn, SUMMARY_SESSION, "Generic summary evidence")?;
+    let summary_count = memory::promote_summary_to_memory_candidates(
+        conn,
+        SUMMARY_SESSION,
+        PROJECT,
+        Some("Build realistic memory governance eval"),
+        Some("Use an in-memory governance eval suite for owner and lifecycle quality checks."),
+        Some("Lesson: summary-derived durable facts must become candidates before activation."),
+        Some("Review summary-derived preferences before activation."),
+    )?;
+    if summary_count == 0 {
+        anyhow::bail!("summary promotion did not create governance eval candidates");
+    }
+    expected_candidate_owners.extend([
+        ExpectedCandidateOwner {
+            text_contains: "in-memory governance eval suite",
+            owner_scope: "repo",
+            owner_key: PROJECT,
+            target_project: Some(PROJECT),
+        },
+        ExpectedCandidateOwner {
+            text_contains: "summary-derived durable facts",
+            owner_scope: "repo",
+            owner_key: PROJECT,
+            target_project: Some(PROJECT),
+        },
+        ExpectedCandidateOwner {
+            text_contains: "Review summary-derived preferences",
+            owner_scope: "repo",
+            owner_key: PROJECT,
+            target_project: Some(PROJECT),
+        },
+    ]);
+    seed_routing_candidate_fixtures(conn, &mut expected_candidate_owners)?;
+
+    Ok(FixtureSeed {
+        expected_owners,
+        expected_candidate_owners,
+        lifecycle_counts,
+    })
+}
+
+fn seed_routing_candidate_fixtures(
+    conn: &mut Connection,
+    expected_candidate_owners: &mut Vec<ExpectedCandidateOwner>,
+) -> Result<()> {
+    for (session, text, owner_scope, owner_key, target_project) in [
+        (
+            "governance-route-repo-codex",
+            "The repo file src/approval_panel.rs renders Codex approval copy for product UI.",
+            "repo",
+            PROJECT,
+            Some(PROJECT),
+        ),
+        (
+            "governance-route-tool-codex",
+            "Codex CLI sandbox approval mode must stay workspace-write.",
+            "tool",
+            "codex-cli",
+            None,
+        ),
+        (
+            "governance-route-domain-grok",
+            "Grok API accepts image references for xAI integration tests.",
+            "domain",
+            "grok-api",
+            None,
+        ),
+        (
+            "governance-route-domain-warp",
+            "Warp terminal launch configuration belongs to the macOS domain.",
+            "domain",
+            "macos",
+            None,
+        ),
+    ] {
+        record_summary_evidence(conn, session, text)?;
+        let count = memory::promote_summary_to_memory_candidates(
+            conn,
+            session,
+            PROJECT,
+            Some("Route governance candidate"),
+            Some(text),
+            None,
+            None,
+        )?;
+        if count != 1 {
+            anyhow::bail!("expected one routed summary candidate for {session}, got {count}");
+        }
+        expected_candidate_owners.push(ExpectedCandidateOwner {
+            text_contains: text,
+            owner_scope,
+            owner_key,
+            target_project,
+        });
+    }
+    Ok(())
+}
+
+fn insert_repo_fixtures(conn: &Connection, expected_owners: &mut Vec<ExpectedOwner>) -> Result<()> {
+    for (project, topic_key, title, content, memory_type) in [
+        (
+            NESTED_SRC_PROJECT,
+            "repo-dnd-pointer",
+            "Stash DnD uses pointer sensors",
+            "The nested repo UI in src/dnd.rs uses pointer sensors for drag drop ordering.",
+            "decision",
+        ),
+        (
+            NESTED_CRATE_PROJECT,
+            "repo-agent-crate-cache",
+            "Agent crate cache policy",
+            "The crates/agent package stores eval cache files under target/remem-governance.",
+            "architecture",
+        ),
+        (
+            PROJECT,
+            "repo-codex-file-exception",
+            "Repo approval panel mentions Codex",
+            "The repo file src/approval_panel.rs renders Codex approval copy for this product UI.",
+            "decision",
+        ),
+    ] {
+        insert_fixture_memory(
+            conn,
+            project,
+            topic_key,
+            title,
+            content,
+            memory_type,
+            Some("main"),
+            "repo",
+            PROJECT,
+            Some(PROJECT),
+            "startup_core",
+            "active",
+        )?;
+        expected_owners.push(ExpectedOwner {
+            topic_key,
+            owner_scope: "repo",
+            owner_key: PROJECT,
+            target_project: Some(PROJECT),
+        });
+    }
+    Ok(())
+}
+
+fn insert_pollution_fixtures(
+    conn: &Connection,
+    expected_owners: &mut Vec<ExpectedOwner>,
+) -> Result<()> {
+    for (topic_key, title, content, owner_scope, owner_key) in [
+        (
+            "tool-codex-approval",
+            "Codex approval mode",
+            "Codex CLI approval mode uses workspace-write for sandboxed shell commands.",
+            "tool",
+            "codex-cli",
+        ),
+        (
+            "domain-grok-api",
+            "Grok API image references",
+            "The Grok API accepts image references and belongs to the xAI integration domain.",
+            "domain",
+            "grok-api",
+        ),
+        (
+            "domain-warp-config",
+            "Warp terminal launch config",
+            "Warp terminal launch configuration belongs to the macOS terminal domain.",
+            "domain",
+            "macos",
+        ),
+    ] {
+        insert_fixture_memory(
+            conn,
+            PROJECT,
+            topic_key,
+            title,
+            content,
+            "discovery",
+            None,
+            owner_scope,
+            owner_key,
+            None,
+            "search_only",
+            "active",
+        )?;
+        expected_owners.push(ExpectedOwner {
+            topic_key,
+            owner_scope,
+            owner_key,
+            target_project: None,
+        });
+    }
+    Ok(())
+}
+
+fn insert_lifecycle_fixtures(
+    conn: &Connection,
+    expected_owners: &mut Vec<ExpectedOwner>,
+    lifecycle_counts: &mut LifecycleCounts,
+) -> Result<()> {
+    let add = memory::lifecycle::apply_add(
+        conn,
+        Some("governance-add"),
+        PROJECT,
+        Some("repo-test-command"),
+        "Governance eval test command",
+        "Run cargo test eval::governance after changing governance fixtures.",
+        "decision",
+        Some("src/eval/governance.rs"),
+        Some("main"),
+        "project",
+    )?;
+    count_lifecycle(lifecycle_counts, add.op);
+    expected_owners.push(ExpectedOwner {
+        topic_key: "repo-test-command",
+        owner_scope: "repo",
+        owner_key: PROJECT,
+        target_project: Some(PROJECT),
+    });
+
+    let old_toolbar = insert_fixture_memory(
+        conn,
+        PROJECT,
+        "repo-toolbar-color",
+        "Toolbar color was blue",
+        "Toolbar color was blue in theme v1.",
+        "decision",
+        Some("main"),
+        "repo",
+        PROJECT,
+        Some(PROJECT),
+        "startup_core",
+        "active",
+    )?;
+    let update = memory::lifecycle::apply_update(
+        conn,
+        Some("governance-update"),
+        PROJECT,
+        "repo-toolbar-color",
+        "Toolbar color is emerald",
+        "Toolbar color is emerald in theme v2.",
+        "decision",
+        Some("src/theme.rs"),
+        Some("main"),
+        "project",
+        &[old_toolbar],
+    )?;
+    count_lifecycle(lifecycle_counts, update.op);
+    expected_owners.push(ExpectedOwner {
+        topic_key: "repo-toolbar-color",
+        owner_scope: "repo",
+        owner_key: PROJECT,
+        target_project: Some(PROJECT),
+    });
+
+    let obsolete = insert_fixture_memory(
+        conn,
+        PROJECT,
+        "repo-dev-server-port",
+        "Dev server port 3000",
+        "Dev server currently running on port 3000.",
+        "discovery",
+        Some("main"),
+        "repo",
+        PROJECT,
+        Some(PROJECT),
+        "startup_core",
+        "active",
+    )?;
+    let invalidate = memory::lifecycle::apply_invalidate(
+        conn,
+        PROJECT,
+        &[obsolete],
+        Some("port changed after later evidence"),
+    )?;
+    count_lifecycle(lifecycle_counts, invalidate.op);
+    count_lifecycle(
+        lifecycle_counts,
+        memory::lifecycle::noop("duplicate same evidence").op,
+    );
+    count_lifecycle(
+        lifecycle_counts,
+        memory::lifecycle::defer("ambiguous owner route").op,
+    );
+    Ok(())
+}
+
+fn insert_branch_fixtures(
+    conn: &Connection,
+    expected_owners: &mut Vec<ExpectedOwner>,
+) -> Result<()> {
+    for (topic_key, title, content, branch) in [
+        (
+            "decision-1111111111111111",
+            "Main branch build cache policy",
+            "[Context: Governance branch cache policy]\nMain branch uses cargo test --workspace for build cache verification.",
+            "main",
+        ),
+        (
+            "decision-2222222222222222",
+            "Feature branch wasm snapshot",
+            "[Context: Governance branch cache policy]\nFeature branch uses an experimental wasm snapshot build cache.",
+            "feature/wasm-cache",
+        ),
+    ] {
+        insert_fixture_memory(
+            conn,
+            PROJECT,
+            topic_key,
+            title,
+            content,
+            "decision",
+            Some(branch),
+            "repo",
+            PROJECT,
+            Some(PROJECT),
+            "startup_core",
+            "active",
+        )?;
+        expected_owners.push(ExpectedOwner {
+            topic_key,
+            owner_scope: "repo",
+            owner_key: PROJECT,
+            target_project: Some(PROJECT),
+        });
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_fixture_memory(
+    conn: &Connection,
+    project: &str,
+    topic_key: &str,
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    branch: Option<&str>,
+    owner_scope: &str,
+    owner_key: &str,
+    target_project: Option<&str>,
+    context_class: &str,
+    status: &str,
+) -> Result<i64> {
+    let id = memory::insert_memory_full(
+        conn,
+        Some("governance-eval"),
+        project,
+        Some(topic_key),
+        title,
+        content,
+        memory_type,
+        None,
+        branch,
+        "project",
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET source_project = ?1,
+             target_project = ?2,
+             owner_scope = ?3,
+             owner_key = ?4,
+             routing_confidence = 1.0,
+             routing_reason = 'governance eval fixture',
+             context_class = ?5,
+             status = ?6
+         WHERE id = ?7",
+        params![
+            project,
+            target_project,
+            owner_scope,
+            owner_key,
+            context_class,
+            status,
+            id
+        ],
+    )?;
+    Ok(id)
+}
+
+fn record_summary_evidence(conn: &Connection, session_id: &str, content: &str) -> Result<i64> {
+    let outcome = db::record_captured_event(
+        conn,
+        &CaptureEventInput {
+            host: "codex-cli",
+            session_id,
+            project: PROJECT,
+            cwd: None,
+            event_type: "session_stop",
+            role: Some("assistant"),
+            tool_name: None,
+            content,
+            task_kind: None,
+        },
+    )?;
+    Ok(outcome.event_row_id)
+}
+
+fn count_lifecycle(counts: &mut LifecycleCounts, op: memory::lifecycle::MemoryLifecycleOp) {
+    match op {
+        memory::lifecycle::MemoryLifecycleOp::Add => counts.add += 1,
+        memory::lifecycle::MemoryLifecycleOp::Update => counts.update += 1,
+        memory::lifecycle::MemoryLifecycleOp::Invalidate => counts.invalidate += 1,
+        memory::lifecycle::MemoryLifecycleOp::Noop => counts.noop += 1,
+        memory::lifecycle::MemoryLifecycleOp::Defer => counts.defer += 1,
+    }
+}
+
+pub(super) fn memory_owner_checks(
+    conn: &Connection,
+    expected: &[ExpectedOwner],
+) -> Result<Vec<OwnerCheckReport>> {
+    expected
+        .iter()
+        .map(|expected| {
+            let actual = conn
+                .query_row(
+                    "SELECT owner_scope, owner_key, target_project
+                     FROM memories
+                     WHERE topic_key = ?1 AND status = 'active'
+                     ORDER BY id DESC
+                     LIMIT 1",
+                    params![expected.topic_key],
+                    |row| {
+                        Ok((
+                            row.get::<_, Option<String>>(0)?,
+                            row.get::<_, Option<String>>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                        ))
+                    },
+                )
+                .optional()?
+                .with_context(|| format!("missing active fixture memory {}", expected.topic_key))?;
+            Ok(owner_check(
+                format!("memory:{}", expected.topic_key),
+                expected.owner_scope,
+                expected.owner_key,
+                expected.target_project,
+                actual,
+            ))
+        })
+        .collect()
+}
+
+pub(super) fn summary_candidate_owner_checks(
+    conn: &Connection,
+    expected: &[ExpectedCandidateOwner],
+) -> Result<Vec<OwnerCheckReport>> {
+    let mut checks = Vec::new();
+    for expected in expected {
+        let pattern = format!("%{}%", expected.text_contains);
+        let (id, memory_type, scope, key, target) = conn
+            .query_row(
+                "SELECT id, memory_type, owner_scope, owner_key, target_project
+                 FROM memory_candidates
+                 WHERE text LIKE ?1
+                 ORDER BY id ASC
+                 LIMIT 1",
+                params![pattern],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                    ))
+                },
+            )
+            .optional()?
+            .with_context(|| {
+                format!(
+                    "missing candidate containing text {:?}",
+                    expected.text_contains
+                )
+            })?;
+        checks.push(owner_check(
+            format!("candidate:{id}:{memory_type}"),
+            expected.owner_scope,
+            expected.owner_key,
+            expected.target_project,
+            (scope, key, target),
+        ));
+    }
+    Ok(checks)
+}
+
+fn owner_check(
+    object_ref: String,
+    expected_scope: &str,
+    expected_key: &str,
+    expected_target_project: Option<&str>,
+    actual: (Option<String>, Option<String>, Option<String>),
+) -> OwnerCheckReport {
+    let (actual_scope, actual_key, actual_target_project) = actual;
+    let pass = actual_scope.as_deref() == Some(expected_scope)
+        && actual_key.as_deref() == Some(expected_key)
+        && actual_target_project.as_deref() == expected_target_project;
+    OwnerCheckReport {
+        object_ref,
+        expected_scope: expected_scope.to_string(),
+        expected_key: expected_key.to_string(),
+        expected_target_project: expected_target_project.map(str::to_string),
+        actual_scope,
+        actual_key,
+        actual_target_project,
+        pass,
+    }
+}
+
+pub(super) fn forbidden_hits(results: &[Memory], forbidden_title_contains: &[&str]) -> Vec<String> {
+    results
+        .iter()
+        .filter(|memory| {
+            forbidden_title_contains.iter().any(|needle| {
+                memory
+                    .title
+                    .to_ascii_lowercase()
+                    .contains(&needle.to_ascii_lowercase())
+            })
+        })
+        .map(|memory| {
+            format!(
+                "{}:{}",
+                memory.topic_key.as_deref().unwrap_or("<no-topic>"),
+                memory.title
+            )
+        })
+        .collect()
+}

--- a/src/eval/governance/run.rs
+++ b/src/eval/governance/run.rs
@@ -1,0 +1,541 @@
+use std::fmt::{self, Display};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{ensure, Context, Result};
+use rusqlite::{params, Connection};
+
+use super::fixture::{
+    forbidden_hits, memory_owner_checks, seed_fixture, summary_candidate_owner_checks, CORPUS_NAME,
+    EXPECTED_SUMMARY_CANDIDATES, NESTED_CRATE_PROJECT, NESTED_SRC_PROJECT, PROJECT,
+    SEARCH_SCENARIOS,
+};
+use super::types::{
+    CandidateSummary, ContextReport, GovernanceEvalMetadata, GovernanceEvalOptions,
+    GovernanceEvalReport, GovernanceMetricSummary, OwnerCheckReport, QueryReport, RateMetric,
+};
+
+pub fn run_sandbox_eval(options: GovernanceEvalOptions) -> Result<GovernanceEvalReport> {
+    let temp_data_dir = TempDataDir::new()?;
+    let data_dir = temp_data_dir.path.clone();
+    crate::db::core::with_data_dir(&data_dir, || {
+        crate::log::with_log_dir(&data_dir, || {
+            let result = run_sandbox_eval_inner(options, &data_dir);
+            temp_data_dir.cleanup_result(result)
+        })
+    })
+}
+
+fn run_sandbox_eval_inner(
+    options: GovernanceEvalOptions,
+    data_dir: &Path,
+) -> Result<GovernanceEvalReport> {
+    let k = options.k.max(1);
+    ensure!(
+        crate::db::db_path().starts_with(data_dir),
+        "governance eval data dir override failed"
+    );
+    let mut conn = Connection::open_in_memory().context("open in-memory governance eval DB")?;
+    crate::migrate::run_migrations(&conn).context("migrate in-memory governance eval DB")?;
+
+    let fixture = seed_fixture(&mut conn)?;
+    let mut owner_checks = memory_owner_checks(&conn, &fixture.expected_owners)?;
+    owner_checks.extend(summary_candidate_owner_checks(
+        &conn,
+        &fixture.expected_candidate_owners,
+    )?);
+    let queries = evaluate_queries(&conn, k)?;
+    let context = evaluate_context(&conn)?;
+    let lifecycle_counts = fixture.lifecycle_counts;
+    let summary_candidates = load_candidate_summary(&conn)?;
+
+    let owner_routing_accuracy = RateMetric::new(
+        owner_checks.iter().filter(|check| check.pass).count(),
+        owner_checks.len(),
+    );
+    let evidence_recall_at_k = evidence_recall(&queries);
+    let active_current_precision = active_current_precision(&queries);
+    let stale_exclusion_rate = category_pass_rate(&queries, "stale_exclusion");
+    let context_injection_precision = context_injection_precision(&context);
+
+    let mut failing_examples = collect_failures(&owner_checks, &queries, &context);
+    if summary_candidates.total != EXPECTED_SUMMARY_CANDIDATES {
+        failing_examples.push(format!(
+            "summary candidates expected total={} got total={}",
+            EXPECTED_SUMMARY_CANDIDATES, summary_candidates.total
+        ));
+    }
+    if summary_candidates.active_summary_memories != 0
+        || summary_candidates.pending_review != summary_candidates.total
+    {
+        failing_examples.push(format!(
+            "summary candidates should stay pending: total={} pending={} auto_promoted={} active_memories={}",
+            summary_candidates.total,
+            summary_candidates.pending_review,
+            summary_candidates.auto_promoted,
+            summary_candidates.active_summary_memories
+        ));
+    }
+    let expected_lifecycle_counts = crate::eval::governance::LifecycleCounts {
+        add: 1,
+        update: 1,
+        invalidate: 1,
+        noop: 1,
+        defer: 1,
+    };
+    if lifecycle_counts != expected_lifecycle_counts {
+        failing_examples.push(format!(
+            "lifecycle counts expected {:?}, got {:?}",
+            expected_lifecycle_counts, lifecycle_counts
+        ));
+    }
+
+    let all_checks_passed = owner_routing_accuracy.is_perfect()
+        && evidence_recall_at_k.is_perfect()
+        && active_current_precision.is_perfect()
+        && stale_exclusion_rate.is_perfect()
+        && context.pass
+        && summary_candidates.total == EXPECTED_SUMMARY_CANDIDATES
+        && summary_candidates.pending_review == summary_candidates.total
+        && summary_candidates.active_summary_memories == 0
+        && failing_examples.is_empty();
+
+    Ok(GovernanceEvalReport {
+        metadata: GovernanceEvalMetadata {
+            corpus: CORPUS_NAME.to_string(),
+            storage: "in-memory sqlite".to_string(),
+            data_dir: data_dir.display().to_string(),
+            real_db_touched: false,
+            project: PROJECT.to_string(),
+            nested_projects: vec![
+                NESTED_SRC_PROJECT.to_string(),
+                NESTED_CRATE_PROJECT.to_string(),
+            ],
+            k,
+        },
+        metrics: GovernanceMetricSummary {
+            owner_routing_accuracy,
+            evidence_recall_at_k,
+            active_current_precision,
+            stale_exclusion_rate,
+            context_injection_precision,
+            all_checks_passed,
+        },
+        lifecycle_counts,
+        summary_candidates,
+        owner_checks,
+        queries,
+        context,
+        failing_examples,
+    })
+}
+
+fn unique_temp_data_dir() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "remem-governance-eval-{}-{}",
+        std::process::id(),
+        nanos
+    ))
+}
+
+struct TempDataDir {
+    path: PathBuf,
+    cleaned: bool,
+}
+
+impl TempDataDir {
+    fn new() -> Result<Self> {
+        let path = unique_temp_data_dir();
+        std::fs::create_dir_all(&path)
+            .with_context(|| format!("create governance eval data dir {}", path.display()))?;
+        Ok(Self {
+            path,
+            cleaned: false,
+        })
+    }
+
+    fn cleanup_result<T>(mut self, result: Result<T>) -> Result<T> {
+        let cleanup = self.cleanup();
+        match (result, cleanup) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Ok(_), Err(err)) => Err(err),
+            (Err(err), Ok(())) => Err(err),
+            (Err(err), Err(cleanup_err)) => {
+                crate::log::warn(
+                    "eval-governance",
+                    &format!("cleanup failed after eval error: {}", cleanup_err),
+                );
+                Err(err)
+            }
+        }
+    }
+
+    fn cleanup(&mut self) -> Result<()> {
+        std::fs::remove_dir_all(&self.path)
+            .with_context(|| format!("remove governance eval data dir {}", self.path.display()))?;
+        self.cleaned = true;
+        Ok(())
+    }
+}
+
+impl Drop for TempDataDir {
+    fn drop(&mut self) {
+        if self.cleaned {
+            return;
+        }
+        if let Err(cleanup_err) = std::fs::remove_dir_all(&self.path) {
+            crate::log::warn(
+                "eval-governance",
+                &format!("cleanup failed during drop: {}", cleanup_err),
+            );
+        }
+    }
+}
+
+fn evaluate_queries(conn: &Connection, k: usize) -> Result<Vec<QueryReport>> {
+    SEARCH_SCENARIOS
+        .iter()
+        .map(|scenario| evaluate_query(conn, scenario, k))
+        .collect()
+}
+
+fn evaluate_query(
+    conn: &Connection,
+    scenario: &super::fixture::SearchScenario,
+    k: usize,
+) -> Result<QueryReport> {
+    let results = crate::retrieval::search::search_with_branch(
+        conn,
+        Some(scenario.query),
+        Some(scenario.project),
+        scenario.memory_type,
+        k.max(1) as i64,
+        0,
+        false,
+        scenario.branch,
+    )?;
+    let result_topic_keys = results
+        .iter()
+        .filter_map(|memory| memory.topic_key.clone())
+        .collect::<Vec<_>>();
+    let result_titles = results
+        .iter()
+        .map(|memory| memory.title.clone())
+        .collect::<Vec<_>>();
+    let matched_expected = scenario
+        .expected_topic_keys
+        .iter()
+        .filter(|expected| result_topic_keys.iter().any(|actual| actual == *expected))
+        .count();
+    let forbidden_hits = forbidden_hits(&results, scenario.forbidden_title_contains);
+    let unexpected_hits = results
+        .iter()
+        .filter(|memory| {
+            memory
+                .topic_key
+                .as_deref()
+                .is_none_or(|topic_key| !scenario.allowed_topic_keys.contains(&topic_key))
+        })
+        .map(|memory| {
+            format!(
+                "{} ({})",
+                memory.topic_key.as_deref().unwrap_or("<missing-topic-key>"),
+                memory.title
+            )
+        })
+        .collect::<Vec<_>>();
+    let pass = matched_expected == scenario.expected_topic_keys.len()
+        && forbidden_hits.is_empty()
+        && unexpected_hits.is_empty();
+
+    Ok(QueryReport {
+        id: scenario.id.to_string(),
+        category: scenario.category.to_string(),
+        query: scenario.query.to_string(),
+        project: scenario.project.to_string(),
+        memory_type: scenario.memory_type.map(str::to_string),
+        branch: scenario.branch.map(str::to_string),
+        expected_topic_keys: scenario
+            .expected_topic_keys
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        result_topic_keys,
+        result_titles,
+        matched_expected,
+        forbidden_hits,
+        unexpected_hits,
+        pass,
+    })
+}
+
+fn evaluate_context(conn: &Connection) -> Result<ContextReport> {
+    let snapshot = crate::context::governance_eval_snapshot(conn, PROJECT, Some("main"))?;
+    let expected_topic_keys = vec![
+        "repo-dnd-pointer".to_string(),
+        "repo-agent-crate-cache".to_string(),
+        "repo-codex-file-exception".to_string(),
+        "repo-toolbar-color".to_string(),
+        "repo-test-command".to_string(),
+        "decision-1111111111111111".to_string(),
+    ];
+    let forbidden_titles = snapshot
+        .rendered_output
+        .lines()
+        .filter(|title| {
+            [
+                "Codex approval mode",
+                "Grok API image references",
+                "Warp terminal launch config",
+                "Toolbar color was blue",
+                "Feature branch wasm snapshot",
+            ]
+            .iter()
+            .any(|needle| title.contains(needle))
+        })
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let expected_present = expected_topic_keys.iter().all(|expected| {
+        snapshot
+            .memory_topic_keys
+            .iter()
+            .any(|actual| actual == expected)
+    });
+    let unexpected_topic_keys = snapshot
+        .memory_topic_keys
+        .iter()
+        .filter(|topic_key| !expected_topic_keys.contains(topic_key))
+        .cloned()
+        .collect::<Vec<_>>();
+    let pass = expected_present
+        && unexpected_topic_keys.is_empty()
+        && forbidden_titles.is_empty()
+        && snapshot.unsafe_owner_included == 0;
+
+    Ok(ContextReport {
+        expected_topic_keys,
+        included_topic_keys: snapshot.memory_topic_keys,
+        included_titles: snapshot.memory_titles,
+        forbidden_titles,
+        unexpected_topic_keys,
+        unsafe_owner_included: snapshot.unsafe_owner_included,
+        excluded_owner_titles: snapshot.excluded_owner_titles,
+        pass,
+    })
+}
+
+fn load_candidate_summary(conn: &Connection) -> Result<CandidateSummary> {
+    let total = candidate_count(conn, None)?;
+    let pending_review = candidate_count(conn, Some("pending_review"))?;
+    let auto_promoted = candidate_count(conn, Some("auto_promoted"))?;
+    let active_summary_memories: usize = conn.query_row(
+        "SELECT COUNT(*)
+         FROM memories
+         WHERE source_candidate_id IN (SELECT id FROM memory_candidates)
+           AND status = 'active'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )? as usize;
+    Ok(CandidateSummary {
+        total,
+        pending_review,
+        auto_promoted,
+        active_summary_memories,
+    })
+}
+
+fn candidate_count(conn: &Connection, status: Option<&str>) -> Result<usize> {
+    match status {
+        Some(status) => Ok(conn.query_row(
+            "SELECT COUNT(*) FROM memory_candidates WHERE review_status = ?1",
+            params![status],
+            |row| row.get::<_, i64>(0),
+        )? as usize),
+        None => Ok(
+            conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+                row.get::<_, i64>(0)
+            })? as usize,
+        ),
+    }
+}
+
+fn evidence_recall(queries: &[QueryReport]) -> RateMetric {
+    let total = queries
+        .iter()
+        .map(|query| query.expected_topic_keys.len())
+        .sum::<usize>();
+    let passed = queries
+        .iter()
+        .map(|query| query.matched_expected)
+        .sum::<usize>();
+    RateMetric::new(passed, total)
+}
+
+fn category_pass_rate(queries: &[QueryReport], category: &str) -> RateMetric {
+    let selected = queries
+        .iter()
+        .filter(|query| query.category == category)
+        .collect::<Vec<_>>();
+    RateMetric::new(
+        selected.iter().filter(|query| query.pass).count(),
+        selected.len(),
+    )
+}
+
+fn active_current_precision(queries: &[QueryReport]) -> RateMetric {
+    let selected = queries
+        .iter()
+        .filter(|query| query.category == "active_current");
+    let mut relevant_results = 0usize;
+    let mut total_results = 0usize;
+    for query in selected {
+        relevant_results += query
+            .result_topic_keys
+            .iter()
+            .filter(|topic_key| query.expected_topic_keys.contains(*topic_key))
+            .count();
+        total_results += query.result_topic_keys.len();
+    }
+    RateMetric::new(relevant_results, total_results)
+}
+
+fn context_injection_precision(context: &ContextReport) -> RateMetric {
+    let expected_included = context
+        .included_topic_keys
+        .iter()
+        .filter(|topic_key| context.expected_topic_keys.contains(topic_key))
+        .count();
+    RateMetric::new(expected_included, context.included_topic_keys.len())
+}
+
+fn collect_failures(
+    owner_checks: &[OwnerCheckReport],
+    queries: &[QueryReport],
+    context: &ContextReport,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    for check in owner_checks.iter().filter(|check| !check.pass) {
+        failures.push(format!(
+            "{} owner expected {}:{} target={:?}, got {:?}:{:?} target={:?}",
+            check.object_ref,
+            check.expected_scope,
+            check.expected_key,
+            check.expected_target_project,
+            check.actual_scope,
+            check.actual_key,
+            check.actual_target_project
+        ));
+    }
+    for query in queries.iter().filter(|query| !query.pass) {
+        failures.push(format!(
+            "{} expected {:?}, forbidden {:?}, got topics {:?}, titles {:?}",
+            query.id,
+            query.expected_topic_keys,
+            query.forbidden_hits,
+            query.result_topic_keys,
+            query.result_titles
+        ));
+    }
+    for query in queries
+        .iter()
+        .filter(|query| !query.unexpected_hits.is_empty())
+    {
+        failures.push(format!(
+            "{} had unexpected hits {:?}",
+            query.id, query.unexpected_hits
+        ));
+    }
+    if !context.pass {
+        failures.push(format!(
+            "context expected {:?}, included {:?}, unexpected {:?}, forbidden {:?}, unsafe_owner_included={}",
+            context.expected_topic_keys,
+            context.included_topic_keys,
+            context.unexpected_topic_keys,
+            context.forbidden_titles,
+            context.unsafe_owner_included
+        ));
+    }
+    failures
+}
+
+impl Display for GovernanceEvalReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "=== remem eval-governance ({}, k={}) ===",
+            self.metadata.corpus, self.metadata.k
+        )?;
+        writeln!(
+            f,
+            "storage: {}; real_db_touched={}",
+            self.metadata.storage, self.metadata.real_db_touched
+        )?;
+        write_metric(
+            f,
+            "owner_routing_accuracy",
+            &self.metrics.owner_routing_accuracy,
+        )?;
+        write_metric(
+            f,
+            "evidence_recall_at_k",
+            &self.metrics.evidence_recall_at_k,
+        )?;
+        write_metric(
+            f,
+            "active_current_precision",
+            &self.metrics.active_current_precision,
+        )?;
+        write_metric(
+            f,
+            "stale_exclusion_rate",
+            &self.metrics.stale_exclusion_rate,
+        )?;
+        write_metric(
+            f,
+            "context_injection_precision",
+            &self.metrics.context_injection_precision,
+        )?;
+        writeln!(
+            f,
+            "lifecycle: add={} update={} invalidate={} noop={} defer={}",
+            self.lifecycle_counts.add,
+            self.lifecycle_counts.update,
+            self.lifecycle_counts.invalidate,
+            self.lifecycle_counts.noop,
+            self.lifecycle_counts.defer
+        )?;
+        writeln!(
+            f,
+            "summary_candidates: total={} pending_review={} auto_promoted={} active_summary_memories={}",
+            self.summary_candidates.total,
+            self.summary_candidates.pending_review,
+            self.summary_candidates.auto_promoted,
+            self.summary_candidates.active_summary_memories
+        )?;
+        writeln!(f, "all_checks_passed: {}", self.metrics.all_checks_passed)?;
+        if self.failing_examples.is_empty() {
+            writeln!(f, "failures: none")?;
+        } else {
+            writeln!(f, "failures:")?;
+            for failure in &self.failing_examples {
+                writeln!(f, "- {failure}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn write_metric(f: &mut fmt::Formatter<'_>, label: &str, metric: &RateMetric) -> fmt::Result {
+    writeln!(
+        f,
+        "{}: {:.1}% ({}/{})",
+        label,
+        metric.rate * 100.0,
+        metric.passed,
+        metric.total
+    )
+}

--- a/src/eval/governance/tests.rs
+++ b/src/eval/governance/tests.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+
+use super::{run_sandbox_eval, GovernanceEvalOptions, LifecycleCounts};
+
+#[test]
+fn governance_eval_sandbox_reports_all_required_metrics() -> Result<()> {
+    let report = run_sandbox_eval(GovernanceEvalOptions { k: 5 })?;
+
+    assert!(!report.metadata.real_db_touched);
+    assert_eq!(report.metadata.storage, "in-memory sqlite");
+    assert!(!std::path::Path::new(&report.metadata.data_dir).exists());
+    assert!(report.metrics.owner_routing_accuracy.is_perfect());
+    assert!(report.metrics.evidence_recall_at_k.is_perfect());
+    assert!(report.metrics.active_current_precision.is_perfect());
+    assert!(report.metrics.stale_exclusion_rate.is_perfect());
+    assert!(report.metrics.context_injection_precision.is_perfect());
+    assert!(report.metrics.all_checks_passed);
+    assert!(report.failing_examples.is_empty());
+    assert_eq!(
+        report.lifecycle_counts,
+        LifecycleCounts {
+            add: 1,
+            update: 1,
+            invalidate: 1,
+            noop: 1,
+            defer: 1
+        }
+    );
+    assert_eq!(report.summary_candidates.total, 7);
+    assert_eq!(report.summary_candidates.pending_review, 7);
+    assert_eq!(report.summary_candidates.auto_promoted, 0);
+    assert_eq!(report.summary_candidates.active_summary_memories, 0);
+    Ok(())
+}
+
+#[test]
+fn governance_eval_context_excludes_pollution_and_stale_rows() -> Result<()> {
+    let report = run_sandbox_eval(GovernanceEvalOptions { k: 5 })?;
+
+    assert!(report
+        .context
+        .included_topic_keys
+        .contains(&"repo-dnd-pointer".to_string()));
+    assert!(report
+        .context
+        .included_topic_keys
+        .contains(&"repo-codex-file-exception".to_string()));
+    assert!(report
+        .context
+        .excluded_owner_titles
+        .contains(&"Codex approval mode".to_string()));
+    assert!(report
+        .context
+        .excluded_owner_titles
+        .contains(&"Grok API image references".to_string()));
+    assert!(report.context.forbidden_titles.is_empty());
+    assert_eq!(report.context.unsafe_owner_included, 0);
+    Ok(())
+}

--- a/src/eval/governance/types.rs
+++ b/src/eval/governance/types.rs
@@ -1,0 +1,128 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy)]
+pub struct GovernanceEvalOptions {
+    pub k: usize,
+}
+
+impl Default for GovernanceEvalOptions {
+    fn default() -> Self {
+        Self { k: 5 }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct GovernanceEvalReport {
+    pub metadata: GovernanceEvalMetadata,
+    pub metrics: GovernanceMetricSummary,
+    pub lifecycle_counts: LifecycleCounts,
+    pub summary_candidates: CandidateSummary,
+    pub owner_checks: Vec<OwnerCheckReport>,
+    pub queries: Vec<QueryReport>,
+    pub context: ContextReport,
+    pub failing_examples: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GovernanceEvalMetadata {
+    pub corpus: String,
+    pub storage: String,
+    pub data_dir: String,
+    pub real_db_touched: bool,
+    pub project: String,
+    pub nested_projects: Vec<String>,
+    pub k: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GovernanceMetricSummary {
+    pub owner_routing_accuracy: RateMetric,
+    pub evidence_recall_at_k: RateMetric,
+    pub active_current_precision: RateMetric,
+    pub stale_exclusion_rate: RateMetric,
+    pub context_injection_precision: RateMetric,
+    pub all_checks_passed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RateMetric {
+    pub passed: usize,
+    pub total: usize,
+    pub rate: f64,
+}
+
+impl RateMetric {
+    pub(super) fn new(passed: usize, total: usize) -> Self {
+        Self {
+            passed,
+            total,
+            rate: if total == 0 {
+                0.0
+            } else {
+                passed as f64 / total as f64
+            },
+        }
+    }
+
+    pub(super) fn is_perfect(&self) -> bool {
+        self.total > 0 && self.passed == self.total
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub struct LifecycleCounts {
+    pub add: usize,
+    pub update: usize,
+    pub invalidate: usize,
+    pub noop: usize,
+    pub defer: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CandidateSummary {
+    pub total: usize,
+    pub pending_review: usize,
+    pub auto_promoted: usize,
+    pub active_summary_memories: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OwnerCheckReport {
+    pub object_ref: String,
+    pub expected_scope: String,
+    pub expected_key: String,
+    pub expected_target_project: Option<String>,
+    pub actual_scope: Option<String>,
+    pub actual_key: Option<String>,
+    pub actual_target_project: Option<String>,
+    pub pass: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QueryReport {
+    pub id: String,
+    pub category: String,
+    pub query: String,
+    pub project: String,
+    pub memory_type: Option<String>,
+    pub branch: Option<String>,
+    pub expected_topic_keys: Vec<String>,
+    pub result_topic_keys: Vec<String>,
+    pub result_titles: Vec<String>,
+    pub matched_expected: usize,
+    pub forbidden_hits: Vec<String>,
+    pub unexpected_hits: Vec<String>,
+    pub pass: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContextReport {
+    pub expected_topic_keys: Vec<String>,
+    pub included_topic_keys: Vec<String>,
+    pub included_titles: Vec<String>,
+    pub forbidden_titles: Vec<String>,
+    pub unexpected_topic_keys: Vec<String>,
+    pub unsafe_owner_included: usize,
+    pub excluded_owner_titles: Vec<String>,
+    pub pass: bool,
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -6,3 +6,5 @@ mod write;
 
 pub use timer::Timer;
 pub use write::{debug, error, info, open_log_append, warn};
+
+pub(crate) use config::with_log_dir;

--- a/src/log/config.rs
+++ b/src/log/config.rs
@@ -1,9 +1,22 @@
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
 pub(crate) const DEFAULT_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
 pub(crate) const LOG_ROTATION_KEEP: usize = 3;
 
+thread_local! {
+    static LOG_DIR_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn with_log_dir<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
+    let _guard = LogDirOverrideGuard::set(dir.to_path_buf());
+    f()
+}
+
 pub(crate) fn log_path() -> Option<PathBuf> {
+    if let Some(path) = LOG_DIR_OVERRIDE.with(|slot| slot.borrow().clone()) {
+        return Some(path.join("remem.log"));
+    }
     Some(crate::db::data_dir().join("remem.log"))
 }
 
@@ -17,4 +30,24 @@ pub(crate) fn log_max_bytes() -> u64 {
 
 pub(crate) fn rotated_log_path(base: &Path, index: usize) -> PathBuf {
     PathBuf::from(format!("{}.{}", base.display(), index))
+}
+
+struct LogDirOverrideGuard {
+    previous: Option<PathBuf>,
+}
+
+impl LogDirOverrideGuard {
+    fn set(path: PathBuf) -> Self {
+        let previous = LOG_DIR_OVERRIDE.with(|slot| slot.replace(Some(path)));
+        Self { previous }
+    }
+}
+
+impl Drop for LogDirOverrideGuard {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        LOG_DIR_OVERRIDE.with(|slot| {
+            slot.replace(previous);
+        });
+    }
 }

--- a/src/log/tests.rs
+++ b/src/log/tests.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use super::config::{log_max_bytes, log_path, DEFAULT_LOG_MAX_BYTES};
+use super::config::{log_max_bytes, log_path, with_log_dir, DEFAULT_LOG_MAX_BYTES};
 use super::open_log_append;
 use super::write::rotate_if_needed;
 use crate::db::test_support::ScopedTestDataDir;
@@ -52,6 +52,24 @@ fn open_log_append_creates_log_file_in_data_dir() {
 
     let path = log_path().expect("log path should resolve");
     assert!(path.exists(), "log file should exist at {:?}", path);
+}
+
+#[test]
+fn with_log_dir_overrides_log_path_for_current_thread() {
+    let dir = std::env::temp_dir().join(format!(
+        "remem-log-override-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("log override dir should create");
+
+    let path = with_log_dir(&dir, || log_path().expect("log path should resolve"));
+
+    assert_eq!(path, dir.join("remem.log"));
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]

--- a/src/memory_candidate/route.rs
+++ b/src/memory_candidate/route.rs
@@ -70,6 +70,7 @@ pub(crate) fn route_candidate<'a>(
     }
     let haystack = haystack.to_ascii_lowercase();
 
+    let repo_file_evidence = candidate.scope == "project" && has_repo_file_evidence(&haystack);
     let mut matches = Vec::new();
     if candidate.scope == "global" {
         matches.push(RouteKind::UserPreference);
@@ -120,6 +121,15 @@ pub(crate) fn route_candidate<'a>(
     }
 
     if matches.is_empty() && candidate.scope == "project" {
+        matches.push(RouteKind::Repo);
+    }
+
+    if repo_file_evidence
+        && matches
+            .iter()
+            .any(|route| *route != RouteKind::UserPreference)
+    {
+        matches.clear();
         matches.push(RouteKind::Repo);
     }
 
@@ -175,6 +185,26 @@ pub(crate) fn route_candidate<'a>(
 
 fn has_any(haystack: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| haystack.contains(needle))
+}
+
+fn has_repo_file_evidence(haystack: &str) -> bool {
+    has_any(
+        haystack,
+        &[
+            "src/",
+            "crates/",
+            "tests/",
+            "benches/",
+            "examples/",
+            "cargo.toml",
+            "package.json",
+            ".rs",
+            ".ts",
+            ".tsx",
+            ".py",
+            ".go",
+        ],
+    )
 }
 
 fn tool_route(owner_key: &str, domain: &str, reason: &str) -> CandidateRoute {
@@ -244,6 +274,20 @@ mod tests {
             "/repo/stash",
             Some("s1"),
             &candidate("Stash drag and drop keeps item ordering in the project UI."),
+            std::iter::empty(),
+        );
+
+        assert_eq!(route.owner_scope, "repo");
+        assert_eq!(route.owner_key, "/repo/stash");
+        assert_eq!(route.target_project.as_deref(), Some("/repo/stash"));
+    }
+
+    #[test]
+    fn repo_file_evidence_overrides_tool_keyword() {
+        let route = route_candidate(
+            "/repo/stash",
+            Some("s1"),
+            &candidate("The repo file src/approval_panel.rs renders Codex approval copy."),
             std::iter::empty(),
         );
 


### PR DESCRIPTION
## Summary

- add `eval-governance` as a sandboxed memory governance quality gate
- cover owner routing, active/current precision, stale and branch exclusion, summary candidate promotion, and startup context injection
- isolate eval data/log paths with thread-local overrides so the user's real remem DB/logs are not touched
- tighten repo-vs-tool routing when project evidence mentions Codex but includes repo file paths

Closes #273

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `REMEM_DATA_DIR=$(mktemp -d /tmp/remem-parent-sentinel.XXXXXX) REMEM_CONTEXT_CANDIDATE_FETCH_LIMIT=1 cargo run --quiet -- eval-governance --json`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
