### PR TITLE
fix(context): surface lesson load failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -8,7 +8,7 @@ use crate::memory::{self, Memory};
 use super::memory_traits::{is_memory_self_diagnostic, is_self_diagnostic_text};
 use super::ownership::{startup_memory_owner_decision, OwnerCounts, OwnerMetadata, OwnerTrace};
 use super::policy::{ContextPolicy, SectionKind};
-use super::types::{LoadedContext, SessionSummaryBrief};
+use super::types::{ContextLoadError, LoadedContext, SessionSummaryBrief};
 
 const BASENAME_SEARCH_LIMIT: i64 = 20;
 const SUMMARY_FETCH_BATCH_SIZE: usize = 25;
@@ -31,6 +31,7 @@ pub(super) fn load_context_data_with_policy(
     current_branch: Option<&str>,
     policy: &ContextPolicy,
 ) -> LoadedContext {
+    let mut errors = Vec::new();
     let memory_selection = load_project_memories(conn, project, current_branch, policy);
     let mut memories = memory_selection.memories;
     sort_memories_by_branch(&mut memories, current_branch);
@@ -41,10 +42,9 @@ pub(super) fn load_context_data_with_policy(
         policy.section_item_limit(SectionKind::Lessons, policy.limits.lesson_limit) as i64,
     )
     .unwrap_or_else(|e| {
-        crate::log::error(
-            "context",
-            &format!("failed to load lessons for {project}: {e}"),
-        );
+        let message = format!("failed to load lessons for {project}: {e}");
+        crate::log::error("context", &message);
+        errors.push(ContextLoadError::new("lessons", message));
         Vec::new()
     });
 
@@ -70,6 +70,7 @@ pub(super) fn load_context_data_with_policy(
         lessons,
         summaries,
         workstreams,
+        errors,
         owner_traces: memory_selection.owner_traces,
         owner_counts: memory_selection.owner_counts,
     }

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -18,11 +18,11 @@ use super::sections::{
     render_memory_index_with_limits_excluding, render_recent_sessions_with_limit,
     render_workstreams_with_limits,
 };
-use super::types::ContextRequest;
+use super::types::{ContextLoadError, ContextRequest};
 
-struct RenderedContext {
-    output: String,
-    stats: ContextRenderStats,
+pub(in crate::context) struct RenderedContext {
+    pub(in crate::context) output: String,
+    pub(in crate::context) stats: ContextRenderStats,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -91,6 +91,7 @@ fn render_loaded_context_for_eval(
     let (preference_output, _) = render_preferences_to_buffer(conn, project, project, policy)?;
     let mut output = preference_output;
 
+    render_context_load_errors(&mut output, &loaded.errors);
     if !loaded.lessons.is_empty() {
         render_lessons_with_limit(
             &mut output,
@@ -210,7 +211,10 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
     Ok(())
 }
 
-fn render_context_output(request: &ContextRequest, debug: bool) -> Result<RenderedContext> {
+pub(in crate::context) fn render_context_output(
+    request: &ContextRequest,
+    debug: bool,
+) -> Result<RenderedContext> {
     let profile = resolve_profile(request.host);
     let policy = profile.default_policy();
     let conn = match db::open_db() {
@@ -220,14 +224,26 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
                 "context",
                 &format!("open_db failed for project={}: {}", request.project, error),
             );
-            return Ok(RenderedContext {
-                output: empty_context_output(request),
-                stats: empty_stats(request),
-            });
+            let mut output = context_error_output(
+                request,
+                &[ContextLoadError::new(
+                    "database",
+                    format!("failed to open remem database: {error}"),
+                )],
+            );
+            let mut stats = empty_stats(request);
+            stats.total_char_limit = policy.limits.total_char_limit;
+            stats.output_chars = char_len(&output);
+            enforce_total_char_limit_preserving_footer(
+                &mut output,
+                policy.limits.total_char_limit,
+                "",
+            );
+            return Ok(RenderedContext { output, stats });
         }
     };
 
-    let loaded = load_context_data_with_policy(
+    let mut loaded = load_context_data_with_policy(
         &conn,
         &request.project,
         request.current_branch.as_deref(),
@@ -237,7 +253,14 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
         match render_preferences_to_buffer(&conn, &request.project, &request.cwd, &policy) {
             Ok(rendered) => rendered,
             Err(error) => {
-                crate::log::warn("context", &format!("render_preferences failed: {}", error));
+                let message = format!(
+                    "failed to render preferences for {}: {error}",
+                    request.project
+                );
+                crate::log::error("context", &message);
+                loaded
+                    .errors
+                    .push(ContextLoadError::new("preferences", message));
                 (
                     String::new(),
                     crate::memory::preference::PreferenceRenderSummary::default(),
@@ -250,6 +273,7 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
         && loaded.lessons.is_empty()
         && loaded.summaries.is_empty()
         && loaded.workstreams.is_empty()
+        && loaded.errors.is_empty()
     {
         return Ok(RenderedContext {
             output: empty_context_output(request),
@@ -271,6 +295,7 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
     }
     output.push('\n');
 
+    render_context_load_errors(&mut output, &loaded.errors);
     let mut stats = ContextRenderStats {
         host: request.host.as_env_value().to_string(),
         branch: request.current_branch.clone(),
@@ -377,6 +402,41 @@ fn render_context_output(request: &ContextRequest, debug: bool) -> Result<Render
         &stats_footer,
     );
     Ok(RenderedContext { output, stats })
+}
+
+fn context_error_output(request: &ContextRequest, errors: &[ContextLoadError]) -> String {
+    let mut output = String::new();
+    output.push_str(&build_context_header(
+        &request.project,
+        request.current_branch.as_deref(),
+        request.hook_source.as_deref(),
+    ));
+    if let Some(note) = context_source_note(request.hook_source.as_deref()) {
+        output.push_str(note);
+        output.push('\n');
+    }
+    output.push('\n');
+    render_context_load_errors(&mut output, errors);
+    output
+}
+
+fn render_context_load_errors(output: &mut String, errors: &[ContextLoadError]) {
+    if errors.is_empty() {
+        return;
+    }
+
+    output.push_str("## Context Load Errors\n");
+    for error in errors {
+        output.push_str("- ");
+        output.push_str(error.section);
+        output.push_str(": ");
+        output.push_str(&truncate_chars_with_ellipsis(
+            &error.message.replace('\n', " "),
+            240,
+        ));
+        output.push('\n');
+    }
+    output.push('\n');
 }
 
 pub(in crate::context) fn empty_context_output(request: &ContextRequest) -> String {

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -30,6 +30,23 @@ fn load_context_data_logs_primary_memory_query_failures() {
 }
 
 #[test]
+fn load_context_data_records_lesson_query_failures() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    conn.execute("DROP TABLE memory_lessons", []).unwrap();
+    let policy = ContextPolicy::from_limits(ContextLimits::default());
+
+    let loaded = load_context_data_with_policy(&conn, "/tmp/remem", None, &policy);
+
+    assert!(loaded.lessons.is_empty());
+    assert_eq!(loaded.errors.len(), 1);
+    assert_eq!(loaded.errors[0].section, "lessons");
+    assert!(loaded.errors[0]
+        .message
+        .contains("failed to load lessons for /tmp/remem"));
+}
+
+#[test]
 fn load_context_data_dedupes_generated_topic_keys_by_workstream_context() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -4,8 +4,8 @@ use crate::workstream::{WorkStream, WorkStreamStatus};
 use super::super::host::HostKind;
 use super::super::policy::ContextLimits;
 use super::super::render::{
-    build_context_header, build_context_stats_footer, empty_context_output, ContextRenderStats,
-    SectionRenderStats,
+    build_context_header, build_context_stats_footer, empty_context_output, render_context_output,
+    ContextRenderStats, SectionRenderStats,
 };
 use super::super::sections::{
     render_core_memory, render_core_memory_with_limits, render_lessons_with_limit,
@@ -445,6 +445,34 @@ fn empty_context_marks_compact_reload_visibly() {
     assert!(output.contains("[REMEM POST-COMPACT RELOAD]"));
     assert!(output.contains("REMEM_CONTEXT_SOURCE=compact"));
     assert!(output.contains("No previous sessions found."));
+}
+
+#[test]
+fn render_context_output_exposes_lesson_query_failures() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-lesson-error");
+    let conn = crate::db::open_db().unwrap();
+    conn.execute("DROP TABLE memory_lessons", []).unwrap();
+    drop(conn);
+
+    let rendered = render_context_output(
+        &ContextRequest {
+            cwd: "/tmp/remem".to_string(),
+            project: "/tmp/remem".to_string(),
+            session_id: None,
+            hook_source: Some("session_start".to_string()),
+            current_branch: Some("main".to_string()),
+            host: HostKind::CodexCli,
+            use_colors: false,
+        },
+        false,
+    )
+    .unwrap();
+
+    assert!(rendered.output.contains("## Context Load Errors"));
+    assert!(rendered
+        .output
+        .contains("- lessons: failed to load lessons for /tmp/remem"));
+    assert!(!rendered.output.contains("No previous sessions found."));
 }
 
 fn sample_lesson(id: i64, title: &str, confidence: f64, reinforcement_count: i64) -> LessonMemory {

--- a/src/context/types.rs
+++ b/src/context/types.rs
@@ -1,6 +1,7 @@
 use crate::memory::lesson::LessonMemory;
 use crate::memory::Memory;
 use crate::workstream::WorkStream;
+use std::fmt;
 
 use super::host::HostKind;
 use super::ownership::{OwnerCounts, OwnerTrace};
@@ -29,6 +30,22 @@ pub(super) struct LoadedContext {
     pub lessons: Vec<LessonMemory>,
     pub summaries: Vec<SessionSummaryBrief>,
     pub workstreams: Vec<WorkStream>,
+    pub errors: Vec<ContextLoadError>,
     pub owner_traces: Vec<OwnerTrace>,
     pub owner_counts: OwnerCounts,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ContextLoadError {
+    pub section: &'static str,
+    pub message: String,
+}
+
+impl ContextLoadError {
+    pub(super) fn new(section: &'static str, error: impl fmt::Display) -> Self {
+        Self {
+            section,
+            message: error.to_string(),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #232.

- Records lesson-loading failures in `LoadedContext` instead of making them indistinguishable from an empty lesson set.
- Renders a visible `Context Load Errors` section in SessionStart/context output when lesson loading, preference rendering, or database open fails.
- Adds regression coverage for both the data loader and rendered context output.
- Bumps crate version to `0.4.20` for the binary-impacting change.

## Validation

- `git diff --check`
- `cargo fmt --check`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test lesson_query_failures`
- `cargo test`
- `cargo run --quiet -- eval-governance --json`

Latest local results: `cargo test` passed with 699 lib tests, plus integration, benchmark, e2e, rate-limit, and doc tests; governance eval reported `all_checks_passed: true`.
