### PR TITLE
test(ai): assert Codex CLI isolation args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/ai/codex_cli.rs
+++ b/src/ai/codex_cli.rs
@@ -168,6 +168,12 @@ mod tests {
             .collect();
 
         assert_eq!(&rendered[..3], ["--ask-for-approval", "never", "exec"]);
+        for isolation_arg in ["--ephemeral", "--ignore-user-config", "--ignore-rules"] {
+            assert!(
+                rendered.iter().any(|arg| arg == isolation_arg),
+                "{rendered:?}"
+            );
+        }
         assert!(rendered.iter().any(|arg| arg == "--json"), "{rendered:?}");
         assert!(
             rendered


### PR DESCRIPTION
## Summary
- Assert Codex CLI child invocations include isolation flags in the existing argument builder test.
- Covers `--ephemeral`, `--ignore-user-config`, and `--ignore-rules` so future changes cannot silently drop them.
- Bump package version to `0.4.22` because CI requires a Cargo.toml version increase for `src/` changes.

## Testing
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `cargo fmt --check`
- `cargo check`
- `cargo test ai::codex_cli::tests::codex_args_put_global_approval_before_exec`
- `cargo clippy -- -D warnings`
- `cargo test`
