### PR TITLE
Improve Codex hook context rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,7 @@ mod policy;
 mod query;
 mod render;
 mod sections;
+mod style;
 
 #[cfg(test)]
 mod tests;

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -494,12 +494,7 @@ fn normalize_context_for_hash(output: &str) -> String {
             }
         }
         let line_for_match = line.trim_start();
-        if line_for_match.starts_with("- updated: ")
-            || line_for_match.starts_with("│ updated: ")
-            || line_for_match.starts_with("└─ updated: ")
-            || line_for_match.starts_with("- source: ")
-            || line_for_match.starts_with("│ source: ")
-            || line_for_match.starts_with("├─ source: ")
+        if is_visual_context_metadata_line(line_for_match)
             || is_context_source_note_line(line_for_match)
             || line_for_match.starts_with("remem context source: ")
             || line_for_match.starts_with("REMEM_CONTEXT_SOURCE=")
@@ -519,6 +514,11 @@ fn normalize_context_for_hash(output: &str) -> String {
             continue;
         }
         if line_for_match.starts_with('╰') && line_for_match.ends_with('╯') {
+            continue;
+        }
+        if let Some(row) = normalize_rail_row_for_hash(line_for_match) {
+            normalized.push_str(&normalize_stats_footer_totals(row));
+            normalized.push('\n');
             continue;
         }
         normalized.push_str(&normalize_stats_footer_totals(line));
@@ -541,11 +541,21 @@ fn strip_panel_right_border(line: &mut String) {
         while line.ends_with(' ') {
             line.pop();
         }
-    } else if let Some(stripped) = line.strip_prefix("├─ ") {
-        *line = format!("│ {stripped}");
-    } else if let Some(stripped) = line.strip_prefix("└─ ") {
-        *line = format!("│ {stripped}");
     }
+}
+
+fn is_visual_context_metadata_line(line: &str) -> bool {
+    let row = normalize_rail_row_for_hash(line).unwrap_or(line);
+    row.starts_with("- updated: ")
+        || row.starts_with("- source: ")
+        || row.starts_with("updated: ")
+        || row.starts_with("source: ")
+}
+
+fn normalize_rail_row_for_hash(line: &str) -> Option<&str> {
+    line.strip_prefix("├─ ")
+        .or_else(|| line.strip_prefix("└─ "))
+        .or_else(|| line.strip_prefix("│ "))
 }
 
 fn normalize_stats_footer_totals(line: &str) -> String {
@@ -602,6 +612,8 @@ fn normalize_budget_footer_line(line: &str) -> Option<String> {
         "- Budget: "
     } else if line.starts_with("│ Budget: ") {
         "│ Budget: "
+    } else if line.starts_with("Budget: ") {
+        "Budget: "
     } else {
         return None;
     };

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -469,15 +469,56 @@ fn normalize_context_for_hash(output: &str) -> String {
         .map(|idx| &output[..idx])
         .unwrap_or(output);
     let mut normalized = String::new();
-    for (idx, line) in without_debug.lines().enumerate() {
-        if idx == 0 {
+    for line in without_debug.lines() {
+        let mut line = super::style::strip_ansi(line);
+        strip_panel_right_border(&mut line);
+        let line = line.as_str();
+        if normalized.is_empty() && line.trim().is_empty() {
+            continue;
+        }
+        if normalized.is_empty() {
+            if matches!(line, "# remem context" | "# remem context delta")
+                || matches!(line, "remem context" | "remem context delta")
+                || line.starts_with("╭─ remem context")
+                || line.starts_with("╭─ remem context delta")
+                || line.starts_with("┌─ remem context")
+                || line.starts_with("┌─ remem context delta")
+            {
+                normalized.push_str("# remem context\n");
+                continue;
+            }
             if let Some(prefix_end) = line.find("] context ") {
                 normalized.push_str(&line[..prefix_end + "] context ".len()]);
                 normalized.push_str("<timestamp>\n");
                 continue;
             }
         }
-        if line.starts_with("remem context source: ") || line.starts_with("REMEM_CONTEXT_SOURCE=") {
+        let line_for_match = line.trim_start();
+        if line_for_match.starts_with("- updated: ")
+            || line_for_match.starts_with("│ updated: ")
+            || line_for_match.starts_with("└─ updated: ")
+            || line_for_match.starts_with("- source: ")
+            || line_for_match.starts_with("│ source: ")
+            || line_for_match.starts_with("├─ source: ")
+            || is_context_source_note_line(line_for_match)
+            || line_for_match.starts_with("remem context source: ")
+            || line_for_match.starts_with("REMEM_CONTEXT_SOURCE=")
+        {
+            continue;
+        }
+        if line_for_match.starts_with("╭─ Loaded") {
+            normalized.push_str("## Loaded\n");
+            continue;
+        }
+        if line_for_match.starts_with("┌─ Loaded") {
+            normalized.push_str("## Loaded\n");
+            continue;
+        }
+        if line_for_match == "Loaded" {
+            normalized.push_str("## Loaded\n");
+            continue;
+        }
+        if line_for_match.starts_with('╰') && line_for_match.ends_with('╯') {
             continue;
         }
         normalized.push_str(&normalize_stats_footer_totals(line));
@@ -486,12 +527,37 @@ fn normalize_context_for_hash(output: &str) -> String {
     normalized
 }
 
+fn is_context_source_note_line(line: &str) -> bool {
+    matches!(
+        line,
+        "Codex compacted the chat, so remem refreshed memory context."
+            | "Context was reloaded after an explicit clear."
+    )
+}
+
+fn strip_panel_right_border(line: &mut String) {
+    if line.starts_with("│ ") && line.ends_with('│') {
+        line.pop();
+        while line.ends_with(' ') {
+            line.pop();
+        }
+    } else if let Some(stripped) = line.strip_prefix("├─ ") {
+        *line = format!("│ {stripped}");
+    } else if let Some(stripped) = line.strip_prefix("└─ ") {
+        *line = format!("│ {stripped}");
+    }
+}
+
 fn normalize_stats_footer_totals(line: &str) -> String {
+    if let Some(normalized) = normalize_budget_footer_line(line) {
+        return normalized;
+    }
+
     const TOTAL_PREFIX: &str = " total=";
     const CHARS_TOKEN: &str = " chars/~";
     const TOKENS_SUFFIX: &str = " tokens";
 
-    if !is_context_stats_footer(line) {
+    if !is_legacy_context_stats_footer_line(line) {
         return line.to_string();
     }
 
@@ -531,12 +597,72 @@ fn normalize_stats_footer_totals(line: &str) -> String {
     normalized
 }
 
-fn is_context_stats_footer(line: &str) -> bool {
+fn normalize_budget_footer_line(line: &str) -> Option<String> {
+    let prefix = if line.starts_with("- Budget: ") {
+        "- Budget: "
+    } else if line.starts_with("│ Budget: ") {
+        "│ Budget: "
+    } else {
+        return None;
+    };
+    const CHARS_TOKEN: &str = " chars (~";
+    const TOKENS_SUFFIX: &str = " tokens)";
+
+    let char_value_start = prefix.len();
+    let chars_offset = line.strip_prefix(prefix)?.find(CHARS_TOKEN)?;
+    let char_value_end = char_value_start + chars_offset;
+    if !line[char_value_start..char_value_end]
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let token_value_start = char_value_end + CHARS_TOKEN.len();
+    let tokens_offset = line[token_value_start..].find(TOKENS_SUFFIX)?;
+    let token_value_end = token_value_start + tokens_offset;
+    if !line[token_value_start..token_value_end]
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let mut normalized = String::with_capacity(line.len());
+    normalized.push_str(&line[..char_value_start]);
+    normalized.push_str("<total>");
+    normalized.push_str(CHARS_TOKEN);
+    normalized.push_str("<tokens>");
+    normalized.push_str(&line[token_value_end..]);
+    Some(normalized)
+}
+
+fn is_legacy_context_stats_footer_line(line: &str) -> bool {
     line.contains(" context memories loaded. ")
         && line.contains(" host=")
         && line.contains(" branch=")
         && line.contains(" total=")
         && line.contains(" truncated=")
+}
+
+fn is_context_stats_footer(text: &str) -> bool {
+    let text = super::style::strip_ansi(text);
+    (text.starts_with("## Loaded\n")
+        && text.contains("\n- Memories: ")
+        && text.contains("\n- Preferences: ")
+        && text.contains("\n- Budget: "))
+        || (text.starts_with("╭─ Loaded")
+            && text.contains("\n│ Memories: ")
+            && text.contains("\n│ Preferences: ")
+            && text.contains("\n│ Budget: "))
+        || (text.starts_with("┌─ Loaded")
+            && text.contains("\n├─ Memories: ")
+            && text.contains("\n├─ Preferences: ")
+            && text.contains("\n└─ Budget: "))
+        || (text.starts_with("Loaded\n")
+            && text.contains("\n├─ Memories: ")
+            && text.contains("\n├─ Preferences: ")
+            && text.contains("\n└─ Budget: "))
 }
 
 fn sha256_hex(value: &str) -> String {

--- a/src/context/injection_gate/delta.rs
+++ b/src/context/injection_gate/delta.rs
@@ -7,15 +7,12 @@ pub(super) fn build_delta_output(output: &str) -> String {
     }
 
     let (body, footer) = split_stats_footer(output);
+    let (header, body_without_header) = delta_header_and_body(body);
     let mut delta = String::new();
-    delta.push_str(&delta_header(body));
+    delta.push_str(&header);
     delta.push_str(
-        "remem context changed since the previous injection. Compact delta shown; run `remem context --force` for a full refresh.\n\n",
+        "Context changed since the previous injection. Showing a compact preview. Full context: `remem context --force`.\n\n",
     );
-    let body_without_header = body
-        .split_once('\n')
-        .map(|(_, rest)| rest)
-        .unwrap_or_default();
     delta.push_str(body_without_header.trim_start_matches('\n'));
 
     enforce_char_limit_preserving_footer(&mut delta, limit, footer);
@@ -23,29 +20,77 @@ pub(super) fn build_delta_output(output: &str) -> String {
 }
 
 fn split_stats_footer(output: &str) -> (&str, &str) {
-    let Some(last_line_start) = output.trim_end_matches('\n').rfind('\n') else {
-        return (output, "");
-    };
-    let footer_start = last_line_start + 1;
-    let footer = &output[footer_start..];
-    if super::is_context_stats_footer(footer.trim_end_matches('\n')) {
-        (&output[..footer_start], footer)
-    } else {
-        (output, "")
+    let trimmed = output.trim_end_matches('\n');
+    let mut offset = 0;
+    for segment in trimmed.split_inclusive('\n') {
+        let footer = &output[offset..];
+        if super::is_context_stats_footer(footer.trim_end_matches('\n')) {
+            return (&output[..offset], footer);
+        }
+        offset += segment.len();
     }
+    (output, "")
 }
 
-fn delta_header(output: &str) -> String {
-    let first_line = output.lines().next().unwrap_or("# remem context");
-    if let Some(context_idx) = first_line.find("] context ") {
-        let mut header = String::new();
-        header.push_str(&first_line[..context_idx]);
-        header.push_str("] context delta ");
-        header.push_str(&first_line[context_idx + "] context ".len()..]);
-        header.push('\n');
-        return header;
+fn delta_header_and_body(output: &str) -> (String, &str) {
+    if let Some(delta) = boxed_delta_header_and_body(output) {
+        return delta;
     }
-    "# remem context delta\n".to_string()
+
+    let first_line = output.lines().next().unwrap_or("# remem context");
+    let first_line = super::super::style::strip_ansi(first_line);
+    if first_line == "# remem context" || first_line == "remem context" {
+        let body = output
+            .split_once('\n')
+            .map(|(_, rest)| rest)
+            .unwrap_or_default();
+        return (
+            super::super::style::context_delta_title_line_like(
+                first_line.as_str(),
+                super::super::style::contains_ansi(output),
+            ),
+            body,
+        );
+    }
+    ("# remem context delta\n\n".to_string(), output)
+}
+
+fn boxed_delta_header_and_body(output: &str) -> Option<(String, &str)> {
+    let use_colors = super::super::style::contains_ansi(output);
+    let mut header = String::new();
+    let mut offset = 0;
+
+    for (idx, segment) in output.split_inclusive('\n').enumerate() {
+        let line = segment.trim_end_matches('\n');
+        let plain_line = super::super::style::strip_ansi(line);
+        if idx == 0 {
+            if !plain_line.starts_with("╭─ remem context")
+                && !plain_line.starts_with("┌─ remem context")
+            {
+                return None;
+            }
+            header.push_str(&super::super::style::context_delta_title_line_like(
+                line, use_colors,
+            ));
+            offset += segment.len();
+            continue;
+        }
+
+        header.push_str(segment);
+        offset += segment.len();
+        if plain_line.starts_with('╰') && plain_line.ends_with('╯') {
+            if output[offset..].starts_with('\n') {
+                header.push('\n');
+                offset += 1;
+            }
+            return Some((header, &output[offset..]));
+        }
+        if plain_line.starts_with("└─ ") {
+            return Some((header, &output[offset..]));
+        }
+    }
+
+    None
 }
 
 fn enforce_char_limit_preserving_footer(output: &mut String, char_limit: usize, footer: &str) {

--- a/src/context/injection_gate/tests.rs
+++ b/src/context/injection_gate/tests.rs
@@ -54,6 +54,14 @@ fn fingerprint_ignores_context_source_note() {
 }
 
 #[test]
+fn fingerprint_ignores_indented_terminal_header_source_and_timestamp() {
+    let a = "remem context\n              ├─ project: /tmp/remem\n              ├─ source: compact\n              └─ updated: 2026-06-02 6:44pm +08:00\nBody\n";
+    let b = "remem context\n              ├─ project: /tmp/remem\n              ├─ source: compact\n              └─ updated: 2026-06-02 6:45pm +08:00\nBody\n";
+
+    assert_eq!(context_fingerprint(a), context_fingerprint(b));
+}
+
+#[test]
 fn fingerprint_keeps_non_footer_total_text() {
     let a = "# [/tmp/remem] context now\nBody total=100 chars/~25 tokens\n";
     let b = "# [/tmp/remem] context now\nBody total=101 chars/~26 tokens\n";

--- a/src/context/injection_gate/tests.rs
+++ b/src/context/injection_gate/tests.rs
@@ -62,6 +62,14 @@ fn fingerprint_ignores_indented_terminal_header_source_and_timestamp() {
 }
 
 #[test]
+fn fingerprint_ignores_codex_color_indent_and_visual_footer_totals() {
+    let plain = "remem context\n├─ project: /tmp/remem\n├─ branch: main\n└─ updated: 2026-06-02 6:44pm +08:00\nBody\n\nLoaded\n├─ Memories: 1 total, 1 core, 0 lessons, 0 indexed\n├─ Preferences: 0 total, 0 project, 0 global\n├─ Sessions: 0\n├─ Workstreams: 0\n└─ Budget: 100 chars (~25 tokens) / 12000, truncated: no\n";
+    let colored = "\x1b[1;36mremem context\x1b[0m\n              ├─ \x1b[1mproject\x1b[0m: /tmp/remem\n              ├─ \x1b[1mbranch\x1b[0m: main\n              └─ \x1b[1mupdated\x1b[0m: 2026-06-02 6:45pm +08:00\nBody\n\n\x1b[1;36mLoaded\x1b[0m\n├─ \x1b[1mMemories\x1b[0m: 1 total, 1 core, 0 lessons, 0 indexed\n├─ \x1b[1mPreferences\x1b[0m: 0 total, 0 project, 0 global\n├─ \x1b[1mSessions\x1b[0m: 0\n├─ \x1b[1mWorkstreams\x1b[0m: 0\n└─ \x1b[1mBudget\x1b[0m: 101 chars (~26 tokens) / 12000, truncated: no\n";
+
+    assert_eq!(context_fingerprint(plain), context_fingerprint(colored));
+}
+
+#[test]
 fn fingerprint_keeps_non_footer_total_text() {
     let a = "# [/tmp/remem] context now\nBody total=100 chars/~25 tokens\n";
     let b = "# [/tmp/remem] context now\nBody total=101 chars/~26 tokens\n";

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use crate::db;
 
-use super::format::{char_len, format_header_datetime, truncate_chars_with_ellipsis};
+use super::format::{char_len, truncate_chars_with_ellipsis};
 use super::host::resolve_profile;
 use super::injection_gate::{apply_context_gate, ContextGateAction, ContextGateDecision};
 use super::invocation::{
@@ -282,14 +282,17 @@ pub(in crate::context) fn render_context_output(
     }
 
     let mut output = String::new();
-    output.push_str(&build_context_header(
+    output.push_str(&build_context_header_with_style(
         &request.project,
         request.current_branch.as_deref(),
         request.hook_source.as_deref(),
+        request.host,
+        request.use_colors,
     ));
     output.push_str(profile.retrieval_hints().line);
     output.push('\n');
     if let Some(note) = context_source_note(request.hook_source.as_deref()) {
+        output.push('\n');
         output.push_str(note);
         output.push('\n');
     }
@@ -390,10 +393,10 @@ pub(in crate::context) fn render_context_output(
     }
 
     stats.output_chars = char_len(&output);
-    let mut stats_footer = build_context_stats_footer(&stats);
+    let mut stats_footer = build_context_stats_footer_with_style(&stats, request.use_colors);
     stats.output_chars += char_len(&stats_footer);
     stats.truncated = stats.total_char_limit > 0 && stats.output_chars > stats.total_char_limit;
-    stats_footer = build_context_stats_footer(&stats);
+    stats_footer = build_context_stats_footer_with_style(&stats, request.use_colors);
     stats.output_chars = char_len(&output) + char_len(&stats_footer);
     output.push_str(&stats_footer);
     enforce_total_char_limit_preserving_footer(
@@ -406,10 +409,12 @@ pub(in crate::context) fn render_context_output(
 
 fn context_error_output(request: &ContextRequest, errors: &[ContextLoadError]) -> String {
     let mut output = String::new();
-    output.push_str(&build_context_header(
+    output.push_str(&build_context_header_with_style(
         &request.project,
         request.current_branch.as_deref(),
         request.hook_source.as_deref(),
+        request.host,
+        request.use_colors,
     ));
     if let Some(note) = context_source_note(request.hook_source.as_deref()) {
         output.push_str(note);
@@ -440,10 +445,12 @@ fn render_context_load_errors(output: &mut String, errors: &[ContextLoadError]) 
 }
 
 pub(in crate::context) fn empty_context_output(request: &ContextRequest) -> String {
-    let header = build_context_header(
+    let header = build_context_header_with_style(
         &request.project,
         request.current_branch.as_deref(),
         request.hook_source.as_deref(),
+        request.host,
+        request.use_colors,
     );
     empty_state_output(&header, context_source_note(request.hook_source.as_deref()))
 }
@@ -515,42 +522,13 @@ pub(in crate::context) struct ContextRenderStats {
     pub truncated: bool,
 }
 
+#[cfg(test)]
 pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats) -> String {
-    let branch = stats.branch.as_deref().unwrap_or("-");
-    let source = context_source_footer(stats.hook_source.as_deref());
-    let estimated_tokens = estimate_tokens(stats.output_chars);
-    format!(
-        "{} context memories loaded. {} core ({} chars). {} lessons ({} chars). {} indexed ({} chars). {} preferences (project:{} global:{}, {} chars). {} sessions ({} chars). owners repo={} user={} workspace={} tool={} domain={} workstream={} session={} legacy={} unknown={}. host={} source={} branch={} total={} chars/~{} tokens limit={} truncated={}\n",
-        stats.memories_loaded,
-        stats.core.count,
-        stats.core.chars,
-        stats.lessons.count,
-        stats.lessons.chars,
-        stats.index.count,
-        stats.index.chars,
-        stats.preferences.count,
-        stats.project_preferences,
-        stats.global_preferences,
-        stats.preferences.chars,
-        stats.sessions.count,
-        stats.sessions.chars,
-        stats.owner_counts.repo,
-        stats.owner_counts.user,
-        stats.owner_counts.workspace,
-        stats.owner_counts.tool,
-        stats.owner_counts.domain,
-        stats.owner_counts.workstream,
-        stats.owner_counts.session,
-        stats.owner_counts.legacy,
-        stats.owner_counts.unknown,
-        stats.host,
-        source,
-        branch,
-        stats.output_chars,
-        estimated_tokens,
-        stats.total_char_limit,
-        if stats.truncated { "yes" } else { "no" },
-    )
+    build_context_stats_footer_with_style(stats, false)
+}
+
+fn build_context_stats_footer_with_style(stats: &ContextRenderStats, use_colors: bool) -> String {
+    super::style::context_stats_footer(stats, use_colors)
 }
 
 pub(in crate::context) fn build_context_debug_trace(
@@ -591,6 +569,21 @@ pub(in crate::context) fn build_context_debug_trace(
         stats.preferences.count,
         stats.sessions.count,
         stats.workstreams.count
+    ));
+    trace.push_str(&format!(
+        "- rendered_chars core={} lessons={} index={} preferences={} sessions={} workstreams={}\n",
+        stats.core.chars,
+        stats.lessons.chars,
+        stats.index.chars,
+        stats.preferences.chars,
+        stats.sessions.chars,
+        stats.workstreams.chars
+    ));
+    trace.push_str(&format!(
+        "- stats host={} branch={} source={}\n",
+        stats.host,
+        stats.branch.as_deref().unwrap_or("-"),
+        stats.hook_source.as_deref().unwrap_or("-")
     ));
     trace.push_str(&format!(
         "- preferences project_rendered={} global_rendered={} reason=scope_limits_then_claude_md_dedup\n",
@@ -688,12 +681,8 @@ pub(in crate::context) fn build_context_debug_trace(
 
 fn context_source_note(source: Option<&str>) -> Option<&'static str> {
     match source?.trim().to_ascii_lowercase().as_str() {
-        "compact" => Some(
-            "REMEM_CONTEXT_SOURCE=compact: Codex compact triggered this memory context reload.",
-        ),
-        "clear" => {
-            Some("REMEM_CONTEXT_SOURCE=clear: context was reloaded after an explicit clear.")
-        }
+        "compact" => Some("Codex compacted the chat, so remem refreshed memory context."),
+        "clear" => Some("Context was reloaded after an explicit clear."),
         _ => None,
     }
 }
@@ -702,10 +691,6 @@ fn context_debug_enabled() -> bool {
     std::env::var("REMEM_CONTEXT_DEBUG")
         .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
         .unwrap_or(false)
-}
-
-fn estimate_tokens(chars: usize) -> usize {
-    (chars + 3) / 4
 }
 
 #[cfg(test)]
@@ -747,41 +732,27 @@ pub(in crate::context) fn enforce_total_char_limit_preserving_footer(
     *output = truncated;
 }
 
+#[cfg(test)]
 pub(in crate::context) fn build_context_header(
     project: &str,
     current_branch: Option<&str>,
     hook_source: Option<&str>,
 ) -> String {
-    let branch_label = current_branch
-        .map(|branch| format!(" @{}", branch))
-        .unwrap_or_default();
-    let source_label = context_source_header_label(hook_source)
-        .map(|label| format!(" [{}]", label))
-        .unwrap_or_default();
-    format!(
-        "# [{}{}] context {}{}\n",
+    build_context_header_with_style(
         project,
-        branch_label,
-        format_header_datetime(),
-        source_label
+        current_branch,
+        hook_source,
+        super::host::HostKind::Unknown,
+        false,
     )
 }
 
-fn context_source_header_label(source: Option<&str>) -> Option<&'static str> {
-    match source?.trim().to_ascii_lowercase().as_str() {
-        "compact" => Some("REMEM POST-COMPACT RELOAD"),
-        "clear" => Some("REMEM CLEAR RELOAD"),
-        _ => None,
-    }
-}
-
-fn context_source_footer(source: Option<&str>) -> &'static str {
-    match source
-        .map(|value| value.trim().to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("compact") => "compact",
-        Some("clear") => "clear",
-        _ => "-",
-    }
+fn build_context_header_with_style(
+    project: &str,
+    current_branch: Option<&str>,
+    hook_source: Option<&str>,
+    host: super::host::HostKind,
+    use_colors: bool,
+) -> String {
+    super::style::context_header(project, current_branch, hook_source, host, use_colors)
 }

--- a/src/context/style.rs
+++ b/src/context/style.rs
@@ -1,0 +1,168 @@
+use super::format::format_header_datetime;
+use super::host::HostKind;
+use super::render::ContextRenderStats;
+
+const ANSI_RESET: &str = "\x1b[0m";
+const ANSI_BOLD_CYAN: &str = "\x1b[1;36m";
+const ANSI_BOLD: &str = "\x1b[1m";
+
+pub(in crate::context) fn context_header(
+    project: &str,
+    current_branch: Option<&str>,
+    hook_source: Option<&str>,
+    host: HostKind,
+    use_colors: bool,
+) -> String {
+    let mut rows = vec![("project", project.to_string())];
+    if let Some(branch) = current_branch {
+        rows.push(("branch", branch.to_string()));
+    }
+    let source = context_source_footer(hook_source);
+    if source != "-" {
+        rows.push(("source", source.to_string()));
+    }
+    rows.push(("updated", format_header_datetime()));
+
+    let mut header = String::new();
+    let row_indent = if host == HostKind::CodexCli && use_colors {
+        "              "
+    } else {
+        ""
+    };
+    push_rail(&mut header, "remem context", &rows, row_indent, use_colors);
+    header.push('\n');
+    header
+}
+
+pub(in crate::context) fn context_delta_title_line_like(
+    _first_line: &str,
+    use_colors: bool,
+) -> String {
+    let mut header = String::new();
+    header.push_str(&rail_title_line("remem context delta", use_colors));
+    header
+}
+
+pub(in crate::context) fn context_stats_footer(
+    stats: &ContextRenderStats,
+    use_colors: bool,
+) -> String {
+    let estimated_tokens = estimate_display_tokens(stats.output_chars);
+    let rows = vec![
+        (
+            "Memories",
+            format!(
+                "{} total, {} core, {} lessons, {} indexed",
+                stats.memories_loaded, stats.core.count, stats.lessons.count, stats.index.count
+            ),
+        ),
+        (
+            "Preferences",
+            format!(
+                "{} total, {} project, {} global",
+                stats.preferences.count, stats.project_preferences, stats.global_preferences
+            ),
+        ),
+        ("Sessions", stats.sessions.count.to_string()),
+        ("Workstreams", stats.workstreams.count.to_string()),
+        (
+            "Budget",
+            format!(
+                "{} chars (~{} tokens) / {}, truncated: {}",
+                stats.output_chars,
+                estimated_tokens,
+                stats.total_char_limit,
+                if stats.truncated { "yes" } else { "no" }
+            ),
+        ),
+    ];
+    let mut footer = String::new();
+    footer.push('\n');
+    push_rail(&mut footer, "Loaded", &rows, "", use_colors);
+    footer
+}
+
+pub(in crate::context) fn strip_ansi(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\x1b' {
+            output.push(ch);
+            continue;
+        }
+
+        if chars.next_if_eq(&'[').is_some() {
+            for code in chars.by_ref() {
+                if ('@'..='~').contains(&code) {
+                    break;
+                }
+            }
+        }
+    }
+    output
+}
+
+pub(in crate::context) fn contains_ansi(input: &str) -> bool {
+    input.contains("\x1b[")
+}
+
+fn push_rail(
+    output: &mut String,
+    title: &str,
+    rows: &[(&str, String)],
+    row_indent: &str,
+    use_colors: bool,
+) {
+    output.push_str(&rail_title_line(title, use_colors));
+    for (idx, (label, value)) in rows.iter().enumerate() {
+        let marker = if idx + 1 == rows.len() {
+            "└─"
+        } else {
+            "├─"
+        };
+        output.push_str(&rail_row_line(row_indent, marker, label, value, use_colors));
+    }
+}
+
+fn rail_title_line(title: &str, use_colors: bool) -> String {
+    let title = if use_colors {
+        paint(title, ANSI_BOLD_CYAN)
+    } else {
+        title.to_string()
+    };
+    format!("{title}\n")
+}
+
+fn rail_row_line(
+    row_indent: &str,
+    marker: &str,
+    label: &str,
+    value: &str,
+    use_colors: bool,
+) -> String {
+    let label = if use_colors {
+        paint(label, ANSI_BOLD)
+    } else {
+        label.to_string()
+    };
+    format!("{row_indent}{marker} {label}: {value}\n")
+}
+
+fn context_source_footer(source: Option<&str>) -> &'static str {
+    match source
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("compact") => "compact",
+        Some("clear") => "clear",
+        _ => "-",
+    }
+}
+
+fn estimate_display_tokens(chars: usize) -> usize {
+    (chars + 3) / 4
+}
+
+fn paint(value: &str, ansi_code: &str) -> String {
+    format!("{ansi_code}{value}{ANSI_RESET}")
+}

--- a/src/context/tests/ownership.rs
+++ b/src/context/tests/ownership.rs
@@ -117,7 +117,7 @@ fn startup_context_excludes_unrelated_tool_and_domain_memories() {
 }
 
 #[test]
-fn debug_trace_and_footer_report_owner_reasons_and_counts() {
+fn debug_trace_reports_owner_reasons_and_counts() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);
     let stash = "/Users/lifcc/Desktop/code/AI/tool/stash";
@@ -186,6 +186,6 @@ fn debug_trace_and_footer_report_owner_reasons_and_counts() {
     assert!(debug.contains("excluded reason=tool_not_relevant_to_startup"));
 
     let footer = build_context_stats_footer(&stats);
-    assert!(footer.contains("owners repo=1 user=0"));
-    assert!(footer.contains("tool=0 domain=0"));
+    assert!(!footer.contains("owners repo="));
+    assert!(!footer.contains("tool=0 domain=0"));
 }

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -410,23 +410,28 @@ fn context_stats_footer_reports_budget_scope_and_truncation() {
         truncated: true,
     });
 
-    assert!(footer.contains("7 context memories loaded"));
-    assert!(footer.contains("2 core (430 chars)"));
-    assert!(footer.contains("1 lessons (180 chars)"));
-    assert!(footer.contains("3 preferences (project:2 global:1"));
-    assert!(footer.contains("host=codex-cli"));
-    assert!(footer.contains("source=compact"));
-    assert!(footer.contains("branch=fix/context"));
-    assert!(footer.contains("total=3200 chars/~800 tokens"));
-    assert!(footer.contains("truncated=yes"));
+    assert!(footer.starts_with("\nLoaded"));
+    assert!(footer.contains("├─ Memories: 7 total, 2 core, 1 lessons, 5 indexed"));
+    assert!(footer.contains("├─ Preferences: 3 total, 2 project, 1 global"));
+    assert!(footer.contains("├─ Sessions: 4"));
+    assert!(footer.contains("├─ Workstreams: 1"));
+    assert!(footer.contains("└─ Budget: 3200 chars (~800 tokens) / 12000, truncated: yes"));
+    assert!(!footer.contains('╮'));
+    assert!(!footer.contains('╯'));
+    assert!(!footer.contains("owners repo="));
 }
 
 #[test]
 fn context_header_marks_compact_reload_visibly() {
     let header = build_context_header("/tmp/remem", Some("main"), Some("compact"));
 
-    assert!(header.starts_with("# [/tmp/remem @main] context "));
-    assert!(header.contains("[REMEM POST-COMPACT RELOAD]"));
+    assert!(header.starts_with("remem context"));
+    assert!(header.contains("├─ project: /tmp/remem"));
+    assert!(header.contains("├─ branch: main"));
+    assert!(header.contains("├─ source: compact"));
+    assert!(header.contains("└─ updated: "));
+    assert!(!header.contains('╮'));
+    assert!(!header.contains('╯'));
 }
 
 #[test]
@@ -441,10 +446,48 @@ fn empty_context_marks_compact_reload_visibly() {
         use_colors: false,
     });
 
-    assert!(output.starts_with("# [/tmp/remem @main] context "));
-    assert!(output.contains("[REMEM POST-COMPACT RELOAD]"));
-    assert!(output.contains("REMEM_CONTEXT_SOURCE=compact"));
+    assert!(output.starts_with("remem context"));
+    assert!(output.contains("├─ source: compact"));
+    assert!(output.contains("Codex compacted the chat, so remem refreshed memory context."));
     assert!(output.contains("No previous sessions found."));
+}
+
+#[test]
+fn empty_context_uses_ansi_when_color_enabled() {
+    let output = empty_context_output(&ContextRequest {
+        cwd: "/tmp/remem".to_string(),
+        project: "/tmp/remem".to_string(),
+        session_id: None,
+        hook_source: Some("compact".to_string()),
+        current_branch: Some("main".to_string()),
+        host: HostKind::CodexCli,
+        use_colors: true,
+    });
+
+    assert!(output.starts_with("\x1b[1;36mremem context\x1b[0m"));
+    assert!(output.contains("\x1b[1;36mremem context\x1b[0m"));
+    assert!(output.contains("├─ \x1b[1mproject\x1b[0m: /tmp/remem"));
+}
+
+#[test]
+fn codex_colored_header_aligns_rows_under_hook_context_value() {
+    let output = empty_context_output(&ContextRequest {
+        cwd: "/tmp/remem".to_string(),
+        project: "/tmp/remem".to_string(),
+        session_id: None,
+        hook_source: None,
+        current_branch: Some("main".to_string()),
+        host: HostKind::CodexCli,
+        use_colors: true,
+    });
+    let plain = super::super::style::strip_ansi(&output);
+    let mut lines = plain.lines();
+
+    assert_eq!(lines.next(), Some("remem context"));
+    let project_line = lines.next().unwrap_or_default();
+    assert!(project_line.ends_with("├─ project: /tmp/remem"));
+    let row_indent = project_line.chars().take_while(|ch| *ch == ' ').count();
+    assert_eq!(row_indent, "hook context: ".chars().count());
 }
 
 #[test]

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -58,7 +58,7 @@ impl HookStrategy {
 fn hook_command(bin: &str, strategy: HookStrategy, subcommand: &str) -> String {
     if subcommand == "context" {
         format!(
-            "REMEM_CONTEXT_HOST={} {} {}",
+            "REMEM_CONTEXT_HOST={} {} {} --color",
             strategy.context_host(),
             bin,
             subcommand

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -7,7 +7,7 @@ fn build_hooks_contains_expected_claude_commands() {
     let hooks = build_hooks("/tmp/remem", HookStrategy::ClaudeCode);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
-        "REMEM_CONTEXT_HOST=claude-code /tmp/remem context"
+        "REMEM_CONTEXT_HOST=claude-code /tmp/remem context --color"
     );
     assert_eq!(
         hooks["UserPromptSubmit"][0]["hooks"][0]["command"],
@@ -32,7 +32,7 @@ fn build_hooks_contains_expected_codex_commands() {
     let hooks = build_hooks("/tmp/remem", HookStrategy::Codex);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
-        "REMEM_CONTEXT_HOST=codex-cli /tmp/remem context"
+        "REMEM_CONTEXT_HOST=codex-cli /tmp/remem context --color"
     );
     assert!(hooks.get("UserPromptSubmit").is_none());
     assert!(hooks.get("PostToolUse").is_none());


### PR DESCRIPTION
## Summary

- render SessionStart context headers/footers through a dedicated terminal style module
- install context hooks with `--color` so Codex/Claude get lightweight ANSI emphasis by default
- align Codex colored header rows under the `hook context:` value instead of column 0
- keep detailed owner counts in debug output and normalize visual-only ANSI/header/footer lines for context fingerprints and deltas

Closes #295.
Also advances part of #228 by keeping compact/clear source notes user-visible without affecting fingerprints.

## Verification

- `cargo check`
- `cargo test`
- `git diff --check`
