### PR TITLE
fix(install): detect duplicate remem binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ remem install --dry-run         # preview config changes
 
 Restart your AI coding tool after installation.
 
+Use one canonical `remem` command on PATH. Standalone and source installs
+should normally live at `~/.local/bin/remem`; Windows standalone installs
+should use `%USERPROFILE%\.local\bin\remem.exe`. If you install through a
+package manager such as Homebrew or Cargo, update through that same channel
+and avoid keeping a second manual copy earlier or later on PATH. `remem doctor`
+and `remem install --dry-run` warn when multiple `remem` executables are
+visible.
+
 ## Use With Codex
 
 For Codex-only setup:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,6 +67,12 @@ remem install --dry-run         # 预览配置改动
 
 安装后重启对应的 AI 编程工具。
 
+PATH 上建议只保留一个 canonical `remem` 命令。Standalone 和源码安装通常放在
+`~/.local/bin/remem`；Windows standalone 安装建议放在
+`%USERPROFILE%\.local\bin\remem.exe`。如果使用 Homebrew 或 Cargo 这类包管理器，
+后续也通过同一个渠道升级，避免 PATH 前后同时残留第二份手动安装的二进制。
+`remem doctor` 和 `remem install --dry-run` 会在检测到多个 `remem` 可执行文件时警告。
+
 ## 在 Codex 中使用
 
 只配置 Codex：

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use toml_edit::DocumentMut;
 
 use super::types::{Check, Status};
@@ -16,10 +16,16 @@ pub(super) fn check_binary() -> Check {
 }
 
 pub(super) fn check_install_paths() -> Check {
-    let configured = std::env::var_os("REMEM_INSTALL_BINARY")
-        .map(PathBuf::from)
-        .or_else(|| std::env::current_exe().ok());
-    let report = crate::install::duplicates::inspect_install_paths(configured.as_deref());
+    let mut configured = configured_remem_paths_for(active_hosts());
+    if configured.is_empty() {
+        configured.extend(
+            std::env::var_os("REMEM_INSTALL_BINARY")
+                .map(PathBuf::from)
+                .or_else(|| std::env::current_exe().ok()),
+        );
+    }
+    let report =
+        crate::install::duplicates::inspect_install_paths_with_configured_paths(&configured);
     Check {
         name: "Install paths",
         status: if report.has_warning() {
@@ -29,6 +35,15 @@ pub(super) fn check_install_paths() -> Check {
         },
         detail: crate::install::duplicates::format_doctor_detail(&report),
     }
+}
+
+fn configured_remem_paths_for(hosts: Vec<HostProbe>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for probe in hosts {
+        paths.extend(configured_hook_paths(&probe.hooks_path));
+        paths.extend(configured_mcp_paths(&probe));
+    }
+    dedupe_paths(paths)
 }
 
 /// A single host we know how to validate. The strings are leaked static
@@ -298,6 +313,101 @@ fn probe_mcp_path<'a>(
     }
 }
 
+fn configured_mcp_paths(probe: &HostProbe) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for path in probe.mcp_paths.iter().filter(|path| path.exists()) {
+        let Some(content) = std::fs::read_to_string(path).ok() else {
+            continue;
+        };
+        match probe.name {
+            "claude" => {
+                if let Ok(doc) = serde_json::from_str::<Value>(&content) {
+                    paths.extend(claude_remem_mcp_command(&doc).map(PathBuf::from));
+                }
+            }
+            "codex" => {
+                if let Ok(doc) = content.parse::<DocumentMut>() {
+                    paths.extend(codex_remem_mcp_command(&doc).map(PathBuf::from));
+                }
+            }
+            _ => {}
+        }
+    }
+    paths
+}
+
+fn configured_hook_paths(path: &PathBuf) -> Vec<PathBuf> {
+    let Some(content) = std::fs::read_to_string(path).ok() else {
+        return Vec::new();
+    };
+    let Ok(doc) = serde_json::from_str::<Value>(&content) else {
+        return Vec::new();
+    };
+    hook_command_strings(&doc)
+        .filter_map(extract_remem_command_path)
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn claude_remem_mcp_command(doc: &Value) -> Option<&str> {
+    doc.get("mcpServers")
+        .and_then(|servers| servers.get("remem"))
+        .and_then(|server| server.get("command"))
+        .and_then(|command| command.as_str())
+}
+
+fn codex_remem_mcp_command(doc: &DocumentMut) -> Option<&str> {
+    doc.get("mcp_servers")
+        .and_then(|servers| servers.as_table())
+        .and_then(|servers| servers.get("remem"))
+        .and_then(|server| server.as_table())
+        .and_then(|server| server.get("command"))
+        .and_then(|command| command.as_str())
+}
+
+fn hook_command_strings(doc: &Value) -> impl Iterator<Item = &str> {
+    doc.get("hooks")
+        .and_then(|hooks| hooks.as_object())
+        .into_iter()
+        .flat_map(|hooks| hooks.values())
+        .filter_map(|entries| entries.as_array())
+        .flatten()
+        .filter_map(|entry| entry.get("hooks").and_then(|hooks| hooks.as_array()))
+        .flatten()
+        .filter_map(|hook| hook.get("command").and_then(|command| command.as_str()))
+}
+
+fn extract_remem_command_path(command: &str) -> Option<&str> {
+    command
+        .split_whitespace()
+        .map(trim_shell_quotes)
+        .find(|token| is_remem_command_token(token))
+}
+
+fn trim_shell_quotes(token: &str) -> &str {
+    token.trim_matches(|c| c == '"' || c == '\'')
+}
+
+fn is_remem_command_token(token: &str) -> bool {
+    if token.contains('=') && !token.contains('/') && !token.contains('\\') {
+        return false;
+    }
+    Path::new(token)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem == "remem")
+}
+
+fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut unique = Vec::new();
+    for path in paths {
+        if !unique.contains(&path) {
+            unique.push(path);
+        }
+    }
+    unique
+}
+
 fn event_has_remem_hook(doc: &Value, event: &str) -> bool {
     doc.get("hooks")
         .and_then(|hooks| hooks.get(event))
@@ -472,6 +582,69 @@ note = "remem"
 
         assert!(matches!(check.status, Status::Fail));
         assert!(check.detail.contains("not registered"), "{}", check.detail);
+    }
+
+    #[test]
+    fn configured_paths_read_codex_hooks_and_mcp_command() {
+        let dir = temp_path("doctor-configured-codex-paths");
+        let hooks_path = dir.join("hooks.json");
+        let mcp_path = dir.join("config.toml");
+        std::fs::write(
+            &hooks_path,
+            r#"{
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "command": "REMEM_CONTEXT_HOST=codex-cli /hooks/bin/remem context --color" }] }],
+    "Stop": [{ "hooks": [{ "command": "REMEM_SUMMARY_EXECUTOR=codex-cli /hooks/bin/remem summarize" }] }]
+  }
+}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &mcp_path,
+            r#"[mcp_servers.remem]
+command = "/mcp/bin/remem"
+"#,
+        )
+        .unwrap();
+
+        let paths = configured_remem_paths_for(vec![HostProbe {
+            name: "codex",
+            hooks_path,
+            mcp_paths: vec![mcp_path],
+        }]);
+
+        assert!(paths.contains(&PathBuf::from("/hooks/bin/remem")));
+        assert!(paths.contains(&PathBuf::from("/mcp/bin/remem")));
+    }
+
+    #[test]
+    fn configured_paths_read_claude_mcp_command() {
+        let dir = temp_path("doctor-configured-claude-paths");
+        let mcp_path = dir.join("claude.json");
+        std::fs::write(
+            &mcp_path,
+            r#"{ "mcpServers": { "remem": { "command": "/claude/bin/remem" } } }"#,
+        )
+        .unwrap();
+
+        let paths = configured_remem_paths_for(vec![HostProbe {
+            name: "claude",
+            hooks_path: dir.join("settings.json"),
+            mcp_paths: vec![mcp_path],
+        }]);
+
+        assert_eq!(paths, vec![PathBuf::from("/claude/bin/remem")]);
+    }
+
+    #[test]
+    fn extract_remem_command_path_ignores_env_assignments() {
+        assert_eq!(
+            extract_remem_command_path(
+                "REMEM_CONTEXT_HOST=codex-cli '/opt/remem/bin/remem' context --color"
+            ),
+            Some("/opt/remem/bin/remem")
+        );
+        assert_eq!(extract_remem_command_path("NOTE=remem echo ok"), None);
     }
 
     #[test]

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -15,6 +15,22 @@ pub(super) fn check_binary() -> Check {
     }
 }
 
+pub(super) fn check_install_paths() -> Check {
+    let configured = std::env::var_os("REMEM_INSTALL_BINARY")
+        .map(PathBuf::from)
+        .or_else(|| std::env::current_exe().ok());
+    let report = crate::install::duplicates::inspect_install_paths(configured.as_deref());
+    Check {
+        name: "Install paths",
+        status: if report.has_warning() {
+            Status::Warn
+        } else {
+            Status::Ok
+        },
+        detail: crate::install::duplicates::format_doctor_detail(&report),
+    }
+}
+
 /// A single host we know how to validate. The strings are leaked static
 /// because `Check::name` takes `&'static str` — every host lives for the
 /// process, so leaking is fine.

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use anyhow::Result;
 
 use super::database::{check_database, check_disk_space, check_pending_queue, check_worker_daemon};
-use super::environment::{check_binary, check_hooks, check_mcp};
+use super::environment::{check_binary, check_hooks, check_install_paths, check_mcp};
 use super::native_memory::check_native_memory_sync;
 use super::schema::check_schema_migration;
 use super::types::{Check, CheckJson, DoctorOutcome, ReportJson, Status, REPORT_SCHEMA_VERSION};
@@ -46,6 +46,7 @@ pub(crate) fn run_doctor_with_writer<W: Write>(
 
 fn collect_checks() -> Vec<Check> {
     let mut checks = vec![check_binary(), check_schema_migration(), check_database()];
+    checks.push(check_install_paths());
     checks.extend(check_hooks());
     checks.extend(check_mcp());
     checks.push(check_worker_daemon());

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,4 +1,5 @@
 mod config;
+pub(crate) mod duplicates;
 mod host;
 mod hosts;
 mod json_io;

--- a/src/install/duplicates.rs
+++ b/src/install/duplicates.rs
@@ -1,0 +1,371 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InstallPathCandidate {
+    pub(crate) path: PathBuf,
+    pub(crate) resolved_path: PathBuf,
+    pub(crate) version: Option<String>,
+    pub(crate) first_on_path: bool,
+    pub(crate) configured: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InstallPathReport {
+    pub(crate) configured_path: Option<PathBuf>,
+    pub(crate) configured_resolved_path: Option<PathBuf>,
+    pub(crate) candidates: Vec<InstallPathCandidate>,
+}
+
+impl InstallPathReport {
+    pub(crate) fn has_warning(&self) -> bool {
+        self.has_duplicates() || self.first_path_differs_from_configured()
+    }
+
+    fn has_duplicates(&self) -> bool {
+        self.candidates.len() > 1
+    }
+
+    fn first_path_differs_from_configured(&self) -> bool {
+        let Some(configured) = self.configured_resolved_path.as_ref() else {
+            return false;
+        };
+        self.candidates
+            .first()
+            .is_some_and(|candidate| &candidate.resolved_path != configured)
+    }
+}
+
+pub(crate) fn inspect_install_paths(configured_path: Option<&Path>) -> InstallPathReport {
+    let path_env = std::env::var_os("PATH").unwrap_or_default();
+    let dirs: Vec<PathBuf> = std::env::split_paths(&path_env).collect();
+    collect_install_paths(
+        dirs,
+        configured_path,
+        default_candidate_names(),
+        probe_version,
+    )
+}
+
+pub(crate) fn format_doctor_detail(report: &InstallPathReport) -> String {
+    let configured = report
+        .configured_path
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    if report.candidates.is_empty() {
+        return format!("no remem executable found on PATH; configured {configured}");
+    }
+
+    let candidate_list = report
+        .candidates
+        .iter()
+        .map(format_candidate)
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    if report.has_warning() {
+        return format!(
+            "{} remem executable(s) found; configured {}; candidates: {}; fix: remove or upgrade stale installs, or put the intended path first in PATH",
+            report.candidates.len(),
+            configured,
+            candidate_list
+        );
+    }
+
+    format!(
+        "one remem executable found; configured {}; candidate: {}",
+        configured, candidate_list
+    )
+}
+
+pub(crate) fn format_warning_lines(report: &InstallPathReport) -> Vec<String> {
+    if !report.has_warning() {
+        return Vec::new();
+    }
+
+    let mut lines = vec!["Install paths: multiple or mismatched remem commands found".to_string()];
+    if let Some(configured) = report.configured_path.as_ref() {
+        lines.push(format!("  config -> {}", configured.display()));
+    }
+    for candidate in &report.candidates {
+        let label = if candidate.first_on_path {
+            "active"
+        } else {
+            "stale "
+        };
+        lines.push(format!("  {label} -> {}", format_candidate(candidate)));
+    }
+    lines.push(
+        "  fix    -> remove or upgrade stale package-manager/manual installs, or put the intended path first in PATH"
+            .to_string(),
+    );
+    lines
+}
+
+fn format_candidate(candidate: &InstallPathCandidate) -> String {
+    let version = candidate
+        .version
+        .as_deref()
+        .unwrap_or("version unavailable");
+    let configured = if candidate.configured {
+        ", configured"
+    } else {
+        ""
+    };
+    format!("{} ({version}{configured})", candidate.path.display())
+}
+
+fn collect_install_paths<F>(
+    dirs: Vec<PathBuf>,
+    configured_path: Option<&Path>,
+    candidate_names: &[&str],
+    mut version_probe: F,
+) -> InstallPathReport
+where
+    F: FnMut(&Path) -> Option<String>,
+{
+    let configured_path = configured_path.map(Path::to_path_buf);
+    let configured_resolved_path = configured_path.as_deref().map(canonical_or_original);
+    let mut seen = HashSet::new();
+    let mut candidates = Vec::new();
+
+    for dir in dirs {
+        for name in candidate_names {
+            let candidate_path = dir.join(name);
+            if !is_candidate_file(&candidate_path) {
+                continue;
+            }
+
+            let resolved_path = canonical_or_original(&candidate_path);
+            if !seen.insert(resolved_path.clone()) {
+                continue;
+            }
+
+            let configured = configured_resolved_path
+                .as_ref()
+                .is_some_and(|path| path == &resolved_path);
+            let first_on_path = candidates.is_empty();
+            let version = version_probe(&candidate_path);
+            candidates.push(InstallPathCandidate {
+                path: candidate_path,
+                resolved_path,
+                version,
+                first_on_path,
+                configured,
+            });
+        }
+    }
+
+    InstallPathReport {
+        configured_path,
+        configured_resolved_path,
+        candidates,
+    }
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn default_candidate_names() -> &'static [&'static str] {
+    candidate_names_for_platform(cfg!(windows))
+}
+
+fn candidate_names_for_platform(windows: bool) -> &'static [&'static str] {
+    if windows {
+        &["remem.exe", "remem.cmd", "remem.bat"]
+    } else {
+        &["remem"]
+    }
+}
+
+fn is_candidate_file(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    is_executable(&metadata)
+}
+
+#[cfg(unix)]
+fn is_executable(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable(_: &std::fs::Metadata) -> bool {
+    true
+}
+
+fn probe_version(path: &Path) -> Option<String> {
+    let mut child = Command::new(path)
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    let deadline = Instant::now() + Duration::from_millis(500);
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                let output = child.wait_with_output().ok()?;
+                return parse_version_output(output.stdout, output.stderr);
+            }
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+}
+
+fn parse_version_output(stdout: Vec<u8>, stderr: Vec<u8>) -> Option<String> {
+    let text = if stdout.is_empty() { stderr } else { stdout };
+    let first_line = String::from_utf8_lossy(&text)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if first_line.is_empty() {
+        None
+    } else {
+        Some(first_line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "remem-install-paths-{label}-{}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn write_candidate(dir: &Path, name: &str, version: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, version).expect("write candidate");
+        #[cfg(unix)]
+        {
+            let mut permissions = std::fs::metadata(&path)
+                .expect("candidate metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&path, permissions).expect("mark executable");
+        }
+        path
+    }
+
+    #[test]
+    fn detects_multiple_unique_unix_candidates() {
+        let first = temp_dir("first");
+        let second = temp_dir("second");
+        let first_path = write_candidate(&first, "remem", "remem 0.4.5");
+        let second_path = write_candidate(&second, "remem", "remem 0.4.1");
+
+        let report =
+            collect_install_paths(vec![first, second], Some(&first_path), &["remem"], |path| {
+                Some(std::fs::read_to_string(path).expect("candidate version"))
+            });
+
+        assert!(report.has_warning());
+        assert_eq!(report.candidates.len(), 2);
+        assert!(report.candidates[0].first_on_path);
+        assert!(report.candidates[0].configured);
+        assert_eq!(report.candidates[1].path, second_path);
+        assert!(format_doctor_detail(&report).contains("2 remem executable(s) found"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_to_same_binary_is_not_duplicate() {
+        let real_dir = temp_dir("real");
+        let link_dir = temp_dir("link");
+        let real = write_candidate(&real_dir, "remem", "remem 0.4.5");
+        let link = link_dir.join("remem");
+        create_symlink(&real, &link).expect("create symlink");
+
+        let report =
+            collect_install_paths(vec![real_dir, link_dir], Some(&real), &["remem"], |path| {
+                Some(std::fs::read_to_string(path).unwrap_or_else(|_| path.display().to_string()))
+            });
+
+        assert!(!report.has_warning());
+        assert_eq!(report.candidates.len(), 1);
+    }
+
+    #[test]
+    fn warns_when_first_path_differs_from_configured_binary() {
+        let stale_dir = temp_dir("stale");
+        let configured_dir = temp_dir("configured");
+        write_candidate(&stale_dir, "remem", "remem 0.4.1");
+        let configured = write_candidate(&configured_dir, "remem", "remem 0.4.5");
+
+        let report = collect_install_paths(
+            vec![stale_dir, configured_dir],
+            Some(&configured),
+            &["remem"],
+            |path| Some(std::fs::read_to_string(path).expect("candidate version")),
+        );
+
+        assert!(report.has_warning());
+        assert!(report.first_path_differs_from_configured());
+        let lines = format_warning_lines(&report).join("\n");
+        assert!(lines.contains("active ->"));
+        assert!(lines.contains("stale  ->"));
+    }
+
+    #[test]
+    fn windows_candidate_names_include_wrappers() {
+        assert_eq!(
+            candidate_names_for_platform(true),
+            ["remem.exe", "remem.cmd", "remem.bat"].as_slice()
+        );
+    }
+
+    #[test]
+    fn parses_first_version_line_from_stdout_or_stderr() {
+        assert_eq!(
+            parse_version_output(b"remem 0.4.5\nextra".to_vec(), Vec::new()),
+            Some("remem 0.4.5".to_string())
+        );
+        assert_eq!(
+            parse_version_output(Vec::new(), b"remem 0.4.6\n".to_vec()),
+            Some("remem 0.4.6".to_string())
+        );
+        assert_eq!(parse_version_output(Vec::new(), Vec::new()), None);
+    }
+
+    #[cfg(unix)]
+    fn create_symlink(from: &Path, to: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(from, to)
+    }
+}

--- a/src/install/duplicates.rs
+++ b/src/install/duplicates.rs
@@ -1,4 +1,6 @@
 use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -129,7 +131,9 @@ where
     F: FnMut(&Path) -> Option<String>,
 {
     let configured_path = configured_path.map(Path::to_path_buf);
-    let configured_resolved_path = configured_path.as_deref().map(canonical_or_original);
+    let configured_resolved_path = configured_path
+        .as_deref()
+        .map(|path| resolve_configured_path(path, &dirs, candidate_names));
     let mut seen = HashSet::new();
     let mut candidates = Vec::new();
 
@@ -169,6 +173,49 @@ where
 
 fn canonical_or_original(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn resolve_configured_path(path: &Path, dirs: &[PathBuf], candidate_names: &[&str]) -> PathBuf {
+    resolve_bare_command_path(path, dirs, candidate_names)
+        .unwrap_or_else(|| canonical_or_original(path))
+}
+
+fn resolve_bare_command_path(
+    path: &Path,
+    dirs: &[PathBuf],
+    candidate_names: &[&str],
+) -> Option<PathBuf> {
+    let command = bare_command_name(path)?;
+    for dir in dirs {
+        let exact = dir.join(path);
+        if is_candidate_file(&exact) {
+            return Some(canonical_or_original(&exact));
+        }
+
+        for name in candidate_names {
+            let candidate = Path::new(name);
+            if candidate.file_stem() != Some(command) {
+                continue;
+            }
+
+            let candidate_path = dir.join(candidate);
+            if is_candidate_file(&candidate_path) {
+                return Some(canonical_or_original(&candidate_path));
+            }
+        }
+    }
+    None
+}
+
+fn bare_command_name(path: &Path) -> Option<&OsStr> {
+    let mut components = path.components();
+    let Some(Component::Normal(name)) = components.next() else {
+        return None;
+    };
+    if components.next().is_some() {
+        return None;
+    }
+    Some(name)
 }
 
 fn default_candidate_names() -> &'static [&'static str] {
@@ -341,6 +388,52 @@ mod tests {
         let lines = format_warning_lines(&report).join("\n");
         assert!(lines.contains("active ->"));
         assert!(lines.contains("stale  ->"));
+    }
+
+    #[test]
+    fn configured_command_name_resolves_through_path() {
+        let bin_dir = temp_dir("command");
+        let configured = PathBuf::from("remem");
+        let expected = write_candidate(&bin_dir, "remem", "remem 0.4.5");
+
+        let report = collect_install_paths(vec![bin_dir], Some(&configured), &["remem"], |path| {
+            match std::fs::read_to_string(path) {
+                Ok(version) => Some(version),
+                Err(error) => panic!("candidate version {}: {error}", path.display()),
+            }
+        });
+
+        assert!(!report.has_warning());
+        assert_eq!(report.configured_path, Some(configured));
+        assert_eq!(
+            report.configured_resolved_path,
+            Some(canonical_or_original(&expected))
+        );
+        assert!(report.candidates[0].configured);
+    }
+
+    #[test]
+    fn configured_command_name_resolves_platform_wrapper() {
+        let bin_dir = temp_dir("wrapper");
+        let configured = PathBuf::from("remem");
+        let expected = write_candidate(&bin_dir, "remem.exe", "remem 0.4.5");
+
+        let report = collect_install_paths(
+            vec![bin_dir],
+            Some(&configured),
+            &["remem.exe", "remem.cmd", "remem.bat"],
+            |path| match std::fs::read_to_string(path) {
+                Ok(version) => Some(version),
+                Err(error) => panic!("candidate version {}: {error}", path.display()),
+            },
+        );
+
+        assert!(!report.has_warning());
+        assert_eq!(
+            report.configured_resolved_path,
+            Some(canonical_or_original(&expected))
+        );
+        assert!(report.candidates[0].configured);
     }
 
     #[test]

--- a/src/install/duplicates.rs
+++ b/src/install/duplicates.rs
@@ -16,14 +16,16 @@ pub(crate) struct InstallPathCandidate {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InstallPathReport {
-    pub(crate) configured_path: Option<PathBuf>,
-    pub(crate) configured_resolved_path: Option<PathBuf>,
+    pub(crate) configured_paths: Vec<PathBuf>,
+    pub(crate) configured_resolved_paths: Vec<PathBuf>,
     pub(crate) candidates: Vec<InstallPathCandidate>,
 }
 
 impl InstallPathReport {
     pub(crate) fn has_warning(&self) -> bool {
-        self.has_duplicates() || self.first_path_differs_from_configured()
+        self.has_duplicates()
+            || self.configured_paths_disagree()
+            || self.first_path_differs_from_configured()
     }
 
     fn has_duplicates(&self) -> bool {
@@ -31,32 +33,43 @@ impl InstallPathReport {
     }
 
     fn first_path_differs_from_configured(&self) -> bool {
-        let Some(configured) = self.configured_resolved_path.as_ref() else {
+        if self.configured_resolved_paths.is_empty() {
             return false;
-        };
-        self.candidates
-            .first()
-            .is_some_and(|candidate| &candidate.resolved_path != configured)
+        }
+        self.candidates.first().is_some_and(|candidate| {
+            !self
+                .configured_resolved_paths
+                .contains(&candidate.resolved_path)
+        })
+    }
+
+    fn configured_paths_disagree(&self) -> bool {
+        unique_paths(&self.configured_resolved_paths).len() > 1
     }
 }
 
 pub(crate) fn inspect_install_paths(configured_path: Option<&Path>) -> InstallPathReport {
+    let configured_paths = configured_path
+        .map(|path| vec![path.to_path_buf()])
+        .unwrap_or_default();
+    inspect_install_paths_with_configured_paths(&configured_paths)
+}
+
+pub(crate) fn inspect_install_paths_with_configured_paths(
+    configured_paths: &[PathBuf],
+) -> InstallPathReport {
     let path_env = std::env::var_os("PATH").unwrap_or_default();
     let dirs: Vec<PathBuf> = std::env::split_paths(&path_env).collect();
     collect_install_paths(
         dirs,
-        configured_path,
+        configured_paths,
         default_candidate_names(),
         probe_version,
     )
 }
 
 pub(crate) fn format_doctor_detail(report: &InstallPathReport) -> String {
-    let configured = report
-        .configured_path
-        .as_ref()
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
+    let configured = format_configured_paths(&report.configured_paths);
 
     if report.candidates.is_empty() {
         return format!("no remem executable found on PATH; configured {configured}");
@@ -90,7 +103,7 @@ pub(crate) fn format_warning_lines(report: &InstallPathReport) -> Vec<String> {
     }
 
     let mut lines = vec!["Install paths: multiple or mismatched remem commands found".to_string()];
-    if let Some(configured) = report.configured_path.as_ref() {
+    for configured in &report.configured_paths {
         lines.push(format!("  config -> {}", configured.display()));
     }
     for candidate in &report.candidates {
@@ -123,17 +136,18 @@ fn format_candidate(candidate: &InstallPathCandidate) -> String {
 
 fn collect_install_paths<F>(
     dirs: Vec<PathBuf>,
-    configured_path: Option<&Path>,
+    configured_paths: &[PathBuf],
     candidate_names: &[&str],
     mut version_probe: F,
 ) -> InstallPathReport
 where
     F: FnMut(&Path) -> Option<String>,
 {
-    let configured_path = configured_path.map(Path::to_path_buf);
-    let configured_resolved_path = configured_path
-        .as_deref()
-        .map(|path| resolve_configured_path(path, &dirs, candidate_names));
+    let configured_paths = configured_paths.to_vec();
+    let configured_resolved_paths = configured_paths
+        .iter()
+        .map(|path| resolve_configured_path(path, &dirs, candidate_names))
+        .collect::<Vec<_>>();
     let mut seen = HashSet::new();
     let mut candidates = Vec::new();
 
@@ -149,9 +163,7 @@ where
                 continue;
             }
 
-            let configured = configured_resolved_path
-                .as_ref()
-                .is_some_and(|path| path == &resolved_path);
+            let configured = configured_resolved_paths.contains(&resolved_path);
             let first_on_path = candidates.is_empty();
             let version = version_probe(&candidate_path);
             candidates.push(InstallPathCandidate {
@@ -165,14 +177,35 @@ where
     }
 
     InstallPathReport {
-        configured_path,
-        configured_resolved_path,
+        configured_paths,
+        configured_resolved_paths,
         candidates,
     }
 }
 
 fn canonical_or_original(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn unique_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut unique = Vec::new();
+    for path in paths {
+        if !unique.contains(path) {
+            unique.push(path.clone());
+        }
+    }
+    unique
+}
+
+fn format_configured_paths(paths: &[PathBuf]) -> String {
+    if paths.is_empty() {
+        return "unknown".to_string();
+    }
+    paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn resolve_configured_path(path: &Path, dirs: &[PathBuf], candidate_names: &[&str]) -> PathBuf {
@@ -338,10 +371,12 @@ mod tests {
         let first_path = write_candidate(&first, "remem", "remem 0.4.5");
         let second_path = write_candidate(&second, "remem", "remem 0.4.1");
 
-        let report =
-            collect_install_paths(vec![first, second], Some(&first_path), &["remem"], |path| {
-                Some(std::fs::read_to_string(path).expect("candidate version"))
-            });
+        let report = collect_install_paths(
+            vec![first, second],
+            std::slice::from_ref(&first_path),
+            &["remem"],
+            |path| Some(std::fs::read_to_string(path).expect("candidate version")),
+        );
 
         assert!(report.has_warning());
         assert_eq!(report.candidates.len(), 2);
@@ -360,10 +395,14 @@ mod tests {
         let link = link_dir.join("remem");
         create_symlink(&real, &link).expect("create symlink");
 
-        let report =
-            collect_install_paths(vec![real_dir, link_dir], Some(&real), &["remem"], |path| {
+        let report = collect_install_paths(
+            vec![real_dir, link_dir],
+            std::slice::from_ref(&real),
+            &["remem"],
+            |path| {
                 Some(std::fs::read_to_string(path).unwrap_or_else(|_| path.display().to_string()))
-            });
+            },
+        );
 
         assert!(!report.has_warning());
         assert_eq!(report.candidates.len(), 1);
@@ -378,7 +417,7 @@ mod tests {
 
         let report = collect_install_paths(
             vec![stale_dir, configured_dir],
-            Some(&configured),
+            std::slice::from_ref(&configured),
             &["remem"],
             |path| Some(std::fs::read_to_string(path).expect("candidate version")),
         );
@@ -396,18 +435,21 @@ mod tests {
         let configured = PathBuf::from("remem");
         let expected = write_candidate(&bin_dir, "remem", "remem 0.4.5");
 
-        let report = collect_install_paths(vec![bin_dir], Some(&configured), &["remem"], |path| {
-            match std::fs::read_to_string(path) {
+        let report = collect_install_paths(
+            vec![bin_dir],
+            std::slice::from_ref(&configured),
+            &["remem"],
+            |path| match std::fs::read_to_string(path) {
                 Ok(version) => Some(version),
                 Err(error) => panic!("candidate version {}: {error}", path.display()),
-            }
-        });
+            },
+        );
 
         assert!(!report.has_warning());
-        assert_eq!(report.configured_path, Some(configured));
+        assert_eq!(report.configured_paths, vec![configured]);
         assert_eq!(
-            report.configured_resolved_path,
-            Some(canonical_or_original(&expected))
+            report.configured_resolved_paths,
+            vec![canonical_or_original(&expected)]
         );
         assert!(report.candidates[0].configured);
     }
@@ -420,7 +462,7 @@ mod tests {
 
         let report = collect_install_paths(
             vec![bin_dir],
-            Some(&configured),
+            std::slice::from_ref(&configured),
             &["remem.exe", "remem.cmd", "remem.bat"],
             |path| match std::fs::read_to_string(path) {
                 Ok(version) => Some(version),
@@ -430,10 +472,28 @@ mod tests {
 
         assert!(!report.has_warning());
         assert_eq!(
-            report.configured_resolved_path,
-            Some(canonical_or_original(&expected))
+            report.configured_resolved_paths,
+            vec![canonical_or_original(&expected)]
         );
         assert!(report.candidates[0].configured);
+    }
+
+    #[test]
+    fn warns_for_multiple_configured_paths() {
+        let first = temp_dir("configured-a");
+        let second = temp_dir("configured-b");
+        let first_path = write_candidate(&first, "remem", "remem 0.4.5");
+        let second_path = write_candidate(&second, "remem", "remem 0.4.5");
+
+        let report = collect_install_paths(
+            vec![first, second],
+            &[first_path, second_path],
+            &["remem"],
+            |path| Some(std::fs::read_to_string(path).expect("candidate version")),
+        );
+
+        assert!(report.has_warning());
+        assert!(report.configured_paths_disagree());
     }
 
     #[test]

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 
+use crate::install::duplicates::{format_warning_lines, inspect_install_paths};
 use crate::install::host::{HookSupport, InstallTarget};
 use crate::install::hosts::resolve_hosts;
 use crate::install::paths::{binary_path, old_hooks_path, remem_data_dir};
@@ -23,6 +24,7 @@ pub fn install(target: InstallTarget, dry_run: bool) -> Result<()> {
             }
         }
         eprintln!("  data   -> {}", remem_data_dir().display());
+        print_install_path_warnings(&bin);
         return Ok(());
     }
 
@@ -43,6 +45,7 @@ pub fn install(target: InstallTarget, dry_run: bool) -> Result<()> {
     let api_token_path = crate::api::ensure_api_token()?;
     eprintln!("  API    -> token {}", api_token_path.display());
     eprintln!("  binary -> {}", bin);
+    print_install_path_warnings(&bin);
 
     let old_path = old_hooks_path();
     if old_path.exists() {
@@ -61,6 +64,20 @@ pub fn install(target: InstallTarget, dry_run: bool) -> Result<()> {
     eprintln!("  3. Run 'remem status' to check system health");
 
     Ok(())
+}
+
+fn print_install_path_warnings(bin: &str) {
+    let report = inspect_install_paths(Some(std::path::Path::new(bin)));
+    let lines = format_warning_lines(&report);
+    if lines.is_empty() {
+        return;
+    }
+
+    eprintln!();
+    eprintln!("Install path warning:");
+    for line in lines {
+        eprintln!("{line}");
+    }
 }
 
 pub fn uninstall(target: InstallTarget, dry_run: bool) -> Result<()> {


### PR DESCRIPTION
## What

- Adds a shared install-path inventory detector for PATH-visible remem binaries.
- Surfaces an Install paths check in remem doctor / doctor --json without changing the JSON schema shape.
- Prints duplicate/mismatched install warnings from remem install and install --dry-run.
- Documents the recommended single canonical install strategy.

Closes #231.

## Verification

- cargo fmt --check
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo check
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test install::duplicates -- --test-threads=1
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test doctor -- --test-threads=1
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test install -- --test-threads=1
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo clippy -- -D warnings
- REMEM_DATA_DIR=/tmp/remem-pr231-test.W2AySI CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test -- --test-threads=1
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- REMEM_INSTALL_BINARY=/tmp/remem CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo run -- install --target all --dry-run