### PR TITLE
Add raw archive CLI search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -19,7 +19,7 @@ pub(super) use maintenance::{
 pub(super) use pending::run_pending;
 pub(super) use preferences::run_preferences;
 pub(super) use query::{
-    run_backfill_entities, run_commit, run_search, run_show, run_status, run_why,
+    run_backfill_entities, run_commit, run_raw, run_search, run_show, run_status, run_why,
 };
 pub(super) use review::run_review;
 pub(super) use scope_cleanup::{

--- a/src/cli/actions/query.rs
+++ b/src/cli/actions/query.rs
@@ -1,5 +1,6 @@
 mod backfill;
 mod commit;
+mod raw;
 mod search;
 mod show;
 mod status;
@@ -9,6 +10,7 @@ mod why;
 
 pub(in crate::cli) use backfill::run_backfill_entities;
 pub(in crate::cli) use commit::run_commit;
+pub(in crate::cli) use raw::run_raw;
 pub(in crate::cli) use search::run_search;
 pub(in crate::cli) use show::run_show;
 pub(in crate::cli) use status::run_status;

--- a/src/cli/actions/query/raw.rs
+++ b/src/cli/actions/query/raw.rs
@@ -1,0 +1,247 @@
+use anyhow::Result;
+use rusqlite::Connection;
+use serde::Serialize;
+
+use crate::cli::types::{RawAction, RawRole};
+use crate::memory::raw_archive::{RawMessage, RawSearchRequest};
+use crate::{db, memory::raw_archive::search_raw_messages};
+
+use super::show::format_memory_timestamp;
+
+pub(in crate::cli) fn run_raw(action: RawAction) -> Result<()> {
+    match action {
+        RawAction::Search {
+            query,
+            project,
+            branch,
+            role,
+            limit,
+            offset,
+            json,
+        } => run_raw_search(
+            &query,
+            project.as_deref(),
+            branch.as_deref(),
+            role,
+            limit,
+            offset,
+            json,
+        ),
+    }
+}
+
+pub(super) fn run_raw_search(
+    query: &str,
+    project: Option<&str>,
+    branch: Option<&str>,
+    role: Option<RawRole>,
+    limit: i64,
+    offset: i64,
+    json: bool,
+) -> Result<()> {
+    let conn = db::open_db()?;
+    let normalized_limit = limit.max(1);
+    let normalized_offset = offset.max(0);
+    let request = build_raw_search_request(
+        query,
+        project,
+        branch,
+        role.map(RawRole::as_str),
+        normalized_limit + 1,
+        normalized_offset,
+    );
+    let mut rows = search_raw_archive(&conn, &request)?;
+    let has_more = rows.len() as i64 > normalized_limit;
+    rows.truncate(normalized_limit as usize);
+
+    if json {
+        let output = build_raw_search_json(
+            query,
+            project,
+            branch,
+            role.map(RawRole::as_str),
+            normalized_limit,
+            normalized_offset,
+            has_more,
+            &rows,
+        );
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    print!(
+        "{}",
+        render_raw_search_results(&rows, normalized_offset, normalized_limit, has_more)
+    );
+    Ok(())
+}
+
+pub(super) fn build_raw_search_request(
+    query: &str,
+    project: Option<&str>,
+    branch: Option<&str>,
+    role: Option<&str>,
+    limit: i64,
+    offset: i64,
+) -> RawSearchRequest {
+    RawSearchRequest {
+        query: query.to_string(),
+        project: project.map(str::to_string),
+        branch: branch.map(str::to_string),
+        role: role.map(str::to_string),
+        limit,
+        offset,
+    }
+}
+
+pub(super) fn search_raw_archive(
+    conn: &Connection,
+    request: &RawSearchRequest,
+) -> Result<Vec<RawMessage>> {
+    search_raw_messages(conn, request)
+}
+
+pub(super) fn render_raw_search_results(
+    rows: &[RawMessage],
+    offset: i64,
+    limit: i64,
+    has_more: bool,
+) -> String {
+    let mut output = String::new();
+    if rows.is_empty() {
+        output.push_str("No raw archive rows found.\n");
+        output.push_str(
+            "Curated search may still have promoted memories: remem search \"<query>\".\n",
+        );
+        return output;
+    }
+
+    output.push_str("Raw archive rows (not curated memories):\n\n");
+    for row in rows {
+        output.push_str(&format_raw_row(row));
+    }
+
+    output.push_str("\nNext:\n");
+    output.push_str("  raw rows are captured chat turns, not curated memories.\n");
+    output.push_str("  promote durable conclusions with review/save_memory.\n");
+    if has_more {
+        output.push_str(&format!(
+            "  remem raw search \"<query>\" --offset {}\n",
+            offset.max(0) + limit.max(1)
+        ));
+    }
+    output
+}
+
+pub(super) fn build_raw_search_json(
+    query: &str,
+    project: Option<&str>,
+    branch: Option<&str>,
+    role: Option<&str>,
+    limit: i64,
+    offset: i64,
+    has_more: bool,
+    rows: &[RawMessage],
+) -> RawSearchJson {
+    let normalized_limit = limit.max(1);
+    let normalized_offset = offset.max(0);
+    RawSearchJson {
+        query: query.to_string(),
+        project: project.map(str::to_string),
+        branch: branch.map(str::to_string),
+        role: role.map(str::to_string),
+        limit: normalized_limit,
+        offset: normalized_offset,
+        source_type: "raw_archive".to_string(),
+        note: "raw archive rows are captured chat turns, not curated memories".to_string(),
+        count: rows.len(),
+        has_more,
+        next_offset: has_more.then_some(normalized_offset + normalized_limit),
+        results: rows.iter().map(RawArchiveRowJson::from).collect(),
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct RawSearchJson {
+    pub query: String,
+    pub project: Option<String>,
+    pub branch: Option<String>,
+    pub role: Option<String>,
+    pub limit: i64,
+    pub offset: i64,
+    pub source_type: String,
+    pub note: String,
+    pub count: usize,
+    pub has_more: bool,
+    pub next_offset: Option<i64>,
+    pub results: Vec<RawArchiveRowJson>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct RawArchiveRowJson {
+    pub id: i64,
+    pub source_type: String,
+    pub session_id: String,
+    pub project: String,
+    pub role: String,
+    pub content: String,
+    pub source: String,
+    pub branch: Option<String>,
+    pub cwd: Option<String>,
+    pub created_at_epoch: i64,
+}
+
+impl From<&RawMessage> for RawArchiveRowJson {
+    fn from(row: &RawMessage) -> Self {
+        Self {
+            id: row.id,
+            source_type: "raw_archive".to_string(),
+            session_id: row.session_id.clone(),
+            project: row.project.clone(),
+            role: row.role.clone(),
+            content: row.content.clone(),
+            source: row.source.clone(),
+            branch: row.branch.clone(),
+            cwd: row.cwd.clone(),
+            created_at_epoch: row.created_at_epoch,
+        }
+    }
+}
+
+fn format_raw_row(row: &RawMessage) -> String {
+    let branch = row
+        .branch
+        .as_deref()
+        .map(|branch| format!(" | branch={branch}"))
+        .unwrap_or_default();
+    let cwd = row
+        .cwd
+        .as_deref()
+        .map(|cwd| format!(" | cwd={cwd}"))
+        .unwrap_or_default();
+    let preview = preview_raw_content(row);
+    let mut output = format!(
+        "  [raw:{}] {} | {} | {} | source={}{}{}\n",
+        row.id,
+        row.role,
+        row.project,
+        format_memory_timestamp(row.created_at_epoch),
+        row.source,
+        branch,
+        cwd
+    );
+    if !preview.is_empty() {
+        output.push_str(&format!("      {}\n", preview));
+    }
+    output
+}
+
+fn preview_raw_content(row: &RawMessage) -> String {
+    row.content
+        .lines()
+        .next()
+        .unwrap_or("")
+        .chars()
+        .take(200)
+        .collect()
+}

--- a/src/cli/actions/query/tests.rs
+++ b/src/cli/actions/query/tests.rs
@@ -1,5 +1,5 @@
 use crate::memory::{
-    raw_archive::RawMessage,
+    raw_archive::{insert_raw_message, RawMessage, ROLE_ASSISTANT, ROLE_USER, SOURCE_HOOK},
     service::{MultiHopMeta, SearchResultSet},
     Memory,
 };
@@ -7,6 +7,10 @@ use crate::retrieval::search::{ChannelContribution, SearchExplain, SearchExplain
 use serde_json::Value;
 
 use super::{
+    raw::{
+        build_raw_search_json, build_raw_search_request, render_raw_search_results,
+        search_raw_archive,
+    },
     search::{
         build_search_json, build_search_request, preview_raw_text, preview_text,
         render_search_results,
@@ -255,6 +259,131 @@ fn cli_search_json_report_is_machine_parseable() -> std::result::Result<(), serd
     assert_eq!(parsed["raw_hits"][0]["id"], 9);
     assert_eq!(parsed["multi_hop"]["entities_discovered"][0], "Mem0");
     assert_eq!(parsed["explain_details"]["query"], "needle");
+    Ok(())
+}
+
+#[test]
+fn cli_raw_search_request_carries_raw_filters() {
+    let request = build_raw_search_request(
+        "literal phrase",
+        Some("/repo"),
+        Some("main"),
+        Some("user"),
+        21,
+        40,
+    );
+
+    assert_eq!(request.query, "literal phrase");
+    assert_eq!(request.project.as_deref(), Some("/repo"));
+    assert_eq!(request.branch.as_deref(), Some("main"));
+    assert_eq!(request.role.as_deref(), Some("user"));
+    assert_eq!(request.limit, 21);
+    assert_eq!(request.offset, 40);
+}
+
+#[test]
+fn cli_raw_search_uses_raw_archive_filters() -> anyhow::Result<()> {
+    let conn = rusqlite::Connection::open_in_memory()?;
+    crate::migrate::run_migrations(&conn)?;
+    insert_raw_message(
+        &conn,
+        "s-user-main",
+        "/repo",
+        ROLE_USER,
+        "literal phrase from user on main",
+        SOURCE_HOOK,
+        Some("main"),
+        Some("/repo"),
+    )?;
+    insert_raw_message(
+        &conn,
+        "s-assistant-main",
+        "/repo",
+        ROLE_ASSISTANT,
+        "literal phrase from assistant on main",
+        SOURCE_HOOK,
+        Some("main"),
+        Some("/repo"),
+    )?;
+    insert_raw_message(
+        &conn,
+        "s-user-feature",
+        "/repo",
+        ROLE_USER,
+        "literal phrase from user on feature",
+        SOURCE_HOOK,
+        Some("feature"),
+        Some("/repo"),
+    )?;
+
+    let request = build_raw_search_request(
+        "literal phrase",
+        Some("/repo"),
+        Some("main"),
+        Some("user"),
+        20,
+        0,
+    );
+    let rows = search_raw_archive(&conn, &request)?;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].role, ROLE_USER);
+    assert_eq!(rows[0].branch.as_deref(), Some("main"));
+    assert!(rows[0].content.contains("literal phrase"));
+    Ok(())
+}
+
+#[test]
+fn cli_raw_search_render_labels_rows_as_raw_not_curated() {
+    let output = render_raw_search_results(&[sample_raw()], 20, 20, true);
+
+    assert!(output.contains("Raw archive rows (not curated memories):"));
+    assert!(
+        output.contains("[raw:9] user | proj | 1970-01-01 00:00 UTC | source=hook | branch=main")
+    );
+    assert!(output.contains("raw rows are captured chat turns, not curated memories."));
+    assert!(output.contains("remem raw search \"<query>\" --offset 40"));
+}
+
+#[test]
+fn cli_raw_search_render_empty_mentions_curated_search() {
+    let output = render_raw_search_results(&[], 0, 20, false);
+
+    assert!(output.contains("No raw archive rows found."));
+    assert!(output.contains("Curated search may still have promoted memories"));
+    assert!(output.contains("remem search \"<query>\""));
+}
+
+#[test]
+fn cli_raw_search_json_report_is_machine_parseable() -> std::result::Result<(), serde_json::Error> {
+    let output = build_raw_search_json(
+        "literal phrase",
+        Some("proj"),
+        Some("main"),
+        Some("user"),
+        20,
+        40,
+        true,
+        &[sample_raw()],
+    );
+
+    let text = serde_json::to_string(&output)?;
+    let parsed: Value = serde_json::from_str(&text)?;
+
+    assert_eq!(parsed["query"], "literal phrase");
+    assert_eq!(parsed["project"], "proj");
+    assert_eq!(parsed["branch"], "main");
+    assert_eq!(parsed["role"], "user");
+    assert_eq!(parsed["source_type"], "raw_archive");
+    assert_eq!(
+        parsed["note"],
+        "raw archive rows are captured chat turns, not curated memories"
+    );
+    assert_eq!(parsed["count"], 1);
+    assert_eq!(parsed["has_more"], true);
+    assert_eq!(parsed["next_offset"], 60);
+    assert_eq!(parsed["results"][0]["source_type"], "raw_archive");
+    assert_eq!(parsed["results"][0]["content"], sample_raw().content);
     Ok(())
 }
 

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -5,9 +5,9 @@ use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 use super::actions::{
     run_admin, run_archive, run_audit_scope, run_backfill_entities, run_cleanup, run_commit,
     run_dream, run_encrypt, run_eval, run_eval_e2e, run_eval_governance, run_eval_local,
-    run_governance, run_import, run_merge_preferences, run_pending, run_preferences, run_reroute,
-    run_review, run_search, run_show, run_status, run_usage, run_why, GovernanceCliRequest,
-    RerouteCliRequest,
+    run_governance, run_import, run_merge_preferences, run_pending, run_preferences, run_raw,
+    run_reroute, run_review, run_search, run_show, run_status, run_usage, run_why,
+    GovernanceCliRequest, RerouteCliRequest,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands};
@@ -176,6 +176,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             explain,
             json,
         )?,
+        Commands::Raw { action } => run_raw(action)?,
         Commands::Commit { action } => run_commit(action)?,
         Commands::Show { id, json } => run_show(id, json)?,
         Commands::Why {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,6 +1,7 @@
 use super::cwd::resolve_cwd_arg;
 use super::types::{
-    Cli, Commands, CommitAction, MemoryGovernanceCliAction, PendingAction, ReviewAction,
+    Cli, Commands, CommitAction, MemoryGovernanceCliAction, PendingAction, RawAction, RawRole,
+    ReviewAction,
 };
 use clap::{CommandFactory, Parser};
 
@@ -117,6 +118,51 @@ fn cli_parses_search_type_alias_and_multi_hop_filters() {
             assert!(!json);
         }
         _ => panic!("expected search command"),
+    }
+}
+
+#[test]
+fn cli_parses_raw_search_filters() {
+    let cli = Cli::parse_from([
+        "remem",
+        "raw",
+        "search",
+        "literal phrase",
+        "--project",
+        "/repo",
+        "--branch",
+        "main",
+        "--role",
+        "user",
+        "--limit",
+        "20",
+        "--offset",
+        "40",
+        "--json",
+    ]);
+
+    match cli.command {
+        Commands::Raw {
+            action:
+                RawAction::Search {
+                    query,
+                    project,
+                    branch,
+                    role,
+                    limit,
+                    offset,
+                    json,
+                },
+        } => {
+            assert_eq!(query, "literal phrase");
+            assert_eq!(project.as_deref(), Some("/repo"));
+            assert_eq!(branch.as_deref(), Some("main"));
+            assert_eq!(role, Some(RawRole::User));
+            assert_eq!(limit, 20);
+            assert_eq!(offset, 40);
+            assert!(json);
+        }
+        _ => panic!("expected raw search command"),
     }
 }
 

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -294,6 +294,11 @@ pub(super) enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Search raw archive rows from the terminal.
+    Raw {
+        #[command(subcommand)]
+        action: RawAction,
+    },
     /// Look up git commits and linked memory sessions.
     Commit {
         #[command(subcommand)]
@@ -441,6 +446,48 @@ pub(in crate::cli) enum CommitAction {
         #[arg(long)]
         json: bool,
     },
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum RawAction {
+    /// Search raw captured user/assistant chat turns, not curated memories.
+    Search {
+        /// Literal phrase or terms to search in raw archive rows.
+        query: String,
+        /// Restrict search to one project path.
+        #[arg(long, short)]
+        project: Option<String>,
+        /// Include rows from this branch plus branchless older rows.
+        #[arg(long)]
+        branch: Option<String>,
+        /// Restrict search to one message role.
+        #[arg(long, value_enum)]
+        role: Option<RawRole>,
+        /// Maximum raw rows to show.
+        #[arg(long, short = 'n', default_value = "20")]
+        limit: i64,
+        /// Result offset for pagination.
+        #[arg(long, default_value = "0")]
+        offset: i64,
+        /// Emit a single JSON object with stable fields for scripts.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(in crate::cli) enum RawRole {
+    User,
+    Assistant,
+}
+
+impl RawRole {
+    pub(in crate::cli) fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+        }
+    }
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
## Summary
- Add `remem raw search <query>` for raw archive rows, explicitly labeled as non-curated chat turns.
- Support project, branch, role, limit, offset, and JSON output for the raw search path.
- Reuse `memory::raw_archive::search_raw_messages` and bump package version to 0.4.24 for the binary change.

Closes #251

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test cli_parses_raw_search_filters`
- `cargo test cli_raw_search`
- `cargo clippy -- -D warnings`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `REMEM_DATA_DIR=$(mktemp -d) REMEM_ALLOW_PLAINTEXT_DB=1 cargo test` (via cleanup wrapper)
- `target/debug/remem raw search "literal phrase" --limit 3` with temporary `REMEM_DATA_DIR`
