### PR TITLE
feat(memory): report durable save feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/api/handlers/save.rs
+++ b/src/api/handlers/save.rs
@@ -3,7 +3,9 @@ use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use crate::memory::service;
 
 use super::super::helpers::{error_response, open_request_db};
-use super::super::types::{DbState, SaveMemoryRequest, SaveMemoryResponse};
+use super::super::types::{
+    DbState, LocalCopyResponse, SaveMemoryNextStepResponse, SaveMemoryRequest, SaveMemoryResponse,
+};
 
 pub(in crate::api) async fn handle_save_memory(
     State(_state): State<DbState>,
@@ -35,9 +37,27 @@ pub(in crate::api) async fn handle_save_memory(
                 id: saved.id,
                 status: saved.status,
                 memory_type: saved.memory_type,
+                project: saved.project,
+                scope: saved.scope,
+                topic_key: saved.topic_key,
+                branch: saved.branch,
+                operation: saved.operation,
+                created_at_epoch: saved.created_at_epoch,
+                updated_at_epoch: saved.updated_at_epoch,
                 upserted: saved.upserted,
+                local_copy: LocalCopyResponse {
+                    status: saved.local_copy.status,
+                    path: saved.local_copy.path,
+                    reason: saved.local_copy.reason,
+                },
                 local_status: saved.local_status,
                 local_path: saved.local_path,
+                next_step: SaveMemoryNextStepResponse {
+                    tool: saved.next_step.tool,
+                    ids: saved.next_step.ids,
+                    source: saved.next_step.source,
+                    reason: saved.next_step.reason,
+                },
             }),
         )
             .into_response(),

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -134,6 +134,64 @@ async fn router_rejects_missing_and_invalid_api_token() {
 }
 
 #[tokio::test]
+async fn save_memory_response_reports_durable_feedback_shape() {
+    let _test_dir = ScopedTestDataDir::new("api-save-feedback");
+    crate::api::ensure_api_token().expect("API token should be created");
+    let token = crate::api::load_api_token().expect("API token should load");
+    let app = super::build_router(0).with_state(DbState);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/memories")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{
+                        "text":"API durable feedback body",
+                        "title":"API feedback",
+                        "project":"proj",
+                        "topic_key":"api-feedback",
+                        "memory_type":"decision",
+                        "scope":"project",
+                        "branch":"main",
+                        "local_copy_enabled":false
+                    }"#,
+                ))
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should complete");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should read");
+    let payload: Value = serde_json::from_slice(&body).expect("save response should be valid json");
+
+    assert_eq!(payload["status"], "saved");
+    assert_eq!(payload["operation"], "inserted");
+    assert_eq!(payload["upserted"], true);
+    assert_eq!(payload["project"], "proj");
+    assert_eq!(payload["scope"], "project");
+    assert_eq!(payload["topic_key"], "api-feedback");
+    assert_eq!(payload["branch"], "main");
+    assert_eq!(payload["local_copy"]["status"], "disabled");
+    assert_eq!(payload["local_status"], "disabled");
+    assert!(payload["local_path"].is_null());
+    assert_eq!(payload["next_step"]["tool"], "get_observations");
+    assert_eq!(payload["next_step"]["source"], "memory");
+    assert_eq!(payload["next_step"]["ids"][0], payload["id"]);
+    assert!(payload["created_at_epoch"]
+        .as_i64()
+        .is_some_and(|ts| ts > 0));
+    assert!(payload["updated_at_epoch"]
+        .as_i64()
+        .is_some_and(|ts| ts > 0));
+}
+
+#[tokio::test]
 async fn router_does_not_emit_cors_allow_origin_for_localhost_origin() {
     let _test_dir = ScopedTestDataDir::new("api-no-cors");
     crate::api::ensure_api_token().expect("API token should be created");

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -113,10 +113,35 @@ pub(super) struct SaveMemoryResponse {
     pub id: i64,
     pub status: String,
     pub memory_type: String,
+    pub project: String,
+    pub scope: String,
+    pub topic_key: Option<String>,
+    pub branch: Option<String>,
+    pub operation: String,
+    pub created_at_epoch: i64,
+    pub updated_at_epoch: i64,
     pub upserted: bool,
+    pub local_copy: LocalCopyResponse,
     pub local_status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub local_path: Option<String>,
+    pub next_step: SaveMemoryNextStepResponse,
+}
+
+#[derive(Serialize)]
+pub(super) struct LocalCopyResponse {
+    pub status: String,
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(super) struct SaveMemoryNextStepResponse {
+    pub tool: String,
+    pub ids: Vec<i64>,
+    pub source: String,
+    pub reason: String,
 }
 
 #[derive(Deserialize)]

--- a/src/mcp/server/tests.rs
+++ b/src/mcp/server/tests.rs
@@ -262,6 +262,45 @@ fn save_memory_local_copy_failures_are_invalid_request() {
 }
 
 #[test]
+fn save_memory_response_reports_durable_feedback_shape() {
+    let _dir = ScopedTestDataDir::new("mcp-save-feedback-shape");
+    let server = MemoryServer::new().expect("memory server should initialize");
+
+    let response = server
+        .save_memory(Parameters(SaveMemoryParams {
+            text: "MCP durable feedback body".to_string(),
+            title: Some("MCP feedback".to_string()),
+            project: Some("proj".to_string()),
+            topic_key: Some("mcp-feedback".to_string()),
+            memory_type: Some("decision".to_string()),
+            files: None,
+            local_path: None,
+            scope: None,
+            branch: Some("main".to_string()),
+            created_at_epoch: None,
+            local_copy_enabled: Some(false),
+        }))
+        .expect("save_memory should succeed");
+    let json: Value = serde_json::from_str(&response).expect("response should be json");
+
+    assert_eq!(json["status"], "saved");
+    assert_eq!(json["operation"], "inserted");
+    assert_eq!(json["upserted"], true);
+    assert_eq!(json["project"], "proj");
+    assert_eq!(json["scope"], "project");
+    assert_eq!(json["topic_key"], "mcp-feedback");
+    assert_eq!(json["branch"], "main");
+    assert_eq!(json["local_copy"]["status"], "disabled");
+    assert_eq!(json["local_status"], "disabled");
+    assert!(json["local_path"].is_null());
+    assert_eq!(json["next_step"]["tool"], "get_observations");
+    assert_eq!(json["next_step"]["source"], "memory");
+    assert_eq!(json["next_step"]["ids"][0], json["id"]);
+    assert!(json["created_at_epoch"].as_i64().is_some_and(|ts| ts > 0));
+    assert!(json["updated_at_epoch"].as_i64().is_some_and(|ts| ts > 0));
+}
+
+#[test]
 fn govern_memory_validation_failures_are_invalid_request() {
     let _dir = ScopedTestDataDir::new("mcp-govern-validation");
     let server = match MemoryServer::new() {

--- a/src/mcp/server/write_tools.rs
+++ b/src/mcp/server/write_tools.rs
@@ -108,9 +108,10 @@ impl MemoryServer {
             crate::log::info(
                 "mcp",
                 &format!(
-                    "save_memory done id={} type={} upserted={} local_status={} local_path={:?}",
+                    "save_memory done id={} type={} operation={} upserted={} local_status={} local_path={:?}",
                     saved.id,
                     saved.memory_type,
+                    saved.operation,
                     saved.upserted,
                     saved.local_status,
                     saved.local_path
@@ -122,9 +123,27 @@ impl MemoryServer {
                     "id": saved.id,
                     "status": saved.status,
                     "memory_type": saved.memory_type,
+                    "project": saved.project,
+                    "scope": saved.scope,
+                    "topic_key": saved.topic_key,
+                    "branch": saved.branch,
+                    "operation": saved.operation,
+                    "created_at_epoch": saved.created_at_epoch,
+                    "updated_at_epoch": saved.updated_at_epoch,
                     "upserted": saved.upserted,
+                    "local_copy": {
+                        "status": saved.local_copy.status,
+                        "path": saved.local_copy.path,
+                        "reason": saved.local_copy.reason,
+                    },
                     "local_status": saved.local_status,
                     "local_path": saved.local_path,
+                    "next_step": {
+                        "tool": saved.next_step.tool,
+                        "ids": saved.next_step.ids,
+                        "source": saved.next_step.source,
+                        "reason": saved.next_step.reason,
+                    },
                 }),
             )
         })

--- a/src/memory/service/save.rs
+++ b/src/memory/service/save.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context, Result};
-use rusqlite::Connection;
+use rusqlite::{params, Connection, OptionalExtension};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -7,7 +7,7 @@ use super::local_copy::{
     build_local_note_content, local_copy_enabled_override, resolve_local_note_path,
     write_local_note,
 };
-use super::types::{SaveMemoryRequest, SaveMemoryResult};
+use super::types::{LocalCopyResult, SaveMemoryNextStep, SaveMemoryRequest, SaveMemoryResult};
 use crate::memory::lesson::{save_lesson, SaveLessonRequest};
 
 #[derive(Debug)]
@@ -41,6 +41,9 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         .and_then(|files| serde_json::to_string(files).ok());
 
     let scope = req.scope.as_deref().unwrap_or("project");
+    let effective_topic_key = effective_topic_key(req, memory_type);
+    let operation = durable_operation(conn, project, effective_topic_key.as_deref(), scope)?;
+
     let mut local_copy = prepare_local_copy(project, title, req).map_err(LocalCopyError::from)?;
     write_local_copy(&mut local_copy).map_err(LocalCopyError::from)?;
 
@@ -91,25 +94,52 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
     };
 
     discard_local_copy_backup(&local_copy);
+    let durable = load_durable_write_details(conn, id)?;
+    let local_copy_result = local_copy.result();
 
     Ok(SaveMemoryResult {
         id,
         status: "saved".to_string(),
-        memory_type: memory_type.to_string(),
+        memory_type: durable.memory_type,
+        project: durable.project,
+        scope: durable.scope,
+        topic_key: durable.topic_key,
+        branch: durable.branch,
+        operation: operation.to_string(),
+        created_at_epoch: durable.created_at_epoch,
+        updated_at_epoch: durable.updated_at_epoch,
         upserted: req.topic_key.is_some(),
-        local_status: local_copy.status.clone(),
-        local_path: local_copy
-            .path
-            .as_ref()
-            .map(|path| path.display().to_string()),
+        local_status: local_copy_result.status.clone(),
+        local_path: local_copy_result.path.clone(),
+        local_copy: local_copy_result,
+        next_step: SaveMemoryNextStep {
+            tool: "get_observations".to_string(),
+            ids: vec![id],
+            source: "memory".to_string(),
+            reason: format!(
+                "Verify the durable memory with get_observations(ids=[{id}], source='memory') or search(project='{}').",
+                durable_project_hint(project)
+            ),
+        },
     })
 }
 
 struct LocalCopyPlan {
     status: String,
     path: Option<PathBuf>,
+    reason: Option<String>,
     content: Option<String>,
     backup: Option<LocalCopyBackup>,
+}
+
+impl LocalCopyPlan {
+    fn result(&self) -> LocalCopyResult {
+        LocalCopyResult {
+            status: self.status.clone(),
+            path: self.path.as_ref().map(|path| path.display().to_string()),
+            reason: self.reason.clone(),
+        }
+    }
 }
 
 struct LocalCopyBackup {
@@ -126,6 +156,7 @@ fn prepare_local_copy(
         return Ok(LocalCopyPlan {
             status: "disabled".to_string(),
             path: None,
+            reason: Some("local copy disabled by request or configuration".to_string()),
             content: None,
             backup: None,
         });
@@ -137,9 +168,84 @@ fn prepare_local_copy(
     Ok(LocalCopyPlan {
         status: "saved".to_string(),
         path: Some(local_path),
+        reason: None,
         content: Some(content),
         backup: None,
     })
+}
+
+fn effective_topic_key(req: &SaveMemoryRequest, memory_type: &str) -> Option<String> {
+    if memory_type == "lesson" {
+        return req.topic_key.clone().or_else(|| {
+            Some(format!(
+                "lesson-{}",
+                crate::memory::slugify_for_topic(&req.text, 64)
+            ))
+        });
+    }
+    req.topic_key.clone()
+}
+
+fn durable_operation(
+    conn: &Connection,
+    project: &str,
+    topic_key: Option<&str>,
+    scope: &str,
+) -> Result<&'static str> {
+    let Some(topic_key) = topic_key.filter(|topic_key| !topic_key.is_empty()) else {
+        return Ok("inserted");
+    };
+    let existing_id = conn
+        .query_row(
+            "SELECT id FROM memories
+             WHERE project = ?1 AND topic_key = ?2 AND scope = ?3
+             LIMIT 1",
+            params![project, topic_key, scope],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()
+        .context("check existing durable memory for topic_key upsert")?;
+    Ok(if existing_id.is_some() {
+        "updated"
+    } else {
+        "inserted"
+    })
+}
+
+struct DurableWriteDetails {
+    project: String,
+    scope: String,
+    topic_key: Option<String>,
+    branch: Option<String>,
+    memory_type: String,
+    created_at_epoch: i64,
+    updated_at_epoch: i64,
+}
+
+fn load_durable_write_details(conn: &Connection, id: i64) -> Result<DurableWriteDetails> {
+    conn.query_row(
+        "SELECT project, COALESCE(scope, 'project'), topic_key, branch, memory_type,
+                created_at_epoch, updated_at_epoch
+         FROM memories
+         WHERE id = ?1",
+        [id],
+        |row| {
+            Ok(DurableWriteDetails {
+                project: row.get(0)?,
+                scope: row.get(1)?,
+                topic_key: row.get(2)?,
+                branch: row.get(3)?,
+                memory_type: row.get(4)?,
+                created_at_epoch: row.get(5)?,
+                updated_at_epoch: row.get(6)?,
+            })
+        },
+    )
+    .with_context(|| format!("load durable write details for memory {id}"))
+}
+
+fn durable_project_hint(project: &str) -> String {
+    project.replace('\'', "\\'")
 }
 
 fn write_local_copy(local_copy: &mut LocalCopyPlan) -> Result<()> {

--- a/src/memory/service/tests.rs
+++ b/src/memory/service/tests.rs
@@ -79,6 +79,127 @@ fn save_memory_preference_defaults_to_project_scope() {
 }
 
 #[test]
+fn save_memory_insert_reports_durable_details() {
+    let _dir = ScopedTestDataDir::new("save-insert-feedback");
+    let conn = db::open_db().expect("db should open");
+    let req = SaveMemoryRequest {
+        text: "Remember the durable feedback shape.".to_string(),
+        title: Some("Durable feedback".to_string()),
+        project: Some("proj".to_string()),
+        memory_type: Some("decision".to_string()),
+        branch: Some("main".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+
+    let saved = save_memory(&conn, &req).expect("save should succeed");
+
+    assert_eq!(saved.status, "saved");
+    assert_eq!(saved.operation, "inserted");
+    assert!(!saved.upserted);
+    assert_eq!(saved.project, "proj");
+    assert_eq!(saved.scope, "project");
+    assert_eq!(saved.topic_key, None);
+    assert_eq!(saved.branch.as_deref(), Some("main"));
+    assert_eq!(saved.local_copy.status, "disabled");
+    assert_eq!(saved.local_status, "disabled");
+    assert_eq!(saved.local_path, None);
+    assert_eq!(saved.next_step.tool, "get_observations");
+    assert_eq!(saved.next_step.ids, vec![saved.id]);
+    assert_eq!(saved.next_step.source, "memory");
+    assert!(saved.created_at_epoch > 0);
+    assert!(saved.updated_at_epoch > 0);
+}
+
+#[test]
+fn save_memory_topic_key_update_reports_updated_operation() {
+    let _dir = ScopedTestDataDir::new("save-topic-update-feedback");
+    let conn = db::open_db().expect("db should open");
+    let first_req = SaveMemoryRequest {
+        text: "First body".to_string(),
+        title: Some("Topic feedback".to_string()),
+        project: Some("proj".to_string()),
+        topic_key: Some("durable-feedback".to_string()),
+        memory_type: Some("discovery".to_string()),
+        scope: Some("project".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+    let first = save_memory(&conn, &first_req).expect("first save should succeed");
+    assert_eq!(first.operation, "inserted");
+    assert!(first.upserted);
+
+    let second_req = SaveMemoryRequest {
+        text: "Updated body".to_string(),
+        title: Some("Topic feedback updated".to_string()),
+        ..first_req
+    };
+    let second = save_memory(&conn, &second_req).expect("second save should succeed");
+
+    assert_eq!(second.id, first.id);
+    assert_eq!(second.operation, "updated");
+    assert!(second.upserted);
+    assert_eq!(second.topic_key.as_deref(), Some("durable-feedback"));
+}
+
+#[test]
+fn save_memory_disabled_local_copy_reports_structured_reason() {
+    let _dir = ScopedTestDataDir::new("save-disabled-local-copy-feedback");
+    let conn = db::open_db().expect("db should open");
+    let req = SaveMemoryRequest {
+        text: "No local copy for this save.".to_string(),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+
+    let saved = save_memory(&conn, &req).expect("save should succeed");
+
+    assert_eq!(saved.local_copy.status, "disabled");
+    assert_eq!(saved.local_copy.path, None);
+    assert!(saved
+        .local_copy
+        .reason
+        .as_deref()
+        .is_some_and(|reason| { reason.contains("disabled") }));
+    assert_eq!(saved.local_status, saved.local_copy.status);
+    assert_eq!(saved.local_path, saved.local_copy.path);
+}
+
+#[test]
+fn save_memory_local_path_override_reports_structured_path() {
+    let test_dir = ScopedTestDataDir::new("save-local-path-feedback");
+    let conn = db::open_db().expect("db should open");
+    let local_path = test_dir
+        .path
+        .join("manual-notes")
+        .join("proj")
+        .join("custom-note.md");
+    let req = SaveMemoryRequest {
+        text: "Local path override body".to_string(),
+        title: Some("Local path override".to_string()),
+        project: Some("proj".to_string()),
+        local_path: Some(local_path.display().to_string()),
+        local_copy_enabled: Some(true),
+        ..SaveMemoryRequest::default()
+    };
+
+    let saved = save_memory(&conn, &req).expect("save should succeed");
+
+    assert_eq!(saved.local_copy.status, "saved");
+    let canonical_local_path = local_path
+        .canonicalize()
+        .expect("saved local path should canonicalize");
+    assert_eq!(
+        saved.local_copy.path.as_deref(),
+        Some(canonical_local_path.to_str().expect("utf8 local path"))
+    );
+    assert_eq!(saved.local_copy.reason, None);
+    assert_eq!(saved.local_status, "saved");
+    assert_eq!(saved.local_path, saved.local_copy.path);
+    assert!(local_path.exists());
+}
+
+#[test]
 fn save_memory_lesson_creates_lesson_metadata() {
     let _dir = ScopedTestDataDir::new("lesson-save-metadata");
     let conn = db::open_db().expect("db should open");

--- a/src/memory/service/types.rs
+++ b/src/memory/service/types.rs
@@ -51,11 +51,37 @@ pub struct SaveMemoryRequest {
 }
 
 #[derive(Debug, Clone)]
+pub struct LocalCopyResult {
+    pub status: String,
+    pub path: Option<String>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SaveMemoryNextStep {
+    pub tool: String,
+    pub ids: Vec<i64>,
+    pub source: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct SaveMemoryResult {
     pub id: i64,
     pub status: String,
     pub memory_type: String,
+    pub project: String,
+    pub scope: String,
+    pub topic_key: Option<String>,
+    pub branch: Option<String>,
+    pub operation: String,
+    pub created_at_epoch: i64,
+    pub updated_at_epoch: i64,
+    /// Compatibility alias: true when the request supplied `topic_key`.
+    /// It does not mean the durable row was updated; use `operation` for that.
     pub upserted: bool,
+    pub local_copy: LocalCopyResult,
     pub local_status: String,
     pub local_path: Option<String>,
+    pub next_step: SaveMemoryNextStep,
 }


### PR DESCRIPTION
Closes #250

## Summary
- Add durable save feedback fields to save_memory responses: project, scope, topic_key, branch, operation, created_at_epoch, updated_at_epoch, local_copy, and next_step.
- Preserve existing compatibility fields id/status/memory_type/upserted/local_status/local_path. `upserted` remains a compatibility alias meaning the request supplied `topic_key`; the actual durable write outcome is `operation: inserted|updated`.
- Add service, MCP, and REST tests for insert/update response shape, disabled local copy, local path override, and API/MCP serialization.
- Bump version to 0.4.24.

## Verification
- `cargo fmt --check`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo check`
- `REMEM_DATA_DIR=$(mktemp -d) CARGO_PROFILE_TEST_DEBUG=0 cargo test save_memory --lib -- --test-threads=1`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -- -D warnings`
- `REMEM_DATA_DIR=$(mktemp -d) CARGO_PROFILE_TEST_DEBUG=0 cargo test --quiet -- --test-threads=1`

## Notes
- Full test was run with `CARGO_PROFILE_TEST_DEBUG=0` because this checkout had low disk headroom during verification.