### PR TITLE
fix: context-gate diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions/context_gate.rs
+++ b/src/cli/actions/context_gate.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection, OpenFlags};
+use rusqlite::{params, Connection};
 use serde::Serialize;
 
 use crate::db;
@@ -34,15 +34,8 @@ pub(in crate::cli) fn run_context_gate_status(
 
 fn open_context_gate_db_read_only() -> Result<Connection> {
     let db_path = db::db_path();
-    if !db_path.exists() {
-        anyhow::bail!("remem database not found at {}", db_path.display());
-    }
-    let key = db::require_cipher_key_or_plaintext_override()?;
-    let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .with_context(|| format!("open read-only remem database {}", db_path.display()))?;
-    db::configure_cipher(&conn, key.as_deref())
-        .with_context(|| format!("unlock read-only remem database {}", db_path.display()))?;
-    Ok(conn)
+    db::open_db_read_only()
+        .with_context(|| format!("open read-only remem database {}", db_path.display()))
 }
 
 fn load_recent_context_gate_rows(
@@ -80,11 +73,11 @@ fn load_recent_context_gate_rows(
                 last_emitted_at: String::new(),
                 emit_count: row.get(9)?,
                 suppress_count: row.get(10)?,
-                reason: String::new(),
+                inferred_reason: String::new(),
             };
             status.updated_at = format_context_gate_timestamp(status.updated_at_epoch);
             status.last_emitted_at = format_context_gate_timestamp(status.last_emitted_epoch);
-            status.reason = infer_context_gate_reason(&status).to_string();
+            status.inferred_reason = infer_context_gate_reason(&status).to_string();
             Ok(status)
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -111,12 +104,12 @@ fn print_context_gate_status(report: &ContextGateStatusReport) {
 
     for row in &report.rows {
         println!(
-            "  {} {} {} source={} reason={} project={} session={} emits={} suppressions={}",
+            "  {} {} {} source={} inferred_reason={} project={} session={} emits={} suppressions={}",
             row.updated_at,
             row.host,
             row.output_mode,
             row.hook_source.as_deref().unwrap_or("-"),
-            row.reason,
+            row.inferred_reason,
             row.project,
             row.session_id.as_deref().unwrap_or("-"),
             row.emit_count,
@@ -132,8 +125,8 @@ fn infer_context_gate_reason(row: &ContextGateStatusRow) -> &'static str {
             "suppressed_source"
         }
         "suppressed" => "same_hash_or_strict",
-        "full" if row.emit_count <= 1 => "first_or_forced",
         "full" if source_requires_restart(row.hook_source.as_deref()) => "restart_source",
+        "full" if row.emit_count <= 1 => "first_or_forced",
         "full" => "repeat_full_or_forced",
         _ => "unknown",
     }
@@ -188,7 +181,7 @@ struct ContextGateStatusRow {
     last_emitted_at: String,
     emit_count: i64,
     suppress_count: i64,
-    reason: String,
+    inferred_reason: String,
 }
 
 #[cfg(test)]
@@ -236,9 +229,65 @@ mod tests {
         assert_eq!(rows[0].host, "codex-cli");
         assert_eq!(rows[0].hook_source.as_deref(), Some("compact"));
         assert_eq!(rows[0].output_mode, "suppressed");
-        assert_eq!(rows[0].reason, "suppressed_source");
+        assert_eq!(rows[0].inferred_reason, "suppressed_source");
         assert_eq!(rows[0].emit_count, 1);
         assert_eq!(rows[0].suppress_count, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn context_gate_status_infers_clear_before_first_emit() {
+        let row = ContextGateStatusRow {
+            host: "codex-cli".to_string(),
+            project: "/tmp/remem".to_string(),
+            injection_key: "session:/tmp/remem:sess-1".to_string(),
+            session_id: Some("sess-1".to_string()),
+            hook_source: Some("clear".to_string()),
+            output_mode: "full".to_string(),
+            output_chars: 200,
+            updated_at_epoch: 100,
+            updated_at: String::new(),
+            last_emitted_epoch: 100,
+            last_emitted_at: String::new(),
+            emit_count: 1,
+            suppress_count: 0,
+            inferred_reason: String::new(),
+        };
+
+        assert_eq!(infer_context_gate_reason(&row), "restart_source");
+    }
+
+    #[test]
+    fn context_gate_status_json_uses_inferred_reason_field() -> Result<()> {
+        let report = ContextGateStatusReport {
+            database: "/tmp/remem/database".to_string(),
+            filters: ContextGateStatusFilters {
+                project: None,
+                session: None,
+                limit: 20,
+            },
+            rows: vec![ContextGateStatusRow {
+                host: "codex-cli".to_string(),
+                project: "/tmp/remem".to_string(),
+                injection_key: "session:/tmp/remem:sess-1".to_string(),
+                session_id: Some("sess-1".to_string()),
+                hook_source: Some("compact".to_string()),
+                output_mode: "suppressed".to_string(),
+                output_chars: 0,
+                updated_at_epoch: 100,
+                updated_at: "1970-01-01 00:01:40 UTC".to_string(),
+                last_emitted_epoch: 100,
+                last_emitted_at: "1970-01-01 00:01:40 UTC".to_string(),
+                emit_count: 1,
+                suppress_count: 2,
+                inferred_reason: "suppressed_source".to_string(),
+            }],
+        };
+
+        let value = serde_json::to_value(report)?;
+
+        assert_eq!(value["rows"][0]["inferred_reason"], "suppressed_source");
+        assert!(value["rows"][0].get("reason").is_none());
         Ok(())
     }
 

--- a/src/cli/actions/context_gate.rs
+++ b/src/cli/actions/context_gate.rs
@@ -37,9 +37,10 @@ fn open_context_gate_db_read_only() -> Result<Connection> {
     if !db_path.exists() {
         anyhow::bail!("remem database not found at {}", db_path.display());
     }
+    let key = db::require_cipher_key_or_plaintext_override()?;
     let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| format!("open read-only remem database {}", db_path.display()))?;
-    db::apply_cipher_key_if_available(&conn)
+    db::configure_cipher(&conn, key.as_deref())
         .with_context(|| format!("unlock read-only remem database {}", db_path.display()))?;
     Ok(conn)
 }
@@ -248,6 +249,27 @@ mod tests {
         let rows = load_recent_context_gate_rows(&conn, None, None, 20)?;
 
         assert!(rows.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn context_gate_status_refuses_plaintext_without_explicit_override() -> Result<()> {
+        let test_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-status-fail-closed");
+        let conn = crate::db::open_db()?;
+        drop(conn);
+        std::env::remove_var(db::ALLOW_PLAINTEXT_ENV);
+
+        let err = open_context_gate_db_read_only()
+            .expect_err("status must fail closed without a cipher key or plaintext override");
+        let message = format!("{err:#}");
+
+        assert!(test_dir.db_path().exists());
+        assert!(message.contains("SQLCipher key"), "got: {message}");
+        assert!(
+            message.contains(db::ALLOW_PLAINTEXT_ENV),
+            "override must be explicit: {message}"
+        );
         Ok(())
     }
 }

--- a/src/cli/actions/context_gate.rs
+++ b/src/cli/actions/context_gate.rs
@@ -1,0 +1,253 @@
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OpenFlags};
+use serde::Serialize;
+
+use crate::db;
+
+pub(in crate::cli) fn run_context_gate_status(
+    project: Option<&str>,
+    session: Option<&str>,
+    limit: i64,
+    json: bool,
+) -> Result<()> {
+    let conn = open_context_gate_db_read_only()?;
+    let project = project.map(db::project_from_cwd);
+    let limit = limit.clamp(1, 200);
+    let rows = load_recent_context_gate_rows(&conn, project.as_deref(), session, limit)?;
+    let report = ContextGateStatusReport {
+        database: db::db_path().display().to_string(),
+        filters: ContextGateStatusFilters {
+            project,
+            session: session.map(str::to_string),
+            limit,
+        },
+        rows,
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_context_gate_status(&report);
+    }
+    Ok(())
+}
+
+fn open_context_gate_db_read_only() -> Result<Connection> {
+    let db_path = db::db_path();
+    if !db_path.exists() {
+        anyhow::bail!("remem database not found at {}", db_path.display());
+    }
+    let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("open read-only remem database {}", db_path.display()))?;
+    db::apply_cipher_key_if_available(&conn)
+        .with_context(|| format!("unlock read-only remem database {}", db_path.display()))?;
+    Ok(conn)
+}
+
+fn load_recent_context_gate_rows(
+    conn: &Connection,
+    project: Option<&str>,
+    session: Option<&str>,
+    limit: i64,
+) -> Result<Vec<ContextGateStatusRow>> {
+    if !context_injections_table_exists(conn)? {
+        return Ok(Vec::new());
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT host, project, injection_key, session_id, hook_source, output_mode,
+                output_chars, updated_at_epoch, last_emitted_epoch, emit_count, suppress_count
+         FROM context_injections
+         WHERE (?1 IS NULL OR project = ?1)
+           AND (?2 IS NULL OR session_id = ?2)
+         ORDER BY updated_at_epoch DESC
+         LIMIT ?3",
+    )?;
+    let rows = stmt
+        .query_map(params![project, session, limit], |row| {
+            let mut status = ContextGateStatusRow {
+                host: row.get(0)?,
+                project: row.get(1)?,
+                injection_key: row.get(2)?,
+                session_id: row.get(3)?,
+                hook_source: row.get(4)?,
+                output_mode: row.get(5)?,
+                output_chars: row.get(6)?,
+                updated_at_epoch: row.get(7)?,
+                updated_at: String::new(),
+                last_emitted_epoch: row.get(8)?,
+                last_emitted_at: String::new(),
+                emit_count: row.get(9)?,
+                suppress_count: row.get(10)?,
+                reason: String::new(),
+            };
+            status.updated_at = format_context_gate_timestamp(status.updated_at_epoch);
+            status.last_emitted_at = format_context_gate_timestamp(status.last_emitted_epoch);
+            status.reason = infer_context_gate_reason(&status).to_string();
+            Ok(status)
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+fn context_injections_table_exists(conn: &Connection) -> Result<bool> {
+    let exists = conn.query_row(
+        "SELECT EXISTS (
+             SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'context_injections'
+         )",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(exists != 0)
+}
+
+fn print_context_gate_status(report: &ContextGateStatusReport) {
+    println!("Recent context injections:");
+    if report.rows.is_empty() {
+        println!("  (none)");
+        return;
+    }
+
+    for row in &report.rows {
+        println!(
+            "  {} {} {} source={} reason={} project={} session={} emits={} suppressions={}",
+            row.updated_at,
+            row.host,
+            row.output_mode,
+            row.hook_source.as_deref().unwrap_or("-"),
+            row.reason,
+            row.project,
+            row.session_id.as_deref().unwrap_or("-"),
+            row.emit_count,
+            row.suppress_count
+        );
+    }
+}
+
+fn infer_context_gate_reason(row: &ContextGateStatusRow) -> &'static str {
+    match row.output_mode.as_str() {
+        "delta" => "changed_hash",
+        "suppressed" if source_is_default_suppressed(row.hook_source.as_deref()) => {
+            "suppressed_source"
+        }
+        "suppressed" => "same_hash_or_strict",
+        "full" if row.emit_count <= 1 => "first_or_forced",
+        "full" if source_requires_restart(row.hook_source.as_deref()) => "restart_source",
+        "full" => "repeat_full_or_forced",
+        _ => "unknown",
+    }
+}
+
+fn source_is_default_suppressed(source: Option<&str>) -> bool {
+    matches!(
+        source.map(|value| value.trim().to_ascii_lowercase()),
+        Some(value) if value == "compact"
+    )
+}
+
+fn source_requires_restart(source: Option<&str>) -> bool {
+    matches!(
+        source.map(|value| value.trim().to_ascii_lowercase()),
+        Some(value) if value == "clear"
+    )
+}
+
+fn format_context_gate_timestamp(epoch: i64) -> String {
+    chrono::DateTime::from_timestamp(epoch, 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Serialize)]
+struct ContextGateStatusReport {
+    database: String,
+    filters: ContextGateStatusFilters,
+    rows: Vec<ContextGateStatusRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct ContextGateStatusFilters {
+    project: Option<String>,
+    session: Option<String>,
+    limit: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct ContextGateStatusRow {
+    host: String,
+    project: String,
+    injection_key: String,
+    session_id: Option<String>,
+    hook_source: Option<String>,
+    output_mode: String,
+    output_chars: i64,
+    updated_at_epoch: i64,
+    updated_at: String,
+    last_emitted_epoch: i64,
+    last_emitted_at: String,
+    emit_count: i64,
+    suppress_count: i64,
+    reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_context_gate_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(include_str!(
+            "../../migrations/v016_context_injection_gate.sql"
+        ))
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn context_gate_status_reads_recent_rows() -> Result<()> {
+        let conn = setup_context_gate_conn();
+        conn.execute(
+            "INSERT INTO context_injections
+             (host, project, injection_key, session_id, transcript_path, hook_source,
+              context_hash, output_mode, output_chars, created_at_epoch, updated_at_epoch,
+              last_emitted_epoch, emit_count, suppress_count)
+             VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            params![
+                "codex-cli",
+                "/tmp/remem",
+                "session:/tmp/remem:sess-1",
+                "sess-1",
+                "compact",
+                "hash-a",
+                "suppressed",
+                0,
+                100,
+                110,
+                100,
+                1,
+                2,
+            ],
+        )?;
+
+        let rows = load_recent_context_gate_rows(&conn, Some("/tmp/remem"), Some("sess-1"), 20)?;
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].host, "codex-cli");
+        assert_eq!(rows[0].hook_source.as_deref(), Some("compact"));
+        assert_eq!(rows[0].output_mode, "suppressed");
+        assert_eq!(rows[0].reason, "suppressed_source");
+        assert_eq!(rows[0].emit_count, 1);
+        assert_eq!(rows[0].suppress_count, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn context_gate_status_missing_table_returns_no_rows() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+
+        let rows = load_recent_context_gate_rows(&conn, None, None, 20)?;
+
+        assert!(rows.is_empty());
+        Ok(())
+    }
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -10,7 +10,11 @@ use super::actions::{
     GovernanceCliRequest, RerouteCliRequest,
 };
 use super::cwd::resolve_cwd_arg;
-use super::types::{Cli, Commands};
+use super::types::{Cli, Commands, ContextGateAction};
+
+#[path = "actions/context_gate.rs"]
+mod context_gate;
+use context_gate::run_context_gate_status;
 
 pub(super) async fn run_cli(cli: Cli) -> Result<()> {
     match cli.command {
@@ -28,6 +32,14 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             }
             context::generate_context_from_cli(cwd, session_id, color, host, debug, force, gate)?;
         }
+        Commands::ContextGate { action } => match action {
+            ContextGateAction::Status {
+                project,
+                session,
+                limit,
+                json,
+            } => run_context_gate_status(project.as_deref(), session.as_deref(), limit, json)?,
+        },
         Commands::SessionInit => {
             if remem_hooks_disabled() {
                 return Ok(());

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,7 +1,7 @@
 use super::cwd::resolve_cwd_arg;
 use super::types::{
-    Cli, Commands, CommitAction, MemoryGovernanceCliAction, PendingAction, RawAction, RawRole,
-    ReviewAction,
+    Cli, Commands, CommitAction, ContextGateAction, MemoryGovernanceCliAction, PendingAction,
+    RawAction, RawRole, ReviewAction,
 };
 use clap::{CommandFactory, Parser};
 
@@ -663,6 +663,11 @@ fn cli_help_mentions_context_gate_modes_and_command_descriptions() {
     let context_help = context.render_long_help().to_string();
     assert!(context_help.contains("off|auto|strict|delta"));
     assert!(context_help.contains("Host profile"));
+    assert!(context_help.contains("REMEM_CONTEXT_HOST"));
+    assert!(context_help.contains("REMEM_CONTEXT_GATE"));
+    assert!(context_help.contains("REMEM_CONTEXT_GATE_HOSTS"));
+    assert!(context_help.contains("REMEM_CONTEXT_SUPPRESS_SOURCES"));
+    assert!(context_help.contains("REMEM_CONTEXT_DEBUG"));
 }
 
 #[test]
@@ -686,5 +691,39 @@ fn cli_parses_context_debug_option() {
             assert!(debug);
         }
         _ => panic!("expected context command"),
+    }
+}
+
+#[test]
+fn cli_parses_context_gate_status_filters() {
+    let cli = Cli::parse_from([
+        "remem",
+        "context-gate",
+        "status",
+        "--project",
+        "/tmp/remem",
+        "--session",
+        "sess-1",
+        "--limit",
+        "7",
+        "--json",
+    ]);
+
+    match cli.command {
+        Commands::ContextGate {
+            action:
+                ContextGateAction::Status {
+                    project,
+                    session,
+                    limit,
+                    json,
+                },
+        } => {
+            assert_eq!(project.as_deref(), Some("/tmp/remem"));
+            assert_eq!(session.as_deref(), Some("sess-1"));
+            assert_eq!(limit, 7);
+            assert!(json);
+        }
+        _ => panic!("expected context-gate status command"),
     }
 }

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -17,6 +17,9 @@ pub(super) struct Cli {
 #[derive(Subcommand)]
 pub(super) enum Commands {
     /// Render SessionStart memory context for the current project.
+    #[command(
+        after_help = "Environment variables:\n  REMEM_CONTEXT_HOST: default host when --host is omitted.\n  REMEM_CONTEXT_GATE: default --gate mode.\n  REMEM_CONTEXT_GATE_HOSTS: comma-separated hosts that use duplicate-injection gating.\n  REMEM_CONTEXT_SUPPRESS_SOURCES: hook sources suppressed when the context hash is unchanged.\n  REMEM_CONTEXT_DEBUG=1: include context rendering and gate diagnostics."
+    )]
     Context {
         /// Project working directory to render context for.
         #[arg(long)]
@@ -24,7 +27,7 @@ pub(super) enum Commands {
         /// Host session ID used by duplicate-injection gating.
         #[arg(long)]
         session_id: Option<String>,
-        /// Host profile: claude-code, codex-cli, or unknown.
+        /// Host profile: claude-code, codex-cli, or unknown. Overrides REMEM_CONTEXT_HOST.
         #[arg(long)]
         host: Option<String>,
         /// Preserve ANSI colors in rendered context.
@@ -36,9 +39,14 @@ pub(super) enum Commands {
         /// Force full context emission and update gate state.
         #[arg(long)]
         force: bool,
-        /// Duplicate-injection gate mode: off, auto, strict, or delta.
+        /// Duplicate-injection gate mode: off, auto, strict, or delta. Overrides REMEM_CONTEXT_GATE.
         #[arg(long, value_name = "off|auto|strict|delta")]
         gate: Option<String>,
+    },
+    /// Inspect recent context duplicate-injection gate decisions.
+    ContextGate {
+        #[command(subcommand)]
+        action: ContextGateAction,
     },
     /// Hook entrypoint for starting a memory capture session.
     SessionInit,
@@ -382,6 +390,25 @@ pub(super) enum Commands {
     Import {
         #[command(subcommand)]
         action: ImportAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum ContextGateAction {
+    /// Show recent read-only context injection rows.
+    Status {
+        /// Restrict rows to one project path.
+        #[arg(long, short)]
+        project: Option<String>,
+        /// Restrict rows to one host session ID.
+        #[arg(long)]
+        session: Option<String>,
+        /// Maximum recent rows to show.
+        #[arg(long, short = 'n', default_value = "20")]
+        limit: i64,
+        /// Emit a single JSON object with stable fields for scripts.
+        #[arg(long)]
+        json: bool,
     },
 }
 

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -35,6 +35,9 @@ pub(super) struct ContextGateDecision {
     pub output: String,
     pub action: ContextGateAction,
     pub reason: &'static str,
+    pub key: Option<String>,
+    pub context_hash: Option<String>,
+    pub output_mode: Option<&'static str>,
 }
 
 #[derive(Debug)]
@@ -113,7 +116,14 @@ pub(super) fn apply_context_gate(
         ) {
             Ok(()) => {
                 log_gate("emit", invocation, &key, "full", &hash);
-                decision(output, ContextGateAction::EmittedFull, "first_or_forced")
+                gate_decision(
+                    output,
+                    ContextGateAction::EmittedFull,
+                    "first_or_forced",
+                    &key,
+                    &hash,
+                    "full",
+                )
             }
             Err(error) => fail_open(output, "gate_write", error),
         };
@@ -131,7 +141,14 @@ pub(super) fn apply_context_gate(
         ) {
             Ok(()) => {
                 log_gate("emit", invocation, &key, "full", &hash);
-                decision(output, ContextGateAction::EmittedFull, "first_or_forced")
+                gate_decision(
+                    output,
+                    ContextGateAction::EmittedFull,
+                    "first_or_forced",
+                    &key,
+                    &hash,
+                    "full",
+                )
             }
             Err(error) => fail_open(output, "gate_write", error),
         };
@@ -148,7 +165,14 @@ pub(super) fn apply_context_gate(
         ) {
             Ok(()) => {
                 log_gate("emit", invocation, &key, "restart_source", &hash);
-                decision(output, ContextGateAction::EmittedFull, "restart_source")
+                gate_decision(
+                    output,
+                    ContextGateAction::EmittedFull,
+                    "restart_source",
+                    &key,
+                    &hash,
+                    "full",
+                )
             }
             Err(error) => fail_open(output, "gate_write", error),
         };
@@ -164,7 +188,14 @@ pub(super) fn apply_context_gate(
             return match record_suppression(&conn, invocation, &key, now) {
                 Ok(()) => {
                     log_gate("suppress", invocation, &key, reason, &hash);
-                    decision(String::new(), ContextGateAction::Suppressed, reason)
+                    gate_decision(
+                        String::new(),
+                        ContextGateAction::Suppressed,
+                        reason,
+                        &key,
+                        &hash,
+                        "suppressed",
+                    )
                 }
                 Err(error) => fail_open(output, "gate_write", error),
             };
@@ -180,10 +211,13 @@ pub(super) fn apply_context_gate(
         ) {
             Ok(()) => {
                 log_gate("emit", invocation, &key, "fallback_cooldown_expired", &hash);
-                decision(
+                gate_decision(
                     output,
                     ContextGateAction::EmittedFull,
                     "fallback_cooldown_expired",
+                    &key,
+                    &hash,
+                    "full",
                 )
             }
             Err(error) => fail_open(output, "gate_write", error),
@@ -194,7 +228,14 @@ pub(super) fn apply_context_gate(
         return match record_suppression(&conn, invocation, &key, now) {
             Ok(()) => {
                 log_gate("suppress", invocation, &key, "strict", &hash);
-                decision(String::new(), ContextGateAction::Suppressed, "strict")
+                gate_decision(
+                    String::new(),
+                    ContextGateAction::Suppressed,
+                    "strict",
+                    &key,
+                    &hash,
+                    "suppressed",
+                )
             }
             Err(error) => fail_open(output, "gate_write", error),
         };
@@ -222,7 +263,7 @@ pub(super) fn apply_context_gate(
     ) {
         Ok(()) => {
             log_gate("emit", invocation, &key, output_mode, &hash);
-            decision(output, action, "changed_hash")
+            gate_decision(output, action, "changed_hash", &key, &hash, output_mode)
         }
         Err(error) => fail_open(output, "gate_write", error),
     }
@@ -237,6 +278,27 @@ fn decision(
         output,
         action,
         reason,
+        key: None,
+        context_hash: None,
+        output_mode: None,
+    }
+}
+
+fn gate_decision(
+    output: String,
+    action: ContextGateAction,
+    reason: &'static str,
+    key: &str,
+    context_hash: &str,
+    output_mode: &'static str,
+) -> ContextGateDecision {
+    ContextGateDecision {
+        output,
+        action,
+        reason,
+        key: Some(key.to_string()),
+        context_hash: Some(context_hash.to_string()),
+        output_mode: Some(output_mode),
     }
 }
 
@@ -469,6 +531,7 @@ fn normalize_context_for_hash(output: &str) -> String {
         .map(|idx| &output[..idx])
         .unwrap_or(output);
     let mut normalized = String::new();
+    let mut skip_blank_after_source_note = false;
     for line in without_debug.lines() {
         let mut line = super::style::strip_ansi(line);
         strip_panel_right_border(&mut line);
@@ -494,8 +557,16 @@ fn normalize_context_for_hash(output: &str) -> String {
             }
         }
         let line_for_match = line.trim_start();
+        if skip_blank_after_source_note && line_for_match.trim().is_empty() {
+            skip_blank_after_source_note = false;
+            continue;
+        }
+        skip_blank_after_source_note = false;
+        if is_context_source_note_line(line_for_match) {
+            skip_blank_after_source_note = normalized.ends_with("\n\n");
+            continue;
+        }
         if is_visual_context_metadata_line(line_for_match)
-            || is_context_source_note_line(line_for_match)
             || line_for_match.starts_with("remem context source: ")
             || line_for_match.starts_with("REMEM_CONTEXT_SOURCE=")
         {

--- a/src/context/injection_gate/tests.rs
+++ b/src/context/injection_gate/tests.rs
@@ -46,10 +46,20 @@ fn fingerprint_ignores_context_source_note() {
     let normal =
         "# [/tmp/remem] context now\nUse `search`/`get_observations` for details.\n\nBody\n";
     let post_compact = "# [/tmp/remem] context now [REMEM POST-COMPACT RELOAD]\nUse `search`/`get_observations` for details.\nREMEM_CONTEXT_SOURCE=compact: Codex compact triggered this memory context reload.\n\nBody\n";
+    let current_compact = "# [/tmp/remem] context now\nUse `search`/`get_observations` for details.\n\nCodex compacted the chat, so remem refreshed memory context.\n\nBody\n";
+    let current_clear = "# [/tmp/remem] context now\nUse `search`/`get_observations` for details.\n\nContext was reloaded after an explicit clear.\n\nBody\n";
 
     assert_eq!(
         context_fingerprint(normal),
         context_fingerprint(post_compact)
+    );
+    assert_eq!(
+        context_fingerprint(normal),
+        context_fingerprint(current_compact)
+    );
+    assert_eq!(
+        context_fingerprint(normal),
+        context_fingerprint(current_clear)
     );
 }
 
@@ -197,6 +207,12 @@ fn compact_source_emits_first_context() {
     assert_eq!(decision.action, ContextGateAction::EmittedFull);
     assert_eq!(decision.reason, "first_or_forced");
     assert_eq!(decision.output, output);
+    assert_eq!(decision.output_mode, Some("full"));
+    assert!(decision
+        .key
+        .as_deref()
+        .is_some_and(|key| key.contains("sess-compact-first")));
+    assert!(decision.context_hash.is_some());
 }
 
 #[test]

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -164,6 +164,7 @@ pub fn generate_context_from_cli(
 
 fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool) -> Result<()> {
     let timer = crate::log::Timer::start("context", &format!("cwd={}", invocation.cwd));
+    let debug_enabled = invocation.debug || context_debug_enabled();
     let request = ContextRequest {
         cwd: invocation.cwd.clone(),
         project: invocation.project.clone(),
@@ -173,16 +174,23 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         host: invocation.host,
         use_colors: invocation.use_colors,
     };
-    let rendered = render_context_output(&request, invocation.debug || context_debug_enabled())?;
-    let decision = if use_gate {
+    let rendered = render_context_output(&request, debug_enabled)?;
+    let mut decision = if use_gate {
         apply_context_gate(&invocation, rendered.output)
     } else {
         ContextGateDecision {
             output: rendered.output,
             action: ContextGateAction::Bypassed,
             reason: "legacy_direct",
+            key: None,
+            context_hash: None,
+            output_mode: None,
         }
     };
+    if debug_enabled {
+        let decision_for_debug = decision.clone();
+        append_context_gate_debug_trace(&mut decision.output, &request, &decision_for_debug);
+    }
     print!("{}", decision.output);
 
     let capabilities = resolve_profile(request.host).capabilities();
@@ -209,6 +217,39 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         rendered.stats.workstreams.count,
     ));
     Ok(())
+}
+
+fn append_context_gate_debug_trace(
+    output: &mut String,
+    request: &ContextRequest,
+    decision: &ContextGateDecision,
+) {
+    if !output.is_empty() && !output.ends_with('\n') {
+        output.push('\n');
+    }
+    if !output.is_empty() {
+        output.push('\n');
+    }
+    output.push_str("## Debug Trace\n");
+    if output.trim_start().starts_with("## Debug Trace") {
+        output.push_str(&format!(
+            "- request host={} project={} cwd={} branch={} session={} source={}\n",
+            request.host.as_env_value(),
+            request.project,
+            request.cwd,
+            request.current_branch.as_deref().unwrap_or("-"),
+            request.session_id.as_deref().unwrap_or("-"),
+            request.hook_source.as_deref().unwrap_or("-")
+        ));
+    }
+    output.push_str(&format!(
+        "- gate action={:?} reason={} output_mode={} key={} hash={}\n",
+        decision.action,
+        decision.reason,
+        decision.output_mode.unwrap_or("-"),
+        decision.key.as_deref().unwrap_or("-"),
+        decision.context_hash.as_deref().unwrap_or("-")
+    ));
 }
 
 pub(in crate::context) fn render_context_output(

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -219,7 +219,7 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
     Ok(())
 }
 
-fn append_context_gate_debug_trace(
+pub(in crate::context) fn append_context_gate_debug_trace(
     output: &mut String,
     request: &ContextRequest,
     decision: &ContextGateDecision,
@@ -231,17 +231,15 @@ fn append_context_gate_debug_trace(
         output.push('\n');
     }
     output.push_str("## Debug Trace\n");
-    if output.trim_start().starts_with("## Debug Trace") {
-        output.push_str(&format!(
-            "- request host={} project={} cwd={} branch={} session={} source={}\n",
-            request.host.as_env_value(),
-            request.project,
-            request.cwd,
-            request.current_branch.as_deref().unwrap_or("-"),
-            request.session_id.as_deref().unwrap_or("-"),
-            request.hook_source.as_deref().unwrap_or("-")
-        ));
-    }
+    output.push_str(&format!(
+        "- request host={} project={} cwd={} branch={} session={} source={}\n",
+        request.host.as_env_value(),
+        request.project,
+        request.cwd,
+        request.current_branch.as_deref().unwrap_or("-"),
+        request.session_id.as_deref().unwrap_or("-"),
+        request.hook_source.as_deref().unwrap_or("-")
+    ));
     output.push_str(&format!(
         "- gate action={:?} reason={} output_mode={} key={} hash={}\n",
         decision.action,

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -2,10 +2,11 @@ use crate::memory::lesson::{LessonMemory, LessonMetadata};
 use crate::workstream::{WorkStream, WorkStreamStatus};
 
 use super::super::host::HostKind;
+use super::super::injection_gate::{ContextGateAction, ContextGateDecision};
 use super::super::policy::ContextLimits;
 use super::super::render::{
-    build_context_header, build_context_stats_footer, empty_context_output, render_context_output,
-    ContextRenderStats, SectionRenderStats,
+    append_context_gate_debug_trace, build_context_header, build_context_stats_footer,
+    empty_context_output, render_context_output, ContextRenderStats, SectionRenderStats,
 };
 use super::super::sections::{
     render_core_memory, render_core_memory_with_limits, render_lessons_with_limit,
@@ -31,6 +32,35 @@ fn render_recent_sessions_truncates_completed_line() {
     assert!(output.contains("=> "));
     assert!(output.contains("..."));
     assert!(!output.contains("ignored"));
+}
+
+#[test]
+fn post_gate_debug_trace_preserves_request_source_for_delta_output() {
+    let request = ContextRequest {
+        cwd: "/tmp/remem".to_string(),
+        project: "/tmp/remem".to_string(),
+        session_id: Some("sess-1".to_string()),
+        hook_source: Some("compact".to_string()),
+        current_branch: Some("main".to_string()),
+        host: HostKind::CodexCli,
+        use_colors: false,
+    };
+    let decision = ContextGateDecision {
+        output: String::new(),
+        action: ContextGateAction::EmittedDelta,
+        reason: "changed_hash",
+        key: Some("session:/tmp/remem:sess-1".to_string()),
+        context_hash: Some("hash-a".to_string()),
+        output_mode: Some("delta"),
+    };
+    let mut output = "[remem context delta truncated]\n".to_string();
+
+    append_context_gate_debug_trace(&mut output, &request, &decision);
+
+    assert!(output.contains(
+        "- request host=codex-cli project=/tmp/remem cwd=/tmp/remem branch=main session=sess-1 source=compact"
+    ));
+    assert!(output.contains("- gate action=EmittedDelta reason=changed_hash output_mode=delta"));
 }
 
 #[test]

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -453,6 +453,24 @@ fn empty_context_marks_compact_reload_visibly() {
 }
 
 #[test]
+fn empty_context_marks_clear_reload_visibly() {
+    let output = empty_context_output(&ContextRequest {
+        cwd: "/tmp/remem".to_string(),
+        project: "/tmp/remem".to_string(),
+        session_id: None,
+        hook_source: Some("clear".to_string()),
+        current_branch: Some("main".to_string()),
+        host: HostKind::CodexCli,
+        use_colors: false,
+    });
+
+    assert!(output.starts_with("remem context"));
+    assert!(output.contains("├─ source: clear"));
+    assert!(output.contains("Context was reloaded after an explicit clear."));
+    assert!(output.contains("No previous sessions found."));
+}
+
+#[test]
 fn empty_context_uses_ansi_when_color_enabled() {
     let output = empty_context_output(&ContextRequest {
         cwd: "/tmp/remem".to_string(),

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 
 thread_local! {
     static DATA_DIR_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
@@ -86,6 +86,16 @@ pub fn open_db() -> Result<Connection> {
     Ok(conn)
 }
 
+pub fn open_db_read_only() -> Result<Connection> {
+    let path = db_path();
+    let key = super::crypto::require_cipher_key_or_plaintext_override()?;
+    if !path.exists() {
+        anyhow::bail!("remem database not found at {}", path.display());
+    }
+
+    open_configured_read_only_connection(&path, key.as_deref())
+}
+
 pub(crate) fn open_configured_connection(path: &Path, key: Option<&str>) -> Result<Connection> {
     let conn = Connection::open(path)
         .with_context(|| format!("Failed to open database: {}", path.display()))?;
@@ -95,6 +105,18 @@ pub(crate) fn open_configured_connection(path: &Path, key: Option<&str>) -> Resu
     conn.execute_batch(
         "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
     )?;
+    Ok(conn)
+}
+
+pub(crate) fn open_configured_read_only_connection(
+    path: &Path,
+    key: Option<&str>,
+) -> Result<Connection> {
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("open read-only remem database {}", path.display()))?;
+
+    super::crypto::configure_cipher(&conn, key)?;
+    conn.execute_batch("PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;")?;
     Ok(conn)
 }
 
@@ -153,5 +175,57 @@ pub fn detect_git_commit(cwd: &str) -> Option<String> {
         None
     } else {
         Some(sha)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::crypto::ALLOW_PLAINTEXT_ENV;
+    use crate::db::test_support::ScopedTestDataDir;
+
+    #[test]
+    fn open_db_read_only_refuses_plaintext_without_explicit_override() -> Result<()> {
+        let test_dir = ScopedTestDataDir::new("readonly-cipher-fail-closed");
+        let conn = crate::db::open_db()?;
+        drop(conn);
+        std::env::remove_var(ALLOW_PLAINTEXT_ENV);
+
+        let err = crate::db::open_db_read_only()
+            .expect_err("read-only open must enforce the plaintext guard");
+
+        let message = err.to_string();
+        assert!(message.contains("SQLCipher key"), "got: {message}");
+        assert!(
+            test_dir.db_path().exists(),
+            "read-only guard must not remove the existing database"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn open_db_read_only_does_not_run_migrations() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("readonly-no-migration");
+        let path = crate::db::db_path();
+        std::fs::create_dir_all(crate::db::data_dir())?;
+        let conn = Connection::open(&path)?;
+        conn.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)", [])?;
+        drop(conn);
+
+        let readonly = crate::db::open_db_read_only()?;
+        let marker_exists: i64 = readonly.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'marker'",
+            [],
+            |row| row.get(0),
+        )?;
+        let migrations_exists: i64 = readonly.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'",
+            [],
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(marker_exists, 1);
+        assert_eq!(migrations_exists, 0);
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes #228

## Summary
- add read-only `remem context-gate status` diagnostics over v016 `context_injections` rows
- include context gate action/reason metadata in debug output
- document context `--gate`, `--host`, and related env vars; keep compact/clear source notes fingerprint-neutral

## Verification
- cargo fmt --check
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo check
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test context_gate -- --test-threads=1
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test --lib injection_gate -- --test-threads=1
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test --lib context -- --test-threads=1
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo clippy -- -D warnings

Full `cargo test -- --test-threads=1` was attempted: 709 passed, 9 unrelated `migrate::tests::dry_run_*` tests failed with `database clone: backup is not supported with encrypted databases`.
