### PR TITLE
Add health inbox actions for status and doctor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions/pending.rs
+++ b/src/cli/actions/pending.rs
@@ -5,14 +5,13 @@ use crate::cli::types::PendingAction;
 use crate::db::{self, pending::admin::FailedPendingRow};
 
 pub(in crate::cli) fn run_pending(action: PendingAction) -> Result<()> {
-    let conn = db::open_db()?;
-
     match action {
         PendingAction::ListFailed {
             project,
             limit,
             json,
         } => {
+            let conn = db::open_db_read_only()?;
             let rows = db::pending::admin::list_failed(&conn, project.as_deref(), limit)?;
             if json {
                 let output = PendingListFailedJson {
@@ -53,6 +52,7 @@ pub(in crate::cli) fn run_pending(action: PendingAction) -> Result<()> {
             dry_run,
         } => {
             if dry_run {
+                let conn = db::open_db_read_only()?;
                 let count = db::pending::admin::count_failed_retry_candidates(
                     &conn,
                     project.as_deref(),
@@ -60,6 +60,7 @@ pub(in crate::cli) fn run_pending(action: PendingAction) -> Result<()> {
                 )?;
                 println!("Would move {} failed rows back to pending.", count);
             } else {
+                let conn = db::open_db()?;
                 let count = db::pending::admin::retry_failed(&conn, project.as_deref(), limit)?;
                 println!("Moved {} failed rows back to pending.", count);
             }
@@ -70,6 +71,7 @@ pub(in crate::cli) fn run_pending(action: PendingAction) -> Result<()> {
             dry_run,
         } => {
             if dry_run {
+                let conn = db::open_db_read_only()?;
                 let count = db::pending::admin::count_failed_purge_candidates(
                     &conn,
                     project.as_deref(),
@@ -80,6 +82,7 @@ pub(in crate::cli) fn run_pending(action: PendingAction) -> Result<()> {
                     count, older_than_days
                 );
             } else {
+                let conn = db::open_db()?;
                 let count =
                     db::pending::admin::purge_failed(&conn, project.as_deref(), older_than_days)?;
                 println!(

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -2,6 +2,9 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use crate::db;
+use crate::doctor::health_action::{
+    queue_actions, render_action_block, worker_once_fallback_human,
+};
 
 pub(in crate::cli) fn run_status(json: bool) -> Result<()> {
     let report = load_status_report()?;
@@ -154,6 +157,9 @@ fn print_status_report(report: &StatusReport) {
     if let Some(owner) = &report.worker_daemon.owner {
         println!("  Owner:        {}", owner);
     }
+    if report.worker_daemon.health == "missing" || report.worker_daemon.health == "stale" {
+        println!("  Fallback:     {}", worker_once_fallback_human());
+    }
     println!();
     println!("Today:");
     println!("  New memories:      {:>4}", report.today.new_memories);
@@ -166,6 +172,13 @@ fn print_status_report(report: &StatusReport) {
             println!("  {:>4}  {}", project.count, project.project);
         }
     }
+
+    let actions = status_health_actions(report);
+    let action_block = render_action_block(&actions);
+    if !action_block.is_empty() {
+        println!();
+        print!("{action_block}");
+    }
 }
 
 fn worker_health_tag(healthy: bool, heartbeat_age_secs: Option<i64>) -> &'static str {
@@ -176,6 +189,15 @@ fn worker_health_tag(healthy: bool, heartbeat_age_secs: Option<i64>) -> &'static
     } else {
         "missing"
     }
+}
+
+fn status_health_actions(report: &StatusReport) -> Vec<crate::doctor::health_action::HealthAction> {
+    queue_actions(
+        report.pending_observations.failed,
+        report.pending_observations.expired,
+        report.jobs.failed,
+        report.jobs.stuck,
+    )
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -261,9 +283,8 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn cli_status_json_report_is_machine_parseable() -> std::result::Result<(), serde_json::Error> {
-        let report = StatusReport {
+    fn status_report_fixture() -> StatusReport {
+        StatusReport {
             version: "0.4.5".to_string(),
             database: StatusDatabase {
                 path: "/tmp/remem-test".to_string(),
@@ -289,16 +310,16 @@ mod tests {
                 ready: 12,
                 delayed: 13,
                 processing: 14,
-                expired: 15,
-                failed: 16,
+                expired: 0,
+                failed: 0,
                 oldest_ready_epoch: Some(17),
                 oldest_ready_age_secs: Some(18),
             },
             jobs: JobStatus {
                 pending: 19,
                 processing: 20,
-                failed: 21,
-                stuck: 22,
+                failed: 0,
+                stuck: 0,
             },
             worker_daemon: WorkerDaemonStatus {
                 health: "healthy".to_string(),
@@ -313,7 +334,16 @@ mod tests {
                 project: "proj".to_string(),
                 count: 26,
             }],
-        };
+        }
+    }
+
+    #[test]
+    fn cli_status_json_report_is_machine_parseable() -> std::result::Result<(), serde_json::Error> {
+        let mut report = status_report_fixture();
+        report.pending_observations.expired = 15;
+        report.pending_observations.failed = 16;
+        report.jobs.failed = 21;
+        report.jobs.stuck = 22;
 
         let text = serde_json::to_string(&report)?;
         let parsed: Value = serde_json::from_str(&text)?;
@@ -326,5 +356,35 @@ mod tests {
         assert_eq!(parsed["worker_daemon"]["health"], "healthy");
         assert_eq!(parsed["top_projects"][0]["project"], "proj");
         Ok(())
+    }
+
+    #[test]
+    fn cli_status_has_no_action_block_when_runtime_is_clear() {
+        let report = status_report_fixture();
+        let actions = status_health_actions(&report);
+
+        assert!(render_action_block(&actions).is_empty());
+    }
+
+    #[test]
+    fn cli_status_renders_action_block_for_runtime_failures() {
+        let mut report = status_report_fixture();
+        report.pending_observations.failed = 43;
+        report.pending_observations.expired = 1;
+        report.jobs.failed = 2;
+        report.jobs.stuck = 3;
+
+        let actions = status_health_actions(&report);
+        let text = render_action_block(&actions);
+
+        assert!(text.contains("Needs attention:"));
+        assert!(text.contains("43 failed pending observations"));
+        assert!(text.contains("inspect: remem pending list-failed --limit 20"));
+        assert!(text.contains("preview retry: remem pending retry-failed --dry-run"));
+        assert!(text.contains("1 expired processing pending observation"));
+        assert!(text.contains("2 failed jobs"));
+        assert!(text.contains("3 stuck jobs"));
+        assert!(text.contains("inspect counts: remem status --json"));
+        assert!(text.contains("recover: remem worker --once"));
     }
 }

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -18,7 +18,7 @@ pub(in crate::cli) fn run_status(json: bool) -> Result<()> {
 }
 
 fn load_status_report() -> Result<StatusReport> {
-    let conn = db::open_db()?;
+    let conn = db::open_db_read_only()?;
     let db_path = db::db_path();
     let db_size = std::fs::metadata(&db_path)
         .with_context(|| format!("failed to stat database path {}", db_path.display()))?

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 
 thread_local! {
     static DATA_DIR_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
@@ -86,6 +86,16 @@ pub fn open_db() -> Result<Connection> {
     Ok(conn)
 }
 
+pub fn open_db_read_only() -> Result<Connection> {
+    let path = db_path();
+    let key = super::crypto::require_cipher_key_or_plaintext_override()?;
+    if !path.exists() {
+        anyhow::bail!("database not found: {}", path.display());
+    }
+
+    open_configured_read_only_connection(&path, key.as_deref())
+}
+
 pub(crate) fn open_configured_connection(path: &Path, key: Option<&str>) -> Result<Connection> {
     let conn = Connection::open(path)
         .with_context(|| format!("Failed to open database: {}", path.display()))?;
@@ -95,6 +105,19 @@ pub(crate) fn open_configured_connection(path: &Path, key: Option<&str>) -> Resu
     conn.execute_batch(
         "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
     )?;
+    Ok(conn)
+}
+
+pub(crate) fn open_configured_read_only_connection(
+    path: &Path,
+    key: Option<&str>,
+) -> Result<Connection> {
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("Failed to open database read-only: {}", path.display()))?;
+
+    super::crypto::configure_cipher(&conn, key)?;
+
+    conn.execute_batch("PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;")?;
     Ok(conn)
 }
 
@@ -153,5 +176,58 @@ pub fn detect_git_commit(cwd: &str) -> Option<String> {
         None
     } else {
         Some(sha)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::db::test_support::ScopedTestDataDir;
+
+    #[test]
+    fn open_db_read_only_does_not_create_missing_database() {
+        let test_dir = ScopedTestDataDir::new("readonly-missing");
+        test_dir.remove_db_files();
+
+        let err = open_db_read_only().expect_err("missing database should fail");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("database not found"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !test_dir.path.exists(),
+            "read-only open must not create data dir"
+        );
+        assert!(
+            !test_dir.db_path().exists(),
+            "read-only open must not create database file"
+        );
+    }
+
+    #[test]
+    fn open_db_read_only_opens_existing_database_without_write_access() -> Result<()> {
+        let test_dir = ScopedTestDataDir::new("readonly-existing");
+        std::fs::create_dir_all(&test_dir.path)?;
+        let setup = Connection::open(test_dir.db_path())?;
+        setup.execute_batch(
+            "CREATE TABLE readonly_probe(id INTEGER PRIMARY KEY);
+             INSERT INTO readonly_probe(id) VALUES (1);",
+        )?;
+        drop(setup);
+
+        let conn = open_db_read_only()?;
+        let count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM readonly_probe", [], |row| row.get(0))?;
+        assert_eq!(count, 1);
+
+        let err = conn
+            .execute("INSERT INTO readonly_probe(id) VALUES (2)", [])
+            .expect_err("read-only connection must reject writes");
+        assert_eq!(err.sqlite_error_code(), Some(rusqlite::ErrorCode::ReadOnly));
+        Ok(())
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,5 +1,6 @@
 mod database;
 mod environment;
+pub(crate) mod health_action;
 mod native_memory;
 mod report;
 mod schema;

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -17,7 +17,7 @@ pub(super) fn check_database() -> Check {
     let size = std::fs::metadata(&db_path)
         .map(|meta| meta.len())
         .unwrap_or(0);
-    match db::open_db() {
+    match db::open_db_read_only() {
         Ok(conn) => match db::query_system_stats(&conn) {
             Ok(stats) => Check {
                 name: "Database",
@@ -44,7 +44,7 @@ pub(super) fn check_database() -> Check {
 }
 
 pub(super) fn check_pending_queue() -> Check {
-    let conn = match db::open_db() {
+    let conn = match db::open_db_read_only() {
         Ok(conn) => conn,
         Err(_) => {
             return Check {
@@ -116,7 +116,7 @@ pub(super) fn check_pending_queue() -> Check {
 }
 
 pub(super) fn check_worker_daemon() -> Check {
-    let conn = match db::open_db() {
+    let conn = match db::open_db_read_only() {
         Ok(conn) => conn,
         Err(_) => {
             return Check {

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -1,5 +1,8 @@
 use super::types::{Check, Status};
 use crate::db;
+use crate::doctor::health_action::{
+    queue_actions, render_inline_hints, worker_once_fallback_detail,
+};
 
 pub(super) fn check_database() -> Check {
     let db_path = db::db_path();
@@ -75,23 +78,33 @@ pub(super) fn check_pending_queue() -> Check {
         stats.stuck_jobs,
     );
 
+    let actions = queue_actions(
+        stats.failed_pending_observations,
+        stats.expired_processing_pending_observations,
+        stats.failed_jobs,
+        stats.stuck_jobs,
+    );
+    let action_suffix = render_inline_hints(&actions)
+        .map(|hints| format!("; actions: {hints}"))
+        .unwrap_or_default();
+
     if stats.expired_processing_pending_observations > 0 || stats.stuck_jobs > 0 {
         Check {
             name: "Pending queue",
             status: Status::Warn,
-            detail: format!("{} (will auto-recover)", detail),
+            detail: format!("{detail} (will auto-recover{action_suffix})"),
         }
     } else if stats.failed_pending_observations > 0 || stats.failed_jobs > 0 {
         Check {
             name: "Pending queue",
             status: Status::Warn,
-            detail: format!("{} (inspect failures)", detail),
+            detail: format!("{detail} (inspect failures{action_suffix})"),
         }
     } else if stats.ready_pending_observations > 100 {
         Check {
             name: "Pending queue",
             status: Status::Warn,
-            detail: format!("{} (backlog building up)", detail),
+            detail: format!("{detail} (backlog building up; action: `remem worker --once`)"),
         }
     } else {
         Check {
@@ -139,14 +152,16 @@ pub(super) fn check_worker_daemon() -> Check {
             name: "Worker daemon",
             status: Status::Warn,
             detail: format!(
-                "stale, last heartbeat {}s ago ({}) — Stop hooks will use worker --once",
-                age_secs, owner
+                "stale, last heartbeat {}s ago ({}); {}",
+                age_secs,
+                owner,
+                worker_once_fallback_detail()
             ),
         },
         _ => Check {
             name: "Worker daemon",
             status: Status::Ok,
-            detail: "not running; Stop hooks will use worker --once".to_string(),
+            detail: format!("not running; {}", worker_once_fallback_detail()),
         },
     }
 }

--- a/src/doctor/health_action.rs
+++ b/src/doctor/health_action.rs
@@ -103,11 +103,11 @@ pub(crate) fn render_inline_hints(actions: &[HealthAction]) -> Option<String> {
 }
 
 pub(crate) fn worker_once_fallback_human() -> &'static str {
-    "Stop hooks run remem worker --once"
+    "when Stop hooks are installed, they run remem worker --once"
 }
 
 pub(crate) fn worker_once_fallback_detail() -> &'static str {
-    "safe fallback: Stop hooks run `remem worker --once`"
+    "safe fallback when Stop hooks are installed: `remem worker --once`"
 }
 
 fn count_title(count: i64, singular: &str, plural: &str) -> String {

--- a/src/doctor/health_action.rs
+++ b/src/doctor/health_action.rs
@@ -1,0 +1,119 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HealthAction {
+    title: String,
+    commands: Vec<HealthCommand>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HealthCommand {
+    label: &'static str,
+    command: &'static str,
+}
+
+impl HealthAction {
+    fn new(title: String) -> Self {
+        Self {
+            title,
+            commands: Vec::new(),
+        }
+    }
+
+    fn command(mut self, label: &'static str, command: &'static str) -> Self {
+        self.commands.push(HealthCommand { label, command });
+        self
+    }
+}
+
+pub(crate) fn queue_actions(
+    failed_pending_observations: i64,
+    expired_processing_pending_observations: i64,
+    failed_jobs: i64,
+    stuck_jobs: i64,
+) -> Vec<HealthAction> {
+    let mut actions = Vec::new();
+
+    if failed_pending_observations > 0 {
+        actions.push(
+            HealthAction::new(count_title(
+                failed_pending_observations,
+                "failed pending observation",
+                "failed pending observations",
+            ))
+            .command("inspect", "remem pending list-failed --limit 20")
+            .command("preview retry", "remem pending retry-failed --dry-run"),
+        );
+    }
+
+    if expired_processing_pending_observations > 0 {
+        actions.push(
+            HealthAction::new(count_title(
+                expired_processing_pending_observations,
+                "expired processing pending observation",
+                "expired processing pending observations",
+            ))
+            .command("inspect counts", "remem status --json"),
+        );
+    }
+
+    if failed_jobs > 0 {
+        actions.push(
+            HealthAction::new(count_title(failed_jobs, "failed job", "failed jobs"))
+                .command("inspect counts", "remem status --json"),
+        );
+    }
+
+    if stuck_jobs > 0 {
+        actions.push(
+            HealthAction::new(count_title(stuck_jobs, "stuck job", "stuck jobs"))
+                .command("inspect counts", "remem status --json")
+                .command("recover", "remem worker --once"),
+        );
+    }
+
+    actions
+}
+
+pub(crate) fn render_action_block(actions: &[HealthAction]) -> String {
+    if actions.is_empty() {
+        return String::new();
+    }
+
+    let mut output = String::from("Needs attention:\n");
+    for action in actions {
+        output.push_str(&format!("  - {}\n", action.title));
+        for command in &action.commands {
+            output.push_str(&format!("    {}: {}\n", command.label, command.command));
+        }
+    }
+    output
+}
+
+pub(crate) fn render_inline_hints(actions: &[HealthAction]) -> Option<String> {
+    let mut rendered = Vec::new();
+    for action in actions {
+        for command in &action.commands {
+            let hint = format!("{}: `{}`", command.label, command.command);
+            if !rendered.contains(&hint) {
+                rendered.push(hint);
+            }
+        }
+    }
+
+    (!rendered.is_empty()).then(|| rendered.join("; "))
+}
+
+pub(crate) fn worker_once_fallback_human() -> &'static str {
+    "Stop hooks run remem worker --once"
+}
+
+pub(crate) fn worker_once_fallback_detail() -> &'static str {
+    "safe fallback: Stop hooks run `remem worker --once`"
+}
+
+fn count_title(count: i64, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {plural}")
+    }
+}

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -293,13 +293,16 @@ fn check_worker_daemon_reports_healthy_heartbeat() {
 }
 
 #[test]
-fn check_worker_daemon_reports_missing_as_fallback_ok() {
+fn check_worker_daemon_reports_missing_as_fallback_ok() -> anyhow::Result<()> {
     let _test_dir = ScopedTestDataDir::new("doctor-worker-missing");
+    let conn = db::open_db()?;
+    drop(conn);
 
     let check = check_worker_daemon();
     assert_eq!(check.icon(), "ok");
     assert_eq!(
         check.detail,
-        "not running; safe fallback: Stop hooks run `remem worker --once`"
+        "not running; safe fallback when Stop hooks are installed: `remem worker --once`"
     );
+    Ok(())
 }

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -4,6 +4,7 @@ use crate::db::test_support::ScopedTestDataDir;
 use crate::{db, memory};
 
 use super::database::{check_database, check_pending_queue, check_worker_daemon};
+use super::health_action::{queue_actions, render_action_block};
 use super::report::{run_doctor_with_writer, DoctorOptions};
 use super::schema::check_schema_migration;
 
@@ -50,7 +51,30 @@ fn check_database_reports_shared_active_memory_count() {
 }
 
 #[test]
-fn check_pending_queue_reports_shared_counts() {
+fn health_action_queue_actions_are_empty_when_runtime_is_clear() {
+    let actions = queue_actions(0, 0, 0, 0);
+    assert!(actions.is_empty());
+    assert!(render_action_block(&actions).is_empty());
+}
+
+#[test]
+fn health_action_queue_actions_render_copy_paste_commands() {
+    let actions = queue_actions(43, 1, 2, 3);
+    let text = render_action_block(&actions);
+
+    assert!(text.contains("Needs attention:"));
+    assert!(text.contains("43 failed pending observations"));
+    assert!(text.contains("inspect: remem pending list-failed --limit 20"));
+    assert!(text.contains("preview retry: remem pending retry-failed --dry-run"));
+    assert!(text.contains("1 expired processing pending observation"));
+    assert!(text.contains("2 failed jobs"));
+    assert!(text.contains("3 stuck jobs"));
+    assert!(text.contains("inspect counts: remem status --json"));
+    assert!(text.contains("recover: remem worker --once"));
+}
+
+#[test]
+fn check_pending_queue_reports_shared_counts() -> anyhow::Result<()> {
     let _test_dir = ScopedTestDataDir::new("doctor-pending");
     let conn = db::open_db().expect("db should open");
     db::enqueue_pending(
@@ -96,27 +120,70 @@ fn check_pending_queue_reports_shared_counts() {
         params![job_id, chrono::Utc::now().timestamp() - 1],
     )
     .expect("job update should succeed");
+    let failed_job_id = db::enqueue_job(
+        &conn,
+        "codex-cli",
+        db::JobType::Summary,
+        "proj-a",
+        Some("session-4"),
+        "{}",
+        1,
+    )?;
+    conn.execute(
+        "UPDATE jobs SET state = 'failed' WHERE id = ?1",
+        params![failed_job_id],
+    )?;
 
     let stats = db::query_system_stats(&conn).expect("system stats should load");
     drop(conn);
 
     let check = check_pending_queue();
     assert_eq!(check.icon(), "WARN");
-    assert_eq!(
-        check.detail,
-        format!(
-            "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} jobs pending, {} processing, {} failed, {} stuck (will auto-recover)",
-            stats.ready_pending_observations,
-            stats.delayed_pending_observations,
-            stats.processing_pending_observations,
-            stats.expired_processing_pending_observations,
-            stats.failed_pending_observations,
-            stats.pending_jobs,
-            stats.processing_jobs,
-            stats.failed_jobs,
-            stats.stuck_jobs,
-        )
+    let expected_counts = format!(
+        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} jobs pending, {} processing, {} failed, {} stuck",
+        stats.ready_pending_observations,
+        stats.delayed_pending_observations,
+        stats.processing_pending_observations,
+        stats.expired_processing_pending_observations,
+        stats.failed_pending_observations,
+        stats.pending_jobs,
+        stats.processing_jobs,
+        stats.failed_jobs,
+        stats.stuck_jobs,
     );
+    assert!(check.detail.contains(&expected_counts), "{}", check.detail);
+    assert!(
+        check.detail.contains("will auto-recover"),
+        "{}",
+        check.detail
+    );
+    assert!(
+        check
+            .detail
+            .contains("inspect: `remem pending list-failed --limit 20`"),
+        "{}",
+        check.detail
+    );
+    assert!(
+        check
+            .detail
+            .contains("preview retry: `remem pending retry-failed --dry-run`"),
+        "{}",
+        check.detail
+    );
+    assert!(
+        check
+            .detail
+            .contains("inspect counts: `remem status --json`"),
+        "{}",
+        check.detail
+    );
+    assert!(
+        check.detail.contains("recover: `remem worker --once`"),
+        "{}",
+        check.detail
+    );
+    Ok(())
 }
 
 #[test]
@@ -233,6 +300,6 @@ fn check_worker_daemon_reports_missing_as_fallback_ok() {
     assert_eq!(check.icon(), "ok");
     assert_eq!(
         check.detail,
-        "not running; Stop hooks will use worker --once"
+        "not running; safe fallback: Stop hooks run `remem worker --once`"
     );
 }


### PR DESCRIPTION
Closes #226

## Summary
- add shared health action rendering for failed pending observations, expired processing rows, failed jobs, and stuck jobs
- render status Needs attention actions only when actionable runtime counts are present
- add concrete doctor warning hints and explicit worker --once fallback wording
- bump version to 0.4.27

## Verification
- cargo fmt --check
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo check
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test status -- --test-threads=1
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test doctor -- --test-threads=1
- CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo clippy -- -D warnings

Note: full cargo test was also attempted. Without REMEM_ALLOW_PLAINTEXT_DB it failed in migration dry-run tests because encrypted database backup is unsupported; with REMEM_ALLOW_PLAINTEXT_DB=1 it still has 6 existing migration dry-run failures in the same backup path.