### PR TITLE
feat(memory): add stable state keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.28"
+version = "0.4.29"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.28"
+version = "0.4.29"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -12,6 +12,7 @@ pub mod raw_archive;
 pub mod scope_cleanup;
 pub mod search_context;
 pub mod service;
+pub mod state_key;
 pub mod store;
 pub mod types;
 

--- a/src/memory/lifecycle.rs
+++ b/src/memory/lifecycle.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Result};
 use rusqlite::{params, Connection};
 
+use crate::memory::state_key::StateKeyDecision;
+
 pub const SHORT_CURRENT_TTL_SECONDS: i64 = 24 * 60 * 60;
 pub const BRANCH_SNAPSHOT_TTL_SECONDS: i64 = 7 * 24 * 60 * 60;
 
@@ -86,8 +88,17 @@ pub fn apply_update(
     superseded_ids: &[i64],
 ) -> Result<LifecycleOutcome> {
     let tx = conn.unchecked_transaction()?;
+    let ownership = lifecycle_ownership(project, scope);
+    let state_key =
+        crate::memory::state_key::derive_state_key(memory_type, Some(topic_key), title, content);
     let mut superseded_targets = superseded_ids.to_vec();
-    superseded_targets.extend(find_active_same_state_key(&tx, project, topic_key, scope)?);
+    superseded_targets.extend(find_active_same_state_or_topic(
+        &tx,
+        &ownership,
+        memory_type,
+        topic_key,
+        state_key.as_ref(),
+    )?);
     let memory_id = insert_replacement_memory(
         &tx,
         session_id,
@@ -99,6 +110,8 @@ pub fn apply_update(
         files,
         branch,
         scope,
+        &ownership,
+        state_key.as_ref(),
     )?;
     let superseded = soft_supersede(&tx, project, &superseded_targets, Some(memory_id))?;
     tx.commit()?;
@@ -143,6 +156,8 @@ fn insert_replacement_memory(
     files: Option<&str>,
     branch: Option<&str>,
     scope: &str,
+    ownership: &LifecycleOwnership<'_>,
+    state_key: Option<&StateKeyDecision>,
 ) -> Result<i64> {
     let now = chrono::Utc::now().timestamp();
     let (expires_at_epoch, valid_from_epoch) =
@@ -153,11 +168,6 @@ fn insert_replacement_memory(
         content,
         files,
     );
-    let (target_project, owner_scope, owner_key) = if scope == "global" {
-        (None, "user", "user:default")
-    } else {
-        (Some(project), "repo", project)
-    };
     conn.execute(
         "INSERT INTO memories
          (session_id, project, topic_key, title, content, memory_type, files, search_context,
@@ -180,31 +190,111 @@ fn insert_replacement_memory(
             now,
             branch,
             scope,
-            project,
-            target_project,
-            owner_scope,
-            owner_key,
+            ownership.source_project,
+            ownership.target_project,
+            ownership.owner_scope,
+            ownership.owner_key,
             expires_at_epoch,
             valid_from_epoch
         ],
     )?;
-    Ok(conn.last_insert_rowid())
+    let memory_id = conn.last_insert_rowid();
+    if let Some(state_key) = state_key {
+        crate::memory::state_key::attach_current_memory(
+            conn,
+            memory_id,
+            ownership.owner_scope,
+            ownership.owner_key,
+            memory_type,
+            state_key,
+            now,
+        )?;
+    }
+    Ok(memory_id)
 }
 
-fn find_active_same_state_key(
+struct LifecycleOwnership<'a> {
+    source_project: &'a str,
+    target_project: Option<&'a str>,
+    owner_scope: &'static str,
+    owner_key: &'a str,
+}
+
+fn lifecycle_ownership<'a>(project: &'a str, scope: &str) -> LifecycleOwnership<'a> {
+    if scope == "global" {
+        LifecycleOwnership {
+            source_project: project,
+            target_project: None,
+            owner_scope: "user",
+            owner_key: "user:default",
+        }
+    } else {
+        LifecycleOwnership {
+            source_project: project,
+            target_project: Some(project),
+            owner_scope: "repo",
+            owner_key: project,
+        }
+    }
+}
+
+fn find_active_same_state_or_topic(
     conn: &Connection,
-    project: &str,
+    ownership: &LifecycleOwnership<'_>,
+    memory_type: &str,
     topic_key: &str,
-    scope: &str,
+    state_key: Option<&StateKeyDecision>,
+) -> Result<Vec<i64>> {
+    let mut ids = Vec::new();
+    if let Some(state_key) = state_key {
+        ids.extend(crate::memory::state_key::active_memory_ids(
+            conn,
+            ownership.owner_scope,
+            ownership.owner_key,
+            memory_type,
+            &state_key.state_key,
+            chrono::Utc::now().timestamp(),
+            false,
+        )?);
+    }
+    ids.extend(find_active_same_topic_key(
+        conn,
+        ownership,
+        memory_type,
+        topic_key,
+    )?);
+    Ok(ids)
+}
+
+fn find_active_same_topic_key(
+    conn: &Connection,
+    ownership: &LifecycleOwnership<'_>,
+    memory_type: &str,
+    topic_key: &str,
 ) -> Result<Vec<i64>> {
     let mut stmt = conn.prepare(
         "SELECT id FROM memories
-         WHERE project = ?1
+         WHERE memory_type = ?1
            AND topic_key = ?2
-           AND COALESCE(scope, 'project') = ?3
+           AND COALESCE(
+                owner_scope,
+                CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
+           ) = ?3
+           AND COALESCE(
+                owner_key,
+                CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user:default' ELSE project END
+           ) = ?4
            AND status = 'active'",
     )?;
-    let rows = stmt.query_map(params![project, topic_key, scope], |row| row.get(0))?;
+    let rows = stmt.query_map(
+        params![
+            memory_type,
+            topic_key,
+            ownership.owner_scope,
+            ownership.owner_key
+        ],
+        |row| row.get(0),
+    )?;
     crate::db::query::collect_rows(rows)
 }
 

--- a/src/memory/lifecycle/ttl_tests.rs
+++ b/src/memory/lifecycle/ttl_tests.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rusqlite::Connection;
 
 use super::*;
@@ -263,5 +263,126 @@ fn state_key_update_inserts_replacement_and_stales_old_fact() -> Result<()> {
     assert_eq!(rows[1].3, "Dev server is running on port 5173.");
     assert!(rows[1].4.is_some());
     assert!(rows[1].5.is_some());
+    Ok(())
+}
+
+#[test]
+fn exact_topic_update_still_replaces_legacy_memory_without_state_key() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let project = "test-lifecycle";
+    let topic_key = "repo:test-lifecycle:legacy-dev-server";
+    let old_id = insert_memory(
+        &conn,
+        Some("s1"),
+        project,
+        Some(topic_key),
+        "Dev server old",
+        "Dev server is running on port 3000.",
+        "discovery",
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memories SET state_key_id = NULL WHERE id = ?1",
+        [old_id],
+    )?;
+    conn.execute("DELETE FROM memory_state_keys", [])?;
+
+    let outcome = apply_update(
+        &conn,
+        Some("s2"),
+        project,
+        topic_key,
+        "Dev server current",
+        "Dev server is running on port 5173.",
+        "discovery",
+        None,
+        None,
+        "project",
+        &[],
+    )?;
+    let new_id = outcome.memory_id.context("replacement id")?;
+
+    assert_eq!(outcome.superseded, 1);
+    let old_status: String = conn.query_row(
+        "SELECT status FROM memories WHERE id = ?1",
+        [old_id],
+        |row| row.get(0),
+    )?;
+    let new_state_key_id: Option<i64> = conn.query_row(
+        "SELECT state_key_id FROM memories WHERE id = ?1",
+        [new_id],
+        |row| row.get(0),
+    )?;
+    assert_eq!(old_status, "stale");
+    assert!(new_state_key_id.is_some());
+    Ok(())
+}
+
+#[test]
+fn hash_like_topic_update_replaces_same_semantic_state_key_and_moves_current_pointer() -> Result<()>
+{
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let project = "test-lifecycle";
+    let add = apply_add(
+        &conn,
+        Some("s1"),
+        project,
+        Some("preference-aaaaaaaa"),
+        "Preference",
+        "Keep verification status separate from data and code changes.",
+        "preference",
+        None,
+        None,
+        "global",
+    )?;
+    let old_id = add.memory_id.context("old memory id")?;
+
+    let outcome = apply_update(
+        &conn,
+        Some("s2"),
+        project,
+        "preference-bbbbbbbb",
+        "Preference",
+        "Report data and code changes separately from verification status.",
+        "preference",
+        None,
+        None,
+        "global",
+        &[],
+    )?;
+    let new_id = outcome.memory_id.context("replacement id")?;
+
+    assert_ne!(old_id, new_id);
+    assert_eq!(outcome.superseded, 1);
+    let (old_status, new_status): (String, String) = conn.query_row(
+        "SELECT old.status, new.status
+         FROM memories old
+         JOIN memories new ON new.id = ?2
+         WHERE old.id = ?1",
+        rusqlite::params![old_id, new_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(old_status, "stale");
+    assert_eq!(new_status, "active");
+
+    let (state_key_id, state_key, current_memory_id): (i64, String, i64) = conn.query_row(
+        "SELECT sk.id, sk.state_key, sk.current_memory_id
+         FROM memories m
+         JOIN memory_state_keys sk ON sk.id = m.state_key_id
+         WHERE m.id = ?1",
+        [new_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    assert_eq!(state_key, "verification-status-separation");
+    assert_eq!(current_memory_id, new_id);
+
+    let old_state_key_id: i64 = conn.query_row(
+        "SELECT state_key_id FROM memories WHERE id = ?1",
+        [old_id],
+        |row| row.get(0),
+    )?;
+    assert_eq!(old_state_key_id, state_key_id);
     Ok(())
 }

--- a/src/memory/state_key.rs
+++ b/src/memory/state_key.rs
@@ -1,0 +1,302 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateKeyDecision {
+    pub state_key: String,
+    pub confidence: f64,
+    pub reason: String,
+}
+
+pub fn derive_state_key(
+    memory_type: &str,
+    topic_key: Option<&str>,
+    title: &str,
+    content: &str,
+) -> Option<StateKeyDecision> {
+    if let Some(topic_key) = stable_state_topic_key(topic_key) {
+        return Some(StateKeyDecision {
+            state_key: topic_key,
+            confidence: 1.0,
+            reason: "stable_topic_key".to_string(),
+        });
+    }
+
+    if memory_type == "preference" {
+        return derive_preference_state_key(title, content);
+    }
+
+    None
+}
+
+pub fn current_memory_id(
+    conn: &Connection,
+    owner_scope: &str,
+    owner_key: &str,
+    memory_type: &str,
+    state_key: &str,
+) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT m.id
+         FROM memory_state_keys sk
+         JOIN memories m ON m.id = sk.current_memory_id
+         WHERE sk.owner_scope = ?1
+           AND sk.owner_key = ?2
+           AND sk.memory_type = ?3
+           AND sk.state_key = ?4
+           AND sk.state_status = 'active'
+           AND m.status = 'active'
+         LIMIT 1",
+        params![owner_scope, owner_key, memory_type, state_key],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub fn active_memory_ids(
+    conn: &Connection,
+    owner_scope: &str,
+    owner_key: &str,
+    memory_type: &str,
+    state_key: &str,
+    now_epoch: i64,
+    require_unexpired: bool,
+) -> Result<Vec<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT m.id
+         FROM memories m
+         JOIN memory_state_keys sk ON sk.id = m.state_key_id
+         WHERE sk.owner_scope = ?1
+           AND sk.owner_key = ?2
+           AND sk.memory_type = ?3
+           AND sk.state_key = ?4
+           AND sk.state_status = 'active'
+           AND m.status = 'active'
+           AND (
+                ?5 = 0
+                OR m.expires_at_epoch IS NULL
+                OR m.expires_at_epoch > ?6
+           )
+         ORDER BY m.updated_at_epoch DESC, m.id DESC",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            owner_scope,
+            owner_key,
+            memory_type,
+            state_key,
+            if require_unexpired { 1_i64 } else { 0_i64 },
+            now_epoch
+        ],
+        |row| row.get(0),
+    )?;
+    crate::db::query::collect_rows(rows)
+}
+
+pub fn attach_current_memory(
+    conn: &Connection,
+    memory_id: i64,
+    owner_scope: &str,
+    owner_key: &str,
+    memory_type: &str,
+    decision: &StateKeyDecision,
+    now_epoch: i64,
+) -> Result<i64> {
+    let state_key_id = upsert_state_key(
+        conn,
+        owner_scope,
+        owner_key,
+        memory_type,
+        decision,
+        Some(memory_id),
+        now_epoch,
+    )?;
+    conn.execute(
+        "UPDATE memories SET state_key_id = ?1 WHERE id = ?2",
+        params![state_key_id, memory_id],
+    )?;
+    Ok(state_key_id)
+}
+
+fn upsert_state_key(
+    conn: &Connection,
+    owner_scope: &str,
+    owner_key: &str,
+    memory_type: &str,
+    decision: &StateKeyDecision,
+    current_memory_id: Option<i64>,
+    now_epoch: i64,
+) -> Result<i64> {
+    conn.execute(
+        "INSERT INTO memory_state_keys
+         (owner_scope, owner_key, memory_type, state_key, state_label, state_status,
+          current_memory_id, created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6, ?7, ?7)
+         ON CONFLICT(owner_scope, owner_key, memory_type, state_key)
+         DO UPDATE SET
+             state_label = COALESCE(excluded.state_label, memory_state_keys.state_label),
+             state_status = 'active',
+             current_memory_id = COALESCE(excluded.current_memory_id, memory_state_keys.current_memory_id),
+             updated_at_epoch = excluded.updated_at_epoch",
+        params![
+            owner_scope,
+            owner_key,
+            memory_type,
+            decision.state_key,
+            decision.state_key.replace('-', " "),
+            current_memory_id,
+            now_epoch
+        ],
+    )?;
+    conn.query_row(
+        "SELECT id FROM memory_state_keys
+         WHERE owner_scope = ?1
+           AND owner_key = ?2
+           AND memory_type = ?3
+           AND state_key = ?4",
+        params![owner_scope, owner_key, memory_type, decision.state_key],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+fn stable_state_topic_key(topic_key: Option<&str>) -> Option<String> {
+    let topic_key = topic_key?.trim();
+    if topic_key.is_empty() || is_hash_like_topic_key(topic_key) {
+        return None;
+    }
+    let slug = crate::memory::promote::slugify_for_topic(topic_key, 120);
+    if slug.is_empty() {
+        None
+    } else {
+        Some(slug)
+    }
+}
+
+fn derive_preference_state_key(title: &str, content: &str) -> Option<StateKeyDecision> {
+    let combined = format!("{title}\n{content}");
+    if mentions_verification_status(&combined) && mentions_data_code_separation(&combined) {
+        return Some(StateKeyDecision {
+            state_key: "verification-status-separation".to_string(),
+            confidence: 0.95,
+            reason: "preference_domain_verification_status_separation".to_string(),
+        });
+    }
+    if mentions_data_code_separation(&combined) {
+        return Some(StateKeyDecision {
+            state_key: "data-code-change-separation".to_string(),
+            confidence: 0.90,
+            reason: "preference_domain_data_code_separation".to_string(),
+        });
+    }
+    if mentions_codesign_binary(&combined) {
+        return Some(StateKeyDecision {
+            state_key: "local-rust-binary-codesign-after-cp".to_string(),
+            confidence: 0.90,
+            reason: "preference_domain_codesign_binary".to_string(),
+        });
+    }
+
+    None
+}
+
+fn is_hash_like_topic_key(topic_key: &str) -> bool {
+    let lower = topic_key.to_ascii_lowercase();
+    let mut parts = lower.rsplitn(2, ['-', '_']);
+    let tail = parts.next().unwrap_or_default();
+    let prefix = parts.next().unwrap_or_default();
+    tail.len() >= 8
+        && tail.chars().all(|ch| ch.is_ascii_hexdigit())
+        && matches!(
+            prefix,
+            "decision"
+                | "discovery"
+                | "preference"
+                | "bugfix"
+                | "lesson"
+                | "procedure"
+                | "architecture"
+        )
+}
+
+fn mentions_verification_status(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("verification status")
+        || lower.contains("verify status")
+        || (text.contains("验证") && text.contains("状态"))
+}
+
+fn mentions_data_code_separation(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    let has_data_code = (lower.contains("data") && lower.contains("code"))
+        || (text.contains("数据") && text.contains("代码"));
+    let has_separation = lower.contains("separat")
+        || lower.contains("distinct")
+        || text.contains("分开")
+        || text.contains("分离")
+        || text.contains("隔离");
+    has_data_code && has_separation
+}
+
+fn mentions_codesign_binary(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("codesign")
+        && (lower.contains("binary")
+            || lower.contains("bin/")
+            || lower.contains("target/release")
+            || lower.contains("cp "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_topic_key_is_preserved_as_state_key() {
+        let decision = derive_state_key(
+            "decision",
+            Some("deploy-target"),
+            "Deploy target",
+            "Deploy to staging.",
+        )
+        .expect("stable topic key should derive");
+        assert_eq!(decision.state_key, "deploy-target");
+        assert_eq!(decision.reason, "stable_topic_key");
+    }
+
+    #[test]
+    fn hash_like_topic_key_uses_ascii_preference_domain() {
+        let decision = derive_state_key(
+            "preference",
+            Some("preference-1234abcd"),
+            "Preference",
+            "Keep verification status separate from data and code changes.",
+        )
+        .expect("semantic preference should derive");
+        assert_eq!(decision.state_key, "verification-status-separation");
+    }
+
+    #[test]
+    fn hash_like_topic_key_uses_cjk_preference_domain() {
+        let decision = derive_state_key(
+            "preference",
+            Some("preference-deadbeef"),
+            "Preference",
+            "验证状态必须和数据、代码变更分开说明。",
+        )
+        .expect("CJK semantic preference should derive");
+        assert_eq!(decision.state_key, "verification-status-separation");
+    }
+
+    #[test]
+    fn ambiguous_hash_like_non_preference_is_not_invented() {
+        assert!(derive_state_key(
+            "decision",
+            Some("decision-deadbeef"),
+            "Decision",
+            "A short ambiguous note.",
+        )
+        .is_none());
+    }
+}

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::memory::search_context::build_search_context;
+use crate::memory::state_key::{self, StateKeyDecision};
 
 pub fn insert_memory(
     conn: &Connection,
@@ -72,10 +73,12 @@ pub fn insert_memory_full(
         crate::memory::lifecycle::ttl_metadata(memory_type, topic_key, content, now);
     let search_context = build_search_context(memory_type, topic_key, content, files);
     let ownership = default_ownership(project, scope);
+    let state_key = state_key::derive_state_key(memory_type, topic_key, title, content);
 
+    let mut existing_id = None;
     if let Some(topic_key) = topic_key {
         if !topic_key.is_empty() {
-            let existing_id: Option<i64> = conn
+            existing_id = conn
                 .query_row(
                     "SELECT id FROM memories
                      WHERE project = ?1 AND topic_key = ?2 AND scope = ?3
@@ -83,80 +86,83 @@ pub fn insert_memory_full(
                     params![project, topic_key, scope],
                     |row| row.get(0),
                 )
-                .ok();
-
-            if let Some(id) = existing_id {
-                conn.execute(
-                    "UPDATE memories SET session_id = ?1, title = ?2, content = ?3, \
-                     memory_type = ?4, files = ?5, updated_at_epoch = ?6, branch = ?7, \
-                     scope = ?8, search_context = ?9, \
-                     status = 'active', valid_to_epoch = NULL, \
-                     expires_at_epoch = ?10, valid_from_epoch = ?11, \
-                     source_project = COALESCE(source_project, ?12), \
-                     target_project = COALESCE(target_project, ?13), \
-                     owner_scope = COALESCE(owner_scope, ?14), \
-                     owner_key = COALESCE(owner_key, ?15), \
-                     context_class = COALESCE(context_class, ?16) \
-                     WHERE id = ?17",
-                    params![
-                        session_id,
-                        title,
-                        content,
-                        memory_type,
-                        files,
-                        now,
-                        branch,
-                        scope,
-                        search_context,
-                        expires_at_epoch,
-                        valid_from_epoch,
-                        ownership.source_project,
-                        ownership.target_project,
-                        ownership.owner_scope,
-                        ownership.owner_key,
-                        ownership.context_class,
-                        id
-                    ],
-                )?;
-                refresh_memory_entities(conn, id, title, content, "entity link refresh failed");
-                return Ok(id);
-            }
+                .optional()?;
         }
     }
 
-    conn.execute(
-        "INSERT INTO memories \
-         (session_id, project, topic_key, title, content, memory_type, files, search_context, \
-          created_at_epoch, updated_at_epoch, status, branch, scope, \
-          source_project, target_project, owner_scope, owner_key, context_class, \
-          expires_at_epoch, valid_from_epoch) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'active', ?11, ?12, \
-                 ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
-        params![
-            session_id,
-            project,
-            topic_key,
-            title,
-            content,
-            memory_type,
-            files,
-            search_context,
-            created_at,
-            now,
-            branch,
-            scope,
-            ownership.source_project,
-            ownership.target_project,
-            ownership.owner_scope,
-            ownership.owner_key,
-            ownership.context_class,
-            expires_at_epoch,
-            valid_from_epoch
-        ],
-    )?;
-    let id = conn.last_insert_rowid();
-    refresh_memory_entities(conn, id, title, content, "entity link failed");
-    Ok(id)
+    if existing_id.is_none() {
+        if let Some(decision) = &state_key {
+            existing_id = state_key::current_memory_id(
+                conn,
+                ownership.owner_scope,
+                ownership.owner_key,
+                memory_type,
+                &decision.state_key,
+            )?;
+        }
+    }
+
+    if let Some(id) = existing_id {
+        return with_memory_savepoint(conn, || {
+            update_existing_memory(
+                conn,
+                id,
+                session_id,
+                topic_key,
+                title,
+                content,
+                memory_type,
+                files,
+                branch,
+                scope,
+                &search_context,
+                expires_at_epoch,
+                valid_from_epoch,
+                &ownership,
+                state_key.as_ref(),
+                now,
+            )?;
+            refresh_memory_entities(conn, id, title, content, "entity link refresh failed");
+            Ok(id)
+        });
+    }
+
+    with_memory_savepoint(conn, || {
+        conn.execute(
+            "INSERT INTO memories \
+             (session_id, project, topic_key, title, content, memory_type, files, search_context, \
+              created_at_epoch, updated_at_epoch, status, branch, scope, \
+              source_project, target_project, owner_scope, owner_key, context_class, \
+              expires_at_epoch, valid_from_epoch) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'active', ?11, ?12, \
+                     ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
+            params![
+                session_id,
+                project,
+                topic_key,
+                title,
+                content,
+                memory_type,
+                files,
+                search_context,
+                created_at,
+                now,
+                branch,
+                scope,
+                ownership.source_project,
+                ownership.target_project,
+                ownership.owner_scope,
+                ownership.owner_key,
+                ownership.context_class,
+                expires_at_epoch,
+                valid_from_epoch
+            ],
+        )?;
+        let id = conn.last_insert_rowid();
+        attach_state_key(conn, id, memory_type, &ownership, state_key.as_ref(), now)?;
+        refresh_memory_entities(conn, id, title, content, "entity link failed");
+        Ok(id)
+    })
 }
 
 struct DefaultOwnership<'a> {
@@ -183,6 +189,109 @@ fn default_ownership<'a>(project: &'a str, scope: &str) -> DefaultOwnership<'a> 
             owner_scope: "repo",
             owner_key: project,
             context_class: "startup_core",
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn update_existing_memory(
+    conn: &Connection,
+    id: i64,
+    session_id: Option<&str>,
+    topic_key: Option<&str>,
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    files: Option<&str>,
+    branch: Option<&str>,
+    scope: &str,
+    search_context: &str,
+    expires_at_epoch: Option<i64>,
+    valid_from_epoch: Option<i64>,
+    ownership: &DefaultOwnership<'_>,
+    state_key: Option<&StateKeyDecision>,
+    now: i64,
+) -> Result<()> {
+    let state_key_id = attach_state_key(conn, id, memory_type, ownership, state_key, now)?;
+    conn.execute(
+        "UPDATE memories SET session_id = ?1, topic_key = ?2, title = ?3, content = ?4, \
+         memory_type = ?5, files = ?6, updated_at_epoch = ?7, branch = ?8, \
+         scope = ?9, search_context = ?10, \
+         status = 'active', valid_to_epoch = NULL, \
+         expires_at_epoch = ?11, valid_from_epoch = ?12, \
+         state_key_id = COALESCE(?13, state_key_id), \
+         source_project = COALESCE(source_project, ?14), \
+         target_project = COALESCE(target_project, ?15), \
+         owner_scope = COALESCE(owner_scope, ?16), \
+         owner_key = COALESCE(owner_key, ?17), \
+         context_class = COALESCE(context_class, ?18) \
+         WHERE id = ?19",
+        params![
+            session_id,
+            topic_key,
+            title,
+            content,
+            memory_type,
+            files,
+            now,
+            branch,
+            scope,
+            search_context,
+            expires_at_epoch,
+            valid_from_epoch,
+            state_key_id,
+            ownership.source_project,
+            ownership.target_project,
+            ownership.owner_scope,
+            ownership.owner_key,
+            ownership.context_class,
+            id
+        ],
+    )?;
+    Ok(())
+}
+
+fn attach_state_key(
+    conn: &Connection,
+    id: i64,
+    memory_type: &str,
+    ownership: &DefaultOwnership<'_>,
+    state_key: Option<&StateKeyDecision>,
+    now: i64,
+) -> Result<Option<i64>> {
+    state_key
+        .map(|decision| {
+            state_key::attach_current_memory(
+                conn,
+                id,
+                ownership.owner_scope,
+                ownership.owner_key,
+                memory_type,
+                decision,
+                now,
+            )
+        })
+        .transpose()
+}
+
+fn with_memory_savepoint<T>(conn: &Connection, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    conn.execute_batch("SAVEPOINT remem_memory_state_write")?;
+    match f() {
+        Ok(value) => {
+            conn.execute_batch("RELEASE SAVEPOINT remem_memory_state_write")?;
+            Ok(value)
+        }
+        Err(error) => {
+            let rollback = conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT remem_memory_state_write;
+                 RELEASE SAVEPOINT remem_memory_state_write;",
+            );
+            if let Err(rollback_error) = rollback {
+                return Err(error.context(format!(
+                    "memory state-key rollback also failed: {rollback_error}"
+                )));
+            }
+            Err(error)
         }
     }
 }

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -213,13 +213,14 @@ fn update_existing_memory(
     now: i64,
 ) -> Result<()> {
     let state_key_id = attach_state_key(conn, id, memory_type, ownership, state_key, now)?;
+    clear_obsolete_state_key_links(conn, id, state_key_id, now)?;
     conn.execute(
         "UPDATE memories SET session_id = ?1, topic_key = ?2, title = ?3, content = ?4, \
          memory_type = ?5, files = ?6, updated_at_epoch = ?7, branch = ?8, \
          scope = ?9, search_context = ?10, \
          status = 'active', valid_to_epoch = NULL, \
          expires_at_epoch = ?11, valid_from_epoch = ?12, \
-         state_key_id = COALESCE(?13, state_key_id), \
+         state_key_id = ?13, \
          source_project = COALESCE(source_project, ?14), \
          target_project = COALESCE(target_project, ?15), \
          owner_scope = COALESCE(owner_scope, ?16), \
@@ -247,6 +248,22 @@ fn update_existing_memory(
             ownership.context_class,
             id
         ],
+    )?;
+    Ok(())
+}
+
+fn clear_obsolete_state_key_links(
+    conn: &Connection,
+    id: i64,
+    active_state_key_id: Option<i64>,
+    now: i64,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE memory_state_keys
+         SET current_memory_id = NULL, updated_at_epoch = ?3
+         WHERE current_memory_id = ?1
+           AND (?2 IS NULL OR id <> ?2)",
+        params![id, active_state_key_id, now],
     )?;
     Ok(())
 }

--- a/src/memory/store/write/tests.rs
+++ b/src/memory/store/write/tests.rs
@@ -142,6 +142,149 @@ fn test_topic_key_upsert_reactivates_archived_row() {
 }
 
 #[test]
+fn test_hash_like_ascii_preference_uses_existing_state_memory() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+
+    let id1 = insert_memory_full(
+        &conn,
+        Some("s1"),
+        "test/proj",
+        Some("preference-11111111"),
+        "Preference",
+        "Keep verification status separate from data and code changes.",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+    let id2 = insert_memory_full(
+        &conn,
+        Some("s2"),
+        "test/proj",
+        Some("preference-22222222"),
+        "Preference",
+        "Report data and code changes separately from verification status.",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+
+    assert_eq!(id1, id2);
+    let (topic_key, state_key, current_memory_id): (String, String, i64) = conn.query_row(
+        "SELECT m.topic_key, sk.state_key, sk.current_memory_id
+             FROM memories m
+             JOIN memory_state_keys sk ON sk.id = m.state_key_id
+             WHERE m.id = ?1",
+        params![id1],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    assert_eq!(topic_key, "preference-22222222");
+    assert_eq!(state_key, "verification-status-separation");
+    assert_eq!(current_memory_id, id1);
+
+    let active_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories WHERE status = 'active'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(active_count, 1);
+    Ok(())
+}
+
+#[test]
+fn test_hash_like_cjk_preference_uses_existing_state_memory() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+
+    let id1 = insert_memory_full(
+        &conn,
+        Some("s1"),
+        "test/proj",
+        Some("preference-aaaaaaaa"),
+        "Preference",
+        "验证状态必须和数据、代码变更分开说明。",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+    let id2 = insert_memory_full(
+        &conn,
+        Some("s2"),
+        "test/proj",
+        Some("preference-bbbbbbbb"),
+        "Preference",
+        "用户要求数据和代码变更要与验证状态分离报告。",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+
+    assert_eq!(id1, id2);
+    let state_key: String = conn.query_row(
+        "SELECT sk.state_key
+             FROM memories m
+             JOIN memory_state_keys sk ON sk.id = m.state_key_id
+             WHERE m.id = ?1",
+        params![id1],
+        |row| row.get(0),
+    )?;
+    assert_eq!(state_key, "verification-status-separation");
+    Ok(())
+}
+
+#[test]
+fn test_same_state_key_text_keeps_distinct_owner_rows() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let content = "Keep verification status separate from data and code changes.";
+
+    let user_id = insert_memory_full(
+        &conn,
+        Some("s1"),
+        "test/proj",
+        Some("preference-11111111"),
+        "Preference",
+        content,
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+    let repo_id = insert_memory_full(
+        &conn,
+        Some("s2"),
+        "test/proj",
+        Some("preference-22222222"),
+        "Preference",
+        content,
+        "preference",
+        None,
+        None,
+        "project",
+        None,
+    )?;
+
+    assert_ne!(user_id, repo_id);
+    let state_rows: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_state_keys
+             WHERE state_key = 'verification-status-separation'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(state_rows, 2);
+    Ok(())
+}
+
+#[test]
 fn test_created_at_override() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);

--- a/src/memory/store/write/tests.rs
+++ b/src/memory/store/write/tests.rs
@@ -196,6 +196,85 @@ fn test_hash_like_ascii_preference_uses_existing_state_memory() -> anyhow::Resul
 }
 
 #[test]
+fn test_hash_like_preference_upsert_clears_obsolete_state_keys() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+
+    let id1 = insert_memory_full(
+        &conn,
+        Some("s1"),
+        "test/proj",
+        Some("preference-11111111"),
+        "Preference",
+        "Keep verification status separate from data and code changes.",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+    let id2 = insert_memory_full(
+        &conn,
+        Some("s2"),
+        "test/proj",
+        Some("preference-11111111"),
+        "Preference",
+        "Keep data and code changes separate in reports.",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+
+    assert_eq!(id1, id2);
+
+    let old_current: Option<i64> = conn.query_row(
+        "SELECT current_memory_id FROM memory_state_keys
+             WHERE state_key = 'verification-status-separation'",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    let new_current: Option<i64> = conn.query_row(
+        "SELECT current_memory_id FROM memory_state_keys
+             WHERE state_key = 'data-code-change-separation'",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    assert_eq!(old_current, None);
+    assert_eq!(new_current, Some(id1));
+
+    let id3 = insert_memory_full(
+        &conn,
+        Some("s3"),
+        "test/proj",
+        Some("preference-11111111"),
+        "Preference",
+        "Prefer concise progress updates.",
+        "preference",
+        None,
+        None,
+        "global",
+        None,
+    )?;
+    assert_eq!(id1, id3);
+
+    let state_key_id: Option<i64> = conn.query_row(
+        "SELECT state_key_id FROM memories WHERE id = ?1",
+        params![id1],
+        |row| row.get(0),
+    )?;
+    let current_slots: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_state_keys WHERE current_memory_id = ?1",
+        params![id1],
+        |row| row.get(0),
+    )?;
+    assert_eq!(state_key_id, None);
+    assert_eq!(current_slots, 0);
+    Ok(())
+}
+
+#[test]
 fn test_hash_like_cjk_preference_uses_existing_state_memory() -> anyhow::Result<()> {
     let conn = Connection::open_in_memory()?;
     setup_memory_schema(&conn);

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -340,7 +340,21 @@ pub mod tests_helper {
                 context_class TEXT,
                 expires_at_epoch INTEGER,
                 valid_from_epoch INTEGER,
-                valid_to_epoch INTEGER
+                valid_to_epoch INTEGER,
+                state_key_id INTEGER
+            );
+            CREATE TABLE memory_state_keys (
+                id INTEGER PRIMARY KEY,
+                owner_scope TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                memory_type TEXT NOT NULL,
+                state_key TEXT NOT NULL,
+                state_label TEXT,
+                state_status TEXT NOT NULL DEFAULT 'active',
+                current_memory_id INTEGER,
+                created_at_epoch INTEGER NOT NULL,
+                updated_at_epoch INTEGER NOT NULL,
+                UNIQUE(owner_scope, owner_key, memory_type, state_key)
             );
             CREATE VIRTUAL TABLE memories_fts USING fts5(
                 title, content, search_context,

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -327,6 +327,12 @@ fn persist_candidate_rows(
             candidate,
             source.route_texts.iter().copied(),
         );
+        let state_key = crate::memory::state_key::derive_state_key(
+            &candidate.memory_type,
+            Some(&candidate.topic_key),
+            &candidate_title(candidate),
+            &candidate.text,
+        );
         let review_status = "pending_review";
         tx.execute(
             "INSERT INTO memory_candidates
@@ -334,9 +340,10 @@ fn persist_candidate_rows(
               confidence, risk_class, review_status, created_at_epoch, updated_at_epoch,
               source_project, target_project, owner_scope, owner_key, topic_domain,
               routing_confidence, routing_reason, context_class, expires_at_epoch,
-              valid_from_epoch)
+              valid_from_epoch, state_key, state_key_confidence, state_key_reason)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10,
-                     ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
+                     ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
+                     ?21, ?22, ?23)",
             params![
                 source.project_id,
                 candidate.scope,
@@ -357,7 +364,12 @@ fn persist_candidate_rows(
                 route.routing_reason,
                 route.context_class,
                 expires_at_epoch,
-                valid_from_epoch
+                valid_from_epoch,
+                state_key
+                    .as_ref()
+                    .map(|decision| decision.state_key.as_str()),
+                state_key.as_ref().map(|decision| decision.confidence),
+                state_key.as_ref().map(|decision| decision.reason.as_str())
             ],
         )?;
         let candidate_id = tx.last_insert_rowid();

--- a/src/memory_candidate/apply.rs
+++ b/src/memory_candidate/apply.rs
@@ -40,7 +40,20 @@ pub(super) fn promote_candidate_to_memory_with_route(
         &candidate.text,
     )
     .is_some();
-    let active = find_active_same_topic(conn, candidate, route, now, candidate_has_ttl)?;
+    let state_key = crate::memory::state_key::derive_state_key(
+        &candidate.memory_type,
+        Some(&candidate.topic_key),
+        &title,
+        &candidate.text,
+    );
+    let active = find_active_same_state_or_topic(
+        conn,
+        candidate,
+        route,
+        state_key.as_ref(),
+        now,
+        candidate_has_ttl,
+    )?;
     if let Some(existing) = active.iter().filter(|row| row.is_current).find(|row| {
         normalize_evidence_text(&row.content) == normalize_evidence_text(&candidate.text)
     }) {
@@ -63,6 +76,7 @@ pub(super) fn promote_candidate_to_memory_with_route(
         &title,
         evidence_json,
         memory_scope,
+        state_key.as_ref(),
     )?;
     let superseded_ids = active.iter().map(|row| row.id).collect::<Vec<_>>();
     let superseded = soft_supersede_routed(conn, &superseded_ids, Some(memory_id))?;
@@ -88,6 +102,13 @@ pub(super) fn update_candidate_after_lifecycle(
         &candidate.text,
         now,
     );
+    let title = candidate_title(candidate);
+    let state_key = crate::memory::state_key::derive_state_key(
+        &candidate.memory_type,
+        Some(&candidate.topic_key),
+        &title,
+        &candidate.text,
+    );
     conn.execute(
         "UPDATE memory_candidates
          SET scope = ?1,
@@ -104,8 +125,11 @@ pub(super) fn update_candidate_after_lifecycle(
              routing_reason = ?12,
              context_class = ?13,
              expires_at_epoch = ?14,
-             valid_from_epoch = ?15
-         WHERE id = ?16",
+             valid_from_epoch = ?15,
+             state_key = ?16,
+             state_key_confidence = ?17,
+             state_key_reason = ?18
+         WHERE id = ?19",
         params![
             candidate.scope,
             candidate.memory_type,
@@ -122,6 +146,11 @@ pub(super) fn update_candidate_after_lifecycle(
             route.context_class,
             expires_at_epoch,
             valid_from_epoch,
+            state_key
+                .as_ref()
+                .map(|decision| decision.state_key.as_str()),
+            state_key.as_ref().map(|decision| decision.confidence),
+            state_key.as_ref().map(|decision| decision.reason.as_str()),
             candidate_id
         ],
     )?;
@@ -187,6 +216,43 @@ fn find_active_same_topic(
     crate::db::query::collect_rows(rows)
 }
 
+fn find_active_same_state_or_topic(
+    conn: &Connection,
+    candidate: &ParsedMemoryCandidate,
+    route: &CandidateRoute,
+    state_key: Option<&crate::memory::state_key::StateKeyDecision>,
+    now_epoch: i64,
+    candidate_has_ttl: bool,
+) -> Result<Vec<ActiveTopicMemory>> {
+    if let Some(state_key) = state_key {
+        let ids = crate::memory::state_key::active_memory_ids(
+            conn,
+            &route.owner_scope,
+            &route.owner_key,
+            &candidate.memory_type,
+            &state_key.state_key,
+            now_epoch,
+            candidate_has_ttl,
+        )?;
+        if !ids.is_empty() {
+            let mut memories = Vec::with_capacity(ids.len());
+            for id in ids {
+                let content =
+                    conn.query_row("SELECT content FROM memories WHERE id = ?1", [id], |row| {
+                        row.get(0)
+                    })?;
+                memories.push(ActiveTopicMemory {
+                    id,
+                    content,
+                    is_current: true,
+                });
+            }
+            return Ok(memories);
+        }
+    }
+    find_active_same_topic(conn, candidate, route, now_epoch, candidate_has_ttl)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn insert_routed_memory(
     conn: &Connection,
@@ -199,6 +265,7 @@ fn insert_routed_memory(
     title: &str,
     evidence_json: &str,
     scope: &str,
+    state_key: Option<&crate::memory::state_key::StateKeyDecision>,
 ) -> Result<i64> {
     let now = chrono::Utc::now().timestamp();
     let (expires_at_epoch, valid_from_epoch) = crate::memory::lifecycle::ttl_metadata(
@@ -251,6 +318,17 @@ fn insert_routed_memory(
         ],
     )?;
     let memory_id = conn.last_insert_rowid();
+    if let Some(state_key) = state_key {
+        crate::memory::state_key::attach_current_memory(
+            conn,
+            memory_id,
+            &route.owner_scope,
+            &route.owner_key,
+            &candidate.memory_type,
+            state_key,
+            now,
+        )?;
+    }
     if candidate.memory_type == "lesson" {
         insert_lesson_metadata(conn, memory_id, candidate, evidence_json, now)?;
     }

--- a/src/memory_candidate/tests.rs
+++ b/src/memory_candidate/tests.rs
@@ -162,46 +162,18 @@ async fn memory_candidate_auto_promotes_low_risk_project_candidate() -> Result<(
             pending_review: 0
         }
     );
-    let (candidate_id, review_status, owner_scope, owner_key, target_project, context_class): (
-        i64,
-        String,
-        String,
-        String,
-        String,
-        String,
-    ) = conn.query_row(
-        "SELECT id, review_status, owner_scope, owner_key, target_project, context_class
+    let (
+        candidate_id,
+        review_status,
+        owner_scope,
+        owner_key,
+        target_project,
+        context_class,
+        candidate_state_key,
+    ): (i64, String, String, String, String, String, String) = conn.query_row(
+        "SELECT id, review_status, owner_scope, owner_key, target_project, context_class, state_key
          FROM memory_candidates",
         [],
-        |row| {
-            Ok((
-                row.get(0)?,
-                row.get(1)?,
-                row.get(2)?,
-                row.get(3)?,
-                row.get(4)?,
-                row.get(5)?,
-            ))
-        },
-    )?;
-    assert_eq!(review_status, "auto_promoted");
-    assert_eq!(owner_scope, "repo");
-    assert_eq!(owner_key, "/tmp/remem");
-    assert_eq!(target_project, "/tmp/remem");
-    assert_eq!(context_class, "startup_core");
-    let (
-        memory_type,
-        topic_key,
-        evidence,
-        source_candidate_id,
-        confidence,
-        memory_owner_scope,
-        memory_owner_key,
-    ): (String, String, String, i64, f64, String, String) = conn.query_row(
-        "SELECT memory_type, topic_key, evidence_event_ids, source_candidate_id, confidence,
-                owner_scope, owner_key
-         FROM memories WHERE source_candidate_id = ?1",
-        params![candidate_id],
         |row| {
             Ok((
                 row.get(0)?,
@@ -214,6 +186,56 @@ async fn memory_candidate_auto_promotes_low_risk_project_candidate() -> Result<(
             ))
         },
     )?;
+    assert_eq!(review_status, "auto_promoted");
+    assert_eq!(owner_scope, "repo");
+    assert_eq!(owner_key, "/tmp/remem");
+    assert_eq!(target_project, "/tmp/remem");
+    assert_eq!(context_class, "startup_core");
+    assert_eq!(candidate_state_key, "decision-worker-loop");
+    let (
+        memory_id,
+        memory_type,
+        topic_key,
+        evidence,
+        source_candidate_id,
+        confidence,
+        memory_owner_scope,
+        memory_owner_key,
+        memory_state_key,
+        current_memory_id,
+    ): (
+        i64,
+        String,
+        String,
+        String,
+        i64,
+        f64,
+        String,
+        String,
+        String,
+        i64,
+    ) = conn.query_row(
+        "SELECT m.id, m.memory_type, m.topic_key, m.evidence_event_ids, m.source_candidate_id,
+                m.confidence, m.owner_scope, m.owner_key, sk.state_key, sk.current_memory_id
+         FROM memories m
+         JOIN memory_state_keys sk ON sk.id = m.state_key_id
+         WHERE m.source_candidate_id = ?1",
+        params![candidate_id],
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+                row.get(7)?,
+                row.get(8)?,
+                row.get(9)?,
+            ))
+        },
+    )?;
     assert_eq!(memory_type, "decision");
     assert_eq!(topic_key, "decision-worker-loop");
     assert_eq!(source_candidate_id, candidate_id);
@@ -221,6 +243,8 @@ async fn memory_candidate_auto_promotes_low_risk_project_candidate() -> Result<(
     assert_eq!(confidence, 0.92);
     assert_eq!(memory_owner_scope, "repo");
     assert_eq!(memory_owner_key, "/tmp/remem");
+    assert_eq!(memory_state_key, "decision-worker-loop");
+    assert_eq!(current_memory_id, memory_id);
     Ok(())
 }
 

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -5,6 +5,10 @@ use super::state::applied_versions;
 use super::{dry_run_pending, run_migrations, MIGRATIONS};
 use crate::db::test_support::{cleanup_temp_db_files, unique_temp_db_path, ScopedTestDataDir};
 
+fn logical_user_version() -> i64 {
+    super::types::OLD_BASELINE_VERSION - 1 + super::latest_schema_version()
+}
+
 #[test]
 fn baseline_creates_all_tables() -> Result<()> {
     let conn = Connection::open_in_memory()?;
@@ -64,11 +68,14 @@ fn full_migration_on_empty_db() -> Result<()> {
     let applied = applied_versions(&conn)?;
     assert_eq!(
         applied,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,]
+        MIGRATIONS
+            .iter()
+            .map(|migration| migration.version)
+            .collect::<Vec<_>>()
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 33);
+    assert_eq!(user_version, logical_user_version());
 
     let has_worker_heartbeats: bool = conn
         .query_row(
@@ -325,7 +332,7 @@ fn auto_upgrades_old_schema_version() -> Result<()> {
     );
 
     let user_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    assert_eq!(user_version, 33);
+    assert_eq!(user_version, logical_user_version());
 
     // Verify missing columns were added
     let has_status: bool = conn
@@ -365,7 +372,7 @@ fn dry_run_reports_logical_version_when_user_version_is_stale() -> Result<()> {
 
     let result = dry_run_pending(&conn)?;
 
-    assert_eq!(result.current_version, 33);
+    assert_eq!(result.current_version, logical_user_version());
     assert_eq!(result.pending_count, 0);
     assert!(result.error.is_none());
     Ok(())

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -37,6 +37,7 @@ const CONVERGENCE_TABLES: &[&str] = &[
     "workstream_sessions",
     "git_commits",
     "git_commit_sessions",
+    "memory_state_keys",
 ];
 
 fn make_upgraded_v10_db() -> Result<Connection> {

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -110,6 +110,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "raw_messages_session_dedup",
         sql: include_str!("../migrations/v021_raw_messages_session_dedup.sql"),
     },
+    Migration {
+        version: 22,
+        name: "memory_state_keys",
+        sql: include_str!("../migrations/v022_memory_state_keys.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v022_memory_state_keys.sql
+++ b/src/migrations/v022_memory_state_keys.sql
@@ -1,0 +1,41 @@
+-- v022_memory_state_keys: stable identity slots for mutable memories.
+--
+-- This migration is metadata-only. It creates current-state identity tables and
+-- nullable links, but it does not merge, stale, or otherwise mutate existing
+-- historical memory rows.
+
+CREATE TABLE memory_state_keys (
+    id INTEGER PRIMARY KEY,
+    owner_scope TEXT NOT NULL,
+    owner_key TEXT NOT NULL,
+    memory_type TEXT NOT NULL,
+    state_key TEXT NOT NULL,
+    state_label TEXT,
+    state_status TEXT NOT NULL DEFAULT 'active',
+    current_memory_id INTEGER,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    UNIQUE(owner_scope, owner_key, memory_type, state_key),
+    FOREIGN KEY(current_memory_id) REFERENCES memories(id)
+);
+
+CREATE INDEX idx_memory_state_keys_owner
+    ON memory_state_keys(owner_scope, owner_key, memory_type, state_status);
+
+CREATE INDEX idx_memory_state_keys_current
+    ON memory_state_keys(current_memory_id)
+    WHERE current_memory_id IS NOT NULL;
+
+ALTER TABLE memories ADD COLUMN state_key_id INTEGER;
+
+ALTER TABLE memory_candidates ADD COLUMN state_key TEXT;
+ALTER TABLE memory_candidates ADD COLUMN state_key_confidence REAL;
+ALTER TABLE memory_candidates ADD COLUMN state_key_reason TEXT;
+
+CREATE INDEX idx_memories_state_key_id
+    ON memories(state_key_id)
+    WHERE state_key_id IS NOT NULL;
+
+CREATE INDEX idx_memory_candidates_state_key
+    ON memory_candidates(owner_scope, owner_key, memory_type, state_key)
+    WHERE state_key IS NOT NULL;

--- a/tests/bench_fixtures.rs
+++ b/tests/bench_fixtures.rs
@@ -126,7 +126,22 @@ pub fn setup_full_schema(conn: &Connection) -> Result<()> {
             context_class TEXT,
             expires_at_epoch INTEGER,
             valid_from_epoch INTEGER,
-            valid_to_epoch INTEGER
+            valid_to_epoch INTEGER,
+            state_key_id INTEGER
+        );
+
+        CREATE TABLE IF NOT EXISTS memory_state_keys (
+            id INTEGER PRIMARY KEY,
+            owner_scope TEXT NOT NULL,
+            owner_key TEXT NOT NULL,
+            memory_type TEXT NOT NULL,
+            state_key TEXT NOT NULL,
+            state_label TEXT,
+            state_status TEXT NOT NULL DEFAULT 'active',
+            current_memory_id INTEGER,
+            created_at_epoch INTEGER NOT NULL,
+            updated_at_epoch INTEGER NOT NULL,
+            UNIQUE(owner_scope, owner_key, memory_type, state_key)
         );
 
         CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
@@ -270,7 +285,10 @@ pub fn setup_full_schema(conn: &Connection) -> Result<()> {
             context_class TEXT,
             expires_at_epoch INTEGER,
             valid_from_epoch INTEGER,
-            valid_to_epoch INTEGER
+            valid_to_epoch INTEGER,
+            state_key TEXT,
+            state_key_confidence REAL,
+            state_key_reason TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_memory_candidates_dedupe
             ON memory_candidates(project_id, scope, memory_type, topic_key, text);


### PR DESCRIPTION
Closes #289

Adds the first Memory State V3 storage slice:

- v022 `memory_state_keys` table plus nullable memory/candidate state-key links
- deterministic state-key derivation for stable topic keys and high-confidence preference domains
- direct-save updates through the same owner/type/state slot even when hash-like topic keys change
- candidate persistence/promotion records state-key metadata and attaches promoted memories to the current state slot

Verification run locally:

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target CARGO_PROFILE_DEV_DEBUG=0 cargo check`
- `CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target CARGO_PROFILE_TEST_DEBUG=0 cargo test state_key -- --test-threads=1`
- `CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target CARGO_PROFILE_TEST_DEBUG=0 cargo test memory::store::write::tests --lib -- --test-threads=1`
- `CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target CARGO_PROFILE_TEST_DEBUG=0 cargo test memory_candidate --lib -- --test-threads=1`
- `CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target CARGO_PROFILE_TEST_DEBUG=0 cargo test columns_match_after_upgrade --lib -- --test-threads=1`
- `CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -- -D warnings`
- `REMEM_DATA_DIR=$(mktemp -d /tmp/remem-pr289-test.XXXXXX) CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target CARGO_PROFILE_TEST_DEBUG=0 cargo test -- --test-threads=1`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`