### PR TITLE
feat(memory): add lifecycle operation audit log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.30"
+version = "0.4.31"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.30"
+version = "0.4.31"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -171,7 +171,7 @@ async fn save_memory_response_reports_durable_feedback_shape() {
     let payload: Value = serde_json::from_slice(&body).expect("save response should be valid json");
 
     assert_eq!(payload["status"], "saved");
-    assert_eq!(payload["operation"], "inserted");
+    assert_eq!(payload["operation"], "add");
     assert_eq!(payload["upserted"], true);
     assert_eq!(payload["project"], "proj");
     assert_eq!(payload["scope"], "project");

--- a/src/dream/apply.rs
+++ b/src/dream/apply.rs
@@ -1,10 +1,40 @@
-use anyhow::Result;
-use rusqlite::Connection;
+use anyhow::{bail, Result};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use super::merge::MergeResult;
+use crate::memory::lifecycle::MemoryLifecycleOp;
+use crate::memory::operation::{insert_operation_log, MemoryOperationInput, MemoryOperationPlan};
 
 pub(super) fn apply(conn: &mut Connection, project: &str, result: &MergeResult) -> Result<()> {
     let tx = conn.transaction()?;
+    let superseded_ids =
+        validate_dream_superseded_ids(&tx, project, &result.memory_type, &result.superseded_ids)?;
+    validate_dream_target_topic(
+        &tx,
+        project,
+        &result.memory_type,
+        &result.topic_key,
+        &superseded_ids,
+    )?;
+    let state_key = crate::memory::state_key::derive_state_key(
+        &result.memory_type,
+        Some(&result.topic_key),
+        &result.title,
+        &result.content,
+    )
+    .map(|decision| decision.state_key);
+    let operation_input = MemoryOperationInput {
+        source: "dream".to_string(),
+        actor: "dream".to_string(),
+        source_project: project.to_string(),
+        owner_scope: "repo".to_string(),
+        owner_key: project.to_string(),
+        memory_type: result.memory_type.clone(),
+        topic_key: Some(result.topic_key.clone()),
+        state_key: state_key.clone(),
+        source_candidate_id: None,
+        confidence: None,
+    };
 
     // Upsert the merged memory (reuses existing topic_key upsert logic)
     let merged_id = crate::memory::insert_memory_full(
@@ -20,16 +50,104 @@ pub(super) fn apply(conn: &mut Connection, project: &str, result: &MergeResult) 
         "project",
         None,
     )?;
+    let actual_superseded_ids = superseded_ids
+        .into_iter()
+        .filter(|id| *id != merged_id)
+        .collect::<Vec<_>>();
 
     crate::memory::lifecycle::soft_supersede(
         &tx,
         project,
-        &result.superseded_ids,
+        &actual_superseded_ids,
         Some(merged_id),
     )?;
+    let op = if result.superseded_ids.is_empty() {
+        MemoryLifecycleOp::Add
+    } else {
+        MemoryLifecycleOp::Update
+    };
+    let plan = MemoryOperationPlan::new(op, state_key, "dream consolidation applied")
+        .with_target_memory_id(Some(merged_id))
+        .with_superseded_ids(actual_superseded_ids);
+    insert_operation_log(&tx, &operation_input, &plan, Some(merged_id))?;
 
     tx.commit()?;
     Ok(())
+}
+
+fn validate_dream_superseded_ids(
+    conn: &Connection,
+    project: &str,
+    memory_type: &str,
+    superseded_ids: &[i64],
+) -> Result<Vec<i64>> {
+    let mut seen = std::collections::HashSet::with_capacity(superseded_ids.len());
+    let mut valid = Vec::new();
+    for id in superseded_ids.iter().copied().filter(|id| seen.insert(*id)) {
+        let exists: bool = conn.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM memories
+                 WHERE id = ?1
+                   AND project = ?2
+                   AND memory_type = ?3
+                   AND COALESCE(
+                        owner_scope,
+                        CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
+                   ) = 'repo'
+                   AND COALESCE(
+                        owner_key,
+                        CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user:default' ELSE project END
+                   ) = ?2
+             )",
+            params![id, project, memory_type],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            bail!("dream superseded memory id={id} is outside project/type/owner neighborhood");
+        }
+        valid.push(id);
+    }
+    Ok(valid)
+}
+
+fn validate_dream_target_topic(
+    conn: &Connection,
+    project: &str,
+    memory_type: &str,
+    topic_key: &str,
+    superseded_ids: &[i64],
+) -> Result<()> {
+    let existing_id = conn
+        .query_row(
+            "SELECT id FROM memories
+             WHERE project = ?1
+               AND memory_type = ?2
+               AND topic_key = ?3
+               AND COALESCE(
+                    owner_scope,
+                    CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
+               ) = 'repo'
+               AND COALESCE(
+                    owner_key,
+                    CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user:default' ELSE project END
+               ) = ?1
+             ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END,
+                      updated_at_epoch DESC,
+                      id DESC
+             LIMIT 1",
+            params![project, memory_type, topic_key],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?;
+    let Some(existing_id) = existing_id else {
+        return Ok(());
+    };
+    if superseded_ids.contains(&existing_id) {
+        return Ok(());
+    }
+    bail!(
+        "dream target topic_key collides with memory id={existing_id} outside superseded neighborhood"
+    );
 }
 
 #[cfg(test)]
@@ -172,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_keeps_reused_topic_key_merge_active() {
+    fn test_apply_keeps_reused_topic_key_merge_active() -> Result<()> {
         let (mut conn, project) = setup();
         let old_id = insert_memory(
             &conn,
@@ -183,8 +301,7 @@ mod tests {
             "oldreusedneedle content",
             "decision",
             None,
-        )
-        .expect("insert");
+        )?;
 
         let result = MergeResult {
             topic_key: "reused-topic".to_owned(),
@@ -193,7 +310,7 @@ mod tests {
             content: "mergedreusedneedle content".to_owned(),
             superseded_ids: vec![old_id],
         };
-        apply(&mut conn, &project, &result).expect("apply");
+        apply(&mut conn, &project, &result)?;
 
         assert_eq!(status_for_id(&conn, old_id), "active");
         assert_eq!(active_count(&conn, &project, "reused-topic"), 1);
@@ -205,6 +322,59 @@ mod tests {
             !fts_indexed(&conn, old_id, "oldreusedneedle"),
             "old content must not remain indexed after the upsert"
         );
+        let operation: String = conn.query_row(
+            "SELECT operation FROM memory_operation_log ORDER BY id DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(operation, "update");
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_rejects_target_topic_collision_outside_superseded_neighborhood() -> Result<()> {
+        let (mut conn, project) = setup();
+        insert_memory(
+            &conn,
+            Some("sess-1"),
+            &project,
+            Some("collision-topic"),
+            "Unrelated title",
+            "unrelated content",
+            "decision",
+            None,
+        )?;
+        let old_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            &project,
+            Some("old-topic"),
+            "Old title",
+            "old content",
+            "decision",
+            None,
+        )?;
+
+        let result = MergeResult {
+            topic_key: "collision-topic".to_owned(),
+            memory_type: "decision".to_owned(),
+            title: "Merged title".to_owned(),
+            content: "merged content".to_owned(),
+            superseded_ids: vec![old_id],
+        };
+
+        let error = apply(&mut conn, &project, &result).expect_err("collision should fail");
+        assert!(
+            error.to_string().contains("target topic_key collides"),
+            "expected collision error, got: {error:?}"
+        );
+        assert_eq!(status_for_id(&conn, old_id), "active");
+        let log_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memory_operation_log", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(log_count, 0);
+        Ok(())
     }
 
     #[test]
@@ -232,6 +402,46 @@ mod tests {
         apply(&mut conn, &project, &result).expect("apply");
 
         assert_eq!(status_for_id(&conn, old_id), "stale");
+    }
+
+    #[test]
+    fn test_apply_records_operation_log_for_superseded_ids() -> Result<()> {
+        let (mut conn, project) = setup();
+        let old_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            &project,
+            None,
+            "old title",
+            "old content",
+            "decision",
+            None,
+        )?;
+
+        let result = MergeResult {
+            topic_key: "logged-merged".to_owned(),
+            memory_type: "decision".to_owned(),
+            title: "Logged title".to_owned(),
+            content: "Logged content".to_owned(),
+            superseded_ids: vec![old_id],
+        };
+        apply(&mut conn, &project, &result)?;
+
+        let (operation, result_memory_id, superseded_ids): (String, i64, String) = conn.query_row(
+            "SELECT operation, result_memory_id, superseded_ids
+             FROM memory_operation_log
+             ORDER BY id DESC
+             LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(operation, "update");
+        assert_ne!(result_memory_id, old_id);
+        assert_eq!(
+            serde_json::from_str::<Vec<i64>>(&superseded_ids)?,
+            vec![old_id]
+        );
+        Ok(())
     }
 
     #[test]
@@ -274,6 +484,52 @@ mod tests {
 
         assert_eq!(active_count(&conn, &project, "merged-topic"), 0);
         assert_eq!(status_for_id(&conn, old_id), "active");
+    }
+
+    #[test]
+    fn test_apply_rolls_back_when_operation_log_insert_fails() -> Result<()> {
+        let (mut conn, project) = setup();
+        let old_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            &project,
+            Some("old-topic"),
+            "old title",
+            "old content",
+            "decision",
+            None,
+        )?;
+        conn.execute_batch(
+            "CREATE TRIGGER fail_operation_log_insert
+             BEFORE INSERT ON memory_operation_log
+             BEGIN
+                 SELECT RAISE(FAIL, 'forced operation log failure');
+             END;",
+        )?;
+
+        let result = MergeResult {
+            topic_key: "merged-topic".to_owned(),
+            memory_type: "decision".to_owned(),
+            title: "Merged title".to_owned(),
+            content: "Merged content".to_owned(),
+            superseded_ids: vec![old_id],
+        };
+
+        let error = apply(&mut conn, &project, &result).expect_err("apply should fail");
+        let error_chain = format!("{error:?}");
+        assert!(
+            error_chain.contains("forced operation log failure"),
+            "expected operation log trigger failure, got: {error_chain}"
+        );
+
+        let log_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memory_operation_log", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(active_count(&conn, &project, "merged-topic"), 0);
+        assert_eq!(status_for_id(&conn, old_id), "active");
+        assert_eq!(log_count, 0);
+        Ok(())
     }
 
     #[test]

--- a/src/mcp/server/tests.rs
+++ b/src/mcp/server/tests.rs
@@ -284,7 +284,7 @@ fn save_memory_response_reports_durable_feedback_shape() {
     let json: Value = serde_json::from_str(&response).expect("response should be json");
 
     assert_eq!(json["status"], "saved");
-    assert_eq!(json["operation"], "inserted");
+    assert_eq!(json["operation"], "add");
     assert_eq!(json["upserted"], true);
     assert_eq!(json["project"], "proj");
     assert_eq!(json["scope"], "project");

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -5,6 +5,7 @@ pub mod format;
 pub mod governance;
 pub mod lesson;
 pub mod lifecycle;
+pub mod operation;
 pub mod preference;
 pub mod procedure;
 pub mod promote;

--- a/src/memory/operation.rs
+++ b/src/memory/operation.rs
@@ -1,0 +1,306 @@
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::memory::lifecycle::MemoryLifecycleOp;
+
+pub const PLANNER_VERSION: &str = "memory-operation-planner-v1";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryOperationInput {
+    pub source: String,
+    pub actor: String,
+    pub source_project: String,
+    pub owner_scope: String,
+    pub owner_key: String,
+    pub memory_type: String,
+    pub topic_key: Option<String>,
+    pub state_key: Option<String>,
+    pub source_candidate_id: Option<i64>,
+    pub confidence: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryOperationPlan {
+    pub op: MemoryLifecycleOp,
+    pub state_key: Option<String>,
+    pub target_memory_id: Option<i64>,
+    pub superseded_ids: Vec<i64>,
+    pub conflicting_ids: Vec<i64>,
+    pub noop_reason: Option<String>,
+    pub defer_reason: Option<String>,
+    pub planner_version: &'static str,
+    pub reason: String,
+}
+
+impl MemoryOperationPlan {
+    pub fn new(
+        op: MemoryLifecycleOp,
+        state_key: Option<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            op,
+            state_key,
+            target_memory_id: None,
+            superseded_ids: Vec::new(),
+            conflicting_ids: Vec::new(),
+            noop_reason: None,
+            defer_reason: None,
+            planner_version: PLANNER_VERSION,
+            reason: reason.into(),
+        }
+    }
+
+    pub fn with_target_memory_id(mut self, memory_id: Option<i64>) -> Self {
+        self.target_memory_id = memory_id;
+        self
+    }
+
+    pub fn with_superseded_ids(mut self, superseded_ids: Vec<i64>) -> Self {
+        self.superseded_ids = superseded_ids;
+        self
+    }
+
+    pub fn with_noop_reason(mut self, reason: impl Into<String>) -> Self {
+        self.noop_reason = Some(reason.into());
+        self
+    }
+
+    pub fn with_defer_reason(mut self, reason: impl Into<String>) -> Self {
+        self.defer_reason = Some(reason.into());
+        self
+    }
+}
+
+pub fn owner_for_scope(project: &str, scope: &str) -> (&'static str, String) {
+    if scope == "global" {
+        ("user", "user:default".to_string())
+    } else {
+        ("repo", project.to_string())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn plan_direct_save(
+    conn: &Connection,
+    source: &str,
+    actor: &str,
+    project: &str,
+    scope: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+    title: &str,
+    content: &str,
+    source_candidate_id: Option<i64>,
+    confidence: Option<f64>,
+) -> Result<(MemoryOperationInput, MemoryOperationPlan)> {
+    let (owner_scope, owner_key) = owner_for_scope(project, scope);
+    let state_key =
+        crate::memory::state_key::derive_state_key(memory_type, topic_key, title, content)
+            .map(|decision| decision.state_key);
+    let existing = existing_memory_for_direct_save(
+        conn,
+        project,
+        scope,
+        memory_type,
+        topic_key,
+        state_key.as_deref(),
+    )?;
+    let input = MemoryOperationInput {
+        source: source.to_string(),
+        actor: actor.to_string(),
+        source_project: project.to_string(),
+        owner_scope: owner_scope.to_string(),
+        owner_key,
+        memory_type: memory_type.to_string(),
+        topic_key: topic_key.map(str::to_string),
+        state_key: state_key.clone(),
+        source_candidate_id,
+        confidence,
+    };
+    let plan = match existing {
+        Some(existing)
+            if existing.status == "active" && same_memory_text(&existing.content, content) =>
+        {
+            MemoryOperationPlan::new(
+                MemoryLifecycleOp::Noop,
+                state_key,
+                "existing active memory already represents this fact",
+            )
+            .with_target_memory_id(Some(existing.id))
+            .with_noop_reason("already represented by active memory")
+        }
+        Some(existing) => MemoryOperationPlan::new(
+            MemoryLifecycleOp::Update,
+            state_key,
+            "existing state/topic memory will be updated",
+        )
+        .with_target_memory_id(Some(existing.id)),
+        None => MemoryOperationPlan::new(
+            MemoryLifecycleOp::Add,
+            state_key,
+            "no existing state/topic memory; add new durable memory",
+        ),
+    };
+    Ok((input, plan))
+}
+
+pub fn operation_for_memory_write(conn: &Connection, memory_id: i64) -> Result<MemoryLifecycleOp> {
+    let created_updated: (i64, i64) = conn
+        .query_row(
+            "SELECT created_at_epoch, updated_at_epoch FROM memories WHERE id = ?1",
+            [memory_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .with_context(|| format!("load memory timestamps for operation result id={memory_id}"))?;
+    Ok(if created_updated.0 == created_updated.1 {
+        MemoryLifecycleOp::Add
+    } else {
+        MemoryLifecycleOp::Update
+    })
+}
+
+pub fn insert_operation_log(
+    conn: &Connection,
+    input: &MemoryOperationInput,
+    plan: &MemoryOperationPlan,
+    result_memory_id: Option<i64>,
+) -> Result<i64> {
+    let now = chrono::Utc::now().timestamp();
+    let superseded_ids = serde_json::to_string(&plan.superseded_ids)
+        .context("serialize memory operation superseded ids")?;
+    let conflicting_ids = serde_json::to_string(&plan.conflicting_ids)
+        .context("serialize memory operation conflicting ids")?;
+    conn.execute(
+        "INSERT INTO memory_operation_log
+         (operation, planner_version, actor, source, owner_scope, owner_key,
+          memory_type, state_key, input_topic_key, source_candidate_id, result_memory_id,
+          superseded_ids, conflicting_ids, noop_reason, defer_reason, confidence, reason,
+          created_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6,
+                 ?7, ?8, ?9, ?10, ?11,
+                 ?12, ?13, ?14, ?15, ?16, ?17,
+                 ?18)",
+        params![
+            plan.op.as_str(),
+            plan.planner_version,
+            input.actor.as_str(),
+            input.source.as_str(),
+            input.owner_scope.as_str(),
+            input.owner_key.as_str(),
+            input.memory_type.as_str(),
+            plan.state_key.as_deref().or(input.state_key.as_deref()),
+            input.topic_key.as_deref(),
+            input.source_candidate_id,
+            result_memory_id.or(plan.target_memory_id),
+            superseded_ids,
+            conflicting_ids,
+            plan.noop_reason.as_deref(),
+            plan.defer_reason.as_deref(),
+            input.confidence,
+            plan.reason.as_str(),
+            now
+        ],
+    )
+    .context("insert memory operation audit log")?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn with_operation_savepoint<T>(conn: &Connection, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    conn.execute_batch("SAVEPOINT remem_memory_operation")?;
+    match f() {
+        Ok(value) => {
+            conn.execute_batch("RELEASE SAVEPOINT remem_memory_operation")?;
+            Ok(value)
+        }
+        Err(error) => {
+            let rollback = conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT remem_memory_operation;
+                 RELEASE SAVEPOINT remem_memory_operation;",
+            );
+            if let Err(rollback_error) = rollback {
+                return Err(error.context(format!(
+                    "memory operation rollback also failed: {rollback_error}"
+                )));
+            }
+            Err(error)
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ExistingMemory {
+    id: i64,
+    content: String,
+    status: String,
+}
+
+fn existing_memory_for_direct_save(
+    conn: &Connection,
+    project: &str,
+    scope: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+    state_key: Option<&str>,
+) -> Result<Option<ExistingMemory>> {
+    if let Some(topic_key) = topic_key.filter(|topic_key| !topic_key.is_empty()) {
+        let existing_id = conn
+            .query_row(
+                "SELECT id, content, status FROM memories
+                 WHERE project = ?1 AND topic_key = ?2 AND scope = ?3
+                 ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END,
+                          updated_at_epoch DESC,
+                          id DESC
+                 LIMIT 1",
+                params![project, topic_key, scope],
+                map_existing_memory,
+            )
+            .optional()
+            .context("check existing durable memory for topic_key upsert")?;
+        if existing_id.is_some() {
+            return Ok(existing_id);
+        }
+    }
+
+    let Some(state_key) = state_key else {
+        return Ok(None);
+    };
+    let (owner_scope, owner_key) = owner_for_scope(project, scope);
+    let Some(id) = crate::memory::state_key::current_memory_id(
+        conn,
+        owner_scope,
+        &owner_key,
+        memory_type,
+        state_key,
+    )?
+    else {
+        return Ok(None);
+    };
+    conn.query_row(
+        "SELECT id, content, status FROM memories WHERE id = ?1",
+        [id],
+        map_existing_memory,
+    )
+    .optional()
+    .with_context(|| format!("load existing memory for state key id={id}"))
+}
+
+fn map_existing_memory(row: &rusqlite::Row<'_>) -> rusqlite::Result<ExistingMemory> {
+    Ok(ExistingMemory {
+        id: row.get(0)?,
+        content: row.get(1)?,
+        status: row.get(2)?,
+    })
+}
+
+pub fn same_memory_text(left: &str, right: &str) -> bool {
+    normalize_memory_text(left) == normalize_memory_text(right)
+}
+
+fn normalize_memory_text(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}

--- a/src/memory/service.rs
+++ b/src/memory/service.rs
@@ -1,5 +1,7 @@
 mod local_copy;
 mod save;
+#[cfg(test)]
+mod save_tests;
 mod search;
 #[cfg(test)]
 mod tests;

--- a/src/memory/service/save.rs
+++ b/src/memory/service/save.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context, Result};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::Connection;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -9,6 +9,7 @@ use super::local_copy::{
 };
 use super::types::{LocalCopyResult, SaveMemoryNextStep, SaveMemoryRequest, SaveMemoryResult};
 use crate::memory::lesson::{save_lesson, SaveLessonRequest};
+use crate::memory::lifecycle::MemoryLifecycleOp;
 
 #[derive(Debug)]
 pub struct LocalCopyError {
@@ -42,47 +43,105 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
 
     let scope = req.scope.as_deref().unwrap_or("project");
     let effective_topic_key = effective_topic_key(req, memory_type);
-    let operation = durable_operation(conn, project, effective_topic_key.as_deref(), scope)?;
 
     let mut local_copy = prepare_local_copy(project, title, req).map_err(LocalCopyError::from)?;
     write_local_copy(&mut local_copy).map_err(LocalCopyError::from)?;
 
     let save_result = if memory_type == "lesson" {
-        save_lesson(
-            conn,
-            &SaveLessonRequest {
-                session_id: None,
+        crate::memory::operation::with_operation_savepoint(conn, || {
+            let (operation_input, operation_plan) = crate::memory::operation::plan_direct_save(
+                conn,
+                "direct",
+                "save_memory",
                 project,
-                topic_key: req.topic_key.as_deref(),
-                title,
-                content: &req.text,
-                confidence: 0.7,
-                source_evidence: None,
-                files: files_json.as_deref(),
-                branch: req.branch.as_deref(),
                 scope,
-                created_at_epoch: req.created_at_epoch,
-                stale_after_epoch: None,
-            },
-        )
+                memory_type,
+                effective_topic_key.as_deref(),
+                title,
+                &req.text,
+                None,
+                None,
+            )?;
+            let id = save_lesson(
+                conn,
+                &SaveLessonRequest {
+                    session_id: None,
+                    project,
+                    topic_key: req.topic_key.as_deref(),
+                    title,
+                    content: &req.text,
+                    confidence: 0.7,
+                    source_evidence: None,
+                    files: files_json.as_deref(),
+                    branch: req.branch.as_deref(),
+                    scope,
+                    created_at_epoch: req.created_at_epoch,
+                    stale_after_epoch: None,
+                },
+            )?;
+            let mut logged_plan = operation_plan.clone();
+            logged_plan.target_memory_id = Some(id);
+            if logged_plan.op == MemoryLifecycleOp::Noop {
+                logged_plan.op = MemoryLifecycleOp::Update;
+                logged_plan.noop_reason = None;
+                logged_plan.reason =
+                    "existing lesson memory was reinforced by direct save".to_string();
+            }
+            crate::memory::operation::insert_operation_log(
+                conn,
+                &operation_input,
+                &logged_plan,
+                Some(id),
+            )?;
+            Ok((id, logged_plan.op))
+        })
     } else {
-        crate::memory::insert_memory_full(
-            conn,
-            None,
-            project,
-            req.topic_key.as_deref(),
-            title,
-            &req.text,
-            memory_type,
-            files_json.as_deref(),
-            req.branch.as_deref(),
-            scope,
-            req.created_at_epoch,
-        )
+        crate::memory::operation::with_operation_savepoint(conn, || {
+            let (operation_input, operation_plan) = crate::memory::operation::plan_direct_save(
+                conn,
+                "direct",
+                "save_memory",
+                project,
+                scope,
+                memory_type,
+                effective_topic_key.as_deref(),
+                title,
+                &req.text,
+                None,
+                None,
+            )?;
+            if operation_plan.op == MemoryLifecycleOp::Noop {
+                let id = operation_plan
+                    .target_memory_id
+                    .ok_or_else(|| anyhow!("noop memory operation missing existing memory id"))?;
+                crate::memory::operation::insert_operation_log(
+                    conn,
+                    &operation_input,
+                    &operation_plan,
+                    Some(id),
+                )?;
+                return Ok((id, MemoryLifecycleOp::Noop));
+            }
+            crate::memory::insert_memory_full_with_operation_log(
+                conn,
+                None,
+                project,
+                req.topic_key.as_deref(),
+                title,
+                &req.text,
+                memory_type,
+                files_json.as_deref(),
+                req.branch.as_deref(),
+                scope,
+                req.created_at_epoch,
+                &operation_input,
+                &operation_plan,
+            )
+        })
     };
 
-    let id = match save_result {
-        Ok(id) => id,
+    let (id, operation) = match save_result {
+        Ok(result) => result,
         Err(err) => {
             if let Err(cleanup_err) = cleanup_local_copy(&local_copy) {
                 return Err(err.context(format!(
@@ -105,7 +164,7 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         scope: durable.scope,
         topic_key: durable.topic_key,
         branch: durable.branch,
-        operation: operation.to_string(),
+        operation: operation.as_str().to_string(),
         created_at_epoch: durable.created_at_epoch,
         updated_at_epoch: durable.updated_at_epoch,
         upserted: req.topic_key.is_some(),
@@ -184,32 +243,6 @@ fn effective_topic_key(req: &SaveMemoryRequest, memory_type: &str) -> Option<Str
         });
     }
     req.topic_key.clone()
-}
-
-fn durable_operation(
-    conn: &Connection,
-    project: &str,
-    topic_key: Option<&str>,
-    scope: &str,
-) -> Result<&'static str> {
-    let Some(topic_key) = topic_key.filter(|topic_key| !topic_key.is_empty()) else {
-        return Ok("inserted");
-    };
-    let existing_id = conn
-        .query_row(
-            "SELECT id FROM memories
-             WHERE project = ?1 AND topic_key = ?2 AND scope = ?3
-             LIMIT 1",
-            params![project, topic_key, scope],
-            |row| row.get::<_, i64>(0),
-        )
-        .optional()
-        .context("check existing durable memory for topic_key upsert")?;
-    Ok(if existing_id.is_some() {
-        "updated"
-    } else {
-        "inserted"
-    })
 }
 
 struct DurableWriteDetails {

--- a/src/memory/service/save_tests.rs
+++ b/src/memory/service/save_tests.rs
@@ -1,0 +1,35 @@
+use super::{save_memory, SaveMemoryRequest};
+use crate::db::{self, test_support::ScopedTestDataDir};
+
+#[test]
+fn repeated_lesson_save_reinforces_metadata_and_logs_update() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("lesson-save-reinforces");
+    let conn = db::open_db()?;
+    let req = SaveMemoryRequest {
+        text: "Lesson: keep operation audit without losing lesson reinforcement.".to_string(),
+        title: Some("Lesson reinforcement".to_string()),
+        project: Some("proj".to_string()),
+        topic_key: Some("lesson-reinforcement".to_string()),
+        memory_type: Some("lesson".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+
+    let first = save_memory(&conn, &req)?;
+    let second = save_memory(&conn, &req)?;
+
+    assert_eq!(first.id, second.id);
+    assert_eq!(second.operation, "update");
+    let reinforcement_count: i64 = conn.query_row(
+        "SELECT reinforcement_count FROM memory_lessons WHERE memory_id = ?1",
+        [first.id],
+        |row| row.get(0),
+    )?;
+    let operations = conn
+        .prepare("SELECT operation FROM memory_operation_log ORDER BY id ASC")?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    assert_eq!(reinforcement_count, 2);
+    assert_eq!(operations, vec!["add".to_string(), "update".to_string()]);
+    Ok(())
+}

--- a/src/memory/service/tests.rs
+++ b/src/memory/service/tests.rs
@@ -79,9 +79,9 @@ fn save_memory_preference_defaults_to_project_scope() {
 }
 
 #[test]
-fn save_memory_insert_reports_durable_details() {
+fn save_memory_insert_reports_durable_details() -> anyhow::Result<()> {
     let _dir = ScopedTestDataDir::new("save-insert-feedback");
-    let conn = db::open_db().expect("db should open");
+    let conn = db::open_db()?;
     let req = SaveMemoryRequest {
         text: "Remember the durable feedback shape.".to_string(),
         title: Some("Durable feedback".to_string()),
@@ -92,10 +92,10 @@ fn save_memory_insert_reports_durable_details() {
         ..SaveMemoryRequest::default()
     };
 
-    let saved = save_memory(&conn, &req).expect("save should succeed");
+    let saved = save_memory(&conn, &req)?;
 
     assert_eq!(saved.status, "saved");
-    assert_eq!(saved.operation, "inserted");
+    assert_eq!(saved.operation, "add");
     assert!(!saved.upserted);
     assert_eq!(saved.project, "proj");
     assert_eq!(saved.scope, "project");
@@ -109,12 +109,19 @@ fn save_memory_insert_reports_durable_details() {
     assert_eq!(saved.next_step.source, "memory");
     assert!(saved.created_at_epoch > 0);
     assert!(saved.updated_at_epoch > 0);
+    let logged_operation: String = conn.query_row(
+        "SELECT operation FROM memory_operation_log WHERE result_memory_id = ?1",
+        [saved.id],
+        |row| row.get(0),
+    )?;
+    assert_eq!(logged_operation, "add");
+    Ok(())
 }
 
 #[test]
-fn save_memory_topic_key_update_reports_updated_operation() {
+fn save_memory_topic_key_update_reports_updated_operation() -> anyhow::Result<()> {
     let _dir = ScopedTestDataDir::new("save-topic-update-feedback");
-    let conn = db::open_db().expect("db should open");
+    let conn = db::open_db()?;
     let first_req = SaveMemoryRequest {
         text: "First body".to_string(),
         title: Some("Topic feedback".to_string()),
@@ -125,8 +132,8 @@ fn save_memory_topic_key_update_reports_updated_operation() {
         local_copy_enabled: Some(false),
         ..SaveMemoryRequest::default()
     };
-    let first = save_memory(&conn, &first_req).expect("first save should succeed");
-    assert_eq!(first.operation, "inserted");
+    let first = save_memory(&conn, &first_req)?;
+    assert_eq!(first.operation, "add");
     assert!(first.upserted);
 
     let second_req = SaveMemoryRequest {
@@ -134,12 +141,56 @@ fn save_memory_topic_key_update_reports_updated_operation() {
         title: Some("Topic feedback updated".to_string()),
         ..first_req
     };
-    let second = save_memory(&conn, &second_req).expect("second save should succeed");
+    let second = save_memory(&conn, &second_req)?;
 
     assert_eq!(second.id, first.id);
-    assert_eq!(second.operation, "updated");
+    assert_eq!(second.operation, "update");
     assert!(second.upserted);
     assert_eq!(second.topic_key.as_deref(), Some("durable-feedback"));
+    let operations = conn
+        .prepare("SELECT operation FROM memory_operation_log ORDER BY id ASC")?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    assert_eq!(operations, vec!["add".to_string(), "update".to_string()]);
+    Ok(())
+}
+
+#[test]
+fn save_memory_repeated_same_fact_reports_noop_operation() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("save-topic-noop-feedback");
+    let conn = db::open_db()?;
+    let req = SaveMemoryRequest {
+        text: "This fact is already represented.".to_string(),
+        title: Some("Represented fact".to_string()),
+        project: Some("proj".to_string()),
+        topic_key: Some("represented-fact".to_string()),
+        memory_type: Some("discovery".to_string()),
+        scope: Some("project".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+    let first = save_memory(&conn, &req)?;
+    let second = save_memory(&conn, &req)?;
+
+    assert_eq!(second.id, first.id);
+    assert_eq!(second.operation, "noop");
+    let memory_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
+    let (operation, noop_reason): (String, Option<String>) = conn.query_row(
+        "SELECT operation, noop_reason
+         FROM memory_operation_log
+         ORDER BY id DESC
+         LIMIT 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(memory_count, 1);
+    assert_eq!(operation, "noop");
+    assert_eq!(
+        noop_reason.as_deref(),
+        Some("already represented by active memory")
+    );
+    Ok(())
 }
 
 #[test]

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -3,6 +3,12 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::memory::search_context::build_search_context;
 use crate::memory::state_key::{self, StateKeyDecision};
+use crate::memory::{
+    lifecycle::MemoryLifecycleOp,
+    operation::{
+        insert_operation_log, with_operation_savepoint, MemoryOperationInput, MemoryOperationPlan,
+    },
+};
 
 pub fn insert_memory(
     conn: &Connection,
@@ -162,6 +168,43 @@ pub fn insert_memory_full(
         attach_state_key(conn, id, memory_type, &ownership, state_key.as_ref(), now)?;
         refresh_memory_entities(conn, id, title, content, "entity link failed");
         Ok(id)
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn insert_memory_full_with_operation_log(
+    conn: &Connection,
+    session_id: Option<&str>,
+    project: &str,
+    topic_key: Option<&str>,
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    files: Option<&str>,
+    branch: Option<&str>,
+    scope: &str,
+    created_at_override: Option<i64>,
+    operation_input: &MemoryOperationInput,
+    operation_plan: &MemoryOperationPlan,
+) -> Result<(i64, MemoryLifecycleOp)> {
+    with_operation_savepoint(conn, || {
+        let id = insert_memory_full(
+            conn,
+            session_id,
+            project,
+            topic_key,
+            title,
+            content,
+            memory_type,
+            files,
+            branch,
+            scope,
+            created_at_override,
+        )?;
+        let mut logged_plan = operation_plan.clone();
+        logged_plan.target_memory_id = Some(id);
+        insert_operation_log(conn, operation_input, &logged_plan, Some(id))?;
+        Ok((id, logged_plan.op))
     })
 }
 

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -356,6 +356,29 @@ pub mod tests_helper {
                 updated_at_epoch INTEGER NOT NULL,
                 UNIQUE(owner_scope, owner_key, memory_type, state_key)
             );
+            CREATE TABLE memory_operation_log (
+                id INTEGER PRIMARY KEY,
+                operation TEXT NOT NULL,
+                planner_version TEXT NOT NULL,
+                actor TEXT NOT NULL,
+                source TEXT NOT NULL,
+                owner_scope TEXT,
+                owner_key TEXT,
+                memory_type TEXT,
+                state_key TEXT,
+                input_topic_key TEXT,
+                source_candidate_id INTEGER,
+                result_memory_id INTEGER,
+                superseded_ids TEXT NOT NULL DEFAULT '[]',
+                conflicting_ids TEXT NOT NULL DEFAULT '[]',
+                noop_reason TEXT,
+                defer_reason TEXT,
+                confidence REAL,
+                reason TEXT,
+                created_at_epoch INTEGER NOT NULL
+            );
+            CREATE INDEX idx_memory_operation_log_state
+                ON memory_operation_log(owner_scope, owner_key, memory_type, state_key, created_at_epoch);
             CREATE VIRTUAL TABLE memories_fts USING fts5(
                 title, content, search_context,
                 content='memories',

--- a/src/memory_candidate/apply.rs
+++ b/src/memory_candidate/apply.rs
@@ -1,7 +1,12 @@
 use anyhow::{bail, Result};
 use rusqlite::{params, Connection};
 
-use super::{candidate_title, normalize_evidence_text, CandidateRoute, ParsedMemoryCandidate};
+use super::{candidate_title, CandidateRoute, ParsedMemoryCandidate};
+use crate::memory::lifecycle::MemoryLifecycleOp;
+use crate::memory::operation::{
+    insert_operation_log, same_memory_text, with_operation_savepoint, MemoryOperationInput,
+    MemoryOperationPlan,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct CandidateApplyOutcome {
@@ -33,58 +38,101 @@ pub(super) fn promote_candidate_to_memory_with_route(
     let title = candidate_title(candidate);
     let memory_project = route.memory_project(source_project);
     let memory_scope = route.memory_scope();
-    let now = chrono::Utc::now().timestamp();
-    let candidate_has_ttl = crate::memory::lifecycle::default_ttl_seconds(
-        &candidate.memory_type,
-        Some(&candidate.topic_key),
-        &candidate.text,
-    )
-    .is_some();
-    let state_key = crate::memory::state_key::derive_state_key(
-        &candidate.memory_type,
-        Some(&candidate.topic_key),
-        &title,
-        &candidate.text,
-    );
-    let active = find_active_same_state_or_topic(
-        conn,
-        candidate,
-        route,
-        state_key.as_ref(),
-        now,
-        candidate_has_ttl,
-    )?;
-    if let Some(existing) = active.iter().filter(|row| row.is_current).find(|row| {
-        normalize_evidence_text(&row.content) == normalize_evidence_text(&candidate.text)
-    }) {
-        return Ok(CandidateApplyOutcome {
-            memory_id: Some(existing.id),
-            promoted: false,
-            noop: true,
-            superseded: 0,
-        });
-    }
 
-    let memory_id = insert_routed_memory(
-        conn,
-        session_id,
-        source_project,
-        &memory_project,
-        candidate_id,
-        candidate,
-        route,
-        &title,
-        evidence_json,
-        memory_scope,
-        state_key.as_ref(),
-    )?;
-    let superseded_ids = active.iter().map(|row| row.id).collect::<Vec<_>>();
-    let superseded = soft_supersede_routed(conn, &superseded_ids, Some(memory_id))?;
-    Ok(CandidateApplyOutcome {
-        memory_id: Some(memory_id),
-        promoted: true,
-        noop: false,
-        superseded,
+    with_operation_savepoint(conn, || {
+        let now = chrono::Utc::now().timestamp();
+        let candidate_has_ttl = crate::memory::lifecycle::default_ttl_seconds(
+            &candidate.memory_type,
+            Some(&candidate.topic_key),
+            &candidate.text,
+        )
+        .is_some();
+        let state_key = crate::memory::state_key::derive_state_key(
+            &candidate.memory_type,
+            Some(&candidate.topic_key),
+            &title,
+            &candidate.text,
+        );
+        let state_key_value = state_key
+            .as_ref()
+            .map(|decision| decision.state_key.clone());
+        let operation_input = MemoryOperationInput {
+            source: "memory_candidate".to_string(),
+            actor: "memory_candidate".to_string(),
+            source_project: source_project.to_string(),
+            owner_scope: route.owner_scope.clone(),
+            owner_key: route.owner_key.clone(),
+            memory_type: candidate.memory_type.clone(),
+            topic_key: Some(candidate.topic_key.clone()),
+            state_key: state_key_value.clone(),
+            source_candidate_id: Some(candidate_id),
+            confidence: Some(candidate.confidence),
+        };
+        let active = find_active_same_state_or_topic(
+            conn,
+            candidate,
+            route,
+            state_key.as_ref(),
+            now,
+            candidate_has_ttl,
+        )?;
+        if let Some(existing) = active
+            .iter()
+            .filter(|row| row.is_current)
+            .find(|row| same_memory_text(&row.content, &candidate.text))
+        {
+            let plan = MemoryOperationPlan::new(
+                MemoryLifecycleOp::Noop,
+                state_key_value,
+                "candidate already represented by active memory",
+            )
+            .with_target_memory_id(Some(existing.id))
+            .with_noop_reason("already represented by active memory");
+            insert_operation_log(conn, &operation_input, &plan, Some(existing.id))?;
+            return Ok(CandidateApplyOutcome {
+                memory_id: Some(existing.id),
+                promoted: false,
+                noop: true,
+                superseded: 0,
+            });
+        }
+
+        let superseded_ids = active.iter().map(|row| row.id).collect::<Vec<_>>();
+        let op = if superseded_ids.is_empty() {
+            MemoryLifecycleOp::Add
+        } else {
+            MemoryLifecycleOp::Update
+        };
+        let reason = if superseded_ids.is_empty() {
+            "candidate creates new current memory"
+        } else {
+            "candidate replaces active state/topic memories"
+        };
+        let mut plan = MemoryOperationPlan::new(op, state_key_value, reason)
+            .with_superseded_ids(superseded_ids.clone());
+
+        let memory_id = insert_routed_memory(
+            conn,
+            session_id,
+            source_project,
+            &memory_project,
+            candidate_id,
+            candidate,
+            route,
+            &title,
+            evidence_json,
+            memory_scope,
+            state_key.as_ref(),
+        )?;
+        plan.target_memory_id = Some(memory_id);
+        let superseded = soft_supersede_routed(conn, &superseded_ids, Some(memory_id))?;
+        insert_operation_log(conn, &operation_input, &plan, Some(memory_id))?;
+        Ok(CandidateApplyOutcome {
+            memory_id: Some(memory_id),
+            promoted: true,
+            noop: false,
+            superseded,
+        })
     })
 }
 

--- a/src/memory_candidate/tests.rs
+++ b/src/memory_candidate/tests.rs
@@ -472,6 +472,23 @@ async fn memory_candidate_existing_same_topic_same_text_becomes_noop() -> Result
         conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
     assert_eq!(review_status, "noop");
     assert_eq!(memory_count, 1);
+    let (operation, source_candidate_id, noop_reason): (String, Option<i64>, Option<String>) = conn
+        .query_row(
+            "SELECT operation, source_candidate_id, noop_reason
+             FROM memory_operation_log
+             ORDER BY id DESC
+             LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+    let candidate_id: i64 =
+        conn.query_row("SELECT id FROM memory_candidates", [], |row| row.get(0))?;
+    assert_eq!(operation, "noop");
+    assert_eq!(source_candidate_id, Some(candidate_id));
+    assert_eq!(
+        noop_reason.as_deref(),
+        Some("already represented by active memory")
+    );
     Ok(())
 }
 
@@ -534,6 +551,19 @@ async fn memory_candidate_newer_same_topic_supersedes_old_memory() -> Result<()>
     assert_eq!(old_status, "stale");
     assert_eq!(active_text, text);
     assert_eq!(memory_count, 2);
+    let (operation, superseded_ids): (String, String) = conn.query_row(
+        "SELECT operation, superseded_ids
+         FROM memory_operation_log
+         ORDER BY id DESC
+         LIMIT 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(operation, "update");
+    assert_eq!(
+        serde_json::from_str::<Vec<i64>>(&superseded_ids)?,
+        vec![old_id]
+    );
     Ok(())
 }
 

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -106,6 +106,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "git_commit_sessions",
         "memory_state_keys",
         "topic_segments",
+        "memory_operation_log",
     ] {
         let exists: bool = conn
             .query_row(

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -39,6 +39,7 @@ const CONVERGENCE_TABLES: &[&str] = &[
     "git_commit_sessions",
     "memory_state_keys",
     "topic_segments",
+    "memory_operation_log",
 ];
 
 fn make_upgraded_v10_db() -> Result<Connection> {

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -120,6 +120,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "topic_segments",
         sql: include_str!("../migrations/v023_topic_segments.sql"),
     },
+    Migration {
+        version: 24,
+        name: "memory_operation_log",
+        sql: include_str!("../migrations/v024_memory_operation_log.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v024_memory_operation_log.sql
+++ b/src/migrations/v024_memory_operation_log.sql
@@ -1,0 +1,29 @@
+-- v024_memory_operation_log: lifecycle operation planner audit trail.
+--
+-- This table records why a durable memory write became add/update/noop/defer.
+-- It is an explanation layer, not the source of truth for memory contents.
+
+CREATE TABLE IF NOT EXISTS memory_operation_log (
+    id INTEGER PRIMARY KEY,
+    operation TEXT NOT NULL,
+    planner_version TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    source TEXT NOT NULL,
+    owner_scope TEXT,
+    owner_key TEXT,
+    memory_type TEXT,
+    state_key TEXT,
+    input_topic_key TEXT,
+    source_candidate_id INTEGER,
+    result_memory_id INTEGER,
+    superseded_ids TEXT NOT NULL DEFAULT '[]',
+    conflicting_ids TEXT NOT NULL DEFAULT '[]',
+    noop_reason TEXT,
+    defer_reason TEXT,
+    confidence REAL,
+    reason TEXT,
+    created_at_epoch INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_operation_log_state
+    ON memory_operation_log(owner_scope, owner_key, memory_type, state_key, created_at_epoch);


### PR DESCRIPTION
Closes #290\n\n## Summary\n- add v024 memory_operation_log migration and shared lifecycle operation audit helpers\n- route direct save, candidate promotion/noop, and dream apply through operation audit logging\n- expose save_memory operation vocabulary as add/update/noop and add regression tests for candidate/dream/direct-save paths\n\n## Verification\n- cargo fmt --check\n- cargo check\n- cargo clippy -- -D warnings\n- cargo test save_memory -- --test-threads=1\n- cargo test memory_candidate -- --test-threads=1\n- cargo test dream -- --test-threads=1\n- REMEM_DATA_DIR=... cargo test migrate -- --test-threads=1\n- cargo test lifecycle -- --test-threads=1\n- cargo test preference -- --test-threads=1\n- REMEM_DATA_DIR=... cargo test -- --test-threads=1\n- REMEM_ALLOW_PLAINTEXT_DB=1 REMEM_DATA_DIR=... cargo run -- context --force --cwd /Users/lifcc/Desktop/code/AI/tools/remem