### PR TITLE
fix(memory): address lifecycle audit review feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.31"
+version = "0.4.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.31"
+version = "0.4.32"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/dream/candidates.rs
+++ b/src/dream/candidates.rs
@@ -32,6 +32,14 @@ pub(super) fn load_clusters(conn: &Connection, project: &str) -> Result<Vec<Clus
          WHERE project = ?1
            AND status = 'active'
            AND updated_at_epoch < ?2
+           AND COALESCE(
+                owner_scope,
+                CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
+           ) = 'repo'
+           AND COALESCE(
+                owner_key,
+                CASE WHEN COALESCE(scope, 'project') = 'global' THEN 'user:default' ELSE project END
+           ) = ?1
          ORDER BY memory_type, topic_key, updated_at_epoch DESC",
     )?;
 
@@ -181,6 +189,9 @@ mod tests {
                  id,
                  project      TEXT,
                  status       TEXT,
+                 scope        TEXT DEFAULT 'project',
+                 owner_scope  TEXT,
+                 owner_key    TEXT,
                  topic_key    TEXT,
                  title        TEXT,
                  content      TEXT,
@@ -203,7 +214,9 @@ mod tests {
         // Insert a row with TEXT in `id` (not coercible to i64) and
         // updated_at_epoch=0 so it passes the recency-guard filter.
         conn.execute(
-            "INSERT INTO memories VALUES (?1, ?2, 'active', NULL, 'title', 'content', 'preference', 0)",
+            "INSERT INTO memories
+             (id, project, status, topic_key, title, content, memory_type, updated_at_epoch)
+             VALUES (?1, ?2, 'active', NULL, 'title', 'content', 'preference', 0)",
             rusqlite::params!["not-an-integer", "test-project"],
         )
         .unwrap();
@@ -224,7 +237,9 @@ mod tests {
         setup_memories_table(&conn);
         // NULL title — updated_at_epoch=0 passes the recency guard.
         conn.execute(
-            "INSERT INTO memories VALUES (1, 'test-project', 'active', NULL, NULL, 'content', 'preference', 0)",
+            "INSERT INTO memories
+             (id, project, status, topic_key, title, content, memory_type, updated_at_epoch)
+             VALUES (1, 'test-project', 'active', NULL, NULL, 'content', 'preference', 0)",
             [],
         )
         .unwrap();
@@ -234,5 +249,33 @@ mod tests {
             result.is_err(),
             "load_clusters must propagate NULL title as an error, not silently replace it with \"\""
         );
+    }
+
+    #[test]
+    fn test_load_clusters_excludes_global_user_owned_memories() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup_memories_table(&conn);
+        for id in 1..=2 {
+            conn.execute(
+                "INSERT INTO memories
+                 (id, project, status, scope, owner_scope, owner_key, topic_key, title, content,
+                  memory_type, updated_at_epoch)
+                 VALUES (?1, 'test-project', 'active', 'global', 'user', 'user:default',
+                         'global-topic-shared', ?2, ?3, 'preference', 0)",
+                rusqlite::params![
+                    id,
+                    format!("global title {id}"),
+                    format!("global content {id}")
+                ],
+            )?;
+        }
+
+        let clusters = load_clusters(&conn, "test-project")?;
+
+        assert!(
+            clusters.is_empty(),
+            "dream should not create repo merge clusters from global/user-owned memories"
+        );
+        Ok(())
     }
 }

--- a/src/memory/operation.rs
+++ b/src/memory/operation.rs
@@ -91,9 +91,12 @@ pub fn plan_direct_save(
     topic_key: Option<&str>,
     title: &str,
     content: &str,
+    files: Option<&str>,
+    branch: Option<&str>,
     source_candidate_id: Option<i64>,
     confidence: Option<f64>,
 ) -> Result<(MemoryOperationInput, MemoryOperationPlan)> {
+    let now = chrono::Utc::now().timestamp();
     let (owner_scope, owner_key) = owner_for_scope(project, scope);
     let state_key =
         crate::memory::state_key::derive_state_key(memory_type, topic_key, title, content)
@@ -119,9 +122,7 @@ pub fn plan_direct_save(
         confidence,
     };
     let plan = match existing {
-        Some(existing)
-            if existing.status == "active" && same_memory_text(&existing.content, content) =>
-        {
+        Some(existing) if existing.matches_noop_write(title, content, files, branch, now) => {
             MemoryOperationPlan::new(
                 MemoryLifecycleOp::Noop,
                 state_key,
@@ -231,8 +232,37 @@ pub fn with_operation_savepoint<T>(conn: &Connection, f: impl FnOnce() -> Result
 #[derive(Debug)]
 struct ExistingMemory {
     id: i64,
+    title: String,
     content: String,
     status: String,
+    files: Option<String>,
+    branch: Option<String>,
+    expires_at_epoch: Option<i64>,
+}
+
+impl ExistingMemory {
+    fn matches_noop_write(
+        &self,
+        title: &str,
+        content: &str,
+        files: Option<&str>,
+        branch: Option<&str>,
+        now_epoch: i64,
+    ) -> bool {
+        self.status == "active"
+            && self.is_current(now_epoch)
+            && self.title == title
+            && same_memory_text(&self.content, content)
+            && self.files.as_deref() == files
+            && self.branch.as_deref() == branch
+    }
+
+    fn is_current(&self, now_epoch: i64) -> bool {
+        match self.expires_at_epoch {
+            Some(expires_at_epoch) => expires_at_epoch > now_epoch,
+            None => true,
+        }
+    }
 }
 
 fn existing_memory_for_direct_save(
@@ -246,7 +276,7 @@ fn existing_memory_for_direct_save(
     if let Some(topic_key) = topic_key.filter(|topic_key| !topic_key.is_empty()) {
         let existing_id = conn
             .query_row(
-                "SELECT id, content, status FROM memories
+                "SELECT id, title, content, status, files, branch, expires_at_epoch FROM memories
                  WHERE project = ?1 AND topic_key = ?2 AND scope = ?3
                  ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END,
                           updated_at_epoch DESC,
@@ -277,7 +307,8 @@ fn existing_memory_for_direct_save(
         return Ok(None);
     };
     conn.query_row(
-        "SELECT id, content, status FROM memories WHERE id = ?1",
+        "SELECT id, title, content, status, files, branch, expires_at_epoch
+         FROM memories WHERE id = ?1",
         [id],
         map_existing_memory,
     )
@@ -288,8 +319,12 @@ fn existing_memory_for_direct_save(
 fn map_existing_memory(row: &rusqlite::Row<'_>) -> rusqlite::Result<ExistingMemory> {
     Ok(ExistingMemory {
         id: row.get(0)?,
-        content: row.get(1)?,
-        status: row.get(2)?,
+        title: row.get(1)?,
+        content: row.get(2)?,
+        status: row.get(3)?,
+        files: row.get(4)?,
+        branch: row.get(5)?,
+        expires_at_epoch: row.get(6)?,
     })
 }
 

--- a/src/memory/service/save.rs
+++ b/src/memory/service/save.rs
@@ -59,6 +59,8 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
                 effective_topic_key.as_deref(),
                 title,
                 &req.text,
+                files_json.as_deref(),
+                req.branch.as_deref(),
                 None,
                 None,
             )?;
@@ -107,6 +109,8 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
                 effective_topic_key.as_deref(),
                 title,
                 &req.text,
+                files_json.as_deref(),
+                req.branch.as_deref(),
                 None,
                 None,
             )?;

--- a/src/memory/service/save_tests.rs
+++ b/src/memory/service/save_tests.rs
@@ -33,3 +33,87 @@ fn repeated_lesson_save_reinforces_metadata_and_logs_update() -> anyhow::Result<
     assert_eq!(operations, vec!["add".to_string(), "update".to_string()]);
     Ok(())
 }
+
+#[test]
+fn direct_save_refreshes_expired_same_text_current_fact() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("save-expired-current-fact-refresh");
+    let conn = db::open_db()?;
+    let req = SaveMemoryRequest {
+        text: "Local dev server is currently running at localhost:5173.".to_string(),
+        title: Some("Dev server status".to_string()),
+        project: Some("proj".to_string()),
+        topic_key: Some("repo:proj:dev-server".to_string()),
+        memory_type: Some("discovery".to_string()),
+        scope: Some("project".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+    let first = save_memory(&conn, &req)?;
+    conn.execute(
+        "UPDATE memories
+         SET expires_at_epoch = ?1, valid_from_epoch = ?2
+         WHERE id = ?3",
+        rusqlite::params![1_i64, 0_i64, first.id],
+    )?;
+
+    let second = save_memory(&conn, &req)?;
+
+    assert_eq!(second.id, first.id);
+    assert_eq!(second.operation, "update");
+    let (status, expires_at): (String, i64) = conn.query_row(
+        "SELECT status, expires_at_epoch FROM memories WHERE id = ?1",
+        [first.id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(status, "active");
+    assert!(
+        expires_at > chrono::Utc::now().timestamp(),
+        "same-text save should refresh expired currentness metadata"
+    );
+    let operation: String = conn.query_row(
+        "SELECT operation FROM memory_operation_log ORDER BY id DESC LIMIT 1",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(operation, "update");
+    Ok(())
+}
+
+#[test]
+fn direct_save_same_text_metadata_change_updates_row() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("save-same-text-metadata-update");
+    let conn = db::open_db()?;
+    let first_req = SaveMemoryRequest {
+        text: "This fact keeps the same content while durable metadata changes.".to_string(),
+        title: Some("Old title".to_string()),
+        project: Some("proj".to_string()),
+        topic_key: Some("metadata-refresh".to_string()),
+        memory_type: Some("discovery".to_string()),
+        files: Some(vec!["src/old.rs".to_string()]),
+        branch: Some("main".to_string()),
+        scope: Some("project".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+    let first = save_memory(&conn, &first_req)?;
+    let second_req = SaveMemoryRequest {
+        title: Some("New title".to_string()),
+        files: Some(vec!["src/new.rs".to_string()]),
+        branch: Some("feature".to_string()),
+        ..first_req
+    };
+
+    let second = save_memory(&conn, &second_req)?;
+
+    assert_eq!(second.id, first.id);
+    assert_eq!(second.operation, "update");
+    let (title, files, branch): (String, Option<String>, Option<String>) = conn.query_row(
+        "SELECT title, files, branch FROM memories WHERE id = ?1",
+        [first.id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    assert_eq!(title, "New title");
+    assert_eq!(files.as_deref(), Some("[\"src/new.rs\"]"));
+    assert_eq!(branch.as_deref(), Some("feature"));
+    Ok(())
+}


### PR DESCRIPTION
Follow-up to #305.

## Summary
- refresh repeated direct saves when an existing same-text memory is expired or durable metadata changes, instead of logging a noop
- exclude global/user-owned memories from dream repo merge clusters so dream does not generate applies that fail owner validation
- bump remem-ai to 0.4.32 for the binary-impacting fix

## Validation
- cargo fmt --check
- git diff --check
- python3 scripts/ci/check_version_bump.py origin/main WORKTREE
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- cargo check
- cargo clippy -- -D warnings
- cargo test