### PR TITLE
feat(memory): add dry-run cleanup plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.32"
+version = "0.4.33"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.32"
+version = "0.4.33"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -23,6 +23,7 @@ pub(super) use query::{
 };
 pub(super) use review::run_review;
 pub(super) use scope_cleanup::{
-    run_archive, run_audit_scope, run_merge_preferences, run_reroute, RerouteCliRequest,
+    run_archive, run_audit_scope, run_memory_cleanup, run_merge_preferences, run_reroute,
+    RerouteCliRequest,
 };
 pub(super) use usage::run_usage;

--- a/src/cli/actions/scope_cleanup.rs
+++ b/src/cli/actions/scope_cleanup.rs
@@ -1,11 +1,16 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use std::path::Path;
 
 use crate::memory::scope_cleanup::{
-    archive_objects, audit_scope, memory_refs_from_ids, merge_preferences, parse_object_refs,
-    reroute_objects, ArchiveRequest, MergePreferencesRequest, ObjectMutation, ObjectRef,
-    RerouteRequest, ScopeAuditReport, ScopeAuditRequest, ScopeMutationResult, TargetProjectUpdate,
+    apply_memory_cleanup_plan, archive_objects, audit_scope, build_preference_cleanup_plan,
+    memory_refs_from_ids, merge_preferences, parse_object_refs, reroute_objects, ArchiveRequest,
+    MemoryCleanupApplyResult, MemoryCleanupPlan, MergePreferencesRequest, ObjectMutation,
+    ObjectRef, RerouteRequest, ScopeAuditReport, ScopeAuditRequest, ScopeMutationResult,
+    TargetProjectUpdate,
 };
 use crate::{db, memory};
+
+use super::super::types::MemoryCleanupType;
 
 pub(in crate::cli) fn run_audit_scope(project: Option<&str>, limit: i64, json: bool) -> Result<()> {
     let project = resolve_project(project);
@@ -91,6 +96,66 @@ pub(in crate::cli) fn run_archive(
     print_mutation_result("scope archive", &result, json)
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(in crate::cli) fn run_memory_cleanup(
+    cwd: Option<&str>,
+    cleanup_type: Option<MemoryCleanupType>,
+    all_types: bool,
+    dry_run: bool,
+    plan_out: Option<&Path>,
+    apply: bool,
+    plan: Option<&Path>,
+    json: bool,
+) -> Result<()> {
+    if apply {
+        if dry_run || plan_out.is_some() || cleanup_type.is_some() || all_types || cwd.is_some() {
+            bail!("--apply only accepts --plan and optional --json");
+        }
+        let plan_path = plan.ok_or_else(|| anyhow::anyhow!("--apply requires --plan"))?;
+        let raw = std::fs::read_to_string(plan_path)
+            .with_context(|| format!("read cleanup plan {}", plan_path.display()))?;
+        let cleanup_plan: MemoryCleanupPlan = serde_json::from_str(&raw)
+            .with_context(|| format!("parse cleanup plan {}", plan_path.display()))?;
+        let conn = db::open_db()?;
+        let result = apply_memory_cleanup_plan(&conn, &cleanup_plan)?;
+        if json {
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        } else {
+            print_cleanup_apply_result(&result);
+        }
+        return Ok(());
+    }
+
+    if plan.is_some() {
+        bail!("--plan is only valid with --apply");
+    }
+    if !dry_run && plan_out.is_none() && !json {
+        bail!("memory cleanup is dry-run-first; use --dry-run, --plan-out, or --json");
+    }
+    let cleanup_type = cleanup_type
+        .or_else(|| all_types.then_some(MemoryCleanupType::Preference))
+        .unwrap_or(MemoryCleanupType::Preference);
+    if cleanup_type != MemoryCleanupType::Preference {
+        bail!("unsupported cleanup type: {}", cleanup_type.as_str());
+    }
+
+    let cwd = crate::cli::cwd::resolve_cwd_arg(cwd.map(str::to_string));
+    let project = db::project_from_cwd(&cwd);
+    let conn = db::open_db()?;
+    let cleanup_plan = build_preference_cleanup_plan(&conn, &project)?;
+    if let Some(path) = plan_out {
+        let json = serde_json::to_string_pretty(&cleanup_plan)?;
+        std::fs::write(path, format!("{json}\n"))
+            .with_context(|| format!("write cleanup plan {}", path.display()))?;
+    }
+    if json {
+        println!("{}", serde_json::to_string_pretty(&cleanup_plan)?);
+    } else {
+        print_cleanup_plan(&cleanup_plan, plan_out, all_types);
+    }
+    Ok(())
+}
+
 pub(in crate::cli) fn run_merge_preferences(
     project: Option<&str>,
     dry_run: bool,
@@ -134,6 +199,80 @@ pub(in crate::cli) fn run_merge_preferences(
         print_mutation(&mutation);
     }
     Ok(())
+}
+
+fn print_cleanup_plan(plan: &MemoryCleanupPlan, plan_out: Option<&Path>, all_types: bool) {
+    let detector = if all_types {
+        "preference (all supported detectors)"
+    } else {
+        "preference"
+    };
+    println!(
+        "memory cleanup dry-run project={} detector={} groups={}",
+        plan.project,
+        detector,
+        plan.groups.len()
+    );
+    for group in &plan.groups {
+        println!(
+            "  group={} owner={} type={} current=memory:{} stale=[{}] confidence={:.2}",
+            group.cluster_key,
+            owner_label(&group.owner_scope, &group.owner_key),
+            group.memory_type,
+            group.current_id,
+            group
+                .stale_ids
+                .iter()
+                .map(i64::to_string)
+                .collect::<Vec<_>>()
+                .join(","),
+            group.confidence
+        );
+        if let Some(state_key) = &group.state_key {
+            println!("    state_key={state_key}");
+        }
+        println!("    reason={}", group.reason);
+        if let Some(content) = &group.merged_content {
+            println!("    preview={}", db::truncate_str(content, 180));
+        }
+    }
+    if let Some(path) = plan_out {
+        println!("plan written: {}", path.display());
+        println!(
+            "apply with: remem memory cleanup --apply --plan {}",
+            path.display()
+        );
+    }
+}
+
+fn print_cleanup_apply_result(result: &MemoryCleanupApplyResult) {
+    println!(
+        "memory cleanup applied project={} groups={} current=[{}] stale=[{}] operations=[{}] edges={}",
+        result.project,
+        result.groups_applied,
+        result
+            .current_ids
+            .iter()
+            .map(i64::to_string)
+            .collect::<Vec<_>>()
+            .join(","),
+        result
+            .stale_ids
+            .iter()
+            .map(i64::to_string)
+            .collect::<Vec<_>>()
+            .join(","),
+        result
+            .operation_ids
+            .iter()
+            .map(i64::to_string)
+            .collect::<Vec<_>>()
+            .join(","),
+        result.edge_count
+    );
+    for mutation in &result.affected {
+        print_mutation(mutation);
+    }
 }
 
 fn resolve_project(project: Option<&str>) -> String {

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -5,12 +5,12 @@ use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 use super::actions::{
     run_admin, run_archive, run_audit_scope, run_backfill_entities, run_cleanup, run_commit,
     run_dream, run_encrypt, run_eval, run_eval_e2e, run_eval_governance, run_eval_local,
-    run_governance, run_import, run_merge_preferences, run_pending, run_preferences, run_raw,
-    run_reroute, run_review, run_search, run_show, run_status, run_usage, run_why,
-    GovernanceCliRequest, RerouteCliRequest,
+    run_governance, run_import, run_memory_cleanup, run_merge_preferences, run_pending,
+    run_preferences, run_raw, run_reroute, run_review, run_search, run_show, run_status, run_usage,
+    run_why, GovernanceCliRequest, RerouteCliRequest,
 };
 use super::cwd::resolve_cwd_arg;
-use super::types::{Cli, Commands, ContextGateAction};
+use super::types::{Cli, Commands, ContextGateAction, MemoryAction};
 
 #[path = "actions/context_gate.rs"]
 mod context_gate;
@@ -69,6 +69,27 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             context::claude_memory::sync_to_claude_memory(&cwd, &project)?;
         }
         Commands::Preferences { action } => run_preferences(action)?,
+        Commands::Memory { action } => match action {
+            MemoryAction::Cleanup {
+                cwd,
+                cleanup_type,
+                all_types,
+                dry_run,
+                plan_out,
+                apply,
+                plan,
+                json,
+            } => run_memory_cleanup(
+                cwd.as_deref(),
+                cleanup_type,
+                all_types,
+                dry_run,
+                plan_out.as_deref(),
+                apply,
+                plan.as_deref(),
+                json,
+            )?,
+        },
         Commands::Pending { action } => run_pending(action)?,
         Commands::Review { action } => run_review(action)?,
         Commands::Govern {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,7 +1,7 @@
 use super::cwd::resolve_cwd_arg;
 use super::types::{
-    Cli, Commands, CommitAction, ContextGateAction, MemoryGovernanceCliAction, PendingAction,
-    RawAction, RawRole, ReviewAction,
+    Cli, Commands, CommitAction, ContextGateAction, MemoryAction, MemoryCleanupType,
+    MemoryGovernanceCliAction, PendingAction, RawAction, RawRole, ReviewAction,
 };
 use clap::{CommandFactory, Parser};
 
@@ -506,6 +506,72 @@ fn cli_parses_scope_cleanup_commands() {
             assert!(!json);
         }
         _ => panic!("expected merge-preferences command"),
+    }
+
+    let cleanup = Cli::parse_from([
+        "remem",
+        "memory",
+        "cleanup",
+        "--cwd",
+        "/tmp/stash",
+        "--type",
+        "preference",
+        "--dry-run",
+        "--plan-out",
+        "/tmp/remem-cleanup.json",
+    ]);
+    match cleanup.command {
+        Commands::Memory {
+            action:
+                MemoryAction::Cleanup {
+                    cwd,
+                    cleanup_type,
+                    all_types,
+                    dry_run,
+                    plan_out,
+                    apply,
+                    plan,
+                    json,
+                },
+        } => {
+            assert_eq!(cwd.as_deref(), Some("/tmp/stash"));
+            assert_eq!(cleanup_type, Some(MemoryCleanupType::Preference));
+            assert!(!all_types);
+            assert!(dry_run);
+            assert_eq!(
+                plan_out.as_deref(),
+                Some(std::path::Path::new("/tmp/remem-cleanup.json"))
+            );
+            assert!(!apply);
+            assert!(plan.is_none());
+            assert!(!json);
+        }
+        _ => panic!("expected memory cleanup command"),
+    }
+
+    let apply_cleanup = Cli::parse_from([
+        "remem",
+        "memory",
+        "cleanup",
+        "--apply",
+        "--plan",
+        "/tmp/remem-cleanup.json",
+        "--json",
+    ]);
+    match apply_cleanup.command {
+        Commands::Memory {
+            action: MemoryAction::Cleanup {
+                apply, plan, json, ..
+            },
+        } => {
+            assert!(apply);
+            assert_eq!(
+                plan.as_deref(),
+                Some(std::path::Path::new("/tmp/remem-cleanup.json"))
+            );
+            assert!(json);
+        }
+        _ => panic!("expected memory cleanup apply command"),
     }
 }
 

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -93,6 +93,11 @@ pub(super) enum Commands {
         #[command(subcommand)]
         action: PreferenceAction,
     },
+    /// Inspect or apply data-only memory governance plans.
+    Memory {
+        #[command(subcommand)]
+        action: MemoryAction,
+    },
     /// Inspect or repair failed pending observation rows.
     Pending {
         #[command(subcommand)]
@@ -425,6 +430,50 @@ pub(in crate::cli) enum PreferenceAction {
     Remove {
         id: i64,
     },
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum MemoryAction {
+    /// Build or apply a dry-run-first memory cleanup plan.
+    Cleanup {
+        /// Project working directory to plan cleanup for.
+        #[arg(long)]
+        cwd: Option<String>,
+        /// Cleanup detector type. The first implementation supports preference.
+        #[arg(long = "type", value_enum)]
+        cleanup_type: Option<MemoryCleanupType>,
+        /// Run every supported detector. Currently equivalent to --type preference.
+        #[arg(long)]
+        all_types: bool,
+        /// Print what would be changed without mutating the database.
+        #[arg(long)]
+        dry_run: bool,
+        /// Write the dry-run JSON plan to this path.
+        #[arg(long)]
+        plan_out: Option<PathBuf>,
+        /// Apply a saved plan. Requires --plan.
+        #[arg(long)]
+        apply: bool,
+        /// Saved cleanup plan JSON to apply.
+        #[arg(long)]
+        plan: Option<PathBuf>,
+        /// Emit a single JSON object with stable fields for scripts.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(in crate::cli) enum MemoryCleanupType {
+    Preference,
+}
+
+impl MemoryCleanupType {
+    pub(in crate::cli) fn as_str(self) -> &'static str {
+        match self {
+            Self::Preference => "preference",
+        }
+    }
 }
 
 #[derive(Subcommand)]

--- a/src/memory/scope_cleanup.rs
+++ b/src/memory/scope_cleanup.rs
@@ -1,6 +1,7 @@
 mod audit;
 mod merge;
 mod mutate;
+mod plan;
 mod refs;
 
 pub use audit::{audit_scope, AuditItem, DuplicateCluster, ScopeAuditReport, ScopeAuditRequest};
@@ -8,6 +9,10 @@ pub use merge::{merge_preferences, MergePreferencesRequest, MergePreferencesResu
 pub use mutate::{
     archive_objects, reroute_objects, ArchiveRequest, ObjectMutation, OwnerSnapshot,
     RerouteRequest, ScopeMutationResult, TargetProjectUpdate,
+};
+pub use plan::{
+    apply_memory_cleanup_plan, build_preference_cleanup_plan, MemoryCleanupApplyResult,
+    MemoryCleanupGroup, MemoryCleanupPlan, MemoryCleanupRowSnapshot, CLEANUP_PLANNER_VERSION,
 };
 pub use refs::{memory_refs_from_ids, parse_object_refs, ObjectRef, ScopeObjectKind};
 

--- a/src/memory/scope_cleanup/audit.rs
+++ b/src/memory/scope_cleanup/audit.rs
@@ -264,21 +264,24 @@ fn take_limit<T>(mut values: Vec<T>, limit: i64) -> Vec<T> {
 
 #[derive(Debug, Clone)]
 pub(super) struct MemoryAuditRow {
-    id: i64,
-    project: String,
-    title: String,
-    content: String,
-    memory_type: String,
-    status: String,
-    scope: Option<String>,
-    source_project: Option<String>,
-    target_project: Option<String>,
-    owner_scope: Option<String>,
-    owner_key: Option<String>,
-    topic_domain: Option<String>,
-    routing_confidence: Option<f64>,
-    context_class: Option<String>,
-    expires_at_epoch: Option<i64>,
+    pub(super) id: i64,
+    pub(super) project: String,
+    pub(super) topic_key: Option<String>,
+    pub(super) title: String,
+    pub(super) content: String,
+    pub(super) memory_type: String,
+    pub(super) status: String,
+    pub(super) scope: Option<String>,
+    pub(super) source_project: Option<String>,
+    pub(super) target_project: Option<String>,
+    pub(super) owner_scope: Option<String>,
+    pub(super) owner_key: Option<String>,
+    pub(super) topic_domain: Option<String>,
+    pub(super) routing_confidence: Option<f64>,
+    pub(super) context_class: Option<String>,
+    pub(super) expires_at_epoch: Option<i64>,
+    pub(super) state_key: Option<String>,
+    pub(super) current_memory_id: Option<i64>,
 }
 
 impl MemoryAuditRow {
@@ -332,33 +335,38 @@ pub(super) fn load_memory_audit_rows(
     project: &str,
 ) -> Result<Vec<MemoryAuditRow>> {
     let mut stmt = conn.prepare(
-        "SELECT id, project, title, content, memory_type, status, scope,
-                source_project, target_project, owner_scope, owner_key, topic_domain,
-                routing_confidence, context_class, expires_at_epoch
-         FROM memories
-         WHERE project = ?1
-            OR source_project = ?1
-            OR target_project = ?1
-            OR (owner_scope = 'repo' AND owner_key = ?1)
-         ORDER BY updated_at_epoch DESC, id DESC",
+        "SELECT m.id, m.project, m.topic_key, m.title, m.content, m.memory_type,
+                m.status, m.scope, m.source_project, m.target_project, m.owner_scope,
+                m.owner_key, m.topic_domain, m.routing_confidence, m.context_class,
+                m.expires_at_epoch, sk.state_key, sk.current_memory_id
+         FROM memories m
+         LEFT JOIN memory_state_keys sk ON sk.id = m.state_key_id
+         WHERE m.project = ?1
+            OR m.source_project = ?1
+            OR m.target_project = ?1
+            OR (m.owner_scope = 'repo' AND m.owner_key = ?1)
+         ORDER BY m.updated_at_epoch DESC, m.id DESC",
     )?;
     let rows = stmt.query_map(params![project], |row| {
         Ok(MemoryAuditRow {
             id: row.get(0)?,
             project: row.get(1)?,
-            title: row.get(2)?,
-            content: row.get(3)?,
-            memory_type: row.get(4)?,
-            status: row.get(5)?,
-            scope: row.get(6)?,
-            source_project: row.get(7)?,
-            target_project: row.get(8)?,
-            owner_scope: row.get(9)?,
-            owner_key: row.get(10)?,
-            topic_domain: row.get(11)?,
-            routing_confidence: row.get(12)?,
-            context_class: row.get(13)?,
-            expires_at_epoch: row.get(14)?,
+            topic_key: row.get(2)?,
+            title: row.get(3)?,
+            content: row.get(4)?,
+            memory_type: row.get(5)?,
+            status: row.get(6)?,
+            scope: row.get(7)?,
+            source_project: row.get(8)?,
+            target_project: row.get(9)?,
+            owner_scope: row.get(10)?,
+            owner_key: row.get(11)?,
+            topic_domain: row.get(12)?,
+            routing_confidence: row.get(13)?,
+            context_class: row.get(14)?,
+            expires_at_epoch: row.get(15)?,
+            state_key: row.get(16)?,
+            current_memory_id: row.get(17)?,
         })
     })?;
     crate::db::query::collect_rows(rows)
@@ -482,17 +490,28 @@ pub(super) fn preference_clusters(rows: &[MemoryAuditRow], project: &str) -> Vec
         ) {
             continue;
         }
-        let key = preference_cluster_key(&row.title, &row.content);
-        let namespace = format!(
-            "{}:{}:{}:{}",
-            row.owner_scope.as_deref().unwrap_or("legacy"),
-            row.owner_key.as_deref().unwrap_or(row.project.as_str()),
-            row.target_project.as_deref().unwrap_or(""),
-            key
-        );
-        groups.entry(namespace).or_default().push(row);
+        for key in preference_cluster_keys(row) {
+            let namespace = format!(
+                "{}:{}:{}:{}",
+                row.owner_scope.as_deref().unwrap_or("legacy"),
+                row.owner_key.as_deref().unwrap_or(row.project.as_str()),
+                row.target_project.as_deref().unwrap_or(""),
+                key
+            );
+            groups.entry(namespace).or_default().push(row);
+        }
     }
-    groups
+    let mut seen_member_sets = HashSet::new();
+    let mut grouped = groups.into_iter().collect::<Vec<_>>();
+    grouped.sort_by(|left, right| {
+        right
+            .1
+            .len()
+            .cmp(&left.1.len())
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    let mut emitted_sets: Vec<HashSet<i64>> = Vec::new();
+    grouped
         .into_iter()
         .filter_map(|(namespace, mut members)| {
             let key = namespace.rsplit(':').next().unwrap_or("unique").to_string();
@@ -500,7 +519,23 @@ pub(super) fn preference_clusters(rows: &[MemoryAuditRow], project: &str) -> Vec
                 return None;
             }
             members.sort_by_key(|row| row.id);
-            let canonical = members.first().copied()?;
+            let member_key = members
+                .iter()
+                .map(|row| row.id.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            if !seen_member_sets.insert(member_key) {
+                return None;
+            }
+            let member_set = members.iter().map(|row| row.id).collect::<HashSet<_>>();
+            if emitted_sets
+                .iter()
+                .any(|emitted| member_set.is_subset(emitted))
+            {
+                return None;
+            }
+            emitted_sets.push(member_set);
+            let canonical = current_member(&members).or_else(|| members.first().copied())?;
             let refs = members
                 .iter()
                 .map(|row| row.object_ref().to_string())
@@ -521,15 +556,40 @@ pub(super) fn preference_clusters(rows: &[MemoryAuditRow], project: &str) -> Vec
         .collect()
 }
 
-fn preference_cluster_key(title: &str, content: &str) -> String {
-    let text = normalize_text(&format!("{title} {content}"));
+fn preference_cluster_keys(row: &MemoryAuditRow) -> Vec<String> {
+    let mut keys = Vec::new();
+    if let Some(state_key) = non_empty(row.state_key.as_deref()) {
+        keys.push(format!("state:{state_key}"));
+    }
+    let text = normalize_text(&format!("{} {}", row.title, row.content));
     if text.contains("ui") && text.contains("critique") {
-        return "ui-critique".to_string();
+        keys.push("ui-critique".to_string());
     }
     if text.contains("direct") && text.contains("review") {
-        return "direct-review".to_string();
+        keys.push("direct-review".to_string());
     }
-    "unique".to_string()
+    let content_key = normalize_text(&row.content);
+    if !content_key.is_empty() {
+        keys.push(format!("text:{content_key}"));
+    }
+    if let Some(topic_key) = non_empty(row.topic_key.as_deref()) {
+        keys.push(format!("topic:{topic_key}"));
+    }
+    if keys.is_empty() {
+        keys.push("unique".to_string());
+    }
+    keys
+}
+
+fn current_member<'a>(members: &[&'a MemoryAuditRow]) -> Option<&'a MemoryAuditRow> {
+    members
+        .iter()
+        .copied()
+        .find(|row| row.current_memory_id == Some(row.id))
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
 }
 
 fn merge_preference_texts(texts: &[&str]) -> String {
@@ -597,6 +657,8 @@ fn normalize_text(value: &str) -> String {
         .map(|ch| {
             if ch.is_ascii_alphanumeric() {
                 ch.to_ascii_lowercase()
+            } else if ch.is_alphanumeric() {
+                ch
             } else {
                 ' '
             }

--- a/src/memory/scope_cleanup/audit.rs
+++ b/src/memory/scope_cleanup/audit.rs
@@ -280,6 +280,7 @@ pub(super) struct MemoryAuditRow {
     pub(super) routing_confidence: Option<f64>,
     pub(super) context_class: Option<String>,
     pub(super) expires_at_epoch: Option<i64>,
+    pub(super) updated_at_epoch: i64,
     pub(super) state_key: Option<String>,
     pub(super) current_memory_id: Option<i64>,
 }
@@ -338,7 +339,7 @@ pub(super) fn load_memory_audit_rows(
         "SELECT m.id, m.project, m.topic_key, m.title, m.content, m.memory_type,
                 m.status, m.scope, m.source_project, m.target_project, m.owner_scope,
                 m.owner_key, m.topic_domain, m.routing_confidence, m.context_class,
-                m.expires_at_epoch, sk.state_key, sk.current_memory_id
+                m.expires_at_epoch, m.updated_at_epoch, sk.state_key, sk.current_memory_id
          FROM memories m
          LEFT JOIN memory_state_keys sk ON sk.id = m.state_key_id
          WHERE m.project = ?1
@@ -365,8 +366,9 @@ pub(super) fn load_memory_audit_rows(
             routing_confidence: row.get(13)?,
             context_class: row.get(14)?,
             expires_at_epoch: row.get(15)?,
-            state_key: row.get(16)?,
-            current_memory_id: row.get(17)?,
+            updated_at_epoch: row.get(16)?,
+            state_key: row.get(17)?,
+            current_memory_id: row.get(18)?,
         })
     })?;
     crate::db::query::collect_rows(rows)
@@ -535,7 +537,9 @@ pub(super) fn preference_clusters(rows: &[MemoryAuditRow], project: &str) -> Vec
                 return None;
             }
             emitted_sets.push(member_set);
-            let canonical = current_member(&members).or_else(|| members.first().copied())?;
+            let canonical = current_member(&members)
+                .or_else(|| latest_member(&members))
+                .or_else(|| members.first().copied())?;
             let refs = members
                 .iter()
                 .map(|row| row.object_ref().to_string())
@@ -586,6 +590,13 @@ fn current_member<'a>(members: &[&'a MemoryAuditRow]) -> Option<&'a MemoryAuditR
         .iter()
         .copied()
         .find(|row| row.current_memory_id == Some(row.id))
+}
+
+fn latest_member<'a>(members: &[&'a MemoryAuditRow]) -> Option<&'a MemoryAuditRow> {
+    members
+        .iter()
+        .copied()
+        .max_by_key(|row| (row.updated_at_epoch, row.id))
 }
 
 fn non_empty(value: Option<&str>) -> Option<&str> {

--- a/src/memory/scope_cleanup/merge.rs
+++ b/src/memory/scope_cleanup/merge.rs
@@ -1,10 +1,10 @@
-use anyhow::{anyhow, bail, Result};
-use rusqlite::{params, Connection};
+use anyhow::Result;
+use rusqlite::Connection;
 use serde::Serialize;
 
 use super::audit::{load_memory_audit_rows, preference_clusters, DuplicateCluster};
-use super::mutate::{insert_scope_cleanup_event, load_target, ObjectMutation, OwnerSnapshot};
-use super::ObjectRef;
+use super::mutate::ObjectMutation;
+use super::plan::{apply_memory_cleanup_plan, build_preference_cleanup_plan};
 
 #[derive(Debug, Clone)]
 pub struct MergePreferencesRequest<'a> {
@@ -38,105 +38,8 @@ pub fn merge_preferences(
         });
     }
 
-    let tx = conn.unchecked_transaction()?;
-    let now = chrono::Utc::now().timestamp();
-    for cluster in &clusters {
-        let canonical_ref = ObjectRef::parse(&cluster.canonical_ref)?;
-        let canonical = load_target(&tx, canonical_ref)?;
-        let merged = cluster
-            .merged_content
-            .as_deref()
-            .ok_or_else(|| anyhow!("duplicate preference cluster missing merged content"))?;
-        let canonical_new_owner = OwnerSnapshot {
-            source_project: canonical
-                .owner
-                .source_project
-                .clone()
-                .or_else(|| canonical.project.clone()),
-            target_project: Some(req.project.to_string()),
-            owner_scope: Some("repo".to_string()),
-            owner_key: Some(req.project.to_string()),
-            topic_domain: canonical.owner.topic_domain.clone(),
-            routing_confidence: canonical.owner.routing_confidence,
-            routing_reason: canonical.owner.routing_reason.clone(),
-            context_class: canonical.owner.context_class.clone(),
-        };
-        let updated = tx.execute(
-            "UPDATE memories
-             SET content = ?1,
-                 status = 'active',
-                 source_project = COALESCE(source_project, project),
-                 target_project = ?2,
-                 owner_scope = 'repo',
-                 owner_key = ?2,
-                 updated_at_epoch = ?3
-             WHERE id = ?4",
-            params![merged, req.project, now, canonical_ref.id],
-        )?;
-        if updated != 1 {
-            bail!("failed to update canonical preference {}", canonical_ref);
-        }
-        affected.push(ObjectMutation {
-            object_ref: canonical_ref.to_string(),
-            title: canonical.title.clone(),
-            previous_status: canonical.status.clone(),
-            new_status: "active".to_string(),
-            previous_owner: canonical.owner.clone(),
-            new_owner: canonical_new_owner.clone(),
-        });
-        insert_scope_cleanup_event(
-            &tx,
-            "merge-preferences",
-            &canonical,
-            "active",
-            &canonical_new_owner,
-            Some("canonical preference updated with merged duplicate content"),
-            now,
-        )?;
-
-        for object_ref in &cluster.refs {
-            if object_ref == &cluster.canonical_ref {
-                continue;
-            }
-            let object_ref = ObjectRef::parse(object_ref)?;
-            let target = load_target(&tx, object_ref)?;
-            let updated = tx.execute(
-                "UPDATE memories SET status = 'stale', updated_at_epoch = ?1 WHERE id = ?2",
-                params![now, object_ref.id],
-            )?;
-            if updated != 1 {
-                bail!("failed to stale duplicate preference {}", object_ref);
-            }
-            affected.push(ObjectMutation {
-                object_ref: object_ref.to_string(),
-                title: target.title.clone(),
-                previous_status: target.status.clone(),
-                new_status: "stale".to_string(),
-                previous_owner: target.owner.clone(),
-                new_owner: target.owner.clone(),
-            });
-            insert_scope_cleanup_event(
-                &tx,
-                "merge-preferences",
-                &target,
-                "stale",
-                &target.owner,
-                Some("duplicate preference superseded by canonical row"),
-                now,
-            )?;
-            crate::memory::edge::insert_replacement_edges(
-                &tx,
-                crate::memory::edge::MemoryEdgeType::Duplicates,
-                &[object_ref.id],
-                canonical_ref.id,
-                crate::memory::edge::MemoryEdgeWriteContext {
-                    reason: Some("duplicate preference merged into canonical row"),
-                    ..Default::default()
-                },
-            )?;
-        }
-    }
-    tx.commit()?;
+    let plan = build_preference_cleanup_plan(conn, req.project)?;
+    affected = apply_memory_cleanup_plan(conn, &plan)?.affected;
     Ok(MergePreferencesResult {
         dry_run,
         project: req.project.to_string(),

--- a/src/memory/scope_cleanup/plan.rs
+++ b/src/memory/scope_cleanup/plan.rs
@@ -8,7 +8,7 @@ use crate::memory::lifecycle::MemoryLifecycleOp;
 use crate::memory::operation::{insert_operation_log, MemoryOperationInput, MemoryOperationPlan};
 
 use super::audit::{load_memory_audit_rows, preference_clusters};
-use super::mutate::{insert_scope_cleanup_event, load_target, ObjectMutation, OwnerSnapshot};
+use super::mutate::{insert_scope_cleanup_event, load_target, ObjectMutation};
 use super::ObjectRef;
 
 pub const CLEANUP_PLANNER_VERSION: &str = "memory-cleanup-v1";
@@ -149,32 +149,14 @@ pub fn apply_memory_cleanup_plan(
         let current_ref = ObjectRef::memory(group.current_id);
         let canonical = load_target(&tx, current_ref)?;
         let current_snapshot = snapshot_for(&group.row_snapshots, group.current_id)?;
-        let new_owner = OwnerSnapshot {
-            source_project: canonical
-                .owner
-                .source_project
-                .clone()
-                .or_else(|| canonical.project.clone()),
-            target_project: Some(plan.project.clone()),
-            owner_scope: Some("repo".to_string()),
-            owner_key: Some(plan.project.clone()),
-            topic_domain: canonical.owner.topic_domain.clone(),
-            routing_confidence: canonical.owner.routing_confidence,
-            routing_reason: canonical.owner.routing_reason.clone(),
-            context_class: canonical.owner.context_class.clone(),
-        };
         let merged = group.merged_content.as_deref();
         let updated = tx.execute(
             "UPDATE memories
              SET content = COALESCE(?1, content),
                  status = 'active',
-                 source_project = COALESCE(source_project, project),
-                 target_project = ?2,
-                 owner_scope = 'repo',
-                 owner_key = ?2,
-                 updated_at_epoch = ?3
-             WHERE id = ?4",
-            params![merged, plan.project, now, group.current_id],
+                 updated_at_epoch = ?2
+             WHERE id = ?3",
+            params![merged, now, group.current_id],
         )?;
         if updated != 1 {
             bail!(
@@ -189,14 +171,14 @@ pub fn apply_memory_cleanup_plan(
             previous_status: canonical.status.clone(),
             new_status: "active".to_string(),
             previous_owner: canonical.owner.clone(),
-            new_owner: new_owner.clone(),
+            new_owner: canonical.owner.clone(),
         });
         insert_scope_cleanup_event(
             &tx,
             "memory-cleanup",
             &canonical,
             "active",
-            &new_owner,
+            &canonical.owner,
             Some(group.reason.as_str()),
             now,
         )?;
@@ -318,6 +300,26 @@ fn validate_group(
         );
     }
 
+    let current_snapshot = snapshot_for(&group.row_snapshots, group.current_id)?;
+    if group.owner_scope != current_snapshot.owner_scope
+        || group.owner_key != current_snapshot.owner_key
+    {
+        bail!(
+            "cleanup group {} owner does not match current row owner",
+            group.cluster_key
+        );
+    }
+    if group.state_key != current_snapshot.state_key {
+        bail!(
+            "cleanup group {} state key does not match current row",
+            group.cluster_key
+        );
+    }
+    let current_owner = current_snapshot.owner_namespace(&plan.project);
+    let current_state_key_id = current_snapshot.state_key_id;
+    let current_state_key = current_snapshot.state_key.as_deref();
+    let topic_group = group.cluster_key.starts_with("topic:");
+
     for snapshot in &group.row_snapshots {
         let current = load_row_snapshot(conn, snapshot.id)?
             .ok_or_else(|| anyhow!("cleanup plan row {} no longer exists", snapshot.id))?;
@@ -343,6 +345,33 @@ fn validate_group(
                 "cleanup plan row {} does not belong to project {}",
                 snapshot.id,
                 plan.project
+            );
+        }
+        if snapshot.owner_namespace(&plan.project) != current_owner {
+            bail!(
+                "cleanup plan row {} owner does not match current row owner",
+                snapshot.id
+            );
+        }
+        match (current_state_key_id, current_state_key) {
+            (Some(state_key_id), _) if snapshot.state_key_id != Some(state_key_id) => {
+                bail!(
+                    "cleanup plan row {} state key does not match current row",
+                    snapshot.id
+                );
+            }
+            (None, Some(state_key)) if snapshot.state_key.as_deref() != Some(state_key) => {
+                bail!(
+                    "cleanup plan row {} state key does not match current row",
+                    snapshot.id
+                );
+            }
+            _ => {}
+        }
+        if topic_group && snapshot.topic_key != current_snapshot.topic_key {
+            bail!(
+                "cleanup plan row {} topic key does not match current row",
+                snapshot.id
             );
         }
     }
@@ -429,6 +458,18 @@ fn load_row_snapshot(conn: &Connection, id: i64) -> Result<Option<MemoryCleanupR
 }
 
 impl MemoryCleanupRowSnapshot {
+    fn owner_namespace(&self, project: &str) -> (String, String) {
+        match (self.owner_scope.as_deref(), self.owner_key.as_deref()) {
+            (Some(scope), Some(key)) => (scope.to_string(), key.to_string()),
+            _ if self.project == project
+                && self.scope.as_deref().unwrap_or("project") != "global" =>
+            {
+                ("legacy_repo".to_string(), project.to_string())
+            }
+            _ => ("legacy_other".to_string(), self.project.clone()),
+        }
+    }
+
     fn belongs_to_project(&self, project: &str) -> bool {
         self.source_project.as_deref() == Some(project)
             || self.target_project.as_deref() == Some(project)

--- a/src/memory/scope_cleanup/plan.rs
+++ b/src/memory/scope_cleanup/plan.rs
@@ -1,0 +1,457 @@
+use anyhow::{anyhow, bail, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+
+use crate::memory::lifecycle::MemoryLifecycleOp;
+use crate::memory::operation::{insert_operation_log, MemoryOperationInput, MemoryOperationPlan};
+
+use super::audit::{load_memory_audit_rows, preference_clusters};
+use super::mutate::{insert_scope_cleanup_event, load_target, ObjectMutation, OwnerSnapshot};
+use super::ObjectRef;
+
+pub const CLEANUP_PLANNER_VERSION: &str = "memory-cleanup-v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryCleanupPlan {
+    pub project: String,
+    pub created_at_epoch: i64,
+    pub planner_version: String,
+    pub groups: Vec<MemoryCleanupGroup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryCleanupGroup {
+    pub cluster_key: String,
+    pub owner_scope: Option<String>,
+    pub owner_key: Option<String>,
+    pub memory_type: String,
+    pub state_key: Option<String>,
+    pub current_id: i64,
+    pub stale_ids: Vec<i64>,
+    pub reason: String,
+    pub confidence: f64,
+    pub preview: Vec<String>,
+    pub merged_content: Option<String>,
+    pub row_snapshots: Vec<MemoryCleanupRowSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryCleanupRowSnapshot {
+    pub id: i64,
+    pub project: String,
+    pub scope: Option<String>,
+    pub source_project: Option<String>,
+    pub target_project: Option<String>,
+    pub status: String,
+    pub content_sha256: String,
+    pub updated_at_epoch: i64,
+    pub owner_scope: Option<String>,
+    pub owner_key: Option<String>,
+    pub memory_type: String,
+    pub topic_key: Option<String>,
+    pub state_key_id: Option<i64>,
+    pub state_key: Option<String>,
+    pub current_memory_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MemoryCleanupApplyResult {
+    pub project: String,
+    pub planner_version: String,
+    pub groups_applied: usize,
+    pub current_ids: Vec<i64>,
+    pub stale_ids: Vec<i64>,
+    pub operation_ids: Vec<i64>,
+    pub edge_count: usize,
+    pub affected: Vec<ObjectMutation>,
+}
+
+pub fn build_preference_cleanup_plan(
+    conn: &Connection,
+    project: &str,
+) -> Result<MemoryCleanupPlan> {
+    let memories = load_memory_audit_rows(conn, project)?;
+    let clusters = preference_clusters(&memories, project);
+    let mut groups = Vec::with_capacity(clusters.len());
+
+    for cluster in clusters {
+        let current_ref = ObjectRef::parse(&cluster.canonical_ref)?;
+        let stale_ids = cluster
+            .refs
+            .iter()
+            .filter(|object_ref| *object_ref != &cluster.canonical_ref)
+            .map(|object_ref| ObjectRef::parse(object_ref).map(|parsed| parsed.id))
+            .collect::<Result<Vec<_>>>()?;
+        if stale_ids.is_empty() {
+            continue;
+        }
+        let mut ids = Vec::with_capacity(stale_ids.len() + 1);
+        ids.push(current_ref.id);
+        ids.extend(stale_ids.iter().copied());
+        let row_snapshots = load_row_snapshots(conn, &ids)?;
+        let current = snapshot_for(&row_snapshots, current_ref.id)?;
+        let preview = row_snapshots
+            .iter()
+            .take(4)
+            .map(|row| format!("memory:{} {}", row.id, row.status))
+            .collect();
+        groups.push(MemoryCleanupGroup {
+            cluster_key: cluster.cluster_key,
+            owner_scope: current.owner_scope.clone(),
+            owner_key: current.owner_key.clone(),
+            memory_type: current.memory_type.clone(),
+            state_key: current.state_key.clone(),
+            current_id: current_ref.id,
+            stale_ids,
+            reason: cluster.reason,
+            confidence: 1.0,
+            preview,
+            merged_content: cluster.merged_content,
+            row_snapshots,
+        });
+    }
+
+    Ok(MemoryCleanupPlan {
+        project: project.to_string(),
+        created_at_epoch: chrono::Utc::now().timestamp(),
+        planner_version: CLEANUP_PLANNER_VERSION.to_string(),
+        groups,
+    })
+}
+
+pub fn apply_memory_cleanup_plan(
+    conn: &Connection,
+    plan: &MemoryCleanupPlan,
+) -> Result<MemoryCleanupApplyResult> {
+    if plan.planner_version != CLEANUP_PLANNER_VERSION {
+        bail!(
+            "unsupported cleanup planner version: {}",
+            plan.planner_version
+        );
+    }
+
+    let tx = conn.unchecked_transaction()?;
+    validate_plan_shape(plan)?;
+    for group in &plan.groups {
+        validate_group(&tx, plan, group)?;
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let mut affected = Vec::new();
+    let mut current_ids = Vec::new();
+    let mut stale_ids = Vec::new();
+    let mut operation_ids = Vec::new();
+    let mut edge_count = 0usize;
+
+    for group in &plan.groups {
+        let current_ref = ObjectRef::memory(group.current_id);
+        let canonical = load_target(&tx, current_ref)?;
+        let current_snapshot = snapshot_for(&group.row_snapshots, group.current_id)?;
+        let new_owner = OwnerSnapshot {
+            source_project: canonical
+                .owner
+                .source_project
+                .clone()
+                .or_else(|| canonical.project.clone()),
+            target_project: Some(plan.project.clone()),
+            owner_scope: Some("repo".to_string()),
+            owner_key: Some(plan.project.clone()),
+            topic_domain: canonical.owner.topic_domain.clone(),
+            routing_confidence: canonical.owner.routing_confidence,
+            routing_reason: canonical.owner.routing_reason.clone(),
+            context_class: canonical.owner.context_class.clone(),
+        };
+        let merged = group.merged_content.as_deref();
+        let updated = tx.execute(
+            "UPDATE memories
+             SET content = COALESCE(?1, content),
+                 status = 'active',
+                 source_project = COALESCE(source_project, project),
+                 target_project = ?2,
+                 owner_scope = 'repo',
+                 owner_key = ?2,
+                 updated_at_epoch = ?3
+             WHERE id = ?4",
+            params![merged, plan.project, now, group.current_id],
+        )?;
+        if updated != 1 {
+            bail!(
+                "failed to update cleanup current memory {}",
+                group.current_id
+            );
+        }
+        current_ids.push(group.current_id);
+        affected.push(ObjectMutation {
+            object_ref: current_ref.to_string(),
+            title: canonical.title.clone(),
+            previous_status: canonical.status.clone(),
+            new_status: "active".to_string(),
+            previous_owner: canonical.owner.clone(),
+            new_owner: new_owner.clone(),
+        });
+        insert_scope_cleanup_event(
+            &tx,
+            "memory-cleanup",
+            &canonical,
+            "active",
+            &new_owner,
+            Some(group.reason.as_str()),
+            now,
+        )?;
+
+        if let Some(state_key_id) = current_snapshot.state_key_id {
+            tx.execute(
+                "UPDATE memory_state_keys
+                 SET current_memory_id = ?1, updated_at_epoch = ?2
+                 WHERE id = ?3",
+                params![group.current_id, now, state_key_id],
+            )?;
+        }
+
+        for stale_id in &group.stale_ids {
+            let stale_ref = ObjectRef::memory(*stale_id);
+            let target = load_target(&tx, stale_ref)?;
+            let updated = tx.execute(
+                "UPDATE memories SET status = 'stale', updated_at_epoch = ?1 WHERE id = ?2",
+                params![now, stale_id],
+            )?;
+            if updated != 1 {
+                bail!("failed to stale cleanup memory {stale_id}");
+            }
+            stale_ids.push(*stale_id);
+            affected.push(ObjectMutation {
+                object_ref: stale_ref.to_string(),
+                title: target.title.clone(),
+                previous_status: target.status.clone(),
+                new_status: "stale".to_string(),
+                previous_owner: target.owner.clone(),
+                new_owner: target.owner.clone(),
+            });
+            insert_scope_cleanup_event(
+                &tx,
+                "memory-cleanup",
+                &target,
+                "stale",
+                &target.owner,
+                Some("duplicate preference superseded by cleanup plan"),
+                now,
+            )?;
+        }
+
+        let operation_id = insert_cleanup_operation_log(&tx, plan, group)?;
+        operation_ids.push(operation_id);
+        edge_count += crate::memory::edge::insert_replacement_edges(
+            &tx,
+            crate::memory::edge::MemoryEdgeType::Duplicates,
+            &group.stale_ids,
+            group.current_id,
+            crate::memory::edge::MemoryEdgeWriteContext {
+                state_key_id: current_snapshot.state_key_id,
+                source_operation_id: Some(operation_id),
+                confidence: Some(group.confidence),
+                reason: Some(group.reason.as_str()),
+                ..Default::default()
+            },
+        )?;
+    }
+
+    tx.commit()?;
+    Ok(MemoryCleanupApplyResult {
+        project: plan.project.clone(),
+        planner_version: plan.planner_version.clone(),
+        groups_applied: plan.groups.len(),
+        current_ids,
+        stale_ids,
+        operation_ids,
+        edge_count,
+        affected,
+    })
+}
+
+fn validate_plan_shape(plan: &MemoryCleanupPlan) -> Result<()> {
+    let mut ids = HashSet::new();
+    for group in &plan.groups {
+        for id in std::iter::once(group.current_id).chain(group.stale_ids.iter().copied()) {
+            if !ids.insert(id) {
+                bail!("cleanup plan lists memory:{id} in more than one action");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_group(
+    conn: &Connection,
+    plan: &MemoryCleanupPlan,
+    group: &MemoryCleanupGroup,
+) -> Result<()> {
+    if group.stale_ids.contains(&group.current_id) {
+        bail!(
+            "cleanup group {} lists current id {} as stale",
+            group.cluster_key,
+            group.current_id
+        );
+    }
+    if group.memory_type != "preference" {
+        bail!(
+            "unsupported cleanup group memory type {}",
+            group.memory_type
+        );
+    }
+    let mut expected_ids = group.stale_ids.clone();
+    expected_ids.push(group.current_id);
+    expected_ids.sort_unstable();
+    expected_ids.dedup();
+    let mut snapshot_ids = group
+        .row_snapshots
+        .iter()
+        .map(|snapshot| snapshot.id)
+        .collect::<Vec<_>>();
+    snapshot_ids.sort_unstable();
+    snapshot_ids.dedup();
+    if snapshot_ids != expected_ids {
+        bail!(
+            "cleanup group {} row snapshots do not match current/stale ids",
+            group.cluster_key
+        );
+    }
+
+    for snapshot in &group.row_snapshots {
+        let current = load_row_snapshot(conn, snapshot.id)?
+            .ok_or_else(|| anyhow!("cleanup plan row {} no longer exists", snapshot.id))?;
+        if &current != snapshot {
+            bail!(
+                "cleanup plan row {} changed since dry-run; refresh the plan before applying",
+                snapshot.id
+            );
+        }
+        if snapshot.status != "active" {
+            bail!("cleanup plan row {} is no longer active", snapshot.id);
+        }
+        if snapshot.memory_type != group.memory_type {
+            bail!(
+                "cleanup plan row {} type {} does not match group type {}",
+                snapshot.id,
+                snapshot.memory_type,
+                group.memory_type
+            );
+        }
+        if !snapshot.belongs_to_project(&plan.project) {
+            bail!(
+                "cleanup plan row {} does not belong to project {}",
+                snapshot.id,
+                plan.project
+            );
+        }
+    }
+    Ok(())
+}
+
+fn insert_cleanup_operation_log(
+    conn: &Connection,
+    plan: &MemoryCleanupPlan,
+    group: &MemoryCleanupGroup,
+) -> Result<i64> {
+    let current = snapshot_for(&group.row_snapshots, group.current_id)?;
+    let mut operation_plan = MemoryOperationPlan::new(
+        MemoryLifecycleOp::Update,
+        group.state_key.clone(),
+        group.reason.clone(),
+    )
+    .with_target_memory_id(Some(group.current_id))
+    .with_superseded_ids(group.stale_ids.clone());
+    operation_plan.planner_version = CLEANUP_PLANNER_VERSION;
+    let input = MemoryOperationInput {
+        source: "memory_cleanup".to_string(),
+        actor: "memory_cleanup".to_string(),
+        source_project: plan.project.clone(),
+        owner_scope: group
+            .owner_scope
+            .clone()
+            .unwrap_or_else(|| "repo".to_string()),
+        owner_key: group
+            .owner_key
+            .clone()
+            .unwrap_or_else(|| plan.project.clone()),
+        memory_type: group.memory_type.clone(),
+        topic_key: current.topic_key.clone(),
+        state_key: group.state_key.clone(),
+        source_candidate_id: None,
+        confidence: Some(group.confidence),
+    };
+    insert_operation_log(conn, &input, &operation_plan, Some(group.current_id))
+}
+
+fn load_row_snapshots(conn: &Connection, ids: &[i64]) -> Result<Vec<MemoryCleanupRowSnapshot>> {
+    ids.iter()
+        .copied()
+        .map(|id| {
+            load_row_snapshot(conn, id)?
+                .ok_or_else(|| anyhow!("cleanup plan target memory:{id} not found"))
+        })
+        .collect()
+}
+
+fn load_row_snapshot(conn: &Connection, id: i64) -> Result<Option<MemoryCleanupRowSnapshot>> {
+    conn.query_row(
+        "SELECT m.id, m.status, m.content, m.updated_at_epoch, m.owner_scope,
+                m.owner_key, m.memory_type, m.topic_key, m.state_key_id, sk.state_key,
+                sk.current_memory_id, m.project, m.scope, m.source_project, m.target_project
+         FROM memories m
+         LEFT JOIN memory_state_keys sk ON sk.id = m.state_key_id
+         WHERE m.id = ?1",
+        params![id],
+        |row| {
+            let content: String = row.get(2)?;
+            Ok(MemoryCleanupRowSnapshot {
+                id: row.get(0)?,
+                status: row.get(1)?,
+                content_sha256: content_sha256(&content),
+                updated_at_epoch: row.get(3)?,
+                owner_scope: row.get(4)?,
+                owner_key: row.get(5)?,
+                memory_type: row.get(6)?,
+                topic_key: row.get(7)?,
+                state_key_id: row.get(8)?,
+                state_key: row.get(9)?,
+                current_memory_id: row.get(10)?,
+                project: row.get(11)?,
+                scope: row.get(12)?,
+                source_project: row.get(13)?,
+                target_project: row.get(14)?,
+            })
+        },
+    )
+    .optional()
+    .with_context(|| format!("load cleanup plan row snapshot for memory:{id}"))
+}
+
+impl MemoryCleanupRowSnapshot {
+    fn belongs_to_project(&self, project: &str) -> bool {
+        self.source_project.as_deref() == Some(project)
+            || self.target_project.as_deref() == Some(project)
+            || (self.owner_scope.as_deref() == Some("repo")
+                && self.owner_key.as_deref() == Some(project))
+            || (self.owner_scope.is_none()
+                && self.project == project
+                && self.scope.as_deref().unwrap_or("project") != "global")
+    }
+}
+
+fn snapshot_for(
+    snapshots: &[MemoryCleanupRowSnapshot],
+    id: i64,
+) -> Result<&MemoryCleanupRowSnapshot> {
+    snapshots
+        .iter()
+        .find(|snapshot| snapshot.id == id)
+        .ok_or_else(|| anyhow!("cleanup plan missing snapshot for memory:{id}"))
+}
+
+fn content_sha256(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("{:x}", hasher.finalize())
+}

--- a/src/memory/scope_cleanup/tests.rs
+++ b/src/memory/scope_cleanup/tests.rs
@@ -302,7 +302,7 @@ fn stash_pollution_audit_classifies_cleanup_buckets() -> Result<()> {
         .duplicate_preferences
         .iter()
         .any(|cluster| cluster.cluster_key == "ui-critique"
-            && cluster.canonical_ref == "memory:1030"
+            && cluster.canonical_ref == "memory:1032"
             && cluster.refs.contains(&"memory:1030".to_string())
             && cluster.refs.contains(&"memory:1032".to_string())
             && !cluster.refs.contains(&"memory:1033".to_string())));
@@ -602,7 +602,7 @@ fn merge_preferences_keeps_one_active_preference_with_merged_content() -> Result
     )?;
     assert!(preview.dry_run);
     assert_eq!(preview.clusters.len(), 1);
-    assert_eq!(preview.clusters[0].canonical_ref, "memory:1030");
+    assert_eq!(preview.clusters[0].canonical_ref, "memory:1032");
     let merged = preview.clusters[0].merged_content.as_deref().unwrap();
     assert!(merged.contains("direct UI critique"));
     assert!(merged.contains("avoid decorative fluff"));
@@ -627,7 +627,7 @@ fn merge_preferences_keeps_one_active_preference_with_merged_content() -> Result
     let canonical_mutation = applied
         .affected
         .iter()
-        .find(|mutation| mutation.object_ref == "memory:1030")
+        .find(|mutation| mutation.object_ref == "memory:1032")
         .expect("canonical mutation should be reported");
     assert_eq!(
         canonical_mutation.new_owner.owner_scope.as_deref(),
@@ -635,7 +635,7 @@ fn merge_preferences_keeps_one_active_preference_with_merged_content() -> Result
     );
     let canonical: (String, String, String, String, String) = conn.query_row(
         "SELECT status, content, owner_scope, owner_key, target_project
-         FROM memories WHERE id = 1030",
+         FROM memories WHERE id = 1032",
         [],
         |row| {
             Ok((
@@ -654,7 +654,7 @@ fn merge_preferences_keeps_one_active_preference_with_merged_content() -> Result
     assert_eq!(canonical.2, "repo");
     assert_eq!(canonical.3, STASH);
     assert_eq!(canonical.4, STASH);
-    for id in [1031, 1032] {
+    for id in [1030, 1031] {
         assert_eq!(
             conn.query_row(
                 "SELECT status, source_project FROM memories WHERE id = ?1",
@@ -703,8 +703,8 @@ fn merge_preferences_keeps_one_active_preference_with_merged_content() -> Result
     assert_eq!(
         duplicate_edges,
         vec![
-            (1031, 1030, "duplicates".to_string()),
-            (1032, 1030, "duplicates".to_string())
+            (1030, 1032, "duplicates".to_string()),
+            (1031, 1032, "duplicates".to_string())
         ]
     );
     Ok(())

--- a/src/memory/scope_cleanup/tests.rs
+++ b/src/memory/scope_cleanup/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::memory;
 use anyhow::Result;
 use rusqlite::{params, Connection};
+mod plan;
 
 const STASH: &str = "/Users/lifcc/Desktop/code/AI/tool/stash";
 const NOW: i64 = 1_780_000_000;

--- a/src/memory/scope_cleanup/tests/plan.rs
+++ b/src/memory/scope_cleanup/tests/plan.rs
@@ -1,0 +1,248 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use crate::memory::scope_cleanup::{
+    apply_memory_cleanup_plan, build_preference_cleanup_plan, MemoryCleanupPlan,
+};
+
+use super::{seed_stash_pollution, setup_conn, STASH};
+
+#[test]
+fn cleanup_plan_detects_ascii_and_cjk_duplicates_without_mutation() -> Result<()> {
+    let conn = setup_conn();
+    insert_pref(
+        &conn,
+        2100,
+        STASH,
+        "Preference: verify before claim",
+        "Always run fresh verification before claiming completion.",
+        Some("pref-a"),
+        "repo",
+        STASH,
+    )?;
+    insert_pref(
+        &conn,
+        2101,
+        STASH,
+        "Preference: fresh verification",
+        "Always run fresh verification before claiming completion.",
+        Some("pref-b"),
+        "repo",
+        STASH,
+    )?;
+    insert_pref(
+        &conn,
+        2110,
+        STASH,
+        "Preference: 中文验收",
+        "提交前必须运行最新测试并说明结果。",
+        Some("pref-c"),
+        "repo",
+        STASH,
+    )?;
+    insert_pref(
+        &conn,
+        2111,
+        STASH,
+        "Preference: 测试说明",
+        "提交前必须运行最新测试并说明结果。",
+        Some("pref-d"),
+        "repo",
+        STASH,
+    )?;
+
+    let plan = build_preference_cleanup_plan(&conn, STASH)?;
+
+    assert_eq!(plan.groups.len(), 2);
+    assert!(plan
+        .groups
+        .iter()
+        .any(|group| group.current_id == 2100 && group.stale_ids == vec![2101]));
+    assert!(plan
+        .groups
+        .iter()
+        .any(|group| group.current_id == 2110 && group.stale_ids == vec![2111]));
+    assert_active(&conn, &[2100, 2101, 2110, 2111])?;
+    Ok(())
+}
+
+#[test]
+fn cleanup_apply_stales_plan_ids_and_writes_audit() -> Result<()> {
+    let conn = setup_conn();
+    seed_stash_pollution(&conn);
+
+    let plan = build_preference_cleanup_plan(&conn, STASH)?;
+    let encoded = serde_json::to_string_pretty(&plan)?;
+    let decoded: MemoryCleanupPlan = serde_json::from_str(&encoded)?;
+    assert_eq!(decoded, plan);
+
+    let result = apply_memory_cleanup_plan(&conn, &decoded)?;
+
+    assert_eq!(result.groups_applied, 1);
+    assert_eq!(result.current_ids, vec![1030]);
+    assert_eq!(result.stale_ids, vec![1031, 1032]);
+    assert_eq!(
+        conn.query_row("SELECT status FROM memories WHERE id = 1030", [], |row| {
+            row.get::<_, String>(0)
+        })?,
+        "active"
+    );
+    for id in [1031, 1032] {
+        assert_eq!(
+            conn.query_row("SELECT status FROM memories WHERE id = ?1", [id], |row| {
+                row.get::<_, String>(0)
+            })?,
+            "stale"
+        );
+    }
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM memory_operation_log
+             WHERE source = 'memory_cleanup' AND planner_version = 'memory-cleanup-v1'",
+            [],
+            |row| row.get::<_, i64>(0)
+        )?,
+        1
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM memory_edges
+             WHERE edge_type = 'duplicates' AND source_operation_id IS NOT NULL",
+            [],
+            |row| row.get::<_, i64>(0)
+        )?,
+        2
+    );
+    Ok(())
+}
+
+#[test]
+fn cleanup_apply_rejects_changed_rows() -> Result<()> {
+    let conn = setup_conn();
+    seed_stash_pollution(&conn);
+    let plan = build_preference_cleanup_plan(&conn, STASH)?;
+
+    conn.execute(
+        "UPDATE memories SET content = ?1, updated_at_epoch = updated_at_epoch + 1 WHERE id = 1031",
+        ["changed after dry-run"],
+    )?;
+    let err = apply_memory_cleanup_plan(&conn, &plan).expect_err("changed rows must be rejected");
+
+    assert!(err.to_string().contains("changed since dry-run"));
+    assert_active(&conn, &[1030, 1031, 1032])?;
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM memory_operation_log", [], |row| {
+            row.get::<_, i64>(0)
+        })?,
+        0
+    );
+    Ok(())
+}
+
+#[test]
+fn cleanup_apply_rejects_plan_project_mismatch() -> Result<()> {
+    let conn = setup_conn();
+    seed_stash_pollution(&conn);
+    let mut plan = build_preference_cleanup_plan(&conn, STASH)?;
+    plan.project = "/tmp/other-project".to_string();
+
+    let err = apply_memory_cleanup_plan(&conn, &plan).expect_err("project mismatch must fail");
+
+    assert!(err.to_string().contains("does not belong to project"));
+    assert_active(&conn, &[1030, 1031, 1032])?;
+    Ok(())
+}
+
+#[test]
+fn cleanup_plan_keeps_cross_owner_preferences_separate() -> Result<()> {
+    let conn = setup_conn();
+    insert_pref(
+        &conn,
+        2200,
+        STASH,
+        "Preference: verify before claim",
+        "Always run fresh verification before claiming completion.",
+        Some("pref-a"),
+        "repo",
+        STASH,
+    )?;
+    insert_pref(
+        &conn,
+        2201,
+        STASH,
+        "Preference: fresh verification",
+        "Always run fresh verification before claiming completion.",
+        Some("pref-b"),
+        "repo",
+        STASH,
+    )?;
+    insert_pref(
+        &conn,
+        2210,
+        STASH,
+        "Preference: global verification",
+        "Always run fresh verification before claiming completion.",
+        Some("pref-c"),
+        "user",
+        "user:default",
+    )?;
+
+    let plan = build_preference_cleanup_plan(&conn, STASH)?;
+
+    assert_eq!(plan.groups.len(), 1);
+    assert_eq!(plan.groups[0].current_id, 2200);
+    assert_eq!(plan.groups[0].stale_ids, vec![2201]);
+    assert_eq!(
+        plan.groups[0].owner_key.as_deref(),
+        Some(STASH),
+        "global preference must not be merged into repo cleanup"
+    );
+    Ok(())
+}
+
+fn insert_pref(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    title: &str,
+    content: &str,
+    topic_key: Option<&str>,
+    owner_scope: &str,
+    owner_key: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO memories
+         (id, project, topic_key, title, content, memory_type, created_at_epoch,
+          updated_at_epoch, status, scope, source_project, target_project, owner_scope,
+          owner_key, routing_confidence, context_class)
+         VALUES (?1, ?2, ?3, ?4, ?5, 'preference', 100, 100, 'active',
+                 'project', ?2, ?6, ?7, ?8, 1.0, 'startup_core')",
+        params![
+            id,
+            project,
+            topic_key,
+            title,
+            content,
+            if owner_scope == "repo" {
+                Some(project)
+            } else {
+                None
+            },
+            owner_scope,
+            owner_key
+        ],
+    )?;
+    Ok(())
+}
+
+fn assert_active(conn: &Connection, ids: &[i64]) -> Result<()> {
+    for id in ids {
+        assert_eq!(
+            conn.query_row("SELECT status FROM memories WHERE id = ?1", [id], |row| {
+                row.get::<_, String>(0)
+            })?,
+            "active"
+        );
+    }
+    Ok(())
+}

--- a/src/memory/scope_cleanup/tests/plan.rs
+++ b/src/memory/scope_cleanup/tests/plan.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
 use rusqlite::{params, Connection};
+use sha2::{Digest, Sha256};
 
 use crate::memory::scope_cleanup::{
     apply_memory_cleanup_plan, build_preference_cleanup_plan, MemoryCleanupPlan,
+    MemoryCleanupRowSnapshot,
 };
 
 use super::{seed_stash_pollution, setup_conn, STASH};
@@ -57,11 +59,11 @@ fn cleanup_plan_detects_ascii_and_cjk_duplicates_without_mutation() -> Result<()
     assert!(plan
         .groups
         .iter()
-        .any(|group| group.current_id == 2100 && group.stale_ids == vec![2101]));
+        .any(|group| group.current_id == 2101 && group.stale_ids == vec![2100]));
     assert!(plan
         .groups
         .iter()
-        .any(|group| group.current_id == 2110 && group.stale_ids == vec![2111]));
+        .any(|group| group.current_id == 2111 && group.stale_ids == vec![2110]));
     assert_active(&conn, &[2100, 2101, 2110, 2111])?;
     Ok(())
 }
@@ -79,15 +81,15 @@ fn cleanup_apply_stales_plan_ids_and_writes_audit() -> Result<()> {
     let result = apply_memory_cleanup_plan(&conn, &decoded)?;
 
     assert_eq!(result.groups_applied, 1);
-    assert_eq!(result.current_ids, vec![1030]);
-    assert_eq!(result.stale_ids, vec![1031, 1032]);
+    assert_eq!(result.current_ids, vec![1032]);
+    assert_eq!(result.stale_ids, vec![1030, 1031]);
     assert_eq!(
-        conn.query_row("SELECT status FROM memories WHERE id = 1030", [], |row| {
+        conn.query_row("SELECT status FROM memories WHERE id = 1032", [], |row| {
             row.get::<_, String>(0)
         })?,
         "active"
     );
-    for id in [1031, 1032] {
+    for id in [1030, 1031] {
         assert_eq!(
             conn.query_row("SELECT status FROM memories WHERE id = ?1", [id], |row| {
                 row.get::<_, String>(0)
@@ -154,6 +156,59 @@ fn cleanup_apply_rejects_plan_project_mismatch() -> Result<()> {
 }
 
 #[test]
+fn cleanup_apply_rejects_hand_edited_cross_owner_group() -> Result<()> {
+    let conn = setup_conn();
+    insert_pref(
+        &conn,
+        2200,
+        STASH,
+        "Preference: verify before claim",
+        "Always run fresh verification before claiming completion.",
+        Some("pref-a"),
+        "repo",
+        STASH,
+    )?;
+    insert_pref(
+        &conn,
+        2201,
+        STASH,
+        "Preference: fresh verification",
+        "Always run fresh verification before claiming completion.",
+        Some("pref-b"),
+        "repo",
+        STASH,
+    )?;
+    insert_pref(
+        &conn,
+        2210,
+        STASH,
+        "Preference: global verification",
+        "Always run fresh verification before claiming completion.",
+        Some("pref-c"),
+        "user",
+        "user:default",
+    )?;
+    let mut plan = build_preference_cleanup_plan(&conn, STASH)?;
+    let group = plan.groups.first_mut().expect("repo duplicate group");
+    group.stale_ids.push(2210);
+    group.row_snapshots.push(snapshot_for_test(
+        2210,
+        STASH,
+        "Always run fresh verification before claiming completion.",
+        Some("pref-c"),
+        Some("user"),
+        Some("user:default"),
+        None,
+    ));
+
+    let err = apply_memory_cleanup_plan(&conn, &plan).expect_err("cross-owner plan must fail");
+
+    assert!(err.to_string().contains("owner does not match"));
+    assert_active(&conn, &[2200, 2201, 2210])?;
+    Ok(())
+}
+
+#[test]
 fn cleanup_plan_keeps_cross_owner_preferences_separate() -> Result<()> {
     let conn = setup_conn();
     insert_pref(
@@ -190,14 +245,48 @@ fn cleanup_plan_keeps_cross_owner_preferences_separate() -> Result<()> {
     let plan = build_preference_cleanup_plan(&conn, STASH)?;
 
     assert_eq!(plan.groups.len(), 1);
-    assert_eq!(plan.groups[0].current_id, 2200);
-    assert_eq!(plan.groups[0].stale_ids, vec![2201]);
+    assert_eq!(plan.groups[0].current_id, 2201);
+    assert_eq!(plan.groups[0].stale_ids, vec![2200]);
     assert_eq!(
         plan.groups[0].owner_key.as_deref(),
         Some(STASH),
         "global preference must not be merged into repo cleanup"
     );
     Ok(())
+}
+
+fn snapshot_for_test(
+    id: i64,
+    project: &str,
+    content: &str,
+    topic_key: Option<&str>,
+    owner_scope: Option<&str>,
+    owner_key: Option<&str>,
+    target_project: Option<&str>,
+) -> MemoryCleanupRowSnapshot {
+    MemoryCleanupRowSnapshot {
+        id,
+        project: project.to_string(),
+        scope: Some("project".to_string()),
+        source_project: Some(project.to_string()),
+        target_project: target_project.map(str::to_string),
+        status: "active".to_string(),
+        content_sha256: content_sha256(content),
+        updated_at_epoch: 100,
+        owner_scope: owner_scope.map(str::to_string),
+        owner_key: owner_key.map(str::to_string),
+        memory_type: "preference".to_string(),
+        topic_key: topic_key.map(str::to_string),
+        state_key_id: None,
+        state_key: None,
+        current_memory_id: None,
+    }
+}
+
+fn content_sha256(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("{:x}", hasher.finalize())
 }
 
 fn insert_pref(


### PR DESCRIPTION
## Summary
- add `remem memory cleanup` for dry-run-first preference cleanup plans
- write stable JSON cleanup plans with row snapshots, project/current/stale ids, reasons, and merged previews
- apply saved plans transactionally with snapshot validation, stale updates, operation log rows, duplicate edges, and scope cleanup events
- keep `merge-preferences` compatible by routing it through the new plan/apply path

Closes #292

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test scope_cleanup -- --test-threads=1`
- `cargo test cli_parses_scope_cleanup_commands -- --test-threads=1`
- `cargo check`
- `cargo clippy -- -D warnings`
- `REMEM_ALLOW_PLAINTEXT_DB=1 REMEM_DATA_DIR=$(mktemp -d /tmp/remem-pr292-cli.XXXXXX) cargo run --quiet -- memory cleanup --cwd <temp-fixture> --type preference --dry-run --json`
- `REMEM_DATA_DIR=$(mktemp -d /tmp/remem-pr292-full.XXXXXX) cargo test -- --test-threads=1`