### PR TITLE
fix(context): surface current-view diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.33"
+version = "0.4.34"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,6 @@
 pub mod claude_memory;
+mod debug;
+mod diagnostics;
 mod format;
 mod host;
 mod injection_gate;

--- a/src/context/debug.rs
+++ b/src/context/debug.rs
@@ -1,0 +1,221 @@
+use super::format::truncate_chars_with_ellipsis;
+use super::policy::ContextPolicy;
+use super::render::ContextRenderStats;
+use super::types::{ContextRequest, LoadedContext};
+
+pub(in crate::context) fn build_context_debug_trace(
+    request: &ContextRequest,
+    policy: &ContextPolicy,
+    loaded: &LoadedContext,
+    stats: &ContextRenderStats,
+) -> String {
+    let mut trace = String::from("## Debug Trace\n");
+    trace.push_str(&format!(
+        "- request host={} project={} cwd={} branch={} session={} source={}\n",
+        request.host.as_env_value(),
+        request.project,
+        request.cwd,
+        request.current_branch.as_deref().unwrap_or("-"),
+        request.session_id.as_deref().unwrap_or("-"),
+        request.hook_source.as_deref().unwrap_or("-")
+    ));
+    trace.push_str(&format!(
+        "- limits total={} core_items={} core_chars={} lessons={} lesson_chars={} index_items={} index_chars={} sessions={} preferences(project={}, global={}, chars={})\n",
+        policy.limits.total_char_limit,
+        policy.limits.core_item_limit,
+        policy.limits.core_char_limit,
+        policy.limits.lesson_limit,
+        policy.limits.lesson_char_limit,
+        policy.limits.memory_index_limit,
+        policy.limits.memory_index_char_limit,
+        policy.limits.session_limit,
+        policy.limits.preference_project_limit,
+        policy.limits.preference_global_limit,
+        policy.limits.preference_char_limit
+    ));
+    trace.push_str(&format!(
+        "- rendered core={} lessons={} index={} preferences={} sessions={} workstreams={}\n",
+        stats.core.count,
+        stats.lessons.count,
+        stats.index.count,
+        stats.preferences.count,
+        stats.sessions.count,
+        stats.workstreams.count
+    ));
+    trace.push_str(&format!(
+        "- rendered_chars core={} lessons={} index={} preferences={} sessions={} workstreams={}\n",
+        stats.core.chars,
+        stats.lessons.chars,
+        stats.index.chars,
+        stats.preferences.chars,
+        stats.sessions.chars,
+        stats.workstreams.chars
+    ));
+    trace.push_str(&format!(
+        "- context diagnostics candidate_pool_total={} current_rows={} selected_ids=[{}]\n",
+        loaded.diagnostics.candidate_pool_total,
+        loaded.diagnostics.current_rows,
+        format_id_list(&loaded.diagnostics.selected_ids)
+    ));
+    for group in &loaded.diagnostics.hidden_duplicate_groups {
+        trace.push_str(&format!(
+            "- hidden duplicate group key={} chosen=#{} hidden=[{}] reason=near_duplicate_legacy_rows\n",
+            group.cluster_key,
+            group.chosen_id,
+            format_id_list(&group.hidden_ids)
+        ));
+    }
+    trace.push_str(&format!(
+        "- preference diagnostics selected_ids=[{}]\n",
+        format_id_list(&loaded.diagnostics.preference_selected_ids)
+    ));
+    for group in &loaded.diagnostics.preference_hidden_duplicate_groups {
+        trace.push_str(&format!(
+            "- hidden preference duplicate group key={} chosen=#{} hidden=[{}] reason=same_owner_topic_key\n",
+            group.cluster_key,
+            group.chosen_id,
+            format_id_list(&group.hidden_ids)
+        ));
+    }
+    for group in &loaded.diagnostics.preference_state_key_groups {
+        trace.push_str(&format!(
+            "- preference state-key group owner={}:{} type={} key={} current={} active=[{}] reason={}\n",
+            group.owner_scope,
+            group.owner_key,
+            group.memory_type,
+            group.state_key,
+            group
+                .current_id
+                .map(|id| format!("#{id}"))
+                .unwrap_or_else(|| "-".to_string()),
+            format_id_list(&group.active_ids),
+            group.reason
+        ));
+    }
+    for group in &loaded.diagnostics.state_key_groups {
+        trace.push_str(&format!(
+            "- state-key group owner={}:{} type={} key={} current={} active=[{}] reason={}\n",
+            group.owner_scope,
+            group.owner_key,
+            group.memory_type,
+            group.state_key,
+            group
+                .current_id
+                .map(|id| format!("#{id}"))
+                .unwrap_or_else(|| "-".to_string()),
+            format_id_list(&group.active_ids),
+            group.reason
+        ));
+    }
+    for exclusion in &loaded.diagnostics.exclusions {
+        trace.push_str(&format!(
+            "- excluded memory id={} reason={} status={} title={}\n",
+            exclusion.id,
+            exclusion.reason,
+            exclusion.status,
+            truncate_chars_with_ellipsis(&exclusion.title, 120)
+        ));
+    }
+    trace.push_str(&format!(
+        "- stats host={} branch={} source={}\n",
+        stats.host,
+        stats.branch.as_deref().unwrap_or("-"),
+        stats.hook_source.as_deref().unwrap_or("-")
+    ));
+    trace.push_str(&format!(
+        "- preferences project_rendered={} global_rendered={} reason=scope_limits_then_claude_md_dedup\n",
+        stats.project_preferences, stats.global_preferences
+    ));
+    trace.push_str(&format!(
+        "- owner counts repo={} user={} workspace={} tool={} domain={} workstream={} session={} legacy={} unknown={}\n",
+        stats.owner_counts.repo,
+        stats.owner_counts.user,
+        stats.owner_counts.workspace,
+        stats.owner_counts.tool,
+        stats.owner_counts.domain,
+        stats.owner_counts.workstream,
+        stats.owner_counts.session,
+        stats.owner_counts.legacy,
+        stats.owner_counts.unknown
+    ));
+    for trace_row in loaded.owner_traces.iter().take(60) {
+        trace.push_str(&format!(
+            "- owner {} id={} scope={} key={} source_project={} target_project={} domain={} context_class={} {} reason={} title={}\n",
+            trace_row.object_kind,
+            trace_row.id,
+            trace_row.owner_scope.as_deref().unwrap_or("-"),
+            trace_row.owner_key.as_deref().unwrap_or("-"),
+            trace_row.source_project.as_deref().unwrap_or("-"),
+            trace_row.target_project.as_deref().unwrap_or("-"),
+            trace_row.topic_domain.as_deref().unwrap_or("-"),
+            trace_row.context_class.as_deref().unwrap_or("-"),
+            if trace_row.included {
+                "included"
+            } else {
+                "excluded"
+            },
+            trace_row.reason,
+            truncate_chars_with_ellipsis(&trace_row.title, 120)
+        ));
+    }
+    if loaded.owner_traces.len() > 60 {
+        trace.push_str(&format!(
+            "- owner trace truncated: {} additional rows omitted\n",
+            loaded.owner_traces.len() - 60
+        ));
+    }
+    for (rank, lesson) in loaded.lessons.iter().enumerate() {
+        trace.push_str(&format!(
+            "- lesson rank={} id={} confidence={:.2} reinforced={} scope={} topic={} title={}\n",
+            rank + 1,
+            lesson.memory.id,
+            lesson.metadata.confidence,
+            lesson.metadata.reinforcement_count,
+            lesson.memory.scope,
+            lesson.memory.topic_key.as_deref().unwrap_or("-"),
+            truncate_chars_with_ellipsis(&lesson.memory.title, 120)
+        ));
+    }
+    for (rank, memory) in loaded.memories.iter().take(30).enumerate() {
+        let target = if stats.core_ids.contains(&memory.id) {
+            "core"
+        } else {
+            "index_candidate"
+        };
+        trace.push_str(&format!(
+            "- memory rank={} id={} type={} scope={} branch={} topic={} target={} reason=loaded_after_scope_branch_dedupe title={}\n",
+            rank + 1,
+            memory.id,
+            memory.memory_type,
+            memory.scope,
+            memory.branch.as_deref().unwrap_or("-"),
+            memory.topic_key.as_deref().unwrap_or("-"),
+            target,
+            truncate_chars_with_ellipsis(&memory.title, 120)
+        ));
+    }
+    if loaded.memories.len() > 30 {
+        trace.push_str(&format!(
+            "- memory trace truncated: {} additional candidates omitted\n",
+            loaded.memories.len() - 30
+        ));
+    }
+    for (rank, summary) in loaded
+        .summaries
+        .iter()
+        .take(policy.limits.session_limit)
+        .enumerate()
+    {
+        trace.push_str(&format!(
+            "- session rank={} reason=recent_after_cluster_filter request={}\n",
+            rank + 1,
+            truncate_chars_with_ellipsis(&summary.request, 120)
+        ));
+    }
+    trace.push('\n');
+    trace
+}
+
+fn format_id_list(ids: &[i64]) -> String {
+    ids.iter().map(i64::to_string).collect::<Vec<_>>().join(",")
+}

--- a/src/context/diagnostics.rs
+++ b/src/context/diagnostics.rs
@@ -1,0 +1,368 @@
+use anyhow::Result;
+use rusqlite::Connection;
+
+use crate::memory;
+
+use super::types::{
+    ContextDiagnostics, ContextExclusion, HiddenDuplicateGroup, StateKeyDiagnosticGroup,
+};
+
+pub(super) fn collect_context_diagnostics(
+    conn: &Connection,
+    project: &str,
+    excluded_types: &[&str],
+    selected_ids: Vec<i64>,
+    hidden_duplicate_groups: Vec<HiddenDuplicateGroup>,
+) -> ContextDiagnostics {
+    let candidate_pool_total = count_context_candidate_pool(conn, project, excluded_types)
+        .unwrap_or_else(|error| {
+            crate::log::error(
+                "context",
+                &format!("failed to count context candidate pool for {project}: {error}"),
+            );
+            0
+        });
+    let exclusions = query_context_lifecycle_exclusions(conn, project, excluded_types, 60)
+        .unwrap_or_else(|error| {
+            crate::log::error(
+                "context",
+                &format!("failed to load context lifecycle diagnostics for {project}: {error}"),
+            );
+            Vec::new()
+        });
+    let state_key_groups = query_state_key_diagnostics(conn, project, excluded_types, 60)
+        .unwrap_or_else(|error| {
+            crate::log::error(
+                "context",
+                &format!("failed to load context state-key diagnostics for {project}: {error}"),
+            );
+            Vec::new()
+        });
+
+    ContextDiagnostics {
+        candidate_pool_total,
+        current_rows: selected_ids.len(),
+        selected_ids,
+        hidden_duplicate_groups,
+        preference_selected_ids: Vec::new(),
+        preference_hidden_duplicate_groups: Vec::new(),
+        preference_state_key_groups: Vec::new(),
+        state_key_groups,
+        exclusions,
+    }
+}
+
+pub(super) fn apply_preference_diagnostics(
+    conn: &Connection,
+    project: &str,
+    rendered_ids: Vec<i64>,
+    diagnostics: &mut ContextDiagnostics,
+) {
+    diagnostics.preference_selected_ids = rendered_ids;
+    diagnostics.preference_hidden_duplicate_groups =
+        query_preference_topic_duplicate_groups(conn, project, 60).unwrap_or_else(|error| {
+            crate::log::error(
+                "context",
+                &format!("failed to load preference duplicate diagnostics for {project}: {error}"),
+            );
+            Vec::new()
+        });
+    diagnostics.preference_state_key_groups =
+        query_preference_state_key_diagnostics(conn, project, 60).unwrap_or_else(|error| {
+            crate::log::error(
+                "context",
+                &format!("failed to load preference state-key diagnostics for {project}: {error}"),
+            );
+            Vec::new()
+        });
+}
+
+fn count_context_candidate_pool(
+    conn: &Connection,
+    project: &str,
+    excluded_types: &[&str],
+) -> Result<usize> {
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    super::query::push_owner_included_filter(project, &mut idx, &mut conditions, &mut params);
+    super::query::push_excluded_type_filter(excluded_types, &mut idx, &mut conditions, &mut params);
+
+    let sql = format!(
+        "SELECT COUNT(*) FROM memories WHERE {}",
+        conditions.join(" AND ")
+    );
+    let refs = crate::db::to_sql_refs(&params);
+    let count = conn.query_row(&sql, refs.as_slice(), |row| row.get::<_, i64>(0))?;
+    Ok(count.max(0) as usize)
+}
+
+fn query_context_lifecycle_exclusions(
+    conn: &Connection,
+    project: &str,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<ContextExclusion>> {
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    super::query::push_owner_included_filter(project, &mut idx, &mut conditions, &mut params);
+    super::query::push_excluded_type_filter(excluded_types, &mut idx, &mut conditions, &mut params);
+    conditions.push(
+        "(status IN ('stale', 'superseded') \
+          OR (status = 'active' AND expires_at_epoch IS NOT NULL \
+              AND expires_at_epoch <= CAST(strftime('%s', 'now') AS INTEGER)))"
+            .to_string(),
+    );
+    params.push(Box::new(limit));
+
+    let sql = format!(
+        "SELECT id, title, status, expires_at_epoch FROM memories \
+         WHERE {} ORDER BY updated_at_epoch DESC LIMIT ?{}",
+        conditions.join(" AND "),
+        idx,
+    );
+    let refs = crate::db::to_sql_refs(&params);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        let status: String = row.get(2)?;
+        let expires_at_epoch: Option<i64> = row.get(3)?;
+        let reason = if status == "superseded" {
+            "superseded"
+        } else if status != "active" {
+            "stale"
+        } else if expires_at_epoch.is_some() {
+            "expired"
+        } else {
+            "stale"
+        };
+        Ok(ContextExclusion {
+            id: row.get(0)?,
+            title: row.get(1)?,
+            reason,
+            status,
+        })
+    })?;
+    crate::db::query::collect_rows(rows)
+}
+
+fn query_preference_topic_duplicate_groups(
+    conn: &Connection,
+    project: &str,
+    limit: usize,
+) -> Result<Vec<HiddenDuplicateGroup>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let sql = format!(
+        "SELECT
+            COALESCE(m.owner_scope, CASE WHEN m.scope = 'global' THEN 'legacy_global' ELSE 'legacy_project' END)
+            || ':' ||
+            COALESCE(m.owner_key, CASE WHEN m.scope = 'global' THEN 'global' ELSE m.project END)
+            || ':topic:' || m.topic_key AS cluster_key,
+            m.id
+         FROM memories m
+         WHERE m.memory_type = 'preference'
+           AND {}
+           AND {}
+           AND m.topic_key IS NOT NULL
+           AND {}
+         ORDER BY cluster_key ASC, m.updated_at_epoch DESC, m.id DESC
+         LIMIT ?2",
+        memory::memory_current_filter_sql("m.status", "m.expires_at_epoch", false),
+        memory::memory_state_key_current_filter_sql("m"),
+        preference_context_owner_filter_sql("m"),
+    );
+    let row_limit = (limit * 8).max(limit);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params![project, row_limit as i64], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    let rows = crate::db::query::collect_rows(rows)?;
+    Ok(build_duplicate_groups(rows, limit))
+}
+
+fn query_preference_state_key_diagnostics(
+    conn: &Connection,
+    project: &str,
+    limit: i64,
+) -> Result<Vec<StateKeyDiagnosticGroup>> {
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
+    let sql = format!(
+        "SELECT sk.owner_scope, sk.owner_key, sk.memory_type, sk.state_key,
+                sk.current_memory_id, GROUP_CONCAT(m.id), COUNT(*),
+                MAX(m.updated_at_epoch)
+         FROM memories m
+         JOIN memory_state_keys sk ON sk.id = m.state_key_id
+         WHERE m.memory_type = 'preference'
+           AND {}
+           AND {}
+         GROUP BY sk.id
+         HAVING COUNT(*) > 1
+         ORDER BY MAX(m.updated_at_epoch) DESC
+         LIMIT ?2",
+        memory::memory_current_filter_sql("m.status", "m.expires_at_epoch", false),
+        preference_context_owner_filter_sql("m"),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params![project, limit], |row| {
+        let id_list: String = row.get(5)?;
+        let mut active_ids = parse_id_list(&id_list).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    error.to_string(),
+                )),
+            )
+        })?;
+        active_ids.sort_unstable();
+        Ok(StateKeyDiagnosticGroup {
+            owner_scope: row.get(0)?,
+            owner_key: row.get(1)?,
+            memory_type: row.get(2)?,
+            state_key: row.get(3)?,
+            current_id: row.get(4)?,
+            active_ids,
+            reason: "ambiguous_active_state_key_group",
+        })
+    })?;
+    crate::db::query::collect_rows(rows)
+}
+
+fn query_state_key_diagnostics(
+    conn: &Connection,
+    project: &str,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<StateKeyDiagnosticGroup>> {
+    if limit <= 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+        Box::new(project.to_string()),
+        Box::new(project.to_string()),
+        Box::new(project.to_string()),
+    ];
+    let mut excluded_filter = String::new();
+    for memory_type in excluded_types {
+        let idx = params.len() + 1;
+        excluded_filter.push_str(&format!(" AND m.memory_type <> ?{idx}"));
+        params.push(Box::new((*memory_type).to_string()));
+    }
+    let limit_idx = params.len() + 1;
+    params.push(Box::new(limit));
+
+    let sql = format!(
+        "SELECT sk.owner_scope, sk.owner_key, sk.memory_type, sk.state_key,
+                sk.current_memory_id, GROUP_CONCAT(m.id), COUNT(*),
+                MAX(m.updated_at_epoch)
+         FROM memories m
+         JOIN memory_state_keys sk ON sk.id = m.state_key_id
+         WHERE ((m.owner_scope = 'repo' AND m.owner_key = ?1)
+                OR (m.owner_scope = 'repo' AND m.target_project = ?2)
+                OR (m.owner_scope IS NULL AND m.project = ?3
+                    AND COALESCE(m.scope, 'project') != 'global'))
+           AND m.status = 'active'
+           AND (m.expires_at_epoch IS NULL
+                OR m.expires_at_epoch > CAST(strftime('%s', 'now') AS INTEGER))
+           {excluded_filter}
+         GROUP BY sk.id
+         HAVING COUNT(*) > 1
+         ORDER BY MAX(m.updated_at_epoch) DESC
+         LIMIT ?{limit_idx}"
+    );
+    let refs = crate::db::to_sql_refs(&params);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        let id_list: String = row.get(5)?;
+        let mut active_ids = parse_id_list(&id_list).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    error.to_string(),
+                )),
+            )
+        })?;
+        active_ids.sort_unstable();
+        Ok(StateKeyDiagnosticGroup {
+            owner_scope: row.get(0)?,
+            owner_key: row.get(1)?,
+            memory_type: row.get(2)?,
+            state_key: row.get(3)?,
+            current_id: row.get(4)?,
+            active_ids,
+            reason: "ambiguous_active_state_key_group",
+        })
+    })?;
+    crate::db::query::collect_rows(rows)
+}
+
+fn build_duplicate_groups(rows: Vec<(String, i64)>, limit: usize) -> Vec<HiddenDuplicateGroup> {
+    let mut groups = Vec::new();
+    let mut current_key: Option<String> = None;
+    let mut current_ids = Vec::new();
+    for (cluster_key, id) in rows {
+        if current_key.as_deref() != Some(cluster_key.as_str()) {
+            push_duplicate_group(&mut groups, current_key.take(), &mut current_ids);
+            current_key = Some(cluster_key);
+            if groups.len() >= limit {
+                return groups;
+            }
+        }
+        current_ids.push(id);
+    }
+    push_duplicate_group(&mut groups, current_key, &mut current_ids);
+    groups.truncate(limit);
+    groups
+}
+
+fn push_duplicate_group(
+    groups: &mut Vec<HiddenDuplicateGroup>,
+    cluster_key: Option<String>,
+    ids: &mut Vec<i64>,
+) {
+    if let Some(cluster_key) = cluster_key {
+        if ids.len() > 1 {
+            groups.push(HiddenDuplicateGroup {
+                cluster_key,
+                chosen_id: ids[0],
+                hidden_ids: ids[1..].to_vec(),
+            });
+        }
+    }
+    ids.clear();
+}
+
+fn preference_context_owner_filter_sql(alias: &str) -> String {
+    format!(
+        "(({alias}.owner_scope = 'repo' AND ({alias}.owner_key = ?1 OR {alias}.target_project = ?1))
+          OR ({alias}.owner_scope IS NULL AND {alias}.project = ?1
+              AND ({alias}.scope IS NULL OR {alias}.scope = 'project'))
+          OR ({alias}.owner_scope = 'user' AND {alias}.owner_key = 'user:default')
+          OR ({alias}.owner_scope IS NULL AND {alias}.scope = 'global'))"
+    )
+}
+
+fn parse_id_list(value: &str) -> Result<Vec<i64>> {
+    value
+        .split(',')
+        .map(|part| {
+            part.trim()
+                .parse::<i64>()
+                .map_err(|error| anyhow::anyhow!("invalid state-key id {part}: {error}"))
+        })
+        .collect()
+}

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -8,7 +8,7 @@ use crate::memory::{self, Memory};
 use super::memory_traits::{is_memory_self_diagnostic, is_self_diagnostic_text};
 use super::ownership::{startup_memory_owner_decision, OwnerCounts, OwnerMetadata, OwnerTrace};
 use super::policy::{ContextPolicy, SectionKind};
-use super::types::{ContextLoadError, LoadedContext, SessionSummaryBrief};
+use super::types::{ContextLoadError, HiddenDuplicateGroup, LoadedContext, SessionSummaryBrief};
 
 const BASENAME_SEARCH_LIMIT: i64 = 20;
 const SUMMARY_FETCH_BATCH_SIZE: usize = 25;
@@ -22,7 +22,7 @@ pub(super) fn load_context_data(
     current_branch: Option<&str>,
 ) -> LoadedContext {
     let policy = ContextPolicy::from_limits(super::policy::ContextLimits::default());
-    load_context_data_with_policy(conn, project, current_branch, &policy)
+    load_context_data_with_policy(conn, project, current_branch, &policy, true)
 }
 
 pub(super) fn load_context_data_with_policy(
@@ -30,9 +30,11 @@ pub(super) fn load_context_data_with_policy(
     project: &str,
     current_branch: Option<&str>,
     policy: &ContextPolicy,
+    collect_diagnostics: bool,
 ) -> LoadedContext {
     let mut errors = Vec::new();
-    let memory_selection = load_project_memories(conn, project, current_branch, policy);
+    let memory_selection =
+        load_project_memories(conn, project, current_branch, policy, collect_diagnostics);
     let mut memories = memory_selection.memories;
     sort_memories_by_branch(&mut memories, current_branch);
     let lessons = memory::lesson::list_lessons_for_context(
@@ -73,6 +75,7 @@ pub(super) fn load_context_data_with_policy(
         errors,
         owner_traces: memory_selection.owner_traces,
         owner_counts: memory_selection.owner_counts,
+        diagnostics: memory_selection.diagnostics,
     }
 }
 
@@ -80,6 +83,7 @@ struct ContextMemorySelection {
     memories: Vec<Memory>,
     owner_traces: Vec<OwnerTrace>,
     owner_counts: OwnerCounts,
+    diagnostics: super::types::ContextDiagnostics,
 }
 
 struct ContextMemoryRow {
@@ -92,6 +96,7 @@ fn load_project_memories(
     project: &str,
     current_branch: Option<&str>,
     policy: &ContextPolicy,
+    collect_diagnostics: bool,
 ) -> ContextMemorySelection {
     let mut memories = Vec::new();
     let mut traces = Vec::new();
@@ -144,11 +149,10 @@ fn load_project_memories(
 
     memories
         .retain(|memory| policy.allows_memory_type(SectionKind::MemoryIndex, &memory.memory_type));
-    let mut selected = limit_self_diagnostic_memories(
-        deduplicate_memory_clusters(memories, current_branch),
-        policy.limits.self_diagnostic_limit,
-    );
+    let (deduped, hidden_duplicate_groups) = deduplicate_memory_clusters(memories, current_branch);
+    let mut selected = limit_self_diagnostic_memories(deduped, policy.limits.self_diagnostic_limit);
     sort_memories_by_branch(&mut selected, current_branch);
+    let selected_id_list = selected.iter().map(|memory| memory.id).collect::<Vec<_>>();
 
     let selected_ids = selected
         .iter()
@@ -193,6 +197,17 @@ fn load_project_memories(
         memories: selected,
         owner_traces: traces,
         owner_counts,
+        diagnostics: if collect_diagnostics {
+            super::diagnostics::collect_context_diagnostics(
+                conn,
+                project,
+                excluded_types,
+                selected_id_list,
+                hidden_duplicate_groups,
+            )
+        } else {
+            super::types::ContextDiagnostics::default()
+        },
     }
 }
 
@@ -215,6 +230,9 @@ fn query_owner_included_memory_rows(
         "status",
         "expires_at_epoch",
         false,
+    ));
+    conditions.push(crate::memory::memory_state_key_current_filter_sql(
+        "memories",
     ));
 
     if let Some(query) = query {
@@ -334,7 +352,7 @@ fn map_context_memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ContextMe
     })
 }
 
-fn push_owner_included_filter(
+pub(super) fn push_owner_included_filter(
     project: &str,
     idx: &mut usize,
     conditions: &mut Vec<String>,
@@ -404,7 +422,7 @@ fn push_context_related_filter(
     ));
 }
 
-fn push_excluded_type_filter(
+pub(super) fn push_excluded_type_filter(
     excluded_types: &[&str],
     idx: &mut usize,
     conditions: &mut Vec<String>,
@@ -446,10 +464,15 @@ fn branch_sort_score(memory: &Memory, current_branch: &str) -> u8 {
 
 struct ClusterRepresentative {
     first_index: usize,
+    cluster_key: String,
     memory: Memory,
+    hidden_ids: Vec<i64>,
 }
 
-fn deduplicate_memory_clusters(memories: Vec<Memory>, current_branch: Option<&str>) -> Vec<Memory> {
+fn deduplicate_memory_clusters(
+    memories: Vec<Memory>,
+    current_branch: Option<&str>,
+) -> (Vec<Memory>, Vec<HiddenDuplicateGroup>) {
     let mut representatives: HashMap<String, ClusterRepresentative> = HashMap::new();
 
     for (index, memory) in memories.into_iter().enumerate() {
@@ -458,15 +481,20 @@ fn deduplicate_memory_clusters(memories: Vec<Memory>, current_branch: Option<&st
             Some(representative) => {
                 if is_better_cluster_representative(&memory, &representative.memory, current_branch)
                 {
+                    representative.hidden_ids.push(representative.memory.id);
                     representative.memory = memory;
+                } else {
+                    representative.hidden_ids.push(memory.id);
                 }
             }
             None => {
                 representatives.insert(
-                    cluster_key,
+                    cluster_key.clone(),
                     ClusterRepresentative {
                         first_index: index,
+                        cluster_key,
                         memory,
+                        hidden_ids: Vec::new(),
                     },
                 );
             }
@@ -475,10 +503,20 @@ fn deduplicate_memory_clusters(memories: Vec<Memory>, current_branch: Option<&st
 
     let mut deduped: Vec<ClusterRepresentative> = representatives.into_values().collect();
     deduped.sort_by_key(|representative| representative.first_index);
-    deduped
+    let hidden_groups = deduped
+        .iter()
+        .filter(|representative| !representative.hidden_ids.is_empty())
+        .map(|representative| HiddenDuplicateGroup {
+            cluster_key: representative.cluster_key.clone(),
+            chosen_id: representative.memory.id,
+            hidden_ids: representative.hidden_ids.clone(),
+        })
+        .collect();
+    let memories = deduped
         .into_iter()
         .map(|representative| representative.memory)
-        .collect()
+        .collect();
+    (memories, hidden_groups)
 }
 
 fn is_better_cluster_representative(

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -20,6 +20,8 @@ use super::sections::{
 };
 use super::types::{ContextLoadError, ContextRequest};
 
+pub(in crate::context) use super::debug::build_context_debug_trace;
+
 pub(in crate::context) struct RenderedContext {
     pub(in crate::context) output: String,
     pub(in crate::context) stats: ContextRenderStats,
@@ -42,7 +44,7 @@ pub(crate) fn governance_eval_snapshot(
     current_branch: Option<&str>,
 ) -> Result<ContextEvalSnapshot> {
     let policy = ContextPolicy::from_limits(ContextLimits::default());
-    let loaded = load_context_data_with_policy(conn, project, current_branch, &policy);
+    let loaded = load_context_data_with_policy(conn, project, current_branch, &policy, true);
     let rendered_output = render_loaded_context_for_eval(conn, project, &policy, &loaded)?;
     let rendered_memories = loaded
         .memories
@@ -287,8 +289,9 @@ pub(in crate::context) fn render_context_output(
         &request.project,
         request.current_branch.as_deref(),
         &policy,
+        debug,
     );
-    let (preference_output, preference_summary) =
+    let (preference_output, preference_details) =
         match render_preferences_to_buffer(&conn, &request.project, &request.cwd, &policy) {
             Ok(rendered) => rendered,
             Err(error) => {
@@ -302,10 +305,11 @@ pub(in crate::context) fn render_context_output(
                     .push(ContextLoadError::new("preferences", message));
                 (
                     String::new(),
-                    crate::memory::preference::PreferenceRenderSummary::default(),
+                    crate::memory::preference::PreferenceRenderDetails::default(),
                 )
             }
         };
+    let preference_summary = preference_details.summary;
 
     if preference_summary.rendered == 0
         && loaded.memories.is_empty()
@@ -426,6 +430,12 @@ pub(in crate::context) fn render_context_output(
     }
 
     if debug {
+        super::diagnostics::apply_preference_diagnostics(
+            &conn,
+            &request.project,
+            preference_details.rendered_ids,
+            &mut loaded.diagnostics,
+        );
         output.push_str(&build_context_debug_trace(
             request, &policy, &loaded, &stats,
         ));
@@ -519,10 +529,10 @@ fn render_preferences_to_buffer(
     project: &str,
     cwd: &str,
     policy: &ContextPolicy,
-) -> Result<(String, crate::memory::preference::PreferenceRenderSummary)> {
+) -> Result<(String, crate::memory::preference::PreferenceRenderDetails)> {
     let mut output = String::new();
     let limits = &policy.limits;
-    let summary = crate::memory::preference::render_preferences_with_limits_detailed(
+    let details = crate::memory::preference::render_preferences_with_context_details(
         &mut output,
         conn,
         project,
@@ -531,7 +541,7 @@ fn render_preferences_to_buffer(
         limits.preference_global_limit,
         limits.preference_char_limit,
     )?;
-    Ok((output, summary))
+    Ok((output, details))
 }
 
 #[derive(Debug, Clone, Default)]
@@ -568,154 +578,6 @@ pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats)
 
 fn build_context_stats_footer_with_style(stats: &ContextRenderStats, use_colors: bool) -> String {
     super::style::context_stats_footer(stats, use_colors)
-}
-
-pub(in crate::context) fn build_context_debug_trace(
-    request: &ContextRequest,
-    policy: &ContextPolicy,
-    loaded: &super::types::LoadedContext,
-    stats: &ContextRenderStats,
-) -> String {
-    let mut trace = String::from("## Debug Trace\n");
-    trace.push_str(&format!(
-        "- request host={} project={} cwd={} branch={} session={} source={}\n",
-        request.host.as_env_value(),
-        request.project,
-        request.cwd,
-        request.current_branch.as_deref().unwrap_or("-"),
-        request.session_id.as_deref().unwrap_or("-"),
-        request.hook_source.as_deref().unwrap_or("-")
-    ));
-    trace.push_str(&format!(
-        "- limits total={} core_items={} core_chars={} lessons={} lesson_chars={} index_items={} index_chars={} sessions={} preferences(project={}, global={}, chars={})\n",
-        policy.limits.total_char_limit,
-        policy.limits.core_item_limit,
-        policy.limits.core_char_limit,
-        policy.limits.lesson_limit,
-        policy.limits.lesson_char_limit,
-        policy.limits.memory_index_limit,
-        policy.limits.memory_index_char_limit,
-        policy.limits.session_limit,
-        policy.limits.preference_project_limit,
-        policy.limits.preference_global_limit,
-        policy.limits.preference_char_limit
-    ));
-    trace.push_str(&format!(
-        "- rendered core={} lessons={} index={} preferences={} sessions={} workstreams={}\n",
-        stats.core.count,
-        stats.lessons.count,
-        stats.index.count,
-        stats.preferences.count,
-        stats.sessions.count,
-        stats.workstreams.count
-    ));
-    trace.push_str(&format!(
-        "- rendered_chars core={} lessons={} index={} preferences={} sessions={} workstreams={}\n",
-        stats.core.chars,
-        stats.lessons.chars,
-        stats.index.chars,
-        stats.preferences.chars,
-        stats.sessions.chars,
-        stats.workstreams.chars
-    ));
-    trace.push_str(&format!(
-        "- stats host={} branch={} source={}\n",
-        stats.host,
-        stats.branch.as_deref().unwrap_or("-"),
-        stats.hook_source.as_deref().unwrap_or("-")
-    ));
-    trace.push_str(&format!(
-        "- preferences project_rendered={} global_rendered={} reason=scope_limits_then_claude_md_dedup\n",
-        stats.project_preferences, stats.global_preferences
-    ));
-    trace.push_str(&format!(
-        "- owner counts repo={} user={} workspace={} tool={} domain={} workstream={} session={} legacy={} unknown={}\n",
-        stats.owner_counts.repo,
-        stats.owner_counts.user,
-        stats.owner_counts.workspace,
-        stats.owner_counts.tool,
-        stats.owner_counts.domain,
-        stats.owner_counts.workstream,
-        stats.owner_counts.session,
-        stats.owner_counts.legacy,
-        stats.owner_counts.unknown
-    ));
-    for trace_row in loaded.owner_traces.iter().take(60) {
-        trace.push_str(&format!(
-            "- owner {} id={} scope={} key={} source_project={} target_project={} domain={} context_class={} {} reason={} title={}\n",
-            trace_row.object_kind,
-            trace_row.id,
-            trace_row.owner_scope.as_deref().unwrap_or("-"),
-            trace_row.owner_key.as_deref().unwrap_or("-"),
-            trace_row.source_project.as_deref().unwrap_or("-"),
-            trace_row.target_project.as_deref().unwrap_or("-"),
-            trace_row.topic_domain.as_deref().unwrap_or("-"),
-            trace_row.context_class.as_deref().unwrap_or("-"),
-            if trace_row.included {
-                "included"
-            } else {
-                "excluded"
-            },
-            trace_row.reason,
-            truncate_chars_with_ellipsis(&trace_row.title, 120)
-        ));
-    }
-    if loaded.owner_traces.len() > 60 {
-        trace.push_str(&format!(
-            "- owner trace truncated: {} additional rows omitted\n",
-            loaded.owner_traces.len() - 60
-        ));
-    }
-    for (rank, lesson) in loaded.lessons.iter().enumerate() {
-        trace.push_str(&format!(
-            "- lesson rank={} id={} confidence={:.2} reinforced={} scope={} topic={} title={}\n",
-            rank + 1,
-            lesson.memory.id,
-            lesson.metadata.confidence,
-            lesson.metadata.reinforcement_count,
-            lesson.memory.scope,
-            lesson.memory.topic_key.as_deref().unwrap_or("-"),
-            truncate_chars_with_ellipsis(&lesson.memory.title, 120)
-        ));
-    }
-    for (rank, memory) in loaded.memories.iter().take(30).enumerate() {
-        let target = if stats.core_ids.contains(&memory.id) {
-            "core"
-        } else {
-            "index_candidate"
-        };
-        trace.push_str(&format!(
-            "- memory rank={} id={} type={} scope={} branch={} topic={} target={} reason=loaded_after_scope_branch_dedupe title={}\n",
-            rank + 1,
-            memory.id,
-            memory.memory_type,
-            memory.scope,
-            memory.branch.as_deref().unwrap_or("-"),
-            memory.topic_key.as_deref().unwrap_or("-"),
-            target,
-            truncate_chars_with_ellipsis(&memory.title, 120)
-        ));
-    }
-    if loaded.memories.len() > 30 {
-        trace.push_str(&format!(
-            "- memory trace truncated: {} additional candidates omitted\n",
-            loaded.memories.len() - 30
-        ));
-    }
-    for (rank, summary) in loaded
-        .summaries
-        .iter()
-        .take(policy.limits.session_limit)
-        .enumerate()
-    {
-        trace.push_str(&format!(
-            "- session rank={} reason=recent_after_cluster_filter request={}\n",
-            rank + 1,
-            truncate_chars_with_ellipsis(&summary.request, 120)
-        ));
-    }
-    trace.push('\n');
-    trace
 }
 
 fn context_source_note(source: Option<&str>) -> Option<&'static str> {

--- a/src/context/tests/diagnostics.rs
+++ b/src/context/tests/diagnostics.rs
@@ -1,0 +1,427 @@
+use crate::memory::types::tests_helper::setup_memory_schema;
+use rusqlite::{params, Connection};
+
+use super::super::host::HostKind;
+use super::super::policy::{ContextLimits, ContextPolicy};
+use super::super::query::load_context_data;
+use super::super::render::{build_context_debug_trace, ContextRenderStats, SectionRenderStats};
+use super::super::types::{ContextRequest, LoadedContext};
+use super::{insert_memory, insert_owned_memory};
+
+#[test]
+fn context_debug_reports_selected_ids_and_hidden_duplicate_groups() {
+    let conn = setup_context_diagnostics_db();
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("decision-1111111111111111"),
+        "decision",
+        "Old context diagnostics decision",
+        "[Context: Build current view context diagnostics]\nOld body",
+        now - 10,
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("decision-2222222222222222"),
+        "decision",
+        "Current context diagnostics decision",
+        "[Context: Build current view context diagnostics]\nCurrent body",
+        now,
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+    let selected_titles = loaded
+        .memories
+        .iter()
+        .map(|memory| memory.title.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        selected_titles,
+        vec!["Current context diagnostics decision"]
+    );
+    assert_eq!(loaded.diagnostics.candidate_pool_total, 2);
+    assert_eq!(loaded.diagnostics.selected_ids, vec![2]);
+    assert_eq!(loaded.diagnostics.hidden_duplicate_groups.len(), 1);
+    assert_eq!(loaded.diagnostics.hidden_duplicate_groups[0].chosen_id, 2);
+    assert_eq!(
+        loaded.diagnostics.hidden_duplicate_groups[0].hidden_ids,
+        vec![1]
+    );
+
+    let debug = debug_trace(project, &loaded);
+    assert!(debug.contains("selected_ids=[2]"));
+    assert!(debug.contains("hidden duplicate group"));
+    assert!(debug.contains("chosen=#2 hidden=[1]"));
+}
+
+#[test]
+fn context_default_hides_stale_superseded_memory() {
+    let conn = setup_context_diagnostics_db();
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("current-toolbar-color"),
+        "decision",
+        "Toolbar color is emerald",
+        "Toolbar color is emerald in the current UI.",
+        now,
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("stale-toolbar-color"),
+        "decision",
+        "Toolbar color was blue",
+        "Toolbar color was blue in an old UI.",
+        now - 1,
+    );
+    insert_memory(
+        &conn,
+        3,
+        project,
+        Some("superseded-toolbar-color"),
+        "decision",
+        "Toolbar color was purple",
+        "Toolbar color was purple before emerald.",
+        now - 2,
+    );
+    conn.execute(
+        "UPDATE memories SET status = 'stale' WHERE id = ?1",
+        params![2],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE memories SET status = 'superseded' WHERE id = ?1",
+        params![3],
+    )
+    .unwrap();
+
+    let loaded = load_context_data(&conn, project, None);
+    let titles = loaded
+        .memories
+        .iter()
+        .map(|memory| memory.title.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(titles, vec!["Toolbar color is emerald"]);
+    assert!(loaded
+        .diagnostics
+        .exclusions
+        .iter()
+        .any(|exclusion| exclusion.id == 2 && exclusion.reason == "stale"));
+    assert!(loaded
+        .diagnostics
+        .exclusions
+        .iter()
+        .any(|exclusion| exclusion.id == 3 && exclusion.reason == "superseded"));
+}
+
+#[test]
+fn context_default_hides_expired_operational_memory() {
+    let conn = setup_context_diagnostics_db();
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("stable-build-command"),
+        "decision",
+        "Run cargo check for context changes",
+        "Use cargo check before submitting context changes.",
+        now,
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("expired-dev-server-port"),
+        "discovery",
+        "Dev server port 3000",
+        "Dev server was temporarily running on port 3000.",
+        now - 1,
+    );
+    conn.execute(
+        "UPDATE memories SET expires_at_epoch = ?1 WHERE id = ?2",
+        params![now - 1, 2],
+    )
+    .unwrap();
+
+    let loaded = load_context_data(&conn, project, None);
+    let titles = loaded
+        .memories
+        .iter()
+        .map(|memory| memory.title.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(titles, vec!["Run cargo check for context changes"]);
+    assert!(loaded
+        .diagnostics
+        .exclusions
+        .iter()
+        .any(|exclusion| exclusion.id == 2 && exclusion.reason == "expired"));
+}
+
+#[test]
+fn context_debug_reports_stale_and_expired_exclusions() {
+    let conn = setup_context_diagnostics_db();
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("current-context-rule"),
+        "decision",
+        "Context debug stays read only",
+        "Context diagnostics must not mutate memory rows.",
+        now,
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("stale-context-rule"),
+        "decision",
+        "Context debug applied cleanup",
+        "Old behavior claimed context cleanup was allowed.",
+        now - 1,
+    );
+    insert_memory(
+        &conn,
+        3,
+        project,
+        Some("expired-context-port"),
+        "discovery",
+        "Temporary context port",
+        "A temporary server port expired before SessionStart.",
+        now - 2,
+    );
+    conn.execute(
+        "UPDATE memories SET status = 'stale' WHERE id = ?1",
+        params![2],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE memories SET expires_at_epoch = ?1 WHERE id = ?2",
+        params![now - 1, 3],
+    )
+    .unwrap();
+
+    let loaded = load_context_data(&conn, project, None);
+    let debug = debug_trace(project, &loaded);
+
+    assert!(debug.contains("excluded memory id=2 reason=stale"));
+    assert!(debug.contains("excluded memory id=3 reason=expired"));
+}
+
+#[test]
+fn context_state_key_current_view_selects_current_row_and_reports_ambiguity() {
+    let conn = setup_context_diagnostics_db();
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("old-verification-rule"),
+        "decision",
+        "Old verification rule",
+        "Verification status and code changes can be mixed.",
+        now - 10,
+    );
+    insert_memory(
+        &conn,
+        2,
+        project,
+        Some("current-verification-rule"),
+        "decision",
+        "Current verification rule",
+        "Keep verification status separate from code changes.",
+        now,
+    );
+    attach_state_key(
+        &conn,
+        10,
+        project,
+        "decision",
+        "verification-status-separation",
+        2,
+        &[1, 2],
+    );
+
+    let loaded = load_context_data(&conn, project, None);
+    let selected_ids = loaded
+        .memories
+        .iter()
+        .map(|memory| memory.id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(selected_ids, vec![2]);
+    assert_eq!(loaded.diagnostics.selected_ids, vec![2]);
+    assert_eq!(loaded.diagnostics.state_key_groups.len(), 1);
+    let group = &loaded.diagnostics.state_key_groups[0];
+    assert_eq!(group.current_id, Some(2));
+    assert_eq!(group.active_ids, vec![1, 2]);
+    assert_eq!(group.reason, "ambiguous_active_state_key_group");
+
+    let debug = debug_trace(project, &loaded);
+    assert!(debug.contains("state-key group"));
+    assert!(debug.contains("current=#2 active=[1,2]"));
+    assert!(debug.contains("reason=ambiguous_active_state_key_group"));
+}
+
+#[test]
+fn context_debug_reports_preference_current_view_state_key_groups() {
+    let conn = setup_context_diagnostics_db();
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_owned_memory(
+        &conn,
+        1,
+        project,
+        Some("pref-cn"),
+        "preference",
+        "Preference: 验证状态隔离",
+        "验证状态必须和代码数据改动分开。",
+        now - 10,
+        "repo",
+        project,
+        Some(project),
+        None,
+    );
+    insert_owned_memory(
+        &conn,
+        2,
+        project,
+        Some("pref-en"),
+        "preference",
+        "Preference: Verification status separation",
+        "Keep verification status separate from code and data changes.",
+        now,
+        "repo",
+        project,
+        Some(project),
+        None,
+    );
+    attach_state_key(
+        &conn,
+        11,
+        project,
+        "preference",
+        "verification-status-separation",
+        2,
+        &[1, 2],
+    );
+
+    let mut preference_output = String::new();
+    let details = crate::memory::preference::render_preferences_with_context_details(
+        &mut preference_output,
+        &conn,
+        project,
+        "/nonexistent",
+        20,
+        0,
+        1500,
+    )
+    .unwrap();
+    assert!(preference_output.contains("Keep verification status separate"));
+    assert!(!preference_output.contains("验证状态必须"));
+    assert_eq!(details.rendered_ids, vec![2]);
+
+    let mut loaded = load_context_data(&conn, project, None);
+    super::super::diagnostics::apply_preference_diagnostics(
+        &conn,
+        project,
+        details.rendered_ids,
+        &mut loaded.diagnostics,
+    );
+    let debug = debug_trace(project, &loaded);
+
+    assert!(debug.contains("preference diagnostics selected_ids=[2]"));
+    assert!(debug.contains("preference state-key group"));
+    assert!(debug.contains("type=preference key=verification-status-separation"));
+    assert!(debug.contains("current=#2 active=[1,2]"));
+}
+
+fn setup_context_diagnostics_db() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_memory_schema(&conn);
+    conn
+}
+
+fn attach_state_key(
+    conn: &Connection,
+    state_key_id: i64,
+    project: &str,
+    memory_type: &str,
+    state_key: &str,
+    current_memory_id: i64,
+    memory_ids: &[i64],
+) {
+    conn.execute(
+        "INSERT INTO memory_state_keys
+         (id, owner_scope, owner_key, memory_type, state_key, state_status,
+          current_memory_id, created_at_epoch, updated_at_epoch)
+         VALUES (?1, 'repo', ?2, ?3, ?4, 'active', ?5, 100, 100)",
+        params![
+            state_key_id,
+            project,
+            memory_type,
+            state_key,
+            current_memory_id
+        ],
+    )
+    .unwrap();
+    for memory_id in memory_ids {
+        conn.execute(
+            "UPDATE memories SET state_key_id = ?1 WHERE id = ?2",
+            params![state_key_id, memory_id],
+        )
+        .unwrap();
+    }
+}
+
+fn debug_trace(project: &str, loaded: &LoadedContext) -> String {
+    let stats = ContextRenderStats {
+        host: "codex-cli".to_string(),
+        memories_loaded: loaded.memories.len(),
+        core: SectionRenderStats {
+            count: loaded.memories.len(),
+            chars: 0,
+        },
+        owner_counts: loaded.owner_counts.clone(),
+        ..ContextRenderStats::default()
+    };
+    let request = ContextRequest {
+        cwd: project.to_string(),
+        project: project.to_string(),
+        session_id: Some("sess-diagnostics".to_string()),
+        hook_source: None,
+        current_branch: None,
+        host: HostKind::CodexCli,
+        use_colors: false,
+    };
+    build_context_debug_trace(
+        &request,
+        &ContextPolicy::from_limits(ContextLimits::default()),
+        loaded,
+        &stats,
+    )
+}

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -17,7 +17,7 @@ fn load_context_data_logs_primary_memory_query_failures() {
     };
     let policy = ContextPolicy::from_limits(ContextLimits::default());
 
-    let loaded = load_context_data_with_policy(&conn, "/tmp/remem", None, &policy);
+    let loaded = load_context_data_with_policy(&conn, "/tmp/remem", None, &policy, true);
 
     assert!(loaded.memories.is_empty());
     let log_path = data_dir.path.join("remem.log");
@@ -36,7 +36,7 @@ fn load_context_data_records_lesson_query_failures() {
     conn.execute("DROP TABLE memory_lessons", []).unwrap();
     let policy = ContextPolicy::from_limits(ContextLimits::default());
 
-    let loaded = load_context_data_with_policy(&conn, "/tmp/remem", None, &policy);
+    let loaded = load_context_data_with_policy(&conn, "/tmp/remem", None, &policy, true);
 
     assert!(loaded.lessons.is_empty());
     assert_eq!(loaded.errors.len(), 1);
@@ -544,7 +544,7 @@ fn load_context_data_filters_lessons_before_candidate_limit_and_keeps_core_memor
         now - 1_000,
     );
 
-    let loaded = load_context_data_with_policy(&conn, project, None, &policy);
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy, true);
 
     assert!(loaded.lessons.is_empty());
     assert!(loaded
@@ -644,7 +644,7 @@ fn load_context_data_excludes_global_non_preferences_from_basename_search() {
         );
     }
 
-    let loaded = load_context_data_with_policy(&conn, project, None, &policy);
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy, true);
 
     assert!(!loaded
         .memories
@@ -729,7 +729,7 @@ fn load_context_data_keeps_core_candidates_when_index_limit_is_small() {
         );
     }
 
-    let loaded = load_context_data_with_policy(&conn, project, None, &policy);
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy, true);
 
     assert!(loaded.memories.len() > limits.memory_index_limit);
     assert!(loaded.memories.len() >= limits.core_item_limit);

--- a/src/context/tests/mod.rs
+++ b/src/context/tests/mod.rs
@@ -2,6 +2,7 @@ use crate::memory::Memory;
 use crate::workstream::{WorkStream, WorkStreamStatus};
 use rusqlite::{params, Connection};
 
+mod diagnostics;
 mod load;
 mod ownership;
 mod render;

--- a/src/context/tests/ownership.rs
+++ b/src/context/tests/ownership.rs
@@ -94,6 +94,7 @@ fn startup_context_excludes_unrelated_tool_and_domain_memories() {
             core_item_limit: 10,
             ..ContextLimits::default()
         }),
+        true,
     );
     let titles = loaded
         .memories
@@ -157,6 +158,7 @@ fn debug_trace_reports_owner_reasons_and_counts() {
         stash,
         None,
         &ContextPolicy::from_limits(ContextLimits::default()),
+        true,
     );
     let stats = ContextRenderStats {
         host: "codex-cli".to_string(),

--- a/src/context/types.rs
+++ b/src/context/types.rs
@@ -33,6 +33,7 @@ pub(super) struct LoadedContext {
     pub errors: Vec<ContextLoadError>,
     pub owner_traces: Vec<OwnerTrace>,
     pub owner_counts: OwnerCounts,
+    pub diagnostics: ContextDiagnostics,
 }
 
 #[derive(Debug, Clone)]
@@ -48,4 +49,43 @@ impl ContextLoadError {
             message: error.to_string(),
         }
     }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct ContextDiagnostics {
+    pub candidate_pool_total: usize,
+    pub current_rows: usize,
+    pub selected_ids: Vec<i64>,
+    pub hidden_duplicate_groups: Vec<HiddenDuplicateGroup>,
+    pub preference_selected_ids: Vec<i64>,
+    pub preference_hidden_duplicate_groups: Vec<HiddenDuplicateGroup>,
+    pub preference_state_key_groups: Vec<StateKeyDiagnosticGroup>,
+    pub state_key_groups: Vec<StateKeyDiagnosticGroup>,
+    pub exclusions: Vec<ContextExclusion>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct HiddenDuplicateGroup {
+    pub cluster_key: String,
+    pub chosen_id: i64,
+    pub hidden_ids: Vec<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ContextExclusion {
+    pub id: i64,
+    pub reason: &'static str,
+    pub status: String,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct StateKeyDiagnosticGroup {
+    pub owner_scope: String,
+    pub owner_key: String,
+    pub memory_type: String,
+    pub state_key: String,
+    pub current_id: Option<i64>,
+    pub active_ids: Vec<i64>,
+    pub reason: &'static str,
 }

--- a/src/memory/preference.rs
+++ b/src/memory/preference.rs
@@ -10,3 +10,4 @@ pub use render::{
     dedup_with_claude_md, render_preferences, render_preferences_with_limits,
     render_preferences_with_limits_detailed, PreferenceRenderSummary,
 };
+pub(crate) use render::{render_preferences_with_context_details, PreferenceRenderDetails};

--- a/src/memory/preference/query.rs
+++ b/src/memory/preference/query.rs
@@ -15,13 +15,17 @@ pub fn query_project_preferences(
     let sql = format!(
         "SELECT {} FROM memories \
          WHERE memory_type = 'preference' AND {} \
+         AND {} \
          AND ((owner_scope = 'repo' AND owner_key = ?1) \
               OR (owner_scope = 'repo' AND target_project = ?1) \
               OR (owner_scope IS NULL AND project = ?1 AND (scope IS NULL OR scope = 'project'))) \
-         GROUP BY COALESCE(topic_key, id) \
+         GROUP BY COALESCE(owner_scope, 'legacy_project'),
+                  COALESCE(owner_key, project),
+                  COALESCE(topic_key, id) \
          ORDER BY MAX(updated_at_epoch) DESC LIMIT ?2",
         memory::MEMORY_COLS,
         memory::memory_current_filter_sql("status", "expires_at_epoch", false),
+        memory::memory_state_key_current_filter_sql("memories"),
     );
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params![project, limit as i64], memory::map_memory_row_pub)?;
@@ -36,12 +40,16 @@ pub fn query_global_preferences(conn: &Connection, limit: usize) -> Result<Vec<M
     let sql = format!(
         "SELECT {} FROM memories \
          WHERE memory_type = 'preference' AND {} \
+         AND {} \
          AND ((owner_scope = 'user' AND owner_key = 'user:default') \
               OR (owner_scope IS NULL AND scope = 'global')) \
-         GROUP BY COALESCE(topic_key, id) \
+         GROUP BY COALESCE(owner_scope, 'legacy_global'),
+                  COALESCE(owner_key, scope, 'global'),
+                  COALESCE(topic_key, id) \
          ORDER BY MAX(updated_at_epoch) DESC LIMIT ?1",
         memory::MEMORY_COLS,
         memory::memory_current_filter_sql("status", "expires_at_epoch", false),
+        memory::memory_state_key_current_filter_sql("memories"),
     );
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params![limit as i64], memory::map_memory_row_pub)?;

--- a/src/memory/preference/render.rs
+++ b/src/memory/preference/render.rs
@@ -12,6 +12,12 @@ pub struct PreferenceRenderSummary {
     pub global_rendered: usize,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct PreferenceRenderDetails {
+    pub summary: PreferenceRenderSummary,
+    pub rendered_ids: Vec<i64>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PreferenceSource {
     Project,
@@ -56,7 +62,7 @@ pub fn render_preferences_with_limits(
     global_limit: usize,
     char_limit: usize,
 ) -> Result<usize> {
-    render_preferences_with_limits_detailed(
+    render_preferences_with_context_details(
         output,
         conn,
         project,
@@ -65,7 +71,7 @@ pub fn render_preferences_with_limits(
         global_limit,
         char_limit,
     )
-    .map(|summary| summary.rendered)
+    .map(|details| details.summary.rendered)
 }
 
 pub fn render_preferences_with_limits_detailed(
@@ -77,8 +83,29 @@ pub fn render_preferences_with_limits_detailed(
     global_limit: usize,
     char_limit: usize,
 ) -> Result<PreferenceRenderSummary> {
+    render_preferences_with_context_details(
+        output,
+        conn,
+        project,
+        cwd,
+        project_limit,
+        global_limit,
+        char_limit,
+    )
+    .map(|details| details.summary)
+}
+
+pub(crate) fn render_preferences_with_context_details(
+    output: &mut String,
+    conn: &Connection,
+    project: &str,
+    cwd: &str,
+    project_limit: usize,
+    global_limit: usize,
+    char_limit: usize,
+) -> Result<PreferenceRenderDetails> {
     let project_prefs = query_project_preferences(conn, project, project_limit)?;
-    let global_prefs = query_global_preferences(conn, global_limit).unwrap_or_default();
+    let global_prefs = query_global_preferences(conn, global_limit)?;
 
     let mut all_prefs: Vec<(Memory, PreferenceSource)> = project_prefs
         .into_iter()
@@ -97,7 +124,7 @@ pub fn render_preferences_with_limits_detailed(
     }
 
     if all_prefs.is_empty() {
-        return Ok(PreferenceRenderSummary::default());
+        return Ok(PreferenceRenderDetails::default());
     }
 
     let memories = all_prefs
@@ -106,12 +133,13 @@ pub fn render_preferences_with_limits_detailed(
         .collect::<Vec<_>>();
     let keep_indices = dedup_with_claude_md(&memories, cwd);
     if keep_indices.is_empty() {
-        return Ok(PreferenceRenderSummary::default());
+        return Ok(PreferenceRenderDetails::default());
     }
 
     output.push_str("## Your Preferences (always apply these)\n");
     let mut total_chars = 0usize;
     let mut summary = PreferenceRenderSummary::default();
+    let mut rendered_ids = Vec::new();
 
     for &idx in &keep_indices {
         let (pref, source) = &all_prefs[idx];
@@ -129,6 +157,7 @@ pub fn render_preferences_with_limits_detailed(
         output.push_str(&line);
         total_chars += line_chars;
         summary.rendered += 1;
+        rendered_ids.push(pref.id);
         match source {
             PreferenceSource::Project => summary.project_rendered += 1,
             PreferenceSource::Global => summary.global_rendered += 1,
@@ -136,5 +165,8 @@ pub fn render_preferences_with_limits_detailed(
     }
     output.push('\n');
 
-    Ok(summary)
+    Ok(PreferenceRenderDetails {
+        summary,
+        rendered_ids,
+    })
 }

--- a/src/memory/preference/tests.rs
+++ b/src/memory/preference/tests.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 
 use crate::memory::{self, Memory};
 
@@ -153,6 +153,109 @@ fn test_user_owner_preferences_are_global_core_preferences() -> Result<()> {
     let prefs = query_global_preferences(&conn, 10)?;
     assert_eq!(prefs.len(), 1);
     assert_eq!(prefs[0].text, "Keep answers concise");
+    Ok(())
+}
+
+#[test]
+fn test_global_preferences_keep_same_topic_across_owner_groups() -> Result<()> {
+    let conn = setup_test_db();
+    insert_preference_row(
+        &conn,
+        1,
+        "legacy/proj",
+        Some("shared-style"),
+        "Preference: Shared style",
+        "Legacy global style preference",
+        "global",
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET owner_scope = NULL, owner_key = NULL
+         WHERE id = ?1",
+        [1],
+    )?;
+    insert_preference_row(
+        &conn,
+        2,
+        "user/proj",
+        Some("shared-style"),
+        "Preference: Shared style",
+        "User-owned style preference",
+        "global",
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET owner_scope = 'user', owner_key = 'user:default'
+         WHERE id = ?1",
+        [2],
+    )?;
+
+    let global = query_global_preferences(&conn, 10)?;
+    let ids = global.iter().map(|memory| memory.id).collect::<Vec<_>>();
+    assert!(ids.contains(&1));
+    assert!(ids.contains(&2));
+    assert_eq!(global.len(), 2);
+    Ok(())
+}
+
+#[test]
+fn test_preferences_use_state_key_current_view_per_owner() -> Result<()> {
+    let conn = setup_test_db();
+    insert_preference_row(
+        &conn,
+        1,
+        "test/proj",
+        Some("pref-cn"),
+        "Preference: 验证状态隔离",
+        "验证状态必须和代码数据改动分开。",
+        "project",
+    )?;
+    insert_preference_row(
+        &conn,
+        2,
+        "test/proj",
+        Some("pref-en"),
+        "Preference: Verification status separation",
+        "Keep verification status separate from code and data changes.",
+        "project",
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET owner_scope = 'repo', owner_key = 'test/proj', target_project = 'test/proj'
+         WHERE id IN (1, 2)",
+        [],
+    )?;
+    attach_preference_state_key(&conn, 10, "repo", "test/proj", 2, &[1, 2])?;
+
+    insert_preference_row(
+        &conn,
+        3,
+        "other/proj",
+        Some("pref-user"),
+        "Preference: Verification status separation",
+        "User-level verification status preference remains separate.",
+        "global",
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET owner_scope = 'user', owner_key = 'user:default'
+         WHERE id = 3",
+        [],
+    )?;
+    attach_preference_state_key(&conn, 11, "user", "user:default", 3, &[3])?;
+
+    let project = query_project_preferences(&conn, "test/proj", 20)?;
+    assert_eq!(
+        project.iter().map(|memory| memory.id).collect::<Vec<_>>(),
+        vec![2]
+    );
+    assert!(project[0].text.contains("separate from code"));
+
+    let global = query_global_preferences(&conn, 10)?;
+    assert_eq!(
+        global.iter().map(|memory| memory.id).collect::<Vec<_>>(),
+        vec![3]
+    );
     Ok(())
 }
 
@@ -368,5 +471,57 @@ fn test_add_and_remove_preference() -> Result<()> {
 
     let prefs = memory::get_memories_by_type(&conn, "test/proj", "preference", 10)?;
     assert!(prefs.is_empty());
+    Ok(())
+}
+
+fn insert_preference_row(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    topic_key: Option<&str>,
+    title: &str,
+    content: &str,
+    scope: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope)
+         VALUES (?1, NULL, ?2, ?3, ?4, ?5, 'preference', NULL, ?6, ?6, 'active', NULL, ?7)",
+        params![
+            id,
+            project,
+            topic_key,
+            title,
+            content,
+            1_710_000_000 + id,
+            scope
+        ],
+    )?;
+    Ok(())
+}
+
+fn attach_preference_state_key(
+    conn: &Connection,
+    state_key_id: i64,
+    owner_scope: &str,
+    owner_key: &str,
+    current_memory_id: i64,
+    memory_ids: &[i64],
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO memory_state_keys
+         (id, owner_scope, owner_key, memory_type, state_key, state_status,
+          current_memory_id, created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?3, 'preference', 'verification-status-separation',
+                 'active', ?4, 100, 100)",
+        params![state_key_id, owner_scope, owner_key, current_memory_id],
+    )?;
+    for memory_id in memory_ids {
+        conn.execute(
+            "UPDATE memories SET state_key_id = ?1 WHERE id = ?2",
+            params![state_key_id, memory_id],
+        )?;
+    }
     Ok(())
 }

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -212,6 +212,23 @@ pub fn memory_current_filter_sql(
     }
 }
 
+pub fn memory_state_key_current_filter_sql(table_alias: &str) -> String {
+    let table_alias = table_alias.trim();
+    let qualifier = if table_alias.is_empty() {
+        String::new()
+    } else {
+        format!("{table_alias}.")
+    };
+    format!(
+        "({qualifier}state_key_id IS NULL OR NOT EXISTS (
+             SELECT 1 FROM memory_state_keys sk
+             WHERE sk.id = {qualifier}state_key_id
+               AND sk.current_memory_id IS NOT NULL
+               AND sk.current_memory_id <> {qualifier}id
+         ))"
+    )
+}
+
 pub fn map_memory_row_pub(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
     map_memory_row(row)
 }


### PR DESCRIPTION
## Summary
- Enforce current-view state-key filtering for context memory and preference rendering paths.
- Add debug-only diagnostics for selected ids, hidden duplicate groups, stale/expired exclusions, state-key ambiguity, and preference duplicate/state-key groups.
- Keep diagnostics off the normal SessionStart hot path unless debug is enabled, and stop silently dropping global preference query errors.

Fixes #293

## Review fixes
- Preference rendering now respects `memory_state_keys.current_memory_id`.
- Preference grouping is owner-aware so repo/user/legacy-global rows with the same topic key are not collapsed together.
- Debug trace reports preference selected ids and preference state-key ambiguity.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test context::tests::diagnostics -- --test-threads=1`
- `cargo test memory::preference -- --test-threads=1`
- `cargo test context -- --test-threads=1`
- `cargo check`
- `cargo clippy -- -D warnings`
- `REMEM_DATA_DIR=$(mktemp -d /tmp/remem-pr293-full3.XXXXXX) CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test -- --test-threads=1`