### PR TITLE
fix(memory): add session memory claims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.34"
+version = "0.4.35"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/api/handlers/save.rs
+++ b/src/api/handlers/save.rs
@@ -20,6 +20,8 @@ pub(in crate::api) async fn handle_save_memory(
         text: req.text,
         title: req.title,
         project: req.project,
+        session_id: req.session_id,
+        host: req.host.or_else(|| Some("api".to_string())),
         topic_key: req.topic_key,
         memory_type: req.memory_type,
         files: req.files,
@@ -28,6 +30,8 @@ pub(in crate::api) async fn handle_save_memory(
         branch: req.branch,
         local_path: req.local_path,
         local_copy_enabled: req.local_copy_enabled,
+        claim_enabled: req.claim_enabled,
+        claim_source: req.claim_source.or_else(|| Some("api_save".to_string())),
     };
 
     match service::save_memory(&conn, &save_req) {
@@ -52,6 +56,9 @@ pub(in crate::api) async fn handle_save_memory(
                 },
                 local_status: saved.local_status,
                 local_path: saved.local_path,
+                claim_status: saved.claim_status,
+                claim_id: saved.claim_id,
+                claim_error: saved.claim_error,
                 next_step: SaveMemoryNextStepResponse {
                     tool: saved.next_step.tool,
                     ids: saved.next_step.ids,

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -180,6 +180,9 @@ async fn save_memory_response_reports_durable_feedback_shape() {
     assert_eq!(payload["local_copy"]["status"], "disabled");
     assert_eq!(payload["local_status"], "disabled");
     assert!(payload["local_path"].is_null());
+    assert_eq!(payload["claim_status"], "saved");
+    assert!(payload["claim_id"].as_i64().is_some_and(|id| id > 0));
+    assert!(payload["claim_error"].is_null());
     assert_eq!(payload["next_step"]["tool"], "get_observations");
     assert_eq!(payload["next_step"]["source"], "memory");
     assert_eq!(payload["next_step"]["ids"][0], payload["id"]);

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -91,6 +91,10 @@ pub(super) struct SaveMemoryRequest {
     #[serde(default)]
     pub project: Option<String>,
     #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
     pub topic_key: Option<String>,
     #[serde(default)]
     pub memory_type: Option<String>,
@@ -106,6 +110,10 @@ pub(super) struct SaveMemoryRequest {
     pub local_path: Option<String>,
     #[serde(default)]
     pub local_copy_enabled: Option<bool>,
+    #[serde(default)]
+    pub claim_enabled: Option<bool>,
+    #[serde(default)]
+    pub claim_source: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -125,6 +133,9 @@ pub(super) struct SaveMemoryResponse {
     pub local_status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub local_path: Option<String>,
+    pub claim_status: String,
+    pub claim_id: Option<i64>,
+    pub claim_error: Option<String>,
     pub next_step: SaveMemoryNextStepResponse,
 }
 

--- a/src/mcp/server/tests.rs
+++ b/src/mcp/server/tests.rs
@@ -205,6 +205,8 @@ fn save_memory_local_copy_failures_are_invalid_request() {
         text: "body".to_string(),
         title: Some("Memory".to_string()),
         project: Some("proj".to_string()),
+        session_id: None,
+        host: None,
         topic_key: None,
         memory_type: None,
         files: None,
@@ -213,6 +215,8 @@ fn save_memory_local_copy_failures_are_invalid_request() {
         branch: None,
         created_at_epoch: None,
         local_copy_enabled: Some(true),
+        claim_enabled: None,
+        claim_source: None,
     }));
 
     let err = match outside {
@@ -241,6 +245,8 @@ fn save_memory_local_copy_failures_are_invalid_request() {
         text: "body".to_string(),
         title: Some("Memory".to_string()),
         project: Some("proj".to_string()),
+        session_id: None,
+        host: None,
         topic_key: None,
         memory_type: None,
         files: None,
@@ -249,6 +255,8 @@ fn save_memory_local_copy_failures_are_invalid_request() {
         branch: None,
         created_at_epoch: None,
         local_copy_enabled: Some(true),
+        claim_enabled: None,
+        claim_source: None,
     }));
 
     let err = match write_failure {
@@ -271,6 +279,8 @@ fn save_memory_response_reports_durable_feedback_shape() {
             text: "MCP durable feedback body".to_string(),
             title: Some("MCP feedback".to_string()),
             project: Some("proj".to_string()),
+            session_id: Some("mcp-session-claim".to_string()),
+            host: None,
             topic_key: Some("mcp-feedback".to_string()),
             memory_type: Some("decision".to_string()),
             files: None,
@@ -279,6 +289,8 @@ fn save_memory_response_reports_durable_feedback_shape() {
             branch: Some("main".to_string()),
             created_at_epoch: None,
             local_copy_enabled: Some(false),
+            claim_enabled: None,
+            claim_source: None,
         }))
         .expect("save_memory should succeed");
     let json: Value = serde_json::from_str(&response).expect("response should be json");
@@ -293,6 +305,9 @@ fn save_memory_response_reports_durable_feedback_shape() {
     assert_eq!(json["local_copy"]["status"], "disabled");
     assert_eq!(json["local_status"], "disabled");
     assert!(json["local_path"].is_null());
+    assert_eq!(json["claim_status"], "saved");
+    assert!(json["claim_id"].as_i64().is_some_and(|id| id > 0));
+    assert!(json["claim_error"].is_null());
     assert_eq!(json["next_step"]["tool"], "get_observations");
     assert_eq!(json["next_step"]["source"], "memory");
     assert_eq!(json["next_step"]["ids"][0], json["id"]);

--- a/src/mcp/server/write_tools.rs
+++ b/src/mcp/server/write_tools.rs
@@ -91,6 +91,12 @@ impl MemoryServer {
                 text: params.text.clone(),
                 title: params.title.clone(),
                 project: params.project.clone(),
+                session_id: params.session_id.clone(),
+                host: params
+                    .host
+                    .clone()
+                    .filter(|host| !host.trim().is_empty())
+                    .or_else(|| Some("codex-cli".to_string())),
                 topic_key: params.topic_key.clone(),
                 memory_type: params.memory_type.clone(),
                 files: params.files.clone(),
@@ -99,6 +105,12 @@ impl MemoryServer {
                 branch,
                 local_path: params.local_path.clone(),
                 local_copy_enabled: params.local_copy_enabled,
+                claim_enabled: params.claim_enabled,
+                claim_source: params
+                    .claim_source
+                    .clone()
+                    .filter(|source| !source.trim().is_empty())
+                    .or_else(|| Some("manual_save".to_string())),
             };
             let saved = service::save_memory(conn, &req).map_err(|e| {
                 crate::log::warn("mcp", &format!("save_memory failed: {}", e));
@@ -138,6 +150,9 @@ impl MemoryServer {
                     },
                     "local_status": saved.local_status,
                     "local_path": saved.local_path,
+                    "claim_status": saved.claim_status,
+                    "claim_id": saved.claim_id,
+                    "claim_error": saved.claim_error,
                     "next_step": {
                         "tool": saved.next_step.tool,
                         "ids": saved.next_step.ids,

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -76,6 +76,12 @@ pub(super) struct SaveMemoryParams {
     #[schemars(description = "Project name")]
     pub project: Option<String>,
     #[schemars(
+        description = "Optional host session id. When provided, Stop summary promotion can suppress exact duplicate candidates from the same session."
+    )]
+    pub session_id: Option<String>,
+    #[schemars(description = "Optional host identifier, e.g. codex-cli, claude-code, api, cli.")]
+    pub host: Option<String>,
+    #[schemars(
         description = "Stable topic identifier for cross-session dedup. Same project+topic_key updates existing memory instead of creating new one. Format: kebab-case descriptive key, e.g. 'fts5-search-strategy', 'auth-middleware-design'."
     )]
     pub topic_key: Option<String>,
@@ -105,6 +111,14 @@ pub(super) struct SaveMemoryParams {
         description = "Override the local markdown backup toggle. Default behavior (when omitted) is controlled by the server config."
     )]
     pub local_copy_enabled: Option<bool>,
+    #[schemars(
+        description = "Override the session claim toggle. Defaults to true; set false to preserve legacy save behavior without claim rows."
+    )]
+    pub claim_enabled: Option<bool>,
+    #[schemars(
+        description = "Optional claim source label. Defaults to manual_save for MCP calls."
+    )]
+    pub claim_source: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,3 +1,4 @@
+pub mod claims;
 pub mod dedup;
 pub mod edge;
 pub mod events;

--- a/src/memory/claims.rs
+++ b/src/memory/claims.rs
@@ -1,0 +1,629 @@
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+
+use crate::memory_candidate::ParsedMemoryCandidate;
+
+const DEFAULT_CLAIM_LOOKBACK_SECS: i64 = 7_200;
+const PREVIEW_CHARS: usize = 240;
+
+pub(crate) struct ClaimWriteRequest<'a> {
+    pub(crate) memory_id: i64,
+    pub(crate) session_id: Option<&'a str>,
+    pub(crate) host: Option<&'a str>,
+    pub(crate) claim_source: &'a str,
+}
+
+struct ClaimMemory {
+    id: i64,
+    project: String,
+    source_project: Option<String>,
+    memory_type: String,
+    topic_key: Option<String>,
+    title: Option<String>,
+    content: String,
+    owner_scope: Option<String>,
+    owner_key: Option<String>,
+    branch: Option<String>,
+}
+
+struct MatchingClaim {
+    id: i64,
+    memory_id: i64,
+    claim_source: String,
+}
+
+struct RecentClaim {
+    id: i64,
+    memory_id: i64,
+    claim_source: String,
+    topic_key: Option<String>,
+    content_fingerprint: String,
+    content: String,
+}
+
+pub(crate) fn claims_enabled(request_enabled: Option<bool>) -> bool {
+    if request_enabled == Some(false) {
+        return false;
+    }
+    match std::env::var("REMEM_MEMORY_CLAIMS") {
+        Ok(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            !(normalized == "off" || normalized == "false" || normalized == "0")
+        }
+        Err(_) => true,
+    }
+}
+
+pub(crate) fn insert_memory_claim(conn: &Connection, input: &ClaimWriteRequest<'_>) -> Result<i64> {
+    let memory = load_claim_memory(conn, input.memory_id)?;
+    let now = chrono::Utc::now().timestamp();
+    let fingerprint = content_fingerprint(
+        &memory.memory_type,
+        memory.owner_scope.as_deref(),
+        memory.owner_key.as_deref(),
+        &memory.content,
+    );
+    let preview = claim_preview(&memory.content);
+    let expires_at = now + claim_lookback_secs();
+    conn.execute(
+        "INSERT INTO memory_claims
+         (memory_id, project, source_project, session_id, host, claim_source,
+          memory_type, topic_key, title, content_fingerprint, content_preview,
+          owner_scope, owner_key, branch, created_at_epoch, expires_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+        params![
+            memory.id,
+            memory.project,
+            memory.source_project,
+            clean_claim_metadata(input.session_id),
+            clean_claim_metadata(input.host),
+            input.claim_source,
+            memory.memory_type,
+            memory.topic_key,
+            memory.title,
+            fingerprint,
+            preview,
+            memory.owner_scope,
+            memory.owner_key,
+            memory.branch,
+            now,
+            expires_at
+        ],
+    )
+    .with_context(|| format!("insert memory claim for memory {}", input.memory_id))?;
+    let claim_id = conn.last_insert_rowid();
+    crate::log::info(
+        "memory-claim",
+        &format!(
+            "saved id={} memory_id={} session={} source={}",
+            claim_id,
+            input.memory_id,
+            input.session_id.unwrap_or("<none>"),
+            input.claim_source
+        ),
+    );
+    Ok(claim_id)
+}
+
+pub(crate) fn filter_summary_candidates_by_claims(
+    conn: &Connection,
+    session_id: &str,
+    project: &str,
+    candidates: &[ParsedMemoryCandidate],
+) -> Vec<ParsedMemoryCandidate> {
+    let session_id = session_id.trim();
+    let summary_host = if session_id.is_empty() {
+        None
+    } else {
+        match latest_session_host(conn, session_id, project) {
+            Ok(host) => host,
+            Err(err) => {
+                crate::log::error(
+                    "memory-claim",
+                    &format!(
+                        "claim host lookup failed session={} project={} error={}",
+                        session_id, project, err
+                    ),
+                );
+                None
+            }
+        }
+    };
+
+    let mut remaining = Vec::new();
+    for candidate in candidates {
+        match matching_claim(
+            conn,
+            session_id,
+            summary_host.as_deref(),
+            project,
+            candidate,
+        ) {
+            Ok(Some(claim)) => {
+                if let Err(err) =
+                    record_noop_and_consume(conn, session_id, project, candidate, &claim)
+                {
+                    crate::log::error(
+                        "memory-claim",
+                        &format!(
+                            "noop audit failed claim_id={} memory_id={} session={} type={} error={}",
+                            claim.id, claim.memory_id, session_id, candidate.memory_type, err
+                        ),
+                    );
+                    remaining.push(candidate.clone());
+                }
+            }
+            Ok(None) => remaining.push(candidate.clone()),
+            Err(err) => {
+                crate::log::error(
+                    "memory-claim",
+                    &format!(
+                        "claim lookup failed session={} project={} type={} error={}",
+                        session_id, project, candidate.memory_type, err
+                    ),
+                );
+                remaining.push(candidate.clone());
+            }
+        }
+    }
+    remaining
+}
+
+fn matching_claim(
+    conn: &Connection,
+    session_id: &str,
+    host: Option<&str>,
+    project: &str,
+    candidate: &ParsedMemoryCandidate,
+) -> Result<Option<MatchingClaim>> {
+    if !session_id.trim().is_empty() {
+        if let Some(claim) = exact_session_claim(conn, session_id, host, project, candidate)? {
+            return Ok(Some(claim));
+        }
+    }
+    recent_project_claim(conn, session_id, host, project, candidate)
+}
+
+fn latest_session_host(
+    conn: &Connection,
+    session_id: &str,
+    project: &str,
+) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT h.name
+         FROM captured_events e
+         JOIN hosts h ON h.id = e.host_id
+         JOIN projects p ON p.id = e.project_id
+         WHERE e.session_id = ?1
+           AND p.project_path = ?2
+         ORDER BY e.id DESC
+         LIMIT 1",
+        params![session_id, project],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn load_claim_memory(conn: &Connection, memory_id: i64) -> Result<ClaimMemory> {
+    conn.query_row(
+        "SELECT id, project, source_project, memory_type, topic_key, title, content,
+                owner_scope, owner_key, branch
+         FROM memories
+         WHERE id = ?1",
+        [memory_id],
+        |row| {
+            Ok(ClaimMemory {
+                id: row.get(0)?,
+                project: row.get(1)?,
+                source_project: row.get(2)?,
+                memory_type: row.get(3)?,
+                topic_key: row.get(4)?,
+                title: row.get(5)?,
+                content: row.get(6)?,
+                owner_scope: row.get(7)?,
+                owner_key: row.get(8)?,
+                branch: row.get(9)?,
+            })
+        },
+    )
+    .with_context(|| format!("load memory {memory_id} for claim"))
+}
+
+fn exact_session_claim(
+    conn: &Connection,
+    session_id: &str,
+    host: Option<&str>,
+    project: &str,
+    candidate: &ParsedMemoryCandidate,
+) -> Result<Option<MatchingClaim>> {
+    let (owner_scope, owner_key) = candidate_owner(project, &candidate.scope);
+    let fingerprint = content_fingerprint(
+        &candidate.memory_type,
+        Some(owner_scope),
+        Some(owner_key),
+        &candidate.text,
+    );
+    let now = chrono::Utc::now().timestamp();
+    conn.query_row(
+        "SELECT id, memory_id, claim_source
+         FROM memory_claims
+         WHERE project = ?1
+           AND session_id = ?2
+           AND memory_type = ?3
+           AND content_fingerprint = ?4
+           AND COALESCE(owner_scope, '') = ?5
+           AND COALESCE(owner_key, '') = ?6
+           AND consumed_at_epoch IS NULL
+           AND (expires_at_epoch IS NULL OR expires_at_epoch > ?7)
+           AND (?8 IS NULL OR host IS NULL OR host = ?8)
+         ORDER BY created_at_epoch DESC, id DESC
+         LIMIT 1",
+        params![
+            project,
+            session_id,
+            candidate.memory_type,
+            fingerprint,
+            owner_scope,
+            owner_key,
+            now,
+            host
+        ],
+        |row| {
+            Ok(MatchingClaim {
+                id: row.get(0)?,
+                memory_id: row.get(1)?,
+                claim_source: row.get(2)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn recent_project_claim(
+    conn: &Connection,
+    session_id: &str,
+    host: Option<&str>,
+    project: &str,
+    candidate: &ParsedMemoryCandidate,
+) -> Result<Option<MatchingClaim>> {
+    let (owner_scope, owner_key) = candidate_owner(project, &candidate.scope);
+    let candidate_fingerprint = content_fingerprint(
+        &candidate.memory_type,
+        Some(owner_scope),
+        Some(owner_key),
+        &candidate.text,
+    );
+    let candidate_normalized = normalize_claim_text(&candidate.text);
+    let now = chrono::Utc::now().timestamp();
+    let min_created_at = now - claim_lookback_secs();
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.memory_id, c.claim_source, c.topic_key,
+                c.content_fingerprint, m.content
+         FROM memory_claims c
+         JOIN memories m ON m.id = c.memory_id
+         WHERE c.project = ?1
+           AND c.memory_type = ?2
+           AND COALESCE(c.owner_scope, '') = ?3
+           AND COALESCE(c.owner_key, '') = ?4
+           AND c.consumed_at_epoch IS NULL
+           AND c.created_at_epoch >= ?5
+           AND (c.expires_at_epoch IS NULL OR c.expires_at_epoch > ?6)
+           AND (?7 = '' OR c.session_id IS NULL OR c.session_id = ?7)
+           AND (?8 IS NULL OR c.host IS NULL OR c.host = ?8)
+         ORDER BY c.created_at_epoch DESC, c.id DESC
+         LIMIT 25",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            project,
+            candidate.memory_type,
+            owner_scope,
+            owner_key,
+            min_created_at,
+            now,
+            session_id.trim(),
+            host
+        ],
+        |row| {
+            Ok(RecentClaim {
+                id: row.get(0)?,
+                memory_id: row.get(1)?,
+                claim_source: row.get(2)?,
+                topic_key: row.get(3)?,
+                content_fingerprint: row.get(4)?,
+                content: row.get(5)?,
+            })
+        },
+    )?;
+    let claims = crate::db::query::collect_rows(rows)?;
+    for claim in claims {
+        if !topic_keys_compatible(claim.topic_key.as_deref(), Some(&candidate.topic_key)) {
+            continue;
+        }
+        if claim.content_fingerprint == candidate_fingerprint
+            || claim_text_similarity(&candidate_normalized, &normalize_claim_text(&claim.content))
+                >= 0.86
+        {
+            return Ok(Some(MatchingClaim {
+                id: claim.id,
+                memory_id: claim.memory_id,
+                claim_source: claim.claim_source,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+fn record_noop_and_consume(
+    conn: &Connection,
+    session_id: &str,
+    project: &str,
+    candidate: &ParsedMemoryCandidate,
+    claim: &MatchingClaim,
+) -> Result<()> {
+    with_claim_savepoint(conn, || {
+        let now = chrono::Utc::now().timestamp();
+        let reason = noop_reason_for_claim_source(&claim.claim_source);
+        conn.execute(
+            "INSERT INTO memory_candidate_noops
+             (project, session_id, memory_claim_id, memory_id, memory_type,
+              topic_key, candidate_text_preview, reason, created_at_epoch)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                project,
+                session_id,
+                claim.id,
+                claim.memory_id,
+                candidate.memory_type,
+                candidate.topic_key,
+                claim_preview(&candidate.text),
+                reason,
+                now
+            ],
+        )?;
+        let updated = conn.execute(
+            "UPDATE memory_claims
+             SET consumed_at_epoch = ?1,
+                 consumed_by_session_id = ?2,
+                 consumed_reason = ?3
+             WHERE id = ?4
+               AND consumed_at_epoch IS NULL",
+            params![now, session_id, reason, claim.id],
+        )?;
+        if updated == 0 {
+            bail!("claim {} was already consumed", claim.id);
+        }
+        crate::log::info(
+            "memory-claim",
+            &format!(
+                "consumed id={} memory_id={} session={} candidate_type={} reason={}",
+                claim.id, claim.memory_id, session_id, candidate.memory_type, reason
+            ),
+        );
+        Ok(())
+    })
+}
+
+fn candidate_owner<'a>(project: &'a str, scope: &str) -> (&'static str, &'a str) {
+    if scope == "global" {
+        ("user", "user:default")
+    } else {
+        ("repo", project)
+    }
+}
+
+fn content_fingerprint(
+    memory_type: &str,
+    owner_scope: Option<&str>,
+    owner_key: Option<&str>,
+    text: &str,
+) -> String {
+    let normalized = normalize_claim_text(text);
+    let mut hasher = Sha256::new();
+    hasher.update(memory_type.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(owner_scope.unwrap_or("").as_bytes());
+    hasher.update(b"\0");
+    hasher.update(owner_key.unwrap_or("").as_bytes());
+    hasher.update(b"\0");
+    hasher.update(normalized.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn claim_lookback_secs() -> i64 {
+    std::env::var("REMEM_MEMORY_CLAIM_LOOKBACK_SECS")
+        .ok()
+        .and_then(|value| value.trim().parse::<i64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_CLAIM_LOOKBACK_SECS)
+}
+
+fn topic_keys_compatible(claim_topic_key: Option<&str>, candidate_topic_key: Option<&str>) -> bool {
+    let claim_topic_key = claim_topic_key.and_then(non_empty);
+    let candidate_topic_key = candidate_topic_key.and_then(non_empty);
+    match (claim_topic_key, candidate_topic_key) {
+        (Some(claim), Some(candidate)) => {
+            claim == candidate || is_hash_like_topic_key(claim) || is_hash_like_topic_key(candidate)
+        }
+        _ => true,
+    }
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn is_hash_like_topic_key(topic_key: &str) -> bool {
+    let lower = topic_key.to_ascii_lowercase();
+    let mut parts = lower.rsplitn(2, ['-', '_']);
+    let tail = parts.next().unwrap_or_default();
+    let prefix = parts.next().unwrap_or_default();
+    tail.len() >= 8
+        && tail.chars().all(|ch| ch.is_ascii_hexdigit())
+        && matches!(
+            prefix,
+            "decision"
+                | "discovery"
+                | "preference"
+                | "bugfix"
+                | "lesson"
+                | "procedure"
+                | "architecture"
+        )
+}
+
+fn claim_text_similarity(left: &str, right: &str) -> f64 {
+    if left == right {
+        return 1.0;
+    }
+    let left_tokens = significant_tokens(left);
+    let right_tokens = significant_tokens(right);
+    if left_tokens.is_empty() || right_tokens.is_empty() {
+        return 0.0;
+    }
+    let intersection = left_tokens.intersection(&right_tokens).count();
+    let union = left_tokens.union(&right_tokens).count();
+    if union == 0 {
+        0.0
+    } else {
+        intersection as f64 / union as f64
+    }
+}
+
+fn significant_tokens(text: &str) -> HashSet<String> {
+    text.split_whitespace()
+        .map(|token| {
+            token
+                .trim_matches(|ch: char| {
+                    ch.is_ascii_punctuation() && ch != '/' && ch != '_' && ch != '-'
+                })
+                .to_string()
+        })
+        .filter(|token| token.chars().count() >= 3 || !token.is_ascii())
+        .filter(|token| !is_claim_stop_token(token))
+        .collect()
+}
+
+fn is_claim_stop_token(token: &str) -> bool {
+    matches!(
+        token,
+        "the"
+            | "and"
+            | "for"
+            | "with"
+            | "from"
+            | "that"
+            | "this"
+            | "should"
+            | "when"
+            | "where"
+            | "what"
+            | "why"
+            | "how"
+            | "into"
+            | "was"
+            | "were"
+    )
+}
+
+fn normalize_claim_text(text: &str) -> String {
+    let text = strip_summary_context(text.trim());
+    let mut parts = Vec::new();
+    for line in text.lines() {
+        let stripped = strip_list_marker(line.trim());
+        let stripped = stripped.trim_matches(|ch: char| {
+            ch.is_ascii_punctuation() && ch != '/' && ch != '_' && ch != '-' && ch != '#'
+        });
+        if !stripped.is_empty() {
+            parts.push(stripped);
+        }
+    }
+    let joined = parts.join(" ");
+    let lowered: String = joined
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii() {
+                ch.to_ascii_lowercase()
+            } else {
+                ch
+            }
+        })
+        .collect();
+    lowered.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn strip_summary_context(text: &str) -> &str {
+    if text.starts_with("[Context:") {
+        if let Some((_, body)) = text.split_once("\n\n") {
+            return body.trim();
+        }
+    }
+    text
+}
+
+fn strip_list_marker(line: &str) -> &str {
+    let line = line.trim_start_matches(['•', '-', '*', '·']).trim_start();
+    let Some(first) = line.chars().next() else {
+        return line;
+    };
+    if first.is_ascii_digit() {
+        if let Some(pos) = line.find(". ") {
+            return line[pos + 2..].trim_start();
+        }
+    }
+    line
+}
+
+fn claim_preview(text: &str) -> String {
+    crate::db::truncate_str(text.trim(), PREVIEW_CHARS).to_string()
+}
+
+fn clean_claim_metadata(value: Option<&str>) -> Option<&str> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    })
+}
+
+fn noop_reason_for_claim_source(source: &str) -> &'static str {
+    match source {
+        "api_save" => "covered_by_api_save",
+        "cli_save" => "covered_by_cli_save",
+        _ => "covered_by_manual_save",
+    }
+}
+
+fn with_claim_savepoint<T>(conn: &Connection, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    conn.execute_batch("SAVEPOINT remem_claim_noop")?;
+    match f() {
+        Ok(value) => {
+            conn.execute_batch("RELEASE SAVEPOINT remem_claim_noop")?;
+            Ok(value)
+        }
+        Err(error) => {
+            let rollback = conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT remem_claim_noop;
+                 RELEASE SAVEPOINT remem_claim_noop;",
+            );
+            if let Err(rollback_error) = rollback {
+                return Err(
+                    error.context(format!("claim noop rollback also failed: {rollback_error}"))
+                );
+            }
+            Err(error)
+        }
+    }
+}

--- a/src/memory/promote/summary.rs
+++ b/src/memory/promote/summary.rs
@@ -25,6 +25,15 @@ pub fn promote_summary_to_memory_candidates(
     if candidates.is_empty() {
         return Ok(0);
     }
+    let candidates = crate::memory::claims::filter_summary_candidates_by_claims(
+        conn,
+        session_id,
+        project,
+        &candidates,
+    );
+    if candidates.is_empty() {
+        return Ok(0);
+    }
 
     let source = summary_candidate_source(conn, session_id, project)?;
     let summary = persist_summary_candidates(

--- a/src/memory/promote/tests/promote.rs
+++ b/src/memory/promote/tests/promote.rs
@@ -4,6 +4,7 @@ use rusqlite::Connection;
 use super::super::promote_summary_to_memory_candidates;
 use super::super::slug::content_hash;
 use crate::db;
+use crate::memory::service::{save_memory, SaveMemoryRequest};
 
 fn setup_conn() -> Result<Connection> {
     let conn = Connection::open_in_memory()?;
@@ -12,10 +13,19 @@ fn setup_conn() -> Result<Connection> {
 }
 
 fn record_summary_evidence(conn: &Connection, session_id: &str, project: &str) -> Result<i64> {
+    record_summary_evidence_with_host(conn, "codex-cli", session_id, project)
+}
+
+fn record_summary_evidence_with_host(
+    conn: &Connection,
+    host: &str,
+    session_id: &str,
+    project: &str,
+) -> Result<i64> {
     let outcome = db::record_captured_event(
         conn,
         &db::CaptureEventInput {
-            host: "codex-cli",
+            host,
             session_id,
             project,
             cwd: Some(project),
@@ -241,6 +251,413 @@ fn test_summary_candidate_content_keeps_compact_context() -> Result<()> {
         text.contains("[Context:"),
         "content should have compact context: {text}"
     );
+    Ok(())
+}
+
+#[test]
+fn summary_candidate_promotion_skips_candidate_covered_by_exact_session_claim() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-claim-suppress";
+    let project = "test/proj";
+    let decision = "Use exact session memory claims to suppress duplicate summary candidates";
+    let saved = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: decision.to_string(),
+            title: Some("Session claim suppression".to_string()),
+            project: Some(project.to_string()),
+            session_id: Some(session_id.to_string()),
+            host: Some("codex-cli".to_string()),
+            memory_type: Some("decision".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    let claim_id = saved
+        .claim_id
+        .ok_or_else(|| anyhow::anyhow!("save_memory should return claim_id"))?;
+    record_summary_evidence(&conn, session_id, project)?;
+
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Finish issue 287"),
+        Some(decision),
+        None,
+        None,
+    )?;
+
+    let candidate_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    let noop: (i64, i64, String, String) = conn.query_row(
+        "SELECT memory_claim_id, memory_id, reason, memory_type
+         FROM memory_candidate_noops",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    let consumed: (Option<i64>, Option<String>, Option<String>) = conn.query_row(
+        "SELECT consumed_at_epoch, consumed_by_session_id, consumed_reason
+         FROM memory_claims
+         WHERE id = ?1",
+        [claim_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+
+    assert_eq!(count, 0);
+    assert_eq!(candidate_count, 0);
+    assert_eq!(noop.0, claim_id);
+    assert_eq!(noop.1, saved.id);
+    assert_eq!(noop.2, "covered_by_manual_save");
+    assert_eq!(noop.3, "decision");
+    assert!(consumed.0.is_some());
+    assert_eq!(consumed.1.as_deref(), Some(session_id));
+    assert_eq!(consumed.2.as_deref(), Some("covered_by_manual_save"));
+    Ok(())
+}
+
+#[test]
+fn summary_candidate_promotion_skips_candidate_covered_by_recent_project_claim() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-claim-recent-fallback";
+    let project = "test/proj";
+    let decision = "Use recent project memory claims when exact session id is unavailable";
+    let saved = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: decision.to_string(),
+            title: Some("Recent claim fallback".to_string()),
+            project: Some(project.to_string()),
+            memory_type: Some("decision".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    let claim_id = saved
+        .claim_id
+        .ok_or_else(|| anyhow::anyhow!("save_memory should return claim_id"))?;
+    record_summary_evidence(&conn, session_id, project)?;
+
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Finish issue 287"),
+        Some(decision),
+        None,
+        None,
+    )?;
+
+    let candidate_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    let noop_session: String = conn.query_row(
+        "SELECT session_id FROM memory_candidate_noops WHERE memory_claim_id = ?1",
+        [claim_id],
+        |row| row.get(0),
+    )?;
+    let consumed_by: Option<String> = conn.query_row(
+        "SELECT consumed_by_session_id FROM memory_claims WHERE id = ?1",
+        [claim_id],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(count, 0);
+    assert_eq!(candidate_count, 0);
+    assert_eq!(noop_session, session_id);
+    assert_eq!(consumed_by.as_deref(), Some(session_id));
+    Ok(())
+}
+
+#[test]
+fn summary_candidate_promotion_skips_high_similarity_recent_claim() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-claim-near-match";
+    let project = "test/proj";
+    let saved = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: "Use session memory claims to suppress duplicate Stop summary candidates."
+                .to_string(),
+            title: Some("Near duplicate claim".to_string()),
+            project: Some(project.to_string()),
+            memory_type: Some("decision".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    let claim_id = saved
+        .claim_id
+        .ok_or_else(|| anyhow::anyhow!("save_memory should return claim_id"))?;
+    record_summary_evidence(&conn, session_id, project)?;
+
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Finish issue 287"),
+        Some("Use session memory claims to suppress duplicate summary candidates"),
+        None,
+        None,
+    )?;
+
+    let candidate_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    let noop_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_candidate_noops WHERE memory_claim_id = ?1",
+        [claim_id],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(count, 0);
+    assert_eq!(candidate_count, 0);
+    assert_eq!(noop_count, 1);
+    Ok(())
+}
+
+#[test]
+fn summary_candidate_promotion_does_not_skip_different_session_claim() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let project = "test/proj";
+    let decision = "Session-specific claims must not suppress another session candidate";
+    let saved = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: decision.to_string(),
+            title: Some("Different session claim".to_string()),
+            project: Some(project.to_string()),
+            session_id: Some("session-a".to_string()),
+            host: Some("codex-cli".to_string()),
+            memory_type: Some("decision".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    record_summary_evidence(&conn, "session-b", project)?;
+
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        "session-b",
+        project,
+        Some("Finish issue 287"),
+        Some(decision),
+        None,
+        None,
+    )?;
+
+    let noop_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidate_noops", [], |row| {
+            row.get(0)
+        })?;
+    let consumed_at: Option<i64> = conn.query_row(
+        "SELECT consumed_at_epoch FROM memory_claims WHERE memory_id = ?1",
+        [saved.id],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(count, 1);
+    assert_eq!(noop_count, 0);
+    assert_eq!(consumed_at, None);
+    Ok(())
+}
+
+#[test]
+fn summary_candidate_promotion_does_not_skip_different_host_claim() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "shared-session-id";
+    let project = "test/proj";
+    let decision = "Host identity is part of exact session claim matching";
+    let saved = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: decision.to_string(),
+            title: Some("Different host claim".to_string()),
+            project: Some(project.to_string()),
+            session_id: Some(session_id.to_string()),
+            host: Some("api".to_string()),
+            memory_type: Some("decision".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    record_summary_evidence_with_host(&conn, "codex-cli", session_id, project)?;
+
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Finish issue 287"),
+        Some(decision),
+        None,
+        None,
+    )?;
+
+    let noop_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidate_noops", [], |row| {
+            row.get(0)
+        })?;
+    let consumed_at: Option<i64> = conn.query_row(
+        "SELECT consumed_at_epoch FROM memory_claims WHERE memory_id = ?1",
+        [saved.id],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(count, 1);
+    assert_eq!(noop_count, 0);
+    assert_eq!(consumed_at, None);
+    Ok(())
+}
+
+#[test]
+fn summary_candidate_promotion_does_not_skip_different_owner_claim() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-claim-owner-boundary";
+    let project = "test/proj";
+    let decision = "Claim matching respects memory owner boundaries";
+    let saved = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: decision.to_string(),
+            title: Some("Owner boundary claim".to_string()),
+            project: Some(project.to_string()),
+            session_id: Some(session_id.to_string()),
+            host: Some("codex-cli".to_string()),
+            memory_type: Some("decision".to_string()),
+            scope: Some("global".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    record_summary_evidence(&conn, session_id, project)?;
+
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Finish issue 287"),
+        Some(decision),
+        None,
+        None,
+    )?;
+
+    let noop_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidate_noops", [], |row| {
+            row.get(0)
+        })?;
+    let consumed_at: Option<i64> = conn.query_row(
+        "SELECT consumed_at_epoch FROM memory_claims WHERE memory_id = ?1",
+        [saved.id],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(count, 1);
+    assert_eq!(noop_count, 0);
+    assert_eq!(consumed_at, None);
+    Ok(())
+}
+
+#[test]
+fn summary_candidate_promotion_does_not_skip_different_memory_type_claim() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-claim-type-boundary";
+    let project = "test/proj";
+    let fact = "Claim matching respects memory type boundaries";
+    let saved = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: fact.to_string(),
+            title: Some("Type boundary claim".to_string()),
+            project: Some(project.to_string()),
+            session_id: Some(session_id.to_string()),
+            host: Some("codex-cli".to_string()),
+            memory_type: Some("decision".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    record_summary_evidence(&conn, session_id, project)?;
+
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Finish issue 287"),
+        None,
+        Some(fact),
+        None,
+    )?;
+
+    let noop_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidate_noops", [], |row| {
+            row.get(0)
+        })?;
+    let consumed_at: Option<i64> = conn.query_row(
+        "SELECT consumed_at_epoch FROM memory_claims WHERE memory_id = ?1",
+        [saved.id],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(count, 1);
+    assert_eq!(noop_count, 0);
+    assert_eq!(consumed_at, None);
+    Ok(())
+}
+
+#[test]
+fn summary_candidate_promotion_does_not_skip_low_similarity_candidate() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let session_id = "session-claim-low-similarity";
+    let project = "test/proj";
+    let saved = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: "Use exact session memory claims only for identical saved facts".to_string(),
+            title: Some("Exact claims".to_string()),
+            project: Some(project.to_string()),
+            session_id: Some(session_id.to_string()),
+            memory_type: Some("decision".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    let claim_id = saved
+        .claim_id
+        .ok_or_else(|| anyhow::anyhow!("save_memory should return claim_id"))?;
+    record_summary_evidence(&conn, session_id, project)?;
+
+    let count = promote_summary_to_memory_candidates(
+        &mut conn,
+        session_id,
+        project,
+        Some("Finish issue 287"),
+        Some("Switch summary extraction to keep unrelated facts in pending review"),
+        None,
+        None,
+    )?;
+
+    let candidate_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    let noop_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_candidate_noops", [], |row| {
+            row.get(0)
+        })?;
+    let consumed_at: Option<i64> = conn.query_row(
+        "SELECT consumed_at_epoch FROM memory_claims WHERE id = ?1",
+        [claim_id],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(count, 1);
+    assert_eq!(candidate_count, 1);
+    assert_eq!(noop_count, 0);
+    assert_eq!(consumed_at, None);
     Ok(())
 }
 

--- a/src/memory/service/save.rs
+++ b/src/memory/service/save.rs
@@ -8,6 +8,7 @@ use super::local_copy::{
     write_local_note,
 };
 use super::types::{LocalCopyResult, SaveMemoryNextStep, SaveMemoryRequest, SaveMemoryResult};
+use crate::memory::claims::{claims_enabled, insert_memory_claim, ClaimWriteRequest};
 use crate::memory::lesson::{save_lesson, SaveLessonRequest};
 use crate::memory::lifecycle::MemoryLifecycleOp;
 
@@ -67,7 +68,7 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
             let id = save_lesson(
                 conn,
                 &SaveLessonRequest {
-                    session_id: None,
+                    session_id: req.session_id.as_deref(),
                     project,
                     topic_key: req.topic_key.as_deref(),
                     title,
@@ -128,7 +129,7 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
             }
             crate::memory::insert_memory_full_with_operation_log(
                 conn,
-                None,
+                req.session_id.as_deref(),
                 project,
                 req.topic_key.as_deref(),
                 title,
@@ -159,6 +160,7 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
     discard_local_copy_backup(&local_copy);
     let durable = load_durable_write_details(conn, id)?;
     let local_copy_result = local_copy.result();
+    let claim_result = write_claim_after_durable_save(conn, id, req);
 
     Ok(SaveMemoryResult {
         id,
@@ -175,6 +177,9 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
         local_status: local_copy_result.status.clone(),
         local_path: local_copy_result.path.clone(),
         local_copy: local_copy_result,
+        claim_status: claim_result.status,
+        claim_id: claim_result.id,
+        claim_error: claim_result.error,
         next_step: SaveMemoryNextStep {
             tool: "get_observations".to_string(),
             ids: vec![id],
@@ -185,6 +190,55 @@ pub fn save_memory(conn: &Connection, req: &SaveMemoryRequest) -> Result<SaveMem
             ),
         },
     })
+}
+
+struct ClaimSaveResult {
+    status: String,
+    id: Option<i64>,
+    error: Option<String>,
+}
+
+fn write_claim_after_durable_save(
+    conn: &Connection,
+    memory_id: i64,
+    req: &SaveMemoryRequest,
+) -> ClaimSaveResult {
+    if !claims_enabled(req.claim_enabled) {
+        return ClaimSaveResult {
+            status: "disabled".to_string(),
+            id: None,
+            error: None,
+        };
+    }
+
+    let claim_source = req.claim_source.as_deref().unwrap_or("manual_save");
+    match insert_memory_claim(
+        conn,
+        &ClaimWriteRequest {
+            memory_id,
+            session_id: req.session_id.as_deref(),
+            host: req.host.as_deref(),
+            claim_source,
+        },
+    ) {
+        Ok(claim_id) => ClaimSaveResult {
+            status: "saved".to_string(),
+            id: Some(claim_id),
+            error: None,
+        },
+        Err(err) => {
+            let error = format!("{err:#}");
+            crate::log::error(
+                "memory-claim",
+                &format!("claim write failed memory_id={} error={}", memory_id, error),
+            );
+            ClaimSaveResult {
+                status: "failed".to_string(),
+                id: None,
+                error: Some(error),
+            }
+        }
+    }
 }
 
 struct LocalCopyPlan {

--- a/src/memory/service/save_tests.rs
+++ b/src/memory/service/save_tests.rs
@@ -117,3 +117,111 @@ fn direct_save_same_text_metadata_change_updates_row() -> anyhow::Result<()> {
     assert_eq!(branch.as_deref(), Some("feature"));
     Ok(())
 }
+
+#[test]
+fn save_memory_creates_manual_claim_after_successful_memory_write() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("save-memory-claim-success");
+    let conn = db::open_db()?;
+    let req = SaveMemoryRequest {
+        text: "Use exact session memory claims to suppress duplicate summary candidates."
+            .to_string(),
+        title: Some("Session claims".to_string()),
+        project: Some("proj".to_string()),
+        session_id: Some("session-claim-success".to_string()),
+        host: Some("codex-cli".to_string()),
+        memory_type: Some("decision".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+
+    let saved = save_memory(&conn, &req)?;
+
+    assert_eq!(saved.claim_status, "saved");
+    let claim_id = saved
+        .claim_id
+        .ok_or_else(|| anyhow::anyhow!("claim id should be returned"))?;
+    assert_eq!(saved.claim_error, None);
+    let claim: (i64, String, String, String, String, String) = conn.query_row(
+        "SELECT memory_id, project, session_id, host, claim_source, memory_type
+         FROM memory_claims
+         WHERE id = ?1",
+        [claim_id],
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+            ))
+        },
+    )?;
+    assert_eq!(claim.0, saved.id);
+    assert_eq!(claim.1, "proj");
+    assert_eq!(claim.2, "session-claim-success");
+    assert_eq!(claim.3, "codex-cli");
+    assert_eq!(claim.4, "manual_save");
+    assert_eq!(claim.5, "decision");
+    Ok(())
+}
+
+#[test]
+fn save_memory_claim_disabled_preserves_existing_behavior() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("save-memory-claim-disabled");
+    let conn = db::open_db()?;
+    let req = SaveMemoryRequest {
+        text: "Claim disabled should still save durable memory.".to_string(),
+        title: Some("Claim disabled".to_string()),
+        project: Some("proj".to_string()),
+        session_id: Some("session-claim-disabled".to_string()),
+        memory_type: Some("discovery".to_string()),
+        local_copy_enabled: Some(false),
+        claim_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+
+    let saved = save_memory(&conn, &req)?;
+
+    assert_eq!(saved.status, "saved");
+    assert_eq!(saved.claim_status, "disabled");
+    assert_eq!(saved.claim_id, None);
+    assert_eq!(saved.claim_error, None);
+    let claim_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_claims", [], |row| row.get(0))?;
+    assert_eq!(claim_count, 0);
+    Ok(())
+}
+
+#[test]
+fn save_memory_claim_write_failure_is_reported_not_silent() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("save-memory-claim-failure");
+    let conn = db::open_db()?;
+    conn.execute("DROP TABLE memory_claims", [])?;
+    let req = SaveMemoryRequest {
+        text: "Durable memory should survive a claim write failure.".to_string(),
+        title: Some("Claim failure".to_string()),
+        project: Some("proj".to_string()),
+        session_id: Some("session-claim-failure".to_string()),
+        memory_type: Some("discovery".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+
+    let saved = save_memory(&conn, &req)?;
+
+    assert_eq!(saved.status, "saved");
+    assert_eq!(saved.claim_status, "failed");
+    assert_eq!(saved.claim_id, None);
+    assert!(saved
+        .claim_error
+        .as_deref()
+        .is_some_and(|error| error.contains("memory_claims")));
+    let memory_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories WHERE id = ?1",
+        [saved.id],
+        |row| row.get(0),
+    )?;
+    assert_eq!(memory_count, 1);
+    Ok(())
+}

--- a/src/memory/service/types.rs
+++ b/src/memory/service/types.rs
@@ -40,6 +40,8 @@ pub struct SaveMemoryRequest {
     pub text: String,
     pub title: Option<String>,
     pub project: Option<String>,
+    pub session_id: Option<String>,
+    pub host: Option<String>,
     pub topic_key: Option<String>,
     pub memory_type: Option<String>,
     pub files: Option<Vec<String>>,
@@ -48,6 +50,8 @@ pub struct SaveMemoryRequest {
     pub branch: Option<String>,
     pub local_path: Option<String>,
     pub local_copy_enabled: Option<bool>,
+    pub claim_enabled: Option<bool>,
+    pub claim_source: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -83,5 +87,8 @@ pub struct SaveMemoryResult {
     pub local_copy: LocalCopyResult,
     pub local_status: String,
     pub local_path: Option<String>,
+    pub claim_status: String,
+    pub claim_id: Option<i64>,
+    pub claim_error: Option<String>,
     pub next_step: SaveMemoryNextStep,
 }

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -6,7 +6,7 @@ use rusqlite::{
 };
 use std::{
     fs::{self, OpenOptions},
-    io::ErrorKind,
+    io::{ErrorKind, Read},
     path::{Path, PathBuf},
     process,
     sync::atomic::{AtomicU64, Ordering},
@@ -45,7 +45,17 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
             });
         }
     };
-    if let Some(key) = crate::db::load_cipher_key() {
+    let clone_key = match clone_cipher_key_for_source(real_conn) {
+        Ok(key) => key,
+        Err(error) => {
+            return Ok(DryRunResult {
+                current_version,
+                pending_count: applied_pending_count(&applied),
+                error: Some(format!("database clone: {}", error)),
+            });
+        }
+    };
+    if let Some(key) = clone_key {
         if let Err(error) = crate::db::configure_cipher(&test_conn, Some(&key)) {
             return Ok(DryRunResult {
                 current_version,
@@ -153,6 +163,51 @@ fn clone_database(src: &Connection, dst: &mut Connection) -> Result<()> {
     let backup = Backup::new(src, dst)?;
     backup.run_to_completion(100, Duration::from_millis(1), None)?;
     Ok(())
+}
+
+fn clone_cipher_key_for_source(src: &Connection) -> Result<Option<String>> {
+    if source_database_looks_encrypted(src)? {
+        return Ok(crate::db::load_cipher_key());
+    }
+    Ok(None)
+}
+
+fn source_database_looks_encrypted(conn: &Connection) -> Result<bool> {
+    let mut stmt = conn.prepare("PRAGMA database_list")?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+    })?;
+    for row in rows {
+        let (name, file) = row?;
+        if name != "main" {
+            continue;
+        }
+        let file = file.trim();
+        if file.is_empty() {
+            return Ok(false);
+        }
+        return sqlite_file_looks_encrypted(Path::new(file));
+    }
+    Ok(false)
+}
+
+fn sqlite_file_looks_encrypted(path: &Path) -> Result<bool> {
+    let mut file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect source database {}", path.display()));
+        }
+    };
+    let mut header = [0_u8; 16];
+    let read = file
+        .read(&mut header)
+        .with_context(|| format!("read source database header {}", path.display()))?;
+    if read < header.len() {
+        return Ok(false);
+    }
+    Ok(&header != b"SQLite format 3\0")
 }
 
 fn query_page_size(conn: &Connection) -> Result<i64> {
@@ -300,6 +355,24 @@ mod tests {
         );
         assert!(!sqlite_sidecar_path(&dry_run_path, "-wal").exists());
         assert!(!sqlite_sidecar_path(&dry_run_path, "-shm").exists());
+
+        cleanup_temp_db_files(&source_path);
+        Ok(())
+    }
+
+    #[test]
+    fn plaintext_source_database_does_not_request_cipher_clone() -> Result<()> {
+        let source_path = unique_temp_db_path("dry-run-plaintext-source");
+        {
+            let source = Connection::open(&source_path)?;
+            source.execute_batch(
+                "CREATE TABLE items (id INTEGER PRIMARY KEY);
+                 INSERT INTO items DEFAULT VALUES;",
+            )?;
+
+            assert!(!source_database_looks_encrypted(&source)?);
+            assert_eq!(clone_cipher_key_for_source(&source)?, None);
+        }
 
         cleanup_temp_db_files(&source_path);
         Ok(())

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -108,6 +108,8 @@ fn full_migration_on_empty_db() -> Result<()> {
         "topic_segments",
         "memory_operation_log",
         "memory_edges",
+        "memory_claims",
+        "memory_candidate_noops",
     ] {
         let exists: bool = conn
             .query_row(
@@ -122,6 +124,11 @@ fn full_migration_on_empty_db() -> Result<()> {
         "idx_memory_edges_from",
         "idx_memory_edges_to",
         "idx_memory_edges_state",
+        "idx_memory_claims_session",
+        "idx_memory_claims_recent",
+        "idx_memory_claims_fingerprint",
+        "idx_memory_candidate_noops_claim",
+        "idx_memory_candidate_noops_project",
     ] {
         let exists: bool = conn
             .query_row(

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -130,6 +130,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "memory_edges",
         sql: include_str!("../migrations/v025_memory_edges.sql"),
     },
+    Migration {
+        version: 26,
+        name: "memory_claims",
+        sql: include_str!("../migrations/v026_memory_claims.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v026_memory_claims.sql
+++ b/src/migrations/v026_memory_claims.sql
@@ -1,0 +1,56 @@
+-- v026_memory_claims: short-lived save_memory claims and summary candidate
+-- noop audit rows for claim-covered duplicates.
+
+CREATE TABLE IF NOT EXISTS memory_claims (
+    id INTEGER PRIMARY KEY,
+    memory_id INTEGER NOT NULL,
+    project TEXT NOT NULL,
+    source_project TEXT,
+    session_id TEXT,
+    host TEXT,
+    claim_source TEXT NOT NULL,
+    memory_type TEXT NOT NULL,
+    topic_key TEXT,
+    title TEXT,
+    content_fingerprint TEXT NOT NULL,
+    content_preview TEXT NOT NULL,
+    owner_scope TEXT,
+    owner_key TEXT,
+    branch TEXT,
+    created_at_epoch INTEGER NOT NULL,
+    expires_at_epoch INTEGER,
+    consumed_at_epoch INTEGER,
+    consumed_by_session_id TEXT,
+    consumed_reason TEXT,
+    FOREIGN KEY(memory_id) REFERENCES memories(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_claims_session
+    ON memory_claims(project, session_id, created_at_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_memory_claims_recent
+    ON memory_claims(project, created_at_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_memory_claims_fingerprint
+    ON memory_claims(project, memory_type, content_fingerprint);
+
+CREATE TABLE IF NOT EXISTS memory_candidate_noops (
+    id INTEGER PRIMARY KEY,
+    project TEXT NOT NULL,
+    session_id TEXT,
+    memory_claim_id INTEGER,
+    memory_id INTEGER,
+    memory_type TEXT NOT NULL,
+    topic_key TEXT,
+    candidate_text_preview TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    FOREIGN KEY(memory_claim_id) REFERENCES memory_claims(id),
+    FOREIGN KEY(memory_id) REFERENCES memories(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_candidate_noops_claim
+    ON memory_candidate_noops(memory_claim_id, created_at_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_memory_candidate_noops_project
+    ON memory_candidate_noops(project, created_at_epoch);


### PR DESCRIPTION
## Summary

Fixes #287.

Adds short-lived memory claims for explicit `save_memory` writes so Stop-summary promotion can keep raw evidence and session summaries while skipping redundant memory candidates for facts already saved durably.

## Changes

- add v026 schema for `memory_claims` and `memory_candidate_noops`
- extend API/MCP save requests with optional `session_id`, `host`, `claim_enabled`, and `claim_source`
- return `claim_status`, `claim_id`, and explicit `claim_error` when claim writing fails after a durable memory save
- filter summary candidates against exact session claims and conservative recent project claims
- record durable noop audit rows and mark consumed claims when suppression is used
- keep fail-open behavior for suppression lookup/write failures: raw archive/session summaries and candidates are preserved when claim matching cannot be proven
- bump version to `0.4.35`

## Review fixes

A read-only review thread found three boundary risks. This PR includes the follow-up fixes:

- recent fallback no longer suppresses claims from a different non-empty session
- exact and fallback matching now respect same/unknown host identity
- suppression has negative coverage for different session, host, owner, memory type, and low-similarity text

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test memory::promote::tests::promote -- --test-threads=1`
- `cargo test memory::service::save_tests -- --test-threads=1`
- `REMEM_DATA_DIR=$(mktemp -d /tmp/remem-pr287-full2.XXXXXX) CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test -- --test-threads=1`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
