### PR TITLE
fix(memory): align direct save topic target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.35"
+version = "0.4.36"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/memory/service/save_tests.rs
+++ b/src/memory/service/save_tests.rs
@@ -119,6 +119,80 @@ fn direct_save_same_text_metadata_change_updates_row() -> anyhow::Result<()> {
 }
 
 #[test]
+fn direct_save_updates_active_duplicate_topic_row() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("save-active-topic-duplicate-target");
+    let conn = db::open_db()?;
+    let req = SaveMemoryRequest {
+        text: "Use the current active duplicate row for planner-aligned writes.".to_string(),
+        title: Some("Planner target".to_string()),
+        project: Some("proj".to_string()),
+        topic_key: Some("planner-target".to_string()),
+        memory_type: Some("discovery".to_string()),
+        scope: Some("project".to_string()),
+        local_copy_enabled: Some(false),
+        ..SaveMemoryRequest::default()
+    };
+    let stale = save_memory(&conn, &req)?;
+    conn.execute(
+        "UPDATE memories
+         SET status = 'stale', updated_at_epoch = ?1
+         WHERE id = ?2",
+        rusqlite::params![10_i64, stale.id],
+    )?;
+    conn.execute(
+        "INSERT INTO memories
+         (session_id, project, topic_key, title, content, memory_type, files, search_context,
+          created_at_epoch, updated_at_epoch, status, branch, scope,
+          source_project, target_project, owner_scope, owner_key, context_class)
+         VALUES (?1, 'proj', 'planner-target', 'Current active row',
+                 'Existing active duplicate content.', 'discovery', NULL,
+                 'Existing active duplicate content.', ?2, ?3, 'active', NULL, 'project',
+                 'proj', 'proj', 'repo', 'proj', 'startup_core')",
+        rusqlite::params!["legacy-active-session", 20_i64, 20_i64],
+    )?;
+    let active = conn.last_insert_rowid();
+    let update_req = SaveMemoryRequest {
+        text: "Updated planner-aligned content.".to_string(),
+        title: Some("Planner target updated".to_string()),
+        ..req
+    };
+
+    let saved = save_memory(&conn, &update_req)?;
+
+    assert_eq!(saved.id, active);
+    assert_eq!(saved.operation, "update");
+    let stale_status: String = conn.query_row(
+        "SELECT status FROM memories WHERE id = ?1",
+        [stale.id],
+        |row| row.get(0),
+    )?;
+    assert_eq!(stale_status, "stale");
+    let active_content: String = conn.query_row(
+        "SELECT content FROM memories WHERE id = ?1",
+        [active],
+        |row| row.get(0),
+    )?;
+    assert_eq!(active_content, "Updated planner-aligned content.");
+    let active_topic_rows: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories
+         WHERE project = 'proj'
+           AND topic_key = 'planner-target'
+           AND scope = 'project'
+           AND status = 'active'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(active_topic_rows, 1);
+    let logged_result: i64 = conn.query_row(
+        "SELECT result_memory_id FROM memory_operation_log ORDER BY id DESC LIMIT 1",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(logged_result, active);
+    Ok(())
+}
+
+#[test]
 fn save_memory_creates_manual_claim_after_successful_memory_write() -> anyhow::Result<()> {
     let _dir = ScopedTestDataDir::new("save-memory-claim-success");
     let conn = db::open_db()?;

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -88,6 +88,9 @@ pub fn insert_memory_full(
                 .query_row(
                     "SELECT id FROM memories
                      WHERE project = ?1 AND topic_key = ?2 AND scope = ?3
+                     ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END,
+                              updated_at_epoch DESC,
+                              id DESC
                      LIMIT 1",
                     params![project, topic_key, scope],
                     |row| row.get(0),


### PR DESCRIPTION
## Summary

Closes #288.

This is a final Memory State V3 hardening fix from the #288 review pass. Direct `save_memory` already plans topic-key writes using active/current rows first, but the lower-level `insert_memory_full` topic-key upsert still selected an arbitrary matching row. In legacy duplicate data, that could reactivate a stale row while the operation log planned against the active row.

## Changes

- align topic-key target selection in `insert_memory_full` with `plan_direct_save`
- prefer active rows, then newest `updated_at_epoch`, then highest `id`
- add a direct-save regression test for stale + active legacy duplicate rows
- bump version to `0.4.36`

## Review

A review thread found no blocker after the fix. It noted one residual non-blocking test gap for two active duplicate rows; the same deterministic ordering covers that path and planner/insert selection are now aligned.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test memory::service::save_tests::direct_save_updates_active_duplicate_topic_row -- --test-threads=1`
- `cargo test memory::service::save_tests -- --test-threads=1`
- `REMEM_DATA_DIR=$(mktemp -d /tmp/remem-288-planner-full.XXXXXX) CARGO_TARGET_DIR=/Users/lifcc/Desktop/code/AI/tools/remem/target cargo test -- --test-threads=1`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
