### PR TITLE
Suppress repeated Codex SessionStart context by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.36"
+version = "0.4.37"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ tools exposed by `remem mcp`, including `search`, `get_observations`,
 
 The default Codex integration is intentionally low-noise: it uses
 `SessionStart` for context injection and `Stop` for background summarization.
-It does not install high-frequency Bash observation by default.
+The installed Codex `SessionStart` hook uses strict duplicate-injection gating,
+so a mid-chat `SessionStart` repeat stays silent after the first injection for
+the same session. It does not install high-frequency Bash observation by
+default.
 
 ## Distribution Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,7 +94,9 @@ remem status
 `search`、`get_observations`、`save_memory`、`workstreams` 和 `timeline`。
 
 默认 Codex 集成刻意保持低噪音：用 `SessionStart` 注入上下文，用 `Stop`
-做后台总结；默认不安装高频 Bash observe hook。
+做后台总结。安装后的 Codex `SessionStart` hook 使用 strict duplicate-injection
+gate，所以同一 session 里中途重复触发的 `SessionStart` 会在首次注入后保持静默；
+默认不安装高频 Bash observe hook。
 
 ## 发布渠道
 

--- a/src/context/injection_gate/tests.rs
+++ b/src/context/injection_gate/tests.rs
@@ -285,6 +285,27 @@ fn compact_source_changed_hash_emits_delta() {
 }
 
 #[test]
+fn strict_mode_suppresses_changed_hash_after_first_context() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-strict-changed");
+    let mut invocation = gate_invocation(Some("sess-strict-changed"));
+    invocation.gate_mode = Some("strict".to_string());
+
+    let first = apply_context_gate(
+        &invocation,
+        "# [/tmp/remem] context now\nBody A\n".to_string(),
+    );
+    assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+    let second = apply_context_gate(
+        &invocation,
+        "# [/tmp/remem] context now\nBody B\n".to_string(),
+    );
+    assert_eq!(second.action, ContextGateAction::Suppressed);
+    assert_eq!(second.reason, "strict");
+    assert!(second.output.is_empty());
+}
+
+#[test]
 fn restart_source_reemits_same_hash_context() {
     let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-restart");
     let mut invocation = gate_invocation(Some("sess-restart"));

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -57,11 +57,16 @@ impl HookStrategy {
 
 fn hook_command(bin: &str, strategy: HookStrategy, subcommand: &str) -> String {
     if subcommand == "context" {
+        let gate_arg = match strategy {
+            HookStrategy::Codex => " --gate strict",
+            HookStrategy::ClaudeCode => "",
+        };
         format!(
-            "REMEM_CONTEXT_HOST={} {} {} --color",
+            "REMEM_CONTEXT_HOST={} {} {} --color{}",
             strategy.context_host(),
             bin,
-            subcommand
+            subcommand,
+            gate_arg
         )
     } else if subcommand == "summarize" {
         format!(

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -32,7 +32,7 @@ fn build_hooks_contains_expected_codex_commands() {
     let hooks = build_hooks("/tmp/remem", HookStrategy::Codex);
     assert_eq!(
         hooks["SessionStart"][0]["hooks"][0]["command"],
-        "REMEM_CONTEXT_HOST=codex-cli /tmp/remem context --color"
+        "REMEM_CONTEXT_HOST=codex-cli /tmp/remem context --color --gate strict"
     );
     assert!(hooks.get("UserPromptSubmit").is_none());
     assert!(hooks.get("PostToolUse").is_none());


### PR DESCRIPTION
## Summary
- install Codex `SessionStart` hooks with `--gate strict` so same-session repeats stay silent after the first injection
- keep Claude Code hook behavior unchanged and keep `auto` / `delta` modes available for explicit use
- document the low-noise Codex behavior and add a strict-mode changed-hash regression test

Fixes #312

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test`