### PR TITLE
fix(migrate): repair memory state key schema drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.36"
+version = "0.4.37"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -201,6 +201,39 @@ fn check_schema_migration_reads_encrypted_database() -> anyhow::Result<()> {
 }
 
 #[test]
+fn check_schema_migration_reports_v022_schema_drift() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-schema-drift");
+    let conn = db::open_db()?;
+    conn.execute_batch(
+        "PRAGMA foreign_keys=OFF;
+         DROP TABLE memory_state_keys;
+         PRAGMA foreign_keys=ON;",
+    )?;
+    drop(conn);
+
+    let check = check_schema_migration();
+    assert_eq!(check.icon(), "FAIL");
+    assert!(
+        check.detail.contains("schema drift"),
+        "got: {}",
+        check.detail
+    );
+    assert!(
+        check
+            .detail
+            .contains("v022_memory_state_keys marked applied"),
+        "got: {}",
+        check.detail
+    );
+    assert!(
+        check.detail.contains("table memory_state_keys"),
+        "got: {}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
 fn run_doctor_with_writer_returns_outcome_and_emits_human_lines() {
     let _test_dir = ScopedTestDataDir::new("doctor-run-human");
     // Ensure DB exists so the database probe doesn't FAIL the run.

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,5 +1,6 @@
 mod dry_run;
 mod run;
+mod schema_drift;
 mod state;
 #[cfg(test)]
 mod tests;
@@ -7,11 +8,14 @@ mod tests;
 mod tests_convergence;
 #[cfg(test)]
 mod tests_schema;
+#[cfg(test)]
+mod tests_schema_drift;
 mod transition;
 mod types;
 
 pub(crate) use dry_run::dry_run_pending;
 pub(crate) use run::run_migrations;
+pub(crate) use schema_drift::validate_schema_invariants;
 #[cfg(test)]
 pub(crate) use types::MIGRATIONS;
 

--- a/src/migrate/dry_run.rs
+++ b/src/migrate/dry_run.rs
@@ -24,6 +24,14 @@ pub(crate) fn dry_run_pending(real_conn: &Connection) -> Result<DryRunResult> {
         .unwrap_or(0);
     let applied = infer_applied_versions(real_conn, raw_current_version)?;
     let current_version = logical_current_version(raw_current_version, &applied);
+    let invariant_errors = super::validate_schema_invariants(real_conn)?;
+    if !invariant_errors.is_empty() {
+        return Ok(DryRunResult {
+            current_version,
+            pending_count: applied_pending_count(&applied),
+            error: Some(format!("schema drift: {}", invariant_errors.join("; "))),
+        });
+    }
 
     let temp_path = match DryRunTempPath::create() {
         Ok(temp_path) => temp_path,

--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use rusqlite::Connection;
 
+use super::schema_drift::repair_known_schema_drift;
 use super::state::{applied_versions, ensure_migration_table, mark_applied};
 use super::transition::transition_from_old_system;
 use super::types::{MIGRATIONS, OLD_BASELINE_VERSION};
@@ -49,6 +50,9 @@ fn run_migrations_locked(conn: &Connection) -> Result<()> {
             "database is at schema v{db_latest} but this binary ({}) only knows up to v{binary_latest}; please upgrade remem and verify `remem --version` reports schema v{db_latest} or newer",
             crate::build_info::version_label()
         ));
+    }
+    for repair in repair_known_schema_drift(conn, &applied)? {
+        crate::log::info("migrate", &format!("repaired schema drift: {repair}"));
     }
     for migration in MIGRATIONS {
         if applied.contains(&migration.version) {

--- a/src/migrate/schema_drift.rs
+++ b/src/migrate/schema_drift.rs
@@ -1,0 +1,154 @@
+use anyhow::{bail, Context, Result};
+use rusqlite::{Connection, OptionalExtension};
+
+use super::state::{applied_versions, has_migration_table};
+use super::transition::add_column_if_missing;
+
+const V022: i64 = 22;
+
+pub(crate) fn validate_schema_invariants(conn: &Connection) -> Result<Vec<String>> {
+    if !has_migration_table(conn) {
+        return Ok(Vec::new());
+    }
+
+    let applied = applied_versions(conn)?;
+    let mut errors = Vec::new();
+    if applied.contains(&V022) {
+        for missing in missing_v022_objects(conn)? {
+            errors.push(format!(
+                "v022_memory_state_keys marked applied but missing {missing}"
+            ));
+        }
+    }
+    Ok(errors)
+}
+
+pub(super) fn repair_known_schema_drift(conn: &Connection, applied: &[i64]) -> Result<Vec<String>> {
+    let mut repaired = Vec::new();
+    if !applied.contains(&V022) {
+        return Ok(repaired);
+    }
+
+    let missing = missing_v022_objects(conn)?;
+    if missing.is_empty() {
+        return Ok(repaired);
+    }
+
+    repair_v022_memory_state_keys(conn).context("repair v022_memory_state_keys schema drift")?;
+    let still_missing = missing_v022_objects(conn)?;
+    if !still_missing.is_empty() {
+        bail!(
+            "repair v022_memory_state_keys schema drift incomplete: {}",
+            still_missing.join(", ")
+        );
+    }
+
+    repaired.push(format!("v022_memory_state_keys ({})", missing.join(", ")));
+    Ok(repaired)
+}
+
+fn repair_v022_memory_state_keys(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS memory_state_keys (
+            id INTEGER PRIMARY KEY,
+            owner_scope TEXT NOT NULL,
+            owner_key TEXT NOT NULL,
+            memory_type TEXT NOT NULL,
+            state_key TEXT NOT NULL,
+            state_label TEXT,
+            state_status TEXT NOT NULL DEFAULT 'active',
+            current_memory_id INTEGER,
+            created_at_epoch INTEGER NOT NULL,
+            updated_at_epoch INTEGER NOT NULL,
+            UNIQUE(owner_scope, owner_key, memory_type, state_key),
+            FOREIGN KEY(current_memory_id) REFERENCES memories(id)
+        );",
+    )?;
+
+    add_column_if_missing(conn, "memories", "state_key_id", "INTEGER")?;
+    add_column_if_missing(conn, "memory_candidates", "state_key", "TEXT")?;
+    add_column_if_missing(conn, "memory_candidates", "state_key_confidence", "REAL")?;
+    add_column_if_missing(conn, "memory_candidates", "state_key_reason", "TEXT")?;
+
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_memory_state_keys_owner
+            ON memory_state_keys(owner_scope, owner_key, memory_type, state_status);
+        CREATE INDEX IF NOT EXISTS idx_memory_state_keys_current
+            ON memory_state_keys(current_memory_id)
+            WHERE current_memory_id IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_memories_state_key_id
+            ON memories(state_key_id)
+            WHERE state_key_id IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_memory_candidates_state_key
+            ON memory_candidates(owner_scope, owner_key, memory_type, state_key)
+            WHERE state_key IS NOT NULL;",
+    )?;
+    Ok(())
+}
+
+fn missing_v022_objects(conn: &Connection) -> Result<Vec<String>> {
+    let mut missing = Vec::new();
+    if !table_exists(conn, "memory_state_keys")? {
+        missing.push("table memory_state_keys".to_string());
+    }
+    for (table, column) in [
+        ("memories", "state_key_id"),
+        ("memory_candidates", "state_key"),
+        ("memory_candidates", "state_key_confidence"),
+        ("memory_candidates", "state_key_reason"),
+    ] {
+        if !column_exists(conn, table, column)? {
+            missing.push(format!("column {table}.{column}"));
+        }
+    }
+    for index in [
+        "idx_memory_state_keys_owner",
+        "idx_memory_state_keys_current",
+        "idx_memories_state_key_id",
+        "idx_memory_candidates_state_key",
+    ] {
+        if !index_exists(conn, index)? {
+            missing.push(format!("index {index}"));
+        }
+    }
+    Ok(missing)
+}
+
+fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+            [table],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+fn index_exists(conn: &Connection, index: &str) -> Result<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?1",
+            [index],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
+    let sql = format!("PRAGMA table_info({})", quote_identifier(table));
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        if name == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}

--- a/src/migrate/tests_schema_drift.rs
+++ b/src/migrate/tests_schema_drift.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use super::{dry_run_pending, run_migrations, MIGRATIONS};
+
+#[test]
+fn run_migrations_repairs_v022_schema_drift() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    create_current_schema_with_v022_missing_objects(&conn)?;
+
+    run_migrations(&conn)?;
+
+    assert!(conn
+        .prepare("SELECT id, state_key FROM memory_state_keys LIMIT 0")
+        .is_ok());
+    assert!(conn
+        .prepare("SELECT state_key_id FROM memories LIMIT 0")
+        .is_ok());
+    assert!(conn
+        .prepare(
+            "SELECT state_key, state_key_confidence, state_key_reason
+             FROM memory_candidates LIMIT 0"
+        )
+        .is_ok());
+    for index in [
+        "idx_memory_state_keys_owner",
+        "idx_memory_state_keys_current",
+        "idx_memories_state_key_id",
+        "idx_memory_candidates_state_key",
+    ] {
+        let exists: bool = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?1",
+                [index],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        assert!(exists, "{index} index should be repaired");
+    }
+    Ok(())
+}
+
+#[test]
+fn dry_run_pending_reports_v022_schema_drift() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    create_current_schema_with_v022_missing_objects(&conn)?;
+
+    let result = dry_run_pending(&conn)?;
+
+    assert_eq!(result.pending_count, 0);
+    let error = result
+        .error
+        .expect("schema drift must be reported even when no migrations are pending");
+    assert!(error.contains("schema drift"));
+    assert!(error.contains("v022_memory_state_keys marked applied"));
+    assert!(error.contains("table memory_state_keys"));
+    Ok(())
+}
+
+fn create_current_schema_with_v022_missing_objects(conn: &Connection) -> Result<()> {
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=OFF;")?;
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version != 22)
+    {
+        conn.execute_batch(migration.sql)?;
+    }
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_epoch INTEGER NOT NULL
+        );",
+    )?;
+    for migration in MIGRATIONS {
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, ?2, 1700000000)",
+            params![migration.version, migration.name],
+        )?;
+    }
+    conn.execute_batch(&format!(
+        "PRAGMA user_version = {}; PRAGMA foreign_keys=ON;",
+        super::types::OLD_BASELINE_VERSION - 1 + super::latest_schema_version()
+    ))?;
+    Ok(())
+}

--- a/src/migrate/transition.rs
+++ b/src/migrate/transition.rs
@@ -180,7 +180,7 @@ pub(super) fn backfill_to_baseline(conn: &Connection) -> Result<()> {
 }
 
 /// Try to add a column; ignore only duplicate-column cases.
-fn add_column_if_missing(
+pub(super) fn add_column_if_missing(
     conn: &Connection,
     table: &str,
     column: &str,


### PR DESCRIPTION
## Summary

Fixes #314.

This PR adds a schema drift guard for the v022 memory_state_keys migration. If `_schema_migrations` records v022 as applied but the table, linked columns, or indexes are missing, the write migration path repairs those objects idempotently. The doctor/dry-run path now reports already-applied migration drift instead of saying the schema is up to date.

## Root cause

`remem doctor` only verified pending migrations. A DB could therefore have no pending migrations while still missing structures from an already-recorded migration, which let runtime paths fail later with `no such table: memory_state_keys`.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test migrate::tests_schema_drift`
- `cargo test check_schema_migration_reports_v022_schema_drift`
- `cargo test`

## Local repair evidence

On the affected local DB, the new doctor check reported v022 missing `memory_state_keys`, `memories.state_key_id`, `memory_candidates.state_key*`, and related indexes. After backing up the DB, running the fixed binary repaired the drift and `remem doctor` now reports Schema `ok`.
