### PR TITLE
docs: clarify host-aware install refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Language: **English** | [简体中文](README.zh-CN.md)
 # Option 1: Homebrew
 brew install majiayu000/tap/remem
 
-# Option 2: Quick install (prebuilt GitHub Release binary)
+# Option 2: Quick install (prebuilt GitHub Release binary, then auto-configures hooks)
 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
 # Pin a specific release or install into a custom bin directory
@@ -57,7 +57,7 @@ cargo build --release
 cp target/release/remem ~/.local/bin/
 codesign -s - -f ~/.local/bin/remem  # required on macOS ARM
 
-# Configure detected Claude Code/Codex hooks + MCP
+# If you used Cargo or source install, configure detected Claude Code/Codex hooks + MCP
 remem install
 
 # Optional: target one host explicitly
@@ -74,6 +74,32 @@ package manager such as Homebrew or Cargo, update through that same channel
 and avoid keeping a second manual copy earlier or later on PATH. `remem doctor`
 and `remem install --dry-run` warn when multiple `remem` executables are
 visible.
+
+### Updating an Existing Install
+
+When you replace the binary manually, rerun `remem install` so existing Claude Code
+and Codex hook commands pick up the current host-aware settings:
+
+```bash
+cargo build --release
+cp target/release/remem ~/.local/bin/
+codesign -s - -f ~/.local/bin/remem  # required on macOS ARM
+remem install --target all
+```
+
+Verify the installed hooks include host-specific context commands:
+
+```bash
+jq -r '.hooks.SessionStart[]?.hooks[]?.command' ~/.claude/settings.json
+jq -r '.hooks.SessionStart[]?.hooks[]?.command' ~/.codex/hooks.json
+```
+
+Expected commands include:
+
+```text
+REMEM_CONTEXT_HOST=claude-code /Users/you/.local/bin/remem context
+REMEM_CONTEXT_HOST=codex-cli /Users/you/.local/bin/remem context
+```
 
 ## Use With Codex
 

--- a/README.md
+++ b/README.md
@@ -94,11 +94,12 @@ jq -r '.hooks.SessionStart[]?.hooks[]?.command' ~/.claude/settings.json
 jq -r '.hooks.SessionStart[]?.hooks[]?.command' ~/.codex/hooks.json
 ```
 
-Expected commands include:
+Expected command prefixes include; additional flags such as `--color` or
+`--gate strict` may follow:
 
 ```text
-REMEM_CONTEXT_HOST=claude-code /Users/you/.local/bin/remem context
-REMEM_CONTEXT_HOST=codex-cli /Users/you/.local/bin/remem context
+REMEM_CONTEXT_HOST=claude-code /Users/you/.local/bin/remem context ...
+REMEM_CONTEXT_HOST=codex-cli /Users/you/.local/bin/remem context ...
 ```
 
 ## Use With Codex

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,7 +33,7 @@
 # 方式 1：Homebrew
 brew install majiayu000/tap/remem
 
-# 方式 2：快速安装（GitHub Release 预编译二进制）
+# 方式 2：快速安装（GitHub Release 预编译二进制，并自动配置 hooks）
 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
 # 固定版本、指定安装目录，或只安装二进制不改 hooks/MCP
@@ -57,7 +57,7 @@ cargo build --release
 cp target/release/remem ~/.local/bin/
 codesign -s - -f ~/.local/bin/remem  # macOS ARM 必须签名
 
-# 配置检测到的 Claude Code/Codex hooks + MCP
+# 如果使用 Cargo 或源码安装，配置检测到的 Claude Code/Codex hooks + MCP
 remem install
 
 # 可选：明确指定安装目标
@@ -72,6 +72,32 @@ PATH 上建议只保留一个 canonical `remem` 命令。Standalone 和源码安
 `%USERPROFILE%\.local\bin\remem.exe`。如果使用 Homebrew 或 Cargo 这类包管理器，
 后续也通过同一个渠道升级，避免 PATH 前后同时残留第二份手动安装的二进制。
 `remem doctor` 和 `remem install --dry-run` 会在检测到多个 `remem` 可执行文件时警告。
+
+### 更新已有安装
+
+手动替换二进制后，需要重新执行 `remem install`，让已有 Claude Code 和
+Codex hook 命令刷新到当前 host-aware 配置：
+
+```bash
+cargo build --release
+cp target/release/remem ~/.local/bin/
+codesign -s - -f ~/.local/bin/remem  # macOS ARM 必须签名
+remem install --target all
+```
+
+验证已安装 hooks 是否包含 host-specific context 命令：
+
+```bash
+jq -r '.hooks.SessionStart[]?.hooks[]?.command' ~/.claude/settings.json
+jq -r '.hooks.SessionStart[]?.hooks[]?.command' ~/.codex/hooks.json
+```
+
+期望包含：
+
+```text
+REMEM_CONTEXT_HOST=claude-code /Users/you/.local/bin/remem context
+REMEM_CONTEXT_HOST=codex-cli /Users/you/.local/bin/remem context
+```
 
 ## 在 Codex 中使用
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,11 +92,12 @@ jq -r '.hooks.SessionStart[]?.hooks[]?.command' ~/.claude/settings.json
 jq -r '.hooks.SessionStart[]?.hooks[]?.command' ~/.codex/hooks.json
 ```
 
-期望包含：
+期望看到这些 command prefix；后面可能继续带 `--color`、`--gate strict`
+等参数：
 
 ```text
-REMEM_CONTEXT_HOST=claude-code /Users/you/.local/bin/remem context
-REMEM_CONTEXT_HOST=codex-cli /Users/you/.local/bin/remem context
+REMEM_CONTEXT_HOST=claude-code /Users/you/.local/bin/remem context ...
+REMEM_CONTEXT_HOST=codex-cli /Users/you/.local/bin/remem context ...
 ```
 
 ## 在 Codex 中使用


### PR DESCRIPTION
## Summary

- Document rerunning `remem install --target all` after manual binary replacement so Claude Code and Codex hooks refresh host-aware settings.
- Add hook verification commands for both English and Simplified Chinese READMEs.
- Preserve the latest README install channel structure while applying the older local docs commit.

Closes #316

## Validation

- `cargo check`
- `cargo test`