### PR TITLE
fix: keep compression sources active on failed replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- Kept compression from marking source observations as compressed when the AI
+  output produces no replacement observations or replacement writes fail.
+
 ### Changed
 - Reframed project metadata and README docs around Claude Code and Codex as
   first-class hosts, including a Codex setup section and distribution channel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.4.37"
+version = "0.4.38"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/summarize/compress.rs
+++ b/src/summarize/compress.rs
@@ -10,7 +10,7 @@ pub async fn process_compress_job(project: &str) -> Result<()> {
 }
 
 async fn maybe_compress(project: &str) -> Result<()> {
-    let conn = db::open_db()?;
+    let mut conn = db::open_db()?;
     let total = db::count_active_observations(&conn, project)?;
     if total <= COMPRESS_THRESHOLD {
         return Ok(());
@@ -49,20 +49,59 @@ async fn maybe_compress(project: &str) -> Result<()> {
         }
     };
 
-    let compressed = format::parse_observations(&response);
-    if !compressed.is_empty() {
-        store_compressed_observations(&conn, project, &response, &compressed)?;
-    }
-
-    let ids: Vec<i64> = old_obs.iter().map(|obs| obs.id).collect();
-    let marked = db::mark_observations_compressed(&conn, &ids)?;
+    let outcome = apply_compression_response(&mut conn, project, &old_obs, &response)?;
     timer.done(&format!(
         "{} old → {} compressed, {} marked",
         old_obs.len(),
-        compressed.len(),
-        marked
+        outcome.compressed_count,
+        outcome.marked_count
     ));
     Ok(())
+}
+
+struct CompressionOutcome {
+    compressed_count: usize,
+    marked_count: usize,
+}
+
+fn apply_compression_response(
+    conn: &mut rusqlite::Connection,
+    project: &str,
+    old_obs: &[crate::db::models::Observation],
+    response: &str,
+) -> Result<CompressionOutcome> {
+    let compressed = format::parse_observations(response);
+    if compressed.is_empty() {
+        crate::log::warn(
+            "compress",
+            &format!(
+                "compression_skipped project={} reason=no_replacement_observations",
+                project
+            ),
+        );
+        return Ok(CompressionOutcome {
+            compressed_count: 0,
+            marked_count: 0,
+        });
+    }
+
+    let ids: Vec<i64> = old_obs.iter().map(|obs| obs.id).collect();
+    let marked =
+        store_compressed_observations_and_mark_sources(conn, project, response, &compressed, &ids)
+            .map_err(|err| {
+                crate::log::error(
+                    "compress",
+                    &format!(
+                        "compression_failed project={} reason=replacement_write_or_source_mark_failed error={}",
+                        project, err
+                    ),
+                );
+                err
+            })?;
+    Ok(CompressionOutcome {
+        compressed_count: compressed.len(),
+        marked_count: marked,
+    })
 }
 
 fn build_compress_events(old_obs: &[crate::db::models::Observation]) -> String {
@@ -118,4 +157,165 @@ fn store_compressed_observations(
     }
 
     Ok(())
+}
+
+fn store_compressed_observations_and_mark_sources(
+    conn: &mut rusqlite::Connection,
+    project: &str,
+    response: &str,
+    compressed: &[format::ParsedObservation],
+    source_ids: &[i64],
+) -> Result<usize> {
+    let tx = conn.transaction()?;
+    store_compressed_observations(&tx, project, response, compressed)?;
+    let marked = db::mark_observations_compressed(&tx, source_ids)?;
+    tx.commit()?;
+    Ok(marked)
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use rusqlite::Connection;
+
+    use super::*;
+
+    const PROJECT: &str = "compress-test";
+
+    fn setup_conn() -> Result<Connection> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        Ok(conn)
+    }
+
+    fn insert_source_observation(conn: &Connection, title: &str) -> Result<i64> {
+        db::insert_observation(
+            conn,
+            "source-session",
+            PROJECT,
+            "discovery",
+            Some(title),
+            None,
+            Some("source narrative"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            1,
+        )
+    }
+
+    fn observation_status(conn: &Connection, id: i64) -> Result<String> {
+        Ok(conn.query_row(
+            "SELECT status FROM observations WHERE id = ?1",
+            [id],
+            |row| row.get(0),
+        )?)
+    }
+
+    fn observation_count(conn: &Connection) -> Result<i64> {
+        Ok(conn.query_row("SELECT COUNT(*) FROM observations", [], |row| row.get(0))?)
+    }
+
+    fn old_obs(conn: &Connection, id: i64) -> Result<Vec<crate::db::models::Observation>> {
+        let rows = db::get_observations_by_ids(conn, &[id], Some(PROJECT))?;
+        anyhow::ensure!(
+            rows.len() == 1,
+            "source observation {id} should exist exactly once"
+        );
+        Ok(rows)
+    }
+
+    #[test]
+    fn empty_ai_response_leaves_sources_active() -> Result<()> {
+        let mut conn = setup_conn()?;
+        let source_id = insert_source_observation(&conn, "source")?;
+        let sources = old_obs(&conn, source_id)?;
+
+        let outcome = apply_compression_response(&mut conn, PROJECT, &sources, "")?;
+
+        assert_eq!(outcome.compressed_count, 0);
+        assert_eq!(outcome.marked_count, 0);
+        assert_eq!(observation_status(&conn, source_id)?, "active");
+        assert_eq!(observation_count(&conn)?, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_ai_response_leaves_sources_active() -> Result<()> {
+        let mut conn = setup_conn()?;
+        let source_id = insert_source_observation(&conn, "source")?;
+        let sources = old_obs(&conn, source_id)?;
+
+        let outcome = apply_compression_response(
+            &mut conn,
+            PROJECT,
+            &sources,
+            "<observation><title>truncated",
+        )?;
+
+        assert_eq!(outcome.compressed_count, 0);
+        assert_eq!(outcome.marked_count, 0);
+        assert_eq!(observation_status(&conn, source_id)?, "active");
+        assert_eq!(observation_count(&conn)?, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn valid_compression_inserts_replacements_and_marks_sources() -> Result<()> {
+        let mut conn = setup_conn()?;
+        let source_id = insert_source_observation(&conn, "source")?;
+        let sources = old_obs(&conn, source_id)?;
+        let response = r#"
+<observation>
+<type>discovery</type>
+<title>Compressed insight</title>
+<narrative>Condensed source observations.</narrative>
+</observation>
+"#;
+
+        let outcome = apply_compression_response(&mut conn, PROJECT, &sources, response)?;
+
+        assert_eq!(outcome.compressed_count, 1);
+        assert_eq!(outcome.marked_count, 1);
+        assert_eq!(observation_status(&conn, source_id)?, "compressed");
+        assert_eq!(observation_count(&conn)?, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn replacement_insert_failure_rolls_back_source_status_changes() -> Result<()> {
+        let mut conn = setup_conn()?;
+        let source_id = insert_source_observation(&conn, "source")?;
+        let sources = old_obs(&conn, source_id)?;
+        conn.execute_batch(
+            "CREATE TRIGGER block_compressed_insert
+             BEFORE INSERT ON observations
+             WHEN NEW.memory_session_id LIKE 'compressed-%'
+             BEGIN
+                 SELECT RAISE(ABORT, 'blocked replacement insert');
+             END;",
+        )?;
+        let response = r#"
+<observation>
+<type>discovery</type>
+<title>Compressed insight</title>
+<narrative>Condensed source observations.</narrative>
+</observation>
+"#;
+
+        let err = match apply_compression_response(&mut conn, PROJECT, &sources, response) {
+            Ok(_) => anyhow::bail!("replacement insert failure should be reported"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("blocked replacement insert"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(observation_status(&conn, source_id)?, "active");
+        assert_eq!(observation_count(&conn)?, 1);
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- Keep compression from marking source observations compressed when parsed AI output yields no replacements.
- Write compressed replacements and source status updates in one transaction.
- Add focused regression coverage for empty, malformed, successful, and failed replacement writes.
- Bump package version to 0.4.38 for the binary-impacting change.

## Validation
- cargo fmt --check
- cargo test summarize::compress
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- cargo check
- cargo test

Closes #321