### PR TITLE
fix(compress): only retire observations after replacement writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/db/observation.rs
+++ b/src/db/observation.rs
@@ -112,7 +112,9 @@ pub fn mark_observations_compressed(conn: &Connection, ids: &[i64]) -> Result<us
     }
     let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{i}")).collect();
     let sql = format!(
-        "UPDATE observations SET status = 'compressed' WHERE id IN ({})",
+        "UPDATE observations
+         SET status = 'compressed'
+         WHERE status IN ('active', 'stale') AND id IN ({})",
         placeholders.join(", ")
     );
     let mut stmt = conn.prepare(&sql)?;

--- a/src/summarize/compress.rs
+++ b/src/summarize/compress.rs
@@ -5,6 +5,9 @@ use crate::memory::format;
 
 use super::constants::{COMPRESS_BATCH, COMPRESS_PROMPT, COMPRESS_THRESHOLD, KEEP_RECENT};
 
+const NO_REPLACEMENTS_REASON: &str = "no replacement observations parsed";
+const INVALID_REPLACEMENTS_REASON: &str = "invalid replacement observations parsed";
+
 pub async fn process_compress_job(host: &str, project: &str, profile: Option<&str>) -> Result<()> {
     maybe_compress(host, project, profile).await
 }
@@ -155,7 +158,13 @@ fn apply_compression_response(
     let compressed = format::parse_observations(response);
     if compressed.is_empty() {
         return Ok(CompressionOutcome::Skipped {
-            reason: "no replacement observations parsed",
+            reason: NO_REPLACEMENTS_REASON,
+            source_count: source_ids.len(),
+        });
+    }
+    if compressed.iter().any(|obs| !has_replacement_content(obs)) {
+        return Ok(CompressionOutcome::Skipped {
+            reason: INVALID_REPLACEMENTS_REASON,
             source_count: source_ids.len(),
         });
     }
@@ -163,12 +172,30 @@ fn apply_compression_response(
     with_compression_savepoint(conn, || {
         store_compressed_observations(conn, project, response, &compressed)?;
         let marked = db::mark_observations_compressed(conn, source_ids)?;
+        if marked != source_ids.len() {
+            anyhow::bail!(
+                "marked {marked} of {} source observations compressed",
+                source_ids.len()
+            );
+        }
         Ok(CompressionOutcome::Compressed {
             source_count: source_ids.len(),
             replacement_count: compressed.len(),
             marked_count: marked,
         })
     })
+}
+
+fn has_replacement_content(obs: &format::ParsedObservation) -> bool {
+    has_text(obs.title.as_deref())
+        || has_text(obs.subtitle.as_deref())
+        || has_text(obs.narrative.as_deref())
+        || !obs.facts.is_empty()
+        || !obs.concepts.is_empty()
+}
+
+fn has_text(value: Option<&str>) -> bool {
+    value.is_some_and(|value| !value.trim().is_empty())
 }
 
 fn with_compression_savepoint<T>(
@@ -196,202 +223,4 @@ fn with_compression_savepoint<T>(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use rusqlite::{params, Connection};
-
-    fn setup_observation_schema(conn: &Connection) -> Result<()> {
-        conn.execute_batch(
-            "CREATE TABLE observations (
-                id INTEGER PRIMARY KEY,
-                memory_session_id TEXT NOT NULL,
-                project TEXT,
-                type TEXT NOT NULL,
-                title TEXT,
-                subtitle TEXT,
-                narrative TEXT,
-                facts TEXT,
-                concepts TEXT,
-                files_read TEXT,
-                files_modified TEXT,
-                prompt_number INTEGER,
-                created_at TEXT,
-                created_at_epoch INTEGER,
-                discovery_tokens INTEGER DEFAULT 0,
-                status TEXT DEFAULT 'active',
-                last_accessed_epoch INTEGER,
-                branch TEXT,
-                commit_sha TEXT
-            );",
-        )?;
-        Ok(())
-    }
-
-    fn insert_source_observation(conn: &Connection, status: &str) -> Result<i64> {
-        let id = db::insert_observation(
-            conn,
-            "source-session",
-            "proj",
-            "discovery",
-            Some("Source"),
-            None,
-            Some("Source observation"),
-            None,
-            None,
-            None,
-            None,
-            None,
-            0,
-        )?;
-        conn.execute(
-            "UPDATE observations SET status = ?1 WHERE id = ?2",
-            params![status, id],
-        )?;
-        Ok(id)
-    }
-
-    fn statuses_for(conn: &Connection, ids: &[i64]) -> Result<Vec<String>> {
-        let placeholders = ids
-            .iter()
-            .enumerate()
-            .map(|(idx, _)| format!("?{}", idx + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let sql =
-            format!("SELECT status FROM observations WHERE id IN ({placeholders}) ORDER BY id");
-        let params = ids
-            .iter()
-            .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
-            .collect::<Vec<_>>();
-        let refs = crate::db::to_sql_refs(&params);
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(0))?;
-        crate::db::query::collect_rows(rows)
-    }
-
-    fn compressed_titles(conn: &Connection) -> Result<Vec<String>> {
-        let mut stmt = conn.prepare(
-            "SELECT COALESCE(title, '')
-             FROM observations
-             WHERE memory_session_id LIKE 'compressed-%'
-             ORDER BY id",
-        )?;
-        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-        crate::db::query::collect_rows(rows)
-    }
-
-    fn valid_response(title: &str) -> String {
-        format!(
-            "<observation>
-                <type>decision</type>
-                <title>{title}</title>
-                <narrative>Compressed narrative</narrative>
-             </observation>"
-        )
-    }
-
-    #[test]
-    fn empty_compression_response_leaves_sources_active() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
-        setup_observation_schema(&conn)?;
-        let ids = vec![
-            insert_source_observation(&conn, "active")?,
-            insert_source_observation(&conn, "stale")?,
-        ];
-
-        let outcome = apply_compression_response(&conn, "proj", &ids, "")?;
-
-        assert_eq!(
-            outcome,
-            CompressionOutcome::Skipped {
-                reason: "no replacement observations parsed",
-                source_count: 2,
-            }
-        );
-        assert_eq!(statuses_for(&conn, &ids)?, vec!["active", "stale"]);
-        assert!(compressed_titles(&conn)?.is_empty());
-        Ok(())
-    }
-
-    #[test]
-    fn malformed_compression_response_leaves_sources_active() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
-        setup_observation_schema(&conn)?;
-        let ids = vec![insert_source_observation(&conn, "active")?];
-
-        let outcome = apply_compression_response(
-            &conn,
-            "proj",
-            &ids,
-            "<observation><type>decision</type><title>broken",
-        )?;
-
-        assert_eq!(
-            outcome,
-            CompressionOutcome::Skipped {
-                reason: "no replacement observations parsed",
-                source_count: 1,
-            }
-        );
-        assert_eq!(statuses_for(&conn, &ids)?, vec!["active"]);
-        assert!(compressed_titles(&conn)?.is_empty());
-        Ok(())
-    }
-
-    #[test]
-    fn valid_compression_inserts_replacement_then_marks_sources() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
-        setup_observation_schema(&conn)?;
-        let ids = vec![
-            insert_source_observation(&conn, "active")?,
-            insert_source_observation(&conn, "stale")?,
-        ];
-
-        let outcome =
-            apply_compression_response(&conn, "proj", &ids, &valid_response("Compressed"))?;
-
-        assert_eq!(
-            outcome,
-            CompressionOutcome::Compressed {
-                source_count: 2,
-                replacement_count: 1,
-                marked_count: 2,
-            }
-        );
-        assert_eq!(statuses_for(&conn, &ids)?, vec!["compressed", "compressed"]);
-        assert_eq!(compressed_titles(&conn)?, vec!["Compressed"]);
-        Ok(())
-    }
-
-    #[test]
-    fn replacement_insert_failure_rolls_back_sources_and_replacements() -> Result<()> {
-        let conn = Connection::open_in_memory()?;
-        setup_observation_schema(&conn)?;
-        conn.execute_batch(
-            "CREATE TRIGGER fail_bad_compression
-             BEFORE INSERT ON observations
-             WHEN NEW.memory_session_id LIKE 'compressed-%'
-                  AND NEW.title = 'Bad replacement'
-             BEGIN
-                 SELECT RAISE(FAIL, 'bad compressed insert');
-             END;",
-        )?;
-        let ids = vec![
-            insert_source_observation(&conn, "active")?,
-            insert_source_observation(&conn, "stale")?,
-        ];
-        let response = format!(
-            "{}\n{}",
-            valid_response("Good replacement"),
-            valid_response("Bad replacement")
-        );
-
-        let error = apply_compression_response(&conn, "proj", &ids, &response)
-            .expect_err("insert trigger should fail");
-
-        assert!(error.to_string().contains("bad compressed insert"));
-        assert_eq!(statuses_for(&conn, &ids)?, vec!["active", "stale"]);
-        assert!(compressed_titles(&conn)?.is_empty());
-        Ok(())
-    }
-}
+mod tests;

--- a/src/summarize/compress.rs
+++ b/src/summarize/compress.rs
@@ -51,19 +51,30 @@ async fn maybe_compress(host: &str, project: &str, profile: Option<&str>) -> Res
         }
     };
 
-    let compressed = format::parse_observations(&response);
-    if !compressed.is_empty() {
-        store_compressed_observations(&conn, project, &response, &compressed)?;
-    }
-
     let ids: Vec<i64> = old_obs.iter().map(|obs| obs.id).collect();
-    let marked = db::mark_observations_compressed(&conn, &ids)?;
-    timer.done(&format!(
-        "{} old → {} compressed, {} marked",
-        old_obs.len(),
-        compressed.len(),
-        marked
-    ));
+    let outcome = apply_compression_response(&conn, project, &ids, &response)?;
+    match outcome {
+        CompressionOutcome::Skipped {
+            reason,
+            source_count,
+        } => {
+            crate::log::info(
+                "compress",
+                &format!("project={project} skipped compression: {reason}"),
+            );
+            timer.done(&format!("{source_count} old → skipped ({reason})"));
+        }
+        CompressionOutcome::Compressed {
+            source_count,
+            replacement_count,
+            marked_count,
+        } => {
+            timer.done(&format!(
+                "{} old → {} compressed, {} marked",
+                source_count, replacement_count, marked_count
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -120,4 +131,267 @@ fn store_compressed_observations(
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CompressionOutcome {
+    Skipped {
+        reason: &'static str,
+        source_count: usize,
+    },
+    Compressed {
+        source_count: usize,
+        replacement_count: usize,
+        marked_count: usize,
+    },
+}
+
+fn apply_compression_response(
+    conn: &rusqlite::Connection,
+    project: &str,
+    source_ids: &[i64],
+    response: &str,
+) -> Result<CompressionOutcome> {
+    let compressed = format::parse_observations(response);
+    if compressed.is_empty() {
+        return Ok(CompressionOutcome::Skipped {
+            reason: "no replacement observations parsed",
+            source_count: source_ids.len(),
+        });
+    }
+
+    with_compression_savepoint(conn, || {
+        store_compressed_observations(conn, project, response, &compressed)?;
+        let marked = db::mark_observations_compressed(conn, source_ids)?;
+        Ok(CompressionOutcome::Compressed {
+            source_count: source_ids.len(),
+            replacement_count: compressed.len(),
+            marked_count: marked,
+        })
+    })
+}
+
+fn with_compression_savepoint<T>(
+    conn: &rusqlite::Connection,
+    f: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    conn.execute_batch("SAVEPOINT remem_compression_apply;")?;
+    match f() {
+        Ok(value) => {
+            conn.execute_batch("RELEASE SAVEPOINT remem_compression_apply;")?;
+            Ok(value)
+        }
+        Err(error) => {
+            if let Err(rollback_error) = conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT remem_compression_apply;
+                 RELEASE SAVEPOINT remem_compression_apply;",
+            ) {
+                return Err(error.context(format!(
+                    "compression rollback also failed: {rollback_error}"
+                )));
+            }
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::{params, Connection};
+
+    fn setup_observation_schema(conn: &Connection) -> Result<()> {
+        conn.execute_batch(
+            "CREATE TABLE observations (
+                id INTEGER PRIMARY KEY,
+                memory_session_id TEXT NOT NULL,
+                project TEXT,
+                type TEXT NOT NULL,
+                title TEXT,
+                subtitle TEXT,
+                narrative TEXT,
+                facts TEXT,
+                concepts TEXT,
+                files_read TEXT,
+                files_modified TEXT,
+                prompt_number INTEGER,
+                created_at TEXT,
+                created_at_epoch INTEGER,
+                discovery_tokens INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'active',
+                last_accessed_epoch INTEGER,
+                branch TEXT,
+                commit_sha TEXT
+            );",
+        )?;
+        Ok(())
+    }
+
+    fn insert_source_observation(conn: &Connection, status: &str) -> Result<i64> {
+        let id = db::insert_observation(
+            conn,
+            "source-session",
+            "proj",
+            "discovery",
+            Some("Source"),
+            None,
+            Some("Source observation"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            0,
+        )?;
+        conn.execute(
+            "UPDATE observations SET status = ?1 WHERE id = ?2",
+            params![status, id],
+        )?;
+        Ok(id)
+    }
+
+    fn statuses_for(conn: &Connection, ids: &[i64]) -> Result<Vec<String>> {
+        let placeholders = ids
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| format!("?{}", idx + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql =
+            format!("SELECT status FROM observations WHERE id IN ({placeholders}) ORDER BY id");
+        let params = ids
+            .iter()
+            .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+            .collect::<Vec<_>>();
+        let refs = crate::db::to_sql_refs(&params);
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(0))?;
+        crate::db::query::collect_rows(rows)
+    }
+
+    fn compressed_titles(conn: &Connection) -> Result<Vec<String>> {
+        let mut stmt = conn.prepare(
+            "SELECT COALESCE(title, '')
+             FROM observations
+             WHERE memory_session_id LIKE 'compressed-%'
+             ORDER BY id",
+        )?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        crate::db::query::collect_rows(rows)
+    }
+
+    fn valid_response(title: &str) -> String {
+        format!(
+            "<observation>
+                <type>decision</type>
+                <title>{title}</title>
+                <narrative>Compressed narrative</narrative>
+             </observation>"
+        )
+    }
+
+    #[test]
+    fn empty_compression_response_leaves_sources_active() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup_observation_schema(&conn)?;
+        let ids = vec![
+            insert_source_observation(&conn, "active")?,
+            insert_source_observation(&conn, "stale")?,
+        ];
+
+        let outcome = apply_compression_response(&conn, "proj", &ids, "")?;
+
+        assert_eq!(
+            outcome,
+            CompressionOutcome::Skipped {
+                reason: "no replacement observations parsed",
+                source_count: 2,
+            }
+        );
+        assert_eq!(statuses_for(&conn, &ids)?, vec!["active", "stale"]);
+        assert!(compressed_titles(&conn)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_compression_response_leaves_sources_active() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup_observation_schema(&conn)?;
+        let ids = vec![insert_source_observation(&conn, "active")?];
+
+        let outcome = apply_compression_response(
+            &conn,
+            "proj",
+            &ids,
+            "<observation><type>decision</type><title>broken",
+        )?;
+
+        assert_eq!(
+            outcome,
+            CompressionOutcome::Skipped {
+                reason: "no replacement observations parsed",
+                source_count: 1,
+            }
+        );
+        assert_eq!(statuses_for(&conn, &ids)?, vec!["active"]);
+        assert!(compressed_titles(&conn)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn valid_compression_inserts_replacement_then_marks_sources() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup_observation_schema(&conn)?;
+        let ids = vec![
+            insert_source_observation(&conn, "active")?,
+            insert_source_observation(&conn, "stale")?,
+        ];
+
+        let outcome =
+            apply_compression_response(&conn, "proj", &ids, &valid_response("Compressed"))?;
+
+        assert_eq!(
+            outcome,
+            CompressionOutcome::Compressed {
+                source_count: 2,
+                replacement_count: 1,
+                marked_count: 2,
+            }
+        );
+        assert_eq!(statuses_for(&conn, &ids)?, vec!["compressed", "compressed"]);
+        assert_eq!(compressed_titles(&conn)?, vec!["Compressed"]);
+        Ok(())
+    }
+
+    #[test]
+    fn replacement_insert_failure_rolls_back_sources_and_replacements() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup_observation_schema(&conn)?;
+        conn.execute_batch(
+            "CREATE TRIGGER fail_bad_compression
+             BEFORE INSERT ON observations
+             WHEN NEW.memory_session_id LIKE 'compressed-%'
+                  AND NEW.title = 'Bad replacement'
+             BEGIN
+                 SELECT RAISE(FAIL, 'bad compressed insert');
+             END;",
+        )?;
+        let ids = vec![
+            insert_source_observation(&conn, "active")?,
+            insert_source_observation(&conn, "stale")?,
+        ];
+        let response = format!(
+            "{}\n{}",
+            valid_response("Good replacement"),
+            valid_response("Bad replacement")
+        );
+
+        let error = apply_compression_response(&conn, "proj", &ids, &response)
+            .expect_err("insert trigger should fail");
+
+        assert!(error.to_string().contains("bad compressed insert"));
+        assert_eq!(statuses_for(&conn, &ids)?, vec!["active", "stale"]);
+        assert!(compressed_titles(&conn)?.is_empty());
+        Ok(())
+    }
 }

--- a/src/summarize/compress/tests.rs
+++ b/src/summarize/compress/tests.rs
@@ -1,0 +1,267 @@
+use super::{
+    apply_compression_response, CompressionOutcome, INVALID_REPLACEMENTS_REASON,
+    NO_REPLACEMENTS_REASON,
+};
+use crate::db;
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+fn setup_observation_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE observations (
+            id INTEGER PRIMARY KEY,
+            memory_session_id TEXT NOT NULL,
+            project TEXT,
+            type TEXT NOT NULL,
+            title TEXT,
+            subtitle TEXT,
+            narrative TEXT,
+            facts TEXT,
+            concepts TEXT,
+            files_read TEXT,
+            files_modified TEXT,
+            prompt_number INTEGER,
+            created_at TEXT,
+            created_at_epoch INTEGER,
+            discovery_tokens INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'active',
+            last_accessed_epoch INTEGER,
+            branch TEXT,
+            commit_sha TEXT
+        );",
+    )?;
+    Ok(())
+}
+
+fn insert_source_observation(conn: &Connection, status: &str) -> Result<i64> {
+    let id = db::insert_observation(
+        conn,
+        "source-session",
+        "proj",
+        "discovery",
+        Some("Source"),
+        None,
+        Some("Source observation"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        0,
+    )?;
+    conn.execute(
+        "UPDATE observations SET status = ?1 WHERE id = ?2",
+        params![status, id],
+    )?;
+    Ok(id)
+}
+
+fn statuses_for(conn: &Connection, ids: &[i64]) -> Result<Vec<String>> {
+    let placeholders = ids
+        .iter()
+        .enumerate()
+        .map(|(idx, _)| format!("?{}", idx + 1))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!("SELECT status FROM observations WHERE id IN ({placeholders}) ORDER BY id");
+    let params = ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+        .collect::<Vec<_>>();
+    let refs = crate::db::to_sql_refs(&params);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(0))?;
+    crate::db::query::collect_rows(rows)
+}
+
+fn compressed_titles(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT COALESCE(title, '')
+         FROM observations
+         WHERE memory_session_id LIKE 'compressed-%'
+         ORDER BY id",
+    )?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    crate::db::query::collect_rows(rows)
+}
+
+fn valid_response(title: &str) -> String {
+    format!(
+        "<observation>
+            <type>decision</type>
+            <title>{title}</title>
+            <narrative>Compressed narrative</narrative>
+         </observation>"
+    )
+}
+
+#[test]
+fn empty_compression_response_leaves_sources_active() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_observation_schema(&conn)?;
+    let ids = vec![
+        insert_source_observation(&conn, "active")?,
+        insert_source_observation(&conn, "stale")?,
+    ];
+
+    let outcome = apply_compression_response(&conn, "proj", &ids, "")?;
+
+    assert_eq!(
+        outcome,
+        CompressionOutcome::Skipped {
+            reason: NO_REPLACEMENTS_REASON,
+            source_count: 2,
+        }
+    );
+    assert_eq!(statuses_for(&conn, &ids)?, vec!["active", "stale"]);
+    assert!(compressed_titles(&conn)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn malformed_compression_response_leaves_sources_active() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_observation_schema(&conn)?;
+    let ids = vec![insert_source_observation(&conn, "active")?];
+
+    let outcome = apply_compression_response(
+        &conn,
+        "proj",
+        &ids,
+        "<observation><type>decision</type><title>broken",
+    )?;
+
+    assert_eq!(
+        outcome,
+        CompressionOutcome::Skipped {
+            reason: NO_REPLACEMENTS_REASON,
+            source_count: 1,
+        }
+    );
+    assert_eq!(statuses_for(&conn, &ids)?, vec!["active"]);
+    assert!(compressed_titles(&conn)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn contentless_replacements_do_not_retire_sources() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_observation_schema(&conn)?;
+    let ids = vec![insert_source_observation(&conn, "active")?];
+
+    for response in [
+        "<observation></observation>",
+        "<observation><type>decision</type></observation>",
+    ] {
+        let outcome = apply_compression_response(&conn, "proj", &ids, response)?;
+        assert_eq!(
+            outcome,
+            CompressionOutcome::Skipped {
+                reason: INVALID_REPLACEMENTS_REASON,
+                source_count: 1,
+            }
+        );
+        assert_eq!(statuses_for(&conn, &ids)?, vec!["active"]);
+        assert!(compressed_titles(&conn)?.is_empty());
+    }
+    Ok(())
+}
+
+#[test]
+fn valid_compression_inserts_replacement_then_marks_sources() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_observation_schema(&conn)?;
+    let ids = vec![
+        insert_source_observation(&conn, "active")?,
+        insert_source_observation(&conn, "stale")?,
+    ];
+
+    let outcome = apply_compression_response(&conn, "proj", &ids, &valid_response("Compressed"))?;
+
+    assert_eq!(
+        outcome,
+        CompressionOutcome::Compressed {
+            source_count: 2,
+            replacement_count: 1,
+            marked_count: 2,
+        }
+    );
+    assert_eq!(statuses_for(&conn, &ids)?, vec!["compressed", "compressed"]);
+    assert_eq!(compressed_titles(&conn)?, vec!["Compressed"]);
+    Ok(())
+}
+
+#[test]
+fn partial_source_mark_rolls_back_sources_and_replacements() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_observation_schema(&conn)?;
+    let ids = vec![
+        insert_source_observation(&conn, "active")?,
+        insert_source_observation(&conn, "compressed")?,
+    ];
+
+    let error = apply_compression_response(&conn, "proj", &ids, &valid_response("Compressed"))
+        .expect_err("partial mark should roll back");
+
+    assert!(error
+        .to_string()
+        .contains("marked 1 of 2 source observations compressed"));
+    assert_eq!(statuses_for(&conn, &ids)?, vec!["active", "compressed"]);
+    assert!(compressed_titles(&conn)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn source_mark_failure_rolls_back_replacements() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_observation_schema(&conn)?;
+    conn.execute_batch(
+        "CREATE TRIGGER fail_source_compression
+         BEFORE UPDATE OF status ON observations
+         WHEN NEW.status = 'compressed' AND OLD.status = 'active'
+         BEGIN
+             SELECT RAISE(FAIL, 'source compression failed');
+         END;",
+    )?;
+    let ids = vec![insert_source_observation(&conn, "active")?];
+
+    let error = apply_compression_response(&conn, "proj", &ids, &valid_response("Compressed"))
+        .expect_err("update trigger should fail");
+
+    assert!(error.to_string().contains("source compression failed"));
+    assert_eq!(statuses_for(&conn, &ids)?, vec!["active"]);
+    assert!(compressed_titles(&conn)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn replacement_insert_failure_rolls_back_sources_and_replacements() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_observation_schema(&conn)?;
+    conn.execute_batch(
+        "CREATE TRIGGER fail_bad_compression
+         BEFORE INSERT ON observations
+         WHEN NEW.memory_session_id LIKE 'compressed-%'
+              AND NEW.title = 'Bad replacement'
+         BEGIN
+             SELECT RAISE(FAIL, 'bad compressed insert');
+         END;",
+    )?;
+    let ids = vec![
+        insert_source_observation(&conn, "active")?,
+        insert_source_observation(&conn, "stale")?,
+    ];
+    let response = format!(
+        "{}\n{}",
+        valid_response("Good replacement"),
+        valid_response("Bad replacement")
+    );
+
+    let error = apply_compression_response(&conn, "proj", &ids, &response)
+        .expect_err("insert trigger should fail");
+
+    assert!(error.to_string().contains("bad compressed insert"));
+    assert_eq!(statuses_for(&conn, &ids)?, vec!["active", "stale"]);
+    assert!(compressed_titles(&conn)?.is_empty());
+    Ok(())
+}


### PR DESCRIPTION
Stacked on #336 / `codex/issue-323-entity-refresh`.

Closes #321 once the stack lands on main.

## Summary
- treat compression application as a single savepoint: insert replacement observations first, then mark source observations compressed
- skip source retirement when parsed compression output is empty or malformed
- tighten `mark_observations_compressed` to update only active/stale rows
- bump package version to `0.5.2` for the repository version gate

## Verification
- `cargo fmt`
- `cargo check`
- `cargo test summarize::compress`
- `cargo clippy -- -D warnings`
- `cargo check && cargo clippy -- -D warnings && cargo test`
- `python3 scripts/ci/check_version_bump.py f809e15176661bcc653b887cf6809a2f249e1b38 HEAD`
