### PR TITLE
feat(compress): link compressed observations to source evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -38,6 +38,18 @@ pub struct Observation {
     pub commit_sha: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompressedObservationSource {
+    pub compressed_observation_id: i64,
+    pub source_observation_id: i64,
+    pub source_hash: String,
+    #[serde(skip_serializing)]
+    pub source_snapshot_json: String,
+    pub source_created_at_epoch: i64,
+    pub compression_session_id: String,
+    pub created_at_epoch: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionSummary {
     pub id: i64,

--- a/src/db/observation.rs
+++ b/src/db/observation.rs
@@ -1,5 +1,10 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use rusqlite::{params, Connection};
+use sha2::{Digest, Sha256};
+
+use crate::db::models::{CompressedObservationSource, Observation};
 
 pub fn insert_observation(
     conn: &Connection,
@@ -126,6 +131,141 @@ pub fn mark_observations_compressed(conn: &Connection, ids: &[i64]) -> Result<us
     Ok(stmt.execute(refs.as_slice())?)
 }
 
+pub fn observation_source_hash(observation: &Observation) -> String {
+    let mut hasher = Sha256::new();
+    hash_field(&mut hasher, "hash_version", Some("observation-v1"));
+    hash_i64(&mut hasher, "id", observation.id);
+    hash_field(
+        &mut hasher,
+        "memory_session_id",
+        Some(observation.memory_session_id.as_str()),
+    );
+    hash_field(&mut hasher, "project", observation.project.as_deref());
+    hash_field(&mut hasher, "type", Some(observation.r#type.as_str()));
+    hash_field(&mut hasher, "title", observation.title.as_deref());
+    hash_field(&mut hasher, "subtitle", observation.subtitle.as_deref());
+    hash_field(&mut hasher, "narrative", observation.narrative.as_deref());
+    hash_field(&mut hasher, "facts", observation.facts.as_deref());
+    hash_field(&mut hasher, "concepts", observation.concepts.as_deref());
+    hash_field(&mut hasher, "files_read", observation.files_read.as_deref());
+    hash_field(
+        &mut hasher,
+        "files_modified",
+        observation.files_modified.as_deref(),
+    );
+    hash_optional_i64(
+        &mut hasher,
+        "discovery_tokens",
+        observation.discovery_tokens,
+    );
+    hash_field(
+        &mut hasher,
+        "created_at",
+        Some(observation.created_at.as_str()),
+    );
+    hash_i64(
+        &mut hasher,
+        "created_at_epoch",
+        observation.created_at_epoch,
+    );
+    hash_field(
+        &mut hasher,
+        "content_session_id",
+        observation.content_session_id.as_deref(),
+    );
+    hash_field(&mut hasher, "branch", observation.branch.as_deref());
+    hash_field(&mut hasher, "commit_sha", observation.commit_sha.as_deref());
+
+    format!("sha256:observation-v1:{:x}", hasher.finalize())
+}
+
+pub fn insert_compressed_observation_sources(
+    conn: &Connection,
+    compressed_observation_ids: &[i64],
+    source_observations: &[Observation],
+    compression_session_id: &str,
+) -> Result<usize> {
+    if compressed_observation_ids.is_empty() {
+        return Ok(0);
+    }
+    if source_observations.is_empty() {
+        anyhow::bail!("compressed observations require source observation links");
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let mut inserted = 0;
+    for compressed_id in compressed_observation_ids {
+        for source in source_observations {
+            inserted += conn.execute(
+                "INSERT INTO compressed_observation_sources
+                 (compressed_observation_id, source_observation_id, source_hash,
+                  source_snapshot_json, source_created_at_epoch, compression_session_id,
+                  created_at_epoch)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    *compressed_id,
+                    source.id,
+                    observation_source_hash(source),
+                    observation_source_snapshot_json(source)?,
+                    source.created_at_epoch,
+                    compression_session_id,
+                    now
+                ],
+            )?;
+        }
+    }
+    Ok(inserted)
+}
+
+pub fn load_compressed_observation_sources(
+    conn: &Connection,
+    compressed_observation_ids: &[i64],
+) -> Result<HashMap<i64, Vec<CompressedObservationSource>>> {
+    if compressed_observation_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let placeholders: Vec<String> = (1..=compressed_observation_ids.len())
+        .map(|i| format!("?{i}"))
+        .collect();
+    let sql = format!(
+        "SELECT compressed_observation_id, source_observation_id, source_hash,
+                source_snapshot_json, source_created_at_epoch, compression_session_id,
+                created_at_epoch
+         FROM compressed_observation_sources
+         WHERE compressed_observation_id IN ({})
+         ORDER BY compressed_observation_id, source_observation_id",
+        placeholders.join(", ")
+    );
+    let params: Vec<Box<dyn rusqlite::types::ToSql>> = compressed_observation_ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+        .collect();
+    let refs = super::core::to_sql_refs(&params);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok(CompressedObservationSource {
+            compressed_observation_id: row.get(0)?,
+            source_observation_id: row.get(1)?,
+            source_hash: row.get(2)?,
+            source_snapshot_json: row.get(3)?,
+            source_created_at_epoch: row.get(4)?,
+            compression_session_id: row.get(5)?,
+            created_at_epoch: row.get(6)?,
+        })
+    })?;
+
+    let mut by_compressed_id: HashMap<i64, Vec<CompressedObservationSource>> = HashMap::new();
+    for row in rows {
+        let source = row?;
+        by_compressed_id
+            .entry(source.compressed_observation_id)
+            .or_default()
+            .push(source);
+    }
+    Ok(by_compressed_id)
+}
+
 pub fn update_last_accessed(conn: &Connection, ids: &[i64]) -> Result<()> {
     if ids.is_empty() {
         return Ok(());
@@ -144,4 +284,54 @@ pub fn update_last_accessed(conn: &Connection, ids: &[i64]) -> Result<()> {
     let refs = super::core::to_sql_refs(&params);
     stmt.execute(refs.as_slice())?;
     Ok(())
+}
+
+fn hash_i64(hasher: &mut Sha256, name: &str, value: i64) {
+    let value = value.to_string();
+    hash_field(hasher, name, Some(value.as_str()));
+}
+
+fn observation_source_snapshot_json(observation: &Observation) -> Result<String> {
+    let snapshot = serde_json::json!({
+        "hash_version": "observation-v1",
+        "id": observation.id,
+        "memory_session_id": observation.memory_session_id.as_str(),
+        "project": observation.project.as_deref(),
+        "type": observation.r#type.as_str(),
+        "title": observation.title.as_deref(),
+        "subtitle": observation.subtitle.as_deref(),
+        "narrative": observation.narrative.as_deref(),
+        "facts": observation.facts.as_deref(),
+        "concepts": observation.concepts.as_deref(),
+        "files_read": observation.files_read.as_deref(),
+        "files_modified": observation.files_modified.as_deref(),
+        "discovery_tokens": observation.discovery_tokens,
+        "created_at": observation.created_at.as_str(),
+        "created_at_epoch": observation.created_at_epoch,
+        "content_session_id": observation.content_session_id.as_deref(),
+        "branch": observation.branch.as_deref(),
+        "commit_sha": observation.commit_sha.as_deref(),
+    });
+    Ok(serde_json::to_string(&snapshot)?)
+}
+
+fn hash_optional_i64(hasher: &mut Sha256, name: &str, value: Option<i64>) {
+    match value {
+        Some(value) => hash_i64(hasher, name, value),
+        None => hash_field(hasher, name, None),
+    }
+}
+
+fn hash_field(hasher: &mut Sha256, name: &str, value: Option<&str>) {
+    hasher.update(name.as_bytes());
+    hasher.update(b"\x1f");
+    match value {
+        Some(value) => {
+            hasher.update(value.len().to_string().as_bytes());
+            hasher.update(b"\x1e");
+            hasher.update(value.as_bytes());
+        }
+        None => hasher.update(b"-1"),
+    }
+    hasher.update(b"\x1d");
 }

--- a/src/mcp/server/context_tools.rs
+++ b/src/mcp/server/context_tools.rs
@@ -141,7 +141,15 @@ impl MemoryServer {
                             );
                         }
                     }
-                    errors::to_json_value(TOOL, &observations)?
+                    observation_details_with_compressed_sources(conn, &observations).map_err(
+                        |e| {
+                            crate::log::warn(
+                                "mcp",
+                                &format!("load compressed observation sources failed: {}", e),
+                            );
+                            McpToolError::db_query(TOOL, e)
+                        },
+                    )?
                 }
                 "memory" => {
                     let memories_result =
@@ -181,6 +189,30 @@ impl MemoryServer {
             errors::to_json_pretty(TOOL, &results)
         })
     }
+}
+
+fn observation_details_with_compressed_sources(
+    conn: &rusqlite::Connection,
+    observations: &[db::Observation],
+) -> anyhow::Result<serde_json::Value> {
+    let mut value = serde_json::to_value(observations)?;
+    let Some(items) = value.as_array_mut() else {
+        return Ok(value);
+    };
+    let observation_ids: Vec<i64> = observations
+        .iter()
+        .map(|observation| observation.id)
+        .collect();
+    let sources_by_observation = db::load_compressed_observation_sources(conn, &observation_ids)?;
+    for (item, observation) in items.iter_mut().zip(observations) {
+        let Some(sources) = sources_by_observation.get(&observation.id) else {
+            continue;
+        };
+        if !sources.is_empty() {
+            item["compressed_sources"] = serde_json::to_value(sources)?;
+        }
+    }
+    Ok(value)
 }
 
 fn memory_details_with_topic_traces(

--- a/src/mcp/server/tests.rs
+++ b/src/mcp/server/tests.rs
@@ -12,6 +12,8 @@ use crate::memory;
 use crate::memory::raw_archive::{insert_raw_message, ROLE_USER, SOURCE_HOOK};
 use crate::memory::service::{resolve_local_note_path, sanitize_segment};
 
+mod compressed_sources;
+
 fn assert_mcp_error(
     err: McpToolError,
     expected_code: McpErrorCode,

--- a/src/mcp/server/tests/compressed_sources.rs
+++ b/src/mcp/server/tests/compressed_sources.rs
@@ -1,0 +1,71 @@
+use super::*;
+
+#[test]
+fn get_observations_attaches_compressed_observation_sources() {
+    let _dir = ScopedTestDataDir::new("mcp-compressed-observation-sources");
+    let conn = crate::db::open_db().expect("db opens");
+    let source_id = crate::db::insert_observation(
+        &conn,
+        "source-session",
+        "/repo",
+        "discovery",
+        Some("Source evidence"),
+        None,
+        Some("Original source observation"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        0,
+    )
+    .expect("source observation inserts");
+    let compressed_id = crate::db::insert_observation(
+        &conn,
+        "compressed-test",
+        "/repo",
+        "decision",
+        Some("Compressed decision"),
+        None,
+        Some("Compressed narrative"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        0,
+    )
+    .expect("compressed observation inserts");
+    let sources = crate::db::get_observations_by_ids(&conn, &[source_id], Some("/repo"))
+        .expect("source observation loads");
+    let expected_hash = crate::db::observation_source_hash(&sources[0]);
+    crate::db::insert_compressed_observation_sources(
+        &conn,
+        &[compressed_id],
+        &sources,
+        "compressed-test",
+    )
+    .expect("compressed source links insert");
+    drop(conn);
+
+    let server = MemoryServer::new().expect("memory server should initialize");
+    let expanded = server
+        .get_observations(Parameters(GetObservationsParams {
+            ids: vec![compressed_id],
+            project: Some("/repo".to_string()),
+            source: Some("observation".to_string()),
+        }))
+        .expect("expansion succeeds");
+    let json: Value = serde_json::from_str(&expanded).expect("expanded json");
+
+    assert_eq!(json[0]["id"], compressed_id);
+    assert_eq!(
+        json[0]["compressed_sources"][0]["source_observation_id"],
+        source_id
+    );
+    assert_eq!(
+        json[0]["compressed_sources"][0]["source_hash"],
+        expected_hash
+    );
+    assert!(json[0]["compressed_sources"][0]["source_snapshot_json"].is_null());
+}

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -5,6 +5,8 @@ mod state;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]
+mod tests_compression_provenance;
+#[cfg(test)]
 mod tests_convergence;
 #[cfg(test)]
 mod tests_schema;

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -110,6 +110,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "memory_edges",
         "memory_claims",
         "memory_candidate_noops",
+        "compressed_observation_sources",
     ] {
         let exists: bool = conn
             .query_row(
@@ -129,6 +130,8 @@ fn full_migration_on_empty_db() -> Result<()> {
         "idx_memory_claims_fingerprint",
         "idx_memory_candidate_noops_claim",
         "idx_memory_candidate_noops_project",
+        "idx_compressed_observation_sources_compressed",
+        "idx_compressed_observation_sources_source",
     ] {
         let exists: bool = conn
             .query_row(

--- a/src/migrate/tests_compression_provenance.rs
+++ b/src/migrate/tests_compression_provenance.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use super::run_migrations;
+
+fn link_count(conn: &Connection) -> Result<i64> {
+    Ok(conn.query_row(
+        "SELECT COUNT(*) FROM compressed_observation_sources",
+        [],
+        |row| row.get(0),
+    )?)
+}
+
+#[test]
+fn compressed_source_links_survive_source_delete_but_cascade_from_compressed_row() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+    run_migrations(&conn)?;
+
+    let source_id = crate::db::insert_observation(
+        &conn,
+        "source-session",
+        "proj",
+        "discovery",
+        Some("Source"),
+        None,
+        Some("Original source observation"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        0,
+    )?;
+    let compressed_id = crate::db::insert_observation(
+        &conn,
+        "compressed-test",
+        "proj",
+        "decision",
+        Some("Compressed"),
+        None,
+        Some("Compressed observation"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        0,
+    )?;
+    let sources = crate::db::get_observations_by_ids(&conn, &[source_id], Some("proj"))?;
+    crate::db::insert_compressed_observation_sources(
+        &conn,
+        &[compressed_id],
+        &sources,
+        "compressed-test",
+    )?;
+    assert_eq!(link_count(&conn)?, 1);
+
+    conn.execute("DELETE FROM observations WHERE id = ?1", params![source_id])?;
+    assert_eq!(
+        link_count(&conn)?,
+        1,
+        "retention deleting source rows must preserve provenance"
+    );
+
+    conn.execute(
+        "DELETE FROM observations WHERE id = ?1",
+        params![compressed_id],
+    )?;
+    assert_eq!(
+        link_count(&conn)?,
+        0,
+        "deleting a compressed row should clean its provenance"
+    );
+    Ok(())
+}

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -41,6 +41,7 @@ const CONVERGENCE_TABLES: &[&str] = &[
     "topic_segments",
     "memory_operation_log",
     "memory_edges",
+    "compressed_observation_sources",
 ];
 
 fn make_upgraded_v10_db() -> Result<Connection> {

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -135,6 +135,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "memory_claims",
         sql: include_str!("../migrations/v026_memory_claims.sql"),
     },
+    Migration {
+        version: 27,
+        name: "compressed_observation_sources",
+        sql: include_str!("../migrations/v027_compressed_observation_sources.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v027_compressed_observation_sources.sql
+++ b/src/migrations/v027_compressed_observation_sources.sql
@@ -1,0 +1,25 @@
+-- v027_compressed_observation_sources: deterministic source evidence for
+-- compressed observations.
+--
+-- source_observation_id is intentionally not a foreign key. Retention may
+-- delete old source observations after verifying the compressed row, while the
+-- source id and hash must remain auditable.
+
+CREATE TABLE IF NOT EXISTS compressed_observation_sources (
+    id INTEGER PRIMARY KEY,
+    compressed_observation_id INTEGER NOT NULL,
+    source_observation_id INTEGER NOT NULL,
+    source_hash TEXT NOT NULL,
+    source_snapshot_json TEXT NOT NULL,
+    source_created_at_epoch INTEGER NOT NULL,
+    compression_session_id TEXT NOT NULL,
+    created_at_epoch INTEGER NOT NULL,
+    UNIQUE(compressed_observation_id, source_observation_id),
+    FOREIGN KEY(compressed_observation_id) REFERENCES observations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_compressed_observation_sources_compressed
+    ON compressed_observation_sources(compressed_observation_id);
+
+CREATE INDEX IF NOT EXISTS idx_compressed_observation_sources_source
+    ON compressed_observation_sources(source_observation_id);

--- a/src/summarize/compress.rs
+++ b/src/summarize/compress.rs
@@ -54,8 +54,7 @@ async fn maybe_compress(host: &str, project: &str, profile: Option<&str>) -> Res
         }
     };
 
-    let ids: Vec<i64> = old_obs.iter().map(|obs| obs.id).collect();
-    let outcome = apply_compression_response(&conn, project, &ids, &response)?;
+    let outcome = apply_compression_response(&conn, project, &old_obs, &response)?;
     match outcome {
         CompressionOutcome::Skipped {
             reason,
@@ -101,9 +100,10 @@ fn store_compressed_observations(
     project: &str,
     response: &str,
     compressed: &[format::ParsedObservation],
-) -> Result<()> {
+) -> Result<StoredCompressedObservations> {
     let memory_session_id = format!("compressed-{}", chrono::Utc::now().timestamp());
     let usage = response.len() as i64 / 4;
+    let mut ids = Vec::with_capacity(compressed.len());
 
     for obs in compressed {
         let facts_json = if obs.facts.is_empty() {
@@ -116,7 +116,7 @@ fn store_compressed_observations(
         } else {
             Some(serde_json::to_string(&obs.concepts)?)
         };
-        db::insert_observation(
+        let id = db::insert_observation(
             conn,
             &memory_session_id,
             project,
@@ -131,9 +131,18 @@ fn store_compressed_observations(
             None,
             usage / compressed.len().max(1) as i64,
         )?;
+        ids.push(id);
     }
 
-    Ok(())
+    Ok(StoredCompressedObservations {
+        ids,
+        memory_session_id,
+    })
+}
+
+struct StoredCompressedObservations {
+    ids: Vec<i64>,
+    memory_session_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -152,26 +161,37 @@ enum CompressionOutcome {
 fn apply_compression_response(
     conn: &rusqlite::Connection,
     project: &str,
-    source_ids: &[i64],
+    source_observations: &[db::models::Observation],
     response: &str,
 ) -> Result<CompressionOutcome> {
     let compressed = format::parse_observations(response);
     if compressed.is_empty() {
         return Ok(CompressionOutcome::Skipped {
             reason: NO_REPLACEMENTS_REASON,
-            source_count: source_ids.len(),
+            source_count: source_observations.len(),
         });
     }
     if compressed.iter().any(|obs| !has_replacement_content(obs)) {
         return Ok(CompressionOutcome::Skipped {
             reason: INVALID_REPLACEMENTS_REASON,
-            source_count: source_ids.len(),
+            source_count: source_observations.len(),
         });
     }
 
+    let source_ids: Vec<i64> = source_observations.iter().map(|obs| obs.id).collect();
     with_compression_savepoint(conn, || {
-        store_compressed_observations(conn, project, response, &compressed)?;
-        let marked = db::mark_observations_compressed(conn, source_ids)?;
+        let stored = store_compressed_observations(conn, project, response, &compressed)?;
+        let linked = db::insert_compressed_observation_sources(
+            conn,
+            &stored.ids,
+            source_observations,
+            &stored.memory_session_id,
+        )?;
+        let expected_links = stored.ids.len() * source_observations.len();
+        if linked != expected_links {
+            anyhow::bail!("inserted {linked} of {expected_links} compressed source links");
+        }
+        let marked = db::mark_observations_compressed(conn, &source_ids)?;
         if marked != source_ids.len() {
             anyhow::bail!(
                 "marked {marked} of {} source observations compressed",

--- a/src/summarize/compress/tests.rs
+++ b/src/summarize/compress/tests.rs
@@ -28,6 +28,23 @@ fn setup_observation_schema(conn: &Connection) -> Result<()> {
             last_accessed_epoch INTEGER,
             branch TEXT,
             commit_sha TEXT
+        );
+        CREATE TABLE sdk_sessions (
+            id INTEGER PRIMARY KEY,
+            content_session_id TEXT UNIQUE NOT NULL,
+            memory_session_id TEXT NOT NULL
+        );
+        CREATE TABLE compressed_observation_sources (
+            id INTEGER PRIMARY KEY,
+            compressed_observation_id INTEGER NOT NULL,
+            source_observation_id INTEGER NOT NULL,
+            source_hash TEXT NOT NULL,
+            source_snapshot_json TEXT NOT NULL,
+            source_created_at_epoch INTEGER NOT NULL,
+            compression_session_id TEXT NOT NULL,
+            created_at_epoch INTEGER NOT NULL,
+            UNIQUE(compressed_observation_id, source_observation_id),
+            FOREIGN KEY(compressed_observation_id) REFERENCES observations(id) ON DELETE CASCADE
         );",
     )?;
     Ok(())
@@ -85,6 +102,26 @@ fn compressed_titles(conn: &Connection) -> Result<Vec<String>> {
     crate::db::query::collect_rows(rows)
 }
 
+fn source_observations(conn: &Connection, ids: &[i64]) -> Result<Vec<db::Observation>> {
+    db::get_observations_by_ids(conn, ids, Some("proj"))
+}
+
+fn compressed_source_links(conn: &Connection) -> Result<Vec<(i64, i64, String)>> {
+    let mut stmt = conn.prepare(
+        "SELECT compressed_observation_id, source_observation_id, source_hash
+         FROM compressed_observation_sources
+         ORDER BY compressed_observation_id, source_observation_id",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    crate::db::query::collect_rows(rows)
+}
+
 fn valid_response(title: &str) -> String {
     format!(
         "<observation>
@@ -104,7 +141,8 @@ fn empty_compression_response_leaves_sources_active() -> Result<()> {
         insert_source_observation(&conn, "stale")?,
     ];
 
-    let outcome = apply_compression_response(&conn, "proj", &ids, "")?;
+    let sources = source_observations(&conn, &ids)?;
+    let outcome = apply_compression_response(&conn, "proj", &sources, "")?;
 
     assert_eq!(
         outcome,
@@ -124,10 +162,11 @@ fn malformed_compression_response_leaves_sources_active() -> Result<()> {
     setup_observation_schema(&conn)?;
     let ids = vec![insert_source_observation(&conn, "active")?];
 
+    let sources = source_observations(&conn, &ids)?;
     let outcome = apply_compression_response(
         &conn,
         "proj",
-        &ids,
+        &sources,
         "<observation><type>decision</type><title>broken",
     )?;
 
@@ -149,11 +188,12 @@ fn contentless_replacements_do_not_retire_sources() -> Result<()> {
     setup_observation_schema(&conn)?;
     let ids = vec![insert_source_observation(&conn, "active")?];
 
+    let sources = source_observations(&conn, &ids)?;
     for response in [
         "<observation></observation>",
         "<observation><type>decision</type></observation>",
     ] {
-        let outcome = apply_compression_response(&conn, "proj", &ids, response)?;
+        let outcome = apply_compression_response(&conn, "proj", &sources, response)?;
         assert_eq!(
             outcome,
             CompressionOutcome::Skipped {
@@ -176,7 +216,9 @@ fn valid_compression_inserts_replacement_then_marks_sources() -> Result<()> {
         insert_source_observation(&conn, "stale")?,
     ];
 
-    let outcome = apply_compression_response(&conn, "proj", &ids, &valid_response("Compressed"))?;
+    let sources = source_observations(&conn, &ids)?;
+    let outcome =
+        apply_compression_response(&conn, "proj", &sources, &valid_response("Compressed"))?;
 
     assert_eq!(
         outcome,
@@ -188,6 +230,53 @@ fn valid_compression_inserts_replacement_then_marks_sources() -> Result<()> {
     );
     assert_eq!(statuses_for(&conn, &ids)?, vec!["compressed", "compressed"]);
     assert_eq!(compressed_titles(&conn)?, vec!["Compressed"]);
+    let links = compressed_source_links(&conn)?;
+    assert_eq!(links.len(), 2);
+    for (_, source_id, source_hash) in links {
+        let Some(source) = sources.iter().find(|source| source.id == source_id) else {
+            panic!("linked source should be in original batch");
+        };
+        assert_eq!(source_hash, db::observation_source_hash(source));
+    }
+    Ok(())
+}
+
+#[test]
+fn multi_replacement_compression_links_every_replacement_to_every_source() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_observation_schema(&conn)?;
+    let ids = vec![
+        insert_source_observation(&conn, "active")?,
+        insert_source_observation(&conn, "stale")?,
+    ];
+    let sources = source_observations(&conn, &ids)?;
+    let response = format!(
+        "{}\n{}",
+        valid_response("Compressed one"),
+        valid_response("Compressed two")
+    );
+
+    let outcome = apply_compression_response(&conn, "proj", &sources, &response)?;
+
+    assert_eq!(
+        outcome,
+        CompressionOutcome::Compressed {
+            source_count: 2,
+            replacement_count: 2,
+            marked_count: 2,
+        }
+    );
+    let links = compressed_source_links(&conn)?;
+    assert_eq!(links.len(), 4);
+    for source in &sources {
+        let matching = links
+            .iter()
+            .filter(|(_, source_id, source_hash)| {
+                *source_id == source.id && *source_hash == db::observation_source_hash(source)
+            })
+            .count();
+        assert_eq!(matching, 2);
+    }
     Ok(())
 }
 
@@ -200,7 +289,8 @@ fn partial_source_mark_rolls_back_sources_and_replacements() -> Result<()> {
         insert_source_observation(&conn, "compressed")?,
     ];
 
-    let error = apply_compression_response(&conn, "proj", &ids, &valid_response("Compressed"))
+    let sources = source_observations(&conn, &ids)?;
+    let error = apply_compression_response(&conn, "proj", &sources, &valid_response("Compressed"))
         .expect_err("partial mark should roll back");
 
     assert!(error
@@ -208,6 +298,7 @@ fn partial_source_mark_rolls_back_sources_and_replacements() -> Result<()> {
         .contains("marked 1 of 2 source observations compressed"));
     assert_eq!(statuses_for(&conn, &ids)?, vec!["active", "compressed"]);
     assert!(compressed_titles(&conn)?.is_empty());
+    assert!(compressed_source_links(&conn)?.is_empty());
     Ok(())
 }
 
@@ -225,12 +316,14 @@ fn source_mark_failure_rolls_back_replacements() -> Result<()> {
     )?;
     let ids = vec![insert_source_observation(&conn, "active")?];
 
-    let error = apply_compression_response(&conn, "proj", &ids, &valid_response("Compressed"))
+    let sources = source_observations(&conn, &ids)?;
+    let error = apply_compression_response(&conn, "proj", &sources, &valid_response("Compressed"))
         .expect_err("update trigger should fail");
 
     assert!(error.to_string().contains("source compression failed"));
     assert_eq!(statuses_for(&conn, &ids)?, vec!["active"]);
     assert!(compressed_titles(&conn)?.is_empty());
+    assert!(compressed_source_links(&conn)?.is_empty());
     Ok(())
 }
 
@@ -257,11 +350,13 @@ fn replacement_insert_failure_rolls_back_sources_and_replacements() -> Result<()
         valid_response("Bad replacement")
     );
 
-    let error = apply_compression_response(&conn, "proj", &ids, &response)
+    let sources = source_observations(&conn, &ids)?;
+    let error = apply_compression_response(&conn, "proj", &sources, &response)
         .expect_err("insert trigger should fail");
 
     assert!(error.to_string().contains("bad compressed insert"));
     assert_eq!(statuses_for(&conn, &ids)?, vec!["active", "stale"]);
     assert!(compressed_titles(&conn)?.is_empty());
+    assert!(compressed_source_links(&conn)?.is_empty());
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add v027 compressed_observation_sources provenance table with durable source ids, source hashes, and source snapshots
- write provenance links inside compression savepoint before retiring source observations
- expose compressed_sources from get_observations(source='observation') without changing existing fields

## Stack
- Stacked on #340 / issue #321 (compression atomicity).
- Closes #322 after this stack lands.

## Verification
- cargo fmt --check
- cargo check
- cargo clippy -- -D warnings
- cargo test summarize::compress
- cargo test mcp::server::tests::compressed_sources
- cargo test tests_compression_provenance
- cargo test columns_match_after_upgrade
- cargo test indexes_match_after_upgrade
- cargo test full_migration_on_empty_db
- cargo test
- python3 scripts/ci/check_version_bump.py origin/codex/issue-321-compression-atomic HEAD