### PR TITLE
fix(raw): record transcript ingest failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -48,6 +48,19 @@ fn load_status_report() -> Result<StatusReport> {
             sessions: stats.session_summaries,
             raw_messages: stats.raw_messages,
         },
+        raw_archive: RawArchiveStatus {
+            messages: stats.raw_messages,
+            ingest_failures: stats.raw_ingest_failures,
+            parse_errors: stats.raw_ingest_parse_errors,
+            insert_errors: stats.raw_ingest_insert_errors,
+            latest_failure_epoch: stats.latest_raw_ingest_failure_epoch,
+            latest_failure_age_secs: stats
+                .latest_raw_ingest_failure_epoch
+                .map(|epoch| now.saturating_sub(epoch)),
+            latest_failure_kind: stats.latest_raw_ingest_failure_kind,
+            latest_failure_path: stats.latest_raw_ingest_failure_path,
+            latest_failure_message: stats.latest_raw_ingest_failure_message,
+        },
         capture_pipeline: CapturePipelineStatus {
             captured: stats.captured_events,
             extract_todo: stats.pending_extraction_tasks,
@@ -107,6 +120,23 @@ fn print_status_report(report: &StatusReport) {
     println!("  Observations:  {:>6}", report.totals.observations);
     println!("  Sessions:      {:>6}", report.totals.sessions);
     println!("  Raw messages:  {:>6}", report.totals.raw_messages);
+    println!();
+    println!("Raw archive:");
+    println!("  Messages:     {:>6}", report.raw_archive.messages);
+    println!("  Failures:     {:>6}", report.raw_archive.ingest_failures);
+    if report.raw_archive.ingest_failures > 0 {
+        println!("  Parse errors: {:>6}", report.raw_archive.parse_errors);
+        println!("  Insert err:   {:>6}", report.raw_archive.insert_errors);
+        if let Some(kind) = &report.raw_archive.latest_failure_kind {
+            println!("  Latest kind:  {}", kind);
+        }
+        if let Some(path) = &report.raw_archive.latest_failure_path {
+            println!("  Latest path:  {}", path);
+        }
+        if let Some(age_secs) = report.raw_archive.latest_failure_age_secs {
+            println!("  Latest age:   {:>6}s", age_secs);
+        }
+    }
     println!();
     println!("Capture pipeline:");
     println!("  Captured:     {:>6}", report.capture_pipeline.captured);
@@ -205,6 +235,7 @@ pub(super) struct StatusReport {
     pub version: String,
     pub database: StatusDatabase,
     pub totals: StatusTotals,
+    pub raw_archive: RawArchiveStatus,
     pub capture_pipeline: CapturePipelineStatus,
     pub pending_observations: PendingObservationStatus,
     pub jobs: JobStatus,
@@ -226,6 +257,19 @@ pub(super) struct StatusTotals {
     pub observations: i64,
     pub sessions: i64,
     pub raw_messages: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct RawArchiveStatus {
+    pub messages: i64,
+    pub ingest_failures: i64,
+    pub parse_errors: i64,
+    pub insert_errors: i64,
+    pub latest_failure_epoch: Option<i64>,
+    pub latest_failure_age_secs: Option<i64>,
+    pub latest_failure_kind: Option<String>,
+    pub latest_failure_path: Option<String>,
+    pub latest_failure_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -297,6 +341,17 @@ mod tests {
                 sessions: 3,
                 raw_messages: 4,
             },
+            raw_archive: RawArchiveStatus {
+                messages: 4,
+                ingest_failures: 0,
+                parse_errors: 0,
+                insert_errors: 0,
+                latest_failure_epoch: None,
+                latest_failure_age_secs: None,
+                latest_failure_kind: None,
+                latest_failure_path: None,
+                latest_failure_message: None,
+            },
             capture_pipeline: CapturePipelineStatus {
                 captured: 5,
                 extract_todo: 6,
@@ -340,6 +395,11 @@ mod tests {
     #[test]
     fn cli_status_json_report_is_machine_parseable() -> std::result::Result<(), serde_json::Error> {
         let mut report = status_report_fixture();
+        report.raw_archive.ingest_failures = 1;
+        report.raw_archive.parse_errors = 2;
+        report.raw_archive.insert_errors = 3;
+        report.raw_archive.latest_failure_kind = Some("mixed_errors".to_string());
+        report.raw_archive.latest_failure_path = Some("/bad/raw.jsonl".to_string());
         report.pending_observations.expired = 15;
         report.pending_observations.failed = 16;
         report.jobs.failed = 21;
@@ -351,6 +411,15 @@ mod tests {
         assert_eq!(parsed["version"], "0.4.5");
         assert_eq!(parsed["database"]["size_bytes"], 1_048_576);
         assert_eq!(parsed["totals"]["memories"], 1);
+        assert_eq!(parsed["raw_archive"]["messages"], 4);
+        assert_eq!(parsed["raw_archive"]["ingest_failures"], 1);
+        assert_eq!(parsed["raw_archive"]["parse_errors"], 2);
+        assert_eq!(parsed["raw_archive"]["insert_errors"], 3);
+        assert_eq!(parsed["raw_archive"]["latest_failure_kind"], "mixed_errors");
+        assert_eq!(
+            parsed["raw_archive"]["latest_failure_path"],
+            "/bad/raw.jsonl"
+        );
         assert_eq!(parsed["capture_pipeline"]["extract_todo"], 6);
         assert_eq!(parsed["pending_observations"]["failed"], 16);
         assert_eq!(parsed["worker_daemon"]["health"], "healthy");

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::db::{
     AiUsageBreakdown, AiUsageSourceTotals, AiUsageTotals, DailyAiUsage, WeeklyAiUsage,
@@ -13,6 +13,13 @@ pub struct SystemStats {
     pub active_observations: i64,
     pub session_summaries: i64,
     pub raw_messages: i64,
+    pub raw_ingest_failures: i64,
+    pub raw_ingest_parse_errors: i64,
+    pub raw_ingest_insert_errors: i64,
+    pub latest_raw_ingest_failure_epoch: Option<i64>,
+    pub latest_raw_ingest_failure_kind: Option<String>,
+    pub latest_raw_ingest_failure_path: Option<String>,
+    pub latest_raw_ingest_failure_message: Option<String>,
     pub captured_events: i64,
     pub pending_extraction_tasks: i64,
     pub processing_extraction_tasks: i64,
@@ -49,6 +56,7 @@ pub struct ProjectCount {
 
 pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
     let now = chrono::Utc::now().timestamp();
+    let raw_ingest = query_raw_ingest_failure_stats(conn)?;
     let worker_heartbeat = crate::db::worker::latest_worker_heartbeat(conn)?;
     let healthy_worker_heartbeat = crate::db::worker::healthy_worker_heartbeat(
         conn,
@@ -73,6 +81,13 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
             row.get(0)
         })?,
         raw_messages: conn.query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))?,
+        raw_ingest_failures: raw_ingest.failures,
+        raw_ingest_parse_errors: raw_ingest.parse_errors,
+        raw_ingest_insert_errors: raw_ingest.insert_errors,
+        latest_raw_ingest_failure_epoch: raw_ingest.latest_epoch,
+        latest_raw_ingest_failure_kind: raw_ingest.latest_kind,
+        latest_raw_ingest_failure_path: raw_ingest.latest_path,
+        latest_raw_ingest_failure_message: raw_ingest.latest_message,
         captured_events: conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| {
             row.get(0)
         })?,
@@ -169,6 +184,79 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
         worker_heartbeat_owner: worker_heartbeat.map(|heartbeat| heartbeat.owner),
         worker_heartbeat_age_secs,
     })
+}
+
+#[derive(Debug, Clone, Default)]
+struct RawIngestFailureStats {
+    failures: i64,
+    parse_errors: i64,
+    insert_errors: i64,
+    latest_epoch: Option<i64>,
+    latest_kind: Option<String>,
+    latest_path: Option<String>,
+    latest_message: Option<String>,
+}
+
+fn query_raw_ingest_failure_stats(conn: &Connection) -> Result<RawIngestFailureStats> {
+    if !table_exists(conn, "raw_ingest_failures")? {
+        return Ok(RawIngestFailureStats::default());
+    }
+
+    let (failures, parse_errors, insert_errors) = conn.query_row(
+        "SELECT COUNT(*), COALESCE(SUM(parse_errors), 0), COALESCE(SUM(insert_errors), 0)
+         FROM raw_ingest_failures",
+        [],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        },
+    )?;
+    let latest = conn
+        .query_row(
+            "SELECT created_at_epoch, error_kind, transcript_path, error_message
+             FROM raw_ingest_failures
+             ORDER BY created_at_epoch DESC, id DESC
+             LIMIT 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            },
+        )
+        .optional()?;
+
+    let (latest_epoch, latest_kind, latest_path, latest_message) = match latest {
+        Some((epoch, kind, path, message)) => (Some(epoch), Some(kind), path, Some(message)),
+        None => (None, None, None, None),
+    };
+
+    Ok(RawIngestFailureStats {
+        failures,
+        parse_errors,
+        insert_errors,
+        latest_epoch,
+        latest_kind,
+        latest_path,
+        latest_message,
+    })
+}
+
+fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+            [table],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
 }
 
 pub fn query_daily_activity_stats(

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -30,6 +30,15 @@ fn setup_stats_schema(conn: &Connection) {
         CREATE TABLE raw_messages (
             id INTEGER PRIMARY KEY
         );
+        CREATE TABLE raw_ingest_failures (
+            id INTEGER PRIMARY KEY,
+            transcript_path TEXT,
+            error_kind TEXT NOT NULL,
+            error_message TEXT NOT NULL,
+            parse_errors INTEGER NOT NULL,
+            insert_errors INTEGER NOT NULL,
+            created_at_epoch INTEGER NOT NULL
+        );
         CREATE TABLE captured_events (
             id INTEGER PRIMARY KEY
         );
@@ -117,6 +126,13 @@ fn query_system_stats_and_related_views_share_one_definition() {
     .expect("stale observation insert should succeed");
     conn.execute("INSERT INTO session_summaries (id) VALUES (1)", [])
         .expect("summary insert should succeed");
+    conn.execute(
+        "INSERT INTO raw_ingest_failures
+         (transcript_path, error_kind, error_message, parse_errors, insert_errors, created_at_epoch)
+         VALUES ('/bad/transcript.jsonl', 'parse_errors', 'bad jsonl', 2, 1, 160)",
+        [],
+    )
+    .expect("raw ingest failure insert should succeed");
     conn.execute("INSERT INTO captured_events (id) VALUES (1)", [])
         .expect("captured event insert should succeed");
     conn.execute(
@@ -195,6 +211,13 @@ fn query_system_stats_and_related_views_share_one_definition() {
             active_observations: 1,
             session_summaries: 1,
             raw_messages: 0,
+            raw_ingest_failures: 1,
+            raw_ingest_parse_errors: 2,
+            raw_ingest_insert_errors: 1,
+            latest_raw_ingest_failure_epoch: Some(160),
+            latest_raw_ingest_failure_kind: Some("parse_errors".to_string()),
+            latest_raw_ingest_failure_path: Some("/bad/transcript.jsonl".to_string()),
+            latest_raw_ingest_failure_message: Some("bad jsonl".to_string()),
             captured_events: 1,
             pending_extraction_tasks: 1,
             processing_extraction_tasks: 1,
@@ -245,6 +268,21 @@ fn query_system_stats_and_related_views_share_one_definition() {
             },
         ]
     );
+}
+
+#[test]
+fn query_system_stats_defaults_raw_ingest_failures_when_table_is_absent() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_stats_schema(&conn);
+    conn.execute("DROP TABLE raw_ingest_failures", [])?;
+
+    let system = query_system_stats(&conn)?;
+
+    assert_eq!(system.raw_ingest_failures, 0);
+    assert_eq!(system.raw_ingest_parse_errors, 0);
+    assert_eq!(system.raw_ingest_insert_errors, 0);
+    assert_eq!(system.latest_raw_ingest_failure_epoch, None);
+    Ok(())
 }
 
 fn insert_usage(

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -115,6 +115,58 @@ pub(super) fn check_pending_queue() -> Check {
     }
 }
 
+pub(super) fn check_raw_archive_ingest() -> Check {
+    let conn = match db::open_db_read_only() {
+        Ok(conn) => conn,
+        Err(_) => {
+            return Check {
+                name: "Raw archive ingest",
+                status: Status::Warn,
+                detail: "cannot open database".to_string(),
+            };
+        }
+    };
+
+    let stats = match db::query_system_stats(&conn) {
+        Ok(stats) => stats,
+        Err(err) => {
+            return Check {
+                name: "Raw archive ingest",
+                status: Status::Warn,
+                detail: format!("cannot load raw ingest stats: {}", err),
+            };
+        }
+    };
+
+    if stats.raw_ingest_failures == 0 {
+        return Check {
+            name: "Raw archive ingest",
+            status: Status::Ok,
+            detail: format!("{} raw messages, no ingest failures", stats.raw_messages),
+        };
+    }
+
+    let mut detail = format!(
+        "{} failure(s), parse_errors={}, insert_errors={}",
+        stats.raw_ingest_failures, stats.raw_ingest_parse_errors, stats.raw_ingest_insert_errors
+    );
+    if let Some(kind) = stats.latest_raw_ingest_failure_kind {
+        detail.push_str(&format!("; latest={kind}"));
+    }
+    if let Some(path) = stats.latest_raw_ingest_failure_path {
+        detail.push_str(&format!(" path={path}"));
+    }
+    if let Some(message) = stats.latest_raw_ingest_failure_message {
+        detail.push_str(&format!(" ({})", crate::db::truncate_str(&message, 160)));
+    }
+
+    Check {
+        name: "Raw archive ingest",
+        status: Status::Warn,
+        detail,
+    }
+}
+
 pub(super) fn check_worker_daemon() -> Check {
     let conn = match db::open_db_read_only() {
         Ok(conn) => conn,

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -2,7 +2,10 @@ use std::io::{self, Write};
 
 use anyhow::Result;
 
-use super::database::{check_database, check_disk_space, check_pending_queue, check_worker_daemon};
+use super::database::{
+    check_database, check_disk_space, check_pending_queue, check_raw_archive_ingest,
+    check_worker_daemon,
+};
 use super::environment::{check_binary, check_hooks, check_install_paths, check_mcp};
 use super::native_memory::check_native_memory_sync;
 use super::runtime_config_check::check_runtime_config;
@@ -51,6 +54,7 @@ fn collect_checks() -> Vec<Check> {
     checks.push(check_runtime_config());
     checks.extend(check_hooks());
     checks.extend(check_mcp());
+    checks.push(check_raw_archive_ingest());
     checks.push(check_worker_daemon());
     checks.push(check_pending_queue());
     checks.push(check_native_memory_sync());

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -3,7 +3,9 @@ use rusqlite::params;
 use crate::db::test_support::ScopedTestDataDir;
 use crate::{db, memory};
 
-use super::database::{check_database, check_pending_queue, check_worker_daemon};
+use super::database::{
+    check_database, check_pending_queue, check_raw_archive_ingest, check_worker_daemon,
+};
 use super::health_action::{queue_actions, render_action_block};
 use super::report::{run_doctor_with_writer, DoctorOptions};
 use super::schema::check_schema_migration;
@@ -183,6 +185,28 @@ fn check_pending_queue_reports_shared_counts() -> anyhow::Result<()> {
         "{}",
         check.detail
     );
+    Ok(())
+}
+
+#[test]
+fn check_raw_archive_ingest_warns_on_recorded_failures() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-raw-ingest");
+    let conn = db::open_db()?;
+    conn.execute(
+        "INSERT INTO raw_ingest_failures
+         (project, session_id, source, transcript_path, error_kind, error_message,
+          inserted, duplicates, parse_errors, insert_errors, created_at_epoch)
+         VALUES ('proj-a', 'session-a', 'transcript', '/bad/path.jsonl',
+                 'read_error', 'read failed', 0, 0, 0, 0, ?1)",
+        params![chrono::Utc::now().timestamp()],
+    )?;
+    drop(conn);
+
+    let check = check_raw_archive_ingest();
+    assert_eq!(check.icon(), "WARN");
+    assert!(check.detail.contains("1 failure"), "{}", check.detail);
+    assert!(check.detail.contains("read_error"), "{}", check.detail);
+    assert!(check.detail.contains("/bad/path.jsonl"), "{}", check.detail);
     Ok(())
 }
 

--- a/src/memory/raw_archive.rs
+++ b/src/memory/raw_archive.rs
@@ -50,6 +50,47 @@ pub struct RawInsertOutcome {
     pub inserted: bool,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RawIngestReport {
+    pub inserted: usize,
+    pub duplicates: usize,
+    pub empty_messages: usize,
+    pub skipped_messages: usize,
+    pub parse_errors: usize,
+    pub insert_errors: usize,
+    pub read_error: Option<String>,
+}
+
+impl RawIngestReport {
+    pub fn has_failures(&self) -> bool {
+        self.read_error.is_some() || self.parse_errors > 0 || self.insert_errors > 0
+    }
+
+    pub fn failure_kind(&self) -> Option<&'static str> {
+        match (
+            self.read_error.is_some(),
+            self.parse_errors > 0,
+            self.insert_errors > 0,
+        ) {
+            (true, false, false) => Some("read_error"),
+            (false, true, false) => Some("parse_errors"),
+            (false, false, true) => Some("insert_errors"),
+            (true, _, _) | (_, true, true) => Some("mixed_errors"),
+            (false, false, false) => None,
+        }
+    }
+
+    fn failure_message(&self) -> String {
+        if let Some(error) = &self.read_error {
+            return error.clone();
+        }
+        format!(
+            "parse_errors={} insert_errors={}",
+            self.parse_errors, self.insert_errors
+        )
+    }
+}
+
 pub fn insert_raw_message(
     conn: &Connection,
     session_id: &str,
@@ -95,7 +136,6 @@ pub fn insert_raw_message(
 }
 
 /// Drain a Claude Code transcript JSONL file into raw_messages.
-/// Best-effort: any parse error on a single line is skipped.
 pub fn drain_transcript(
     conn: &Connection,
     transcript_path: &str,
@@ -103,30 +143,53 @@ pub fn drain_transcript(
     project: &str,
     branch: Option<&str>,
     cwd: Option<&str>,
-) -> Result<usize> {
+) -> Result<RawIngestReport> {
     let content = match std::fs::read_to_string(transcript_path) {
         Ok(content) => content,
         Err(error) => {
+            let report = RawIngestReport {
+                read_error: Some(format!(
+                    "read transcript {} failed: {}",
+                    transcript_path, error
+                )),
+                ..RawIngestReport::default()
+            };
             crate::log::warn(
                 "raw-archive",
-                &format!("read transcript {} failed: {}", transcript_path, error),
+                report
+                    .read_error
+                    .as_deref()
+                    .unwrap_or("read transcript failed"),
             );
-            return Ok(0);
+            record_raw_ingest_failure(
+                conn,
+                session_id,
+                project,
+                SOURCE_TRANSCRIPT,
+                Some(transcript_path),
+                &report,
+            )?;
+            return Ok(report);
         }
     };
 
-    let mut new_rows = 0usize;
+    let mut report = RawIngestReport::default();
     for line in content.lines() {
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            report.parse_errors += 1;
             continue;
         };
         let role = match value["type"].as_str() {
             Some("user") => ROLE_USER,
             Some("assistant") => ROLE_ASSISTANT,
-            _ => continue,
+            _ => {
+                report.skipped_messages += 1;
+                continue;
+            }
         };
         let text = extract_message_text(&value);
         if text.trim().is_empty() {
+            report.empty_messages += 1;
             continue;
         }
 
@@ -140,9 +203,11 @@ pub fn drain_transcript(
             branch,
             cwd,
         ) {
-            Ok(Some(outcome)) if outcome.inserted => new_rows += 1,
-            Ok(_) => {}
+            Ok(Some(outcome)) if outcome.inserted => report.inserted += 1,
+            Ok(Some(_)) => report.duplicates += 1,
+            Ok(None) => report.empty_messages += 1,
             Err(error) => {
+                report.insert_errors += 1;
                 crate::log::warn(
                     "raw-archive",
                     &format!("insert raw message failed: {}", error),
@@ -150,7 +215,50 @@ pub fn drain_transcript(
             }
         }
     }
-    Ok(new_rows)
+    if report.has_failures() {
+        record_raw_ingest_failure(
+            conn,
+            session_id,
+            project,
+            SOURCE_TRANSCRIPT,
+            Some(transcript_path),
+            &report,
+        )?;
+    }
+    Ok(report)
+}
+
+pub fn record_raw_ingest_failure(
+    conn: &Connection,
+    session_id: &str,
+    project: &str,
+    source: &str,
+    transcript_path: Option<&str>,
+    report: &RawIngestReport,
+) -> Result<()> {
+    let Some(kind) = report.failure_kind() else {
+        return Ok(());
+    };
+    conn.execute(
+        "INSERT INTO raw_ingest_failures
+         (project, session_id, source, transcript_path, error_kind, error_message,
+          inserted, duplicates, parse_errors, insert_errors, created_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        params![
+            project,
+            session_id,
+            source,
+            transcript_path,
+            kind,
+            crate::db::truncate_str(&report.failure_message(), 1000),
+            report.inserted as i64,
+            report.duplicates as i64,
+            report.parse_errors as i64,
+            report.insert_errors as i64,
+            chrono::Utc::now().timestamp()
+        ],
+    )?;
+    Ok(())
 }
 
 fn extract_message_text(value: &serde_json::Value) -> String {
@@ -270,6 +378,24 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         crate::migrate::run_migrations(&conn).unwrap();
         conn
+    }
+
+    fn write_temp_transcript(name: &str, content: &str) -> Result<std::path::PathBuf> {
+        let path = std::env::temp_dir().join(format!(
+            "remem-{name}-{}-{}.jsonl",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::write(&path, content)?;
+        Ok(path)
+    }
+
+    fn raw_ingest_failure_count(conn: &Connection) -> Result<i64> {
+        Ok(
+            conn.query_row("SELECT COUNT(*) FROM raw_ingest_failures", [], |row| {
+                row.get(0)
+            })?,
+        )
     }
 
     #[test]
@@ -454,5 +580,78 @@ mod tests {
             !branches.contains(&Some("feature".to_string())),
             "{branches:?}"
         );
+    }
+
+    #[test]
+    fn drain_transcript_counts_parse_errors_and_records_failure() -> Result<()> {
+        let conn = setup_conn();
+        let path = write_temp_transcript(
+            "raw-parse-error",
+            format!(
+                "{}\nnot json\n",
+                r#"{"type":"assistant","message":{"content":[{"type":"text","text":"kept message"}]}}"#
+            )
+            .as_str(),
+        )?;
+
+        let report = drain_transcript(
+            &conn,
+            path.to_string_lossy().as_ref(),
+            "session-parse",
+            "/proj",
+            None,
+            None,
+        )?;
+
+        assert_eq!(report.inserted, 1);
+        assert_eq!(report.parse_errors, 1);
+        assert_eq!(raw_ingest_failure_count(&conn)?, 1);
+        let (kind, parse_errors): (String, i64) = conn.query_row(
+            "SELECT error_kind, parse_errors FROM raw_ingest_failures",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(kind, "parse_errors");
+        assert_eq!(parse_errors, 1);
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn drain_transcript_counts_insert_errors_and_records_failure() -> Result<()> {
+        let conn = setup_conn();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_raw_archive_insert
+             BEFORE INSERT ON raw_messages
+             BEGIN
+                 SELECT RAISE(FAIL, 'raw insert failed');
+             END;",
+        )?;
+        let path = write_temp_transcript(
+            "raw-insert-error",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"cannot insert"}]}}"#,
+        )?;
+
+        let report = drain_transcript(
+            &conn,
+            path.to_string_lossy().as_ref(),
+            "session-insert",
+            "/proj",
+            None,
+            None,
+        )?;
+
+        assert_eq!(report.inserted, 0);
+        assert_eq!(report.insert_errors, 1);
+        assert_eq!(raw_ingest_failure_count(&conn)?, 1);
+        let (kind, insert_errors): (String, i64) = conn.query_row(
+            "SELECT error_kind, insert_errors FROM raw_ingest_failures",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(kind, "insert_errors");
+        assert_eq!(insert_errors, 1);
+        std::fs::remove_file(path)?;
+        Ok(())
     }
 }

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -111,6 +111,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "memory_claims",
         "memory_candidate_noops",
         "compressed_observation_sources",
+        "raw_ingest_failures",
     ] {
         let exists: bool = conn
             .query_row(
@@ -132,6 +133,8 @@ fn full_migration_on_empty_db() -> Result<()> {
         "idx_memory_candidate_noops_project",
         "idx_compressed_observation_sources_compressed",
         "idx_compressed_observation_sources_source",
+        "idx_raw_ingest_failures_project_recent",
+        "idx_raw_ingest_failures_session",
     ] {
         let exists: bool = conn
             .query_row(

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -42,6 +42,7 @@ const CONVERGENCE_TABLES: &[&str] = &[
     "memory_operation_log",
     "memory_edges",
     "compressed_observation_sources",
+    "raw_ingest_failures",
 ];
 
 fn make_upgraded_v10_db() -> Result<Connection> {

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -140,6 +140,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "compressed_observation_sources",
         sql: include_str!("../migrations/v027_compressed_observation_sources.sql"),
     },
+    Migration {
+        version: 28,
+        name: "raw_ingest_failures",
+        sql: include_str!("../migrations/v028_raw_ingest_failures.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v028_raw_ingest_failures.sql
+++ b/src/migrations/v028_raw_ingest_failures.sql
@@ -1,0 +1,22 @@
+-- v028_raw_ingest_failures: durable health records for raw archive ingest.
+
+CREATE TABLE IF NOT EXISTS raw_ingest_failures (
+    id INTEGER PRIMARY KEY,
+    project TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    transcript_path TEXT,
+    error_kind TEXT NOT NULL,
+    error_message TEXT NOT NULL,
+    inserted INTEGER NOT NULL DEFAULT 0,
+    duplicates INTEGER NOT NULL DEFAULT 0,
+    parse_errors INTEGER NOT NULL DEFAULT 0,
+    insert_errors INTEGER NOT NULL DEFAULT 0,
+    created_at_epoch INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_raw_ingest_failures_project_recent
+    ON raw_ingest_failures(project, created_at_epoch DESC);
+
+CREATE INDEX IF NOT EXISTS idx_raw_ingest_failures_session
+    ON raw_ingest_failures(session_id, created_at_epoch DESC);

--- a/src/summarize/summary_job/process.rs
+++ b/src/summarize/summary_job/process.rs
@@ -140,29 +140,102 @@ fn capture_raw_archive(
             branch.as_deref(),
             cwd_opt,
         ) {
-            Ok(new_rows) => crate::log::info(
-                "summary-job",
-                &format!(
-                    "raw archive drained transcript new_rows={} project={}",
-                    new_rows, project
-                ),
-            ),
+            Ok(report) => {
+                crate::log::info(
+                    "summary-job",
+                    &format!(
+                        "raw archive drained transcript status={} inserted={} duplicates={} parse_errors={} insert_errors={} read_error={} project={}",
+                        raw_archive_status(&report),
+                        report.inserted,
+                        report.duplicates,
+                        report.parse_errors,
+                        report.insert_errors,
+                        report.read_error.is_some(),
+                        project
+                    ),
+                );
+                if report.read_error.is_some() {
+                    if let Some(last) = hook.last_assistant_message.as_deref() {
+                        insert_raw_hook_fallback(
+                            conn,
+                            session_id,
+                            project,
+                            last,
+                            branch.as_deref(),
+                            cwd_opt,
+                        );
+                    }
+                }
+            }
             Err(error) => crate::log::warn(
                 "summary-job",
                 &format!("raw archive drain failed: {}", error),
             ),
         }
     } else if let Some(last) = hook.last_assistant_message.as_deref() {
-        if let Err(error) = crate::memory::raw_archive::insert_raw_message(
-            conn,
-            session_id,
-            project,
-            crate::memory::raw_archive::ROLE_ASSISTANT,
-            last,
-            crate::memory::raw_archive::SOURCE_HOOK,
-            branch.as_deref(),
-            cwd_opt,
-        ) {
+        insert_raw_hook_fallback(conn, session_id, project, last, branch.as_deref(), cwd_opt);
+    }
+}
+
+fn raw_archive_status(report: &crate::memory::raw_archive::RawIngestReport) -> &'static str {
+    if report.read_error.is_some() {
+        "read_failed"
+    } else if report.parse_errors > 0 || report.insert_errors > 0 {
+        "partial"
+    } else if report.inserted == 0 && report.duplicates > 0 {
+        "duplicate_only"
+    } else {
+        "ok"
+    }
+}
+
+fn insert_raw_hook_fallback(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+    project: &str,
+    last: &str,
+    branch: Option<&str>,
+    cwd: Option<&str>,
+) {
+    match crate::memory::raw_archive::insert_raw_message(
+        conn,
+        session_id,
+        project,
+        crate::memory::raw_archive::ROLE_ASSISTANT,
+        last,
+        crate::memory::raw_archive::SOURCE_HOOK,
+        branch,
+        cwd,
+    ) {
+        Ok(Some(outcome)) => crate::log::info(
+            "summary-job",
+            &format!(
+                "raw archive hook fallback inserted={} duplicate={} project={}",
+                outcome.inserted, !outcome.inserted, project
+            ),
+        ),
+        Ok(None) => crate::log::info(
+            "summary-job",
+            &format!("raw archive hook fallback empty project={}", project),
+        ),
+        Err(error) => {
+            let report = crate::memory::raw_archive::RawIngestReport {
+                insert_errors: 1,
+                ..crate::memory::raw_archive::RawIngestReport::default()
+            };
+            if let Err(record_error) = crate::memory::raw_archive::record_raw_ingest_failure(
+                conn,
+                session_id,
+                project,
+                crate::memory::raw_archive::SOURCE_HOOK,
+                None,
+                &report,
+            ) {
+                crate::log::warn(
+                    "summary-job",
+                    &format!("raw archive failure record failed: {}", record_error),
+                );
+            }
             crate::log::warn(
                 "summary-job",
                 &format!("raw archive insert failed: {}", error),
@@ -211,4 +284,58 @@ fn profile_from_payload(input: &str) -> Option<String> {
                 .filter(|profile| !profile.is_empty())
                 .map(str::to_string)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_support::ScopedTestDataDir;
+
+    #[tokio::test]
+    async fn bad_transcript_path_uses_last_assistant_message_hook_fallback() -> Result<()> {
+        let data_dir = ScopedTestDataDir::new("summary-raw-fallback");
+        let missing_transcript = data_dir.path.join("missing-transcript.jsonl");
+        let payload = serde_json::json!({
+            "session_id": "session-raw-fallback",
+            "cwd": data_dir.path.to_string_lossy(),
+            "transcript_path": missing_transcript.to_string_lossy(),
+            "last_assistant_message": "fallback assistant turn"
+        });
+
+        process_summary_job_input("codex-cli", None, &payload.to_string()).await?;
+
+        let conn = db::open_db()?;
+        let (role, source, content): (String, String, String) = conn.query_row(
+            "SELECT role, source, content FROM raw_messages WHERE session_id = ?1",
+            ["session-raw-fallback"],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(role, crate::memory::raw_archive::ROLE_ASSISTANT);
+        assert_eq!(source, crate::memory::raw_archive::SOURCE_HOOK);
+        assert_eq!(content, "fallback assistant turn");
+
+        let (path, kind): (String, String) = conn.query_row(
+            "SELECT transcript_path, error_kind FROM raw_ingest_failures WHERE session_id = ?1",
+            ["session-raw-fallback"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(path, missing_transcript.to_string_lossy());
+        assert_eq!(kind, "read_error");
+        Ok(())
+    }
+
+    #[test]
+    fn raw_archive_status_distinguishes_duplicate_only_from_failed_zero() {
+        let duplicate_only = crate::memory::raw_archive::RawIngestReport {
+            duplicates: 2,
+            ..crate::memory::raw_archive::RawIngestReport::default()
+        };
+        assert_eq!(raw_archive_status(&duplicate_only), "duplicate_only");
+
+        let read_failed = crate::memory::raw_archive::RawIngestReport {
+            read_error: Some("missing transcript".to_string()),
+            ..crate::memory::raw_archive::RawIngestReport::default()
+        };
+        assert_eq!(raw_archive_status(&read_failed), "read_failed");
+    }
 }


### PR DESCRIPTION
## Summary

- add v028 `raw_ingest_failures` ledger for raw transcript ingest read/parse/insert failures
- return structured raw ingest reports and keep hook fallback capture when a present transcript path is unreadable
- surface raw ingest health in `remem status` and `remem doctor`
- distinguish duplicate-only zero inserts from failed/partial raw ingests in summary logs

Stacked on #341. Closes #320 after the stack lands.

## Verification

- `git diff --check`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `python3 scripts/ci/check_version_bump.py origin/codex/issue-322-compression-provenance HEAD`

## Thread Review

- read-only reviewer thread `019e96ce-9507-7063-8e4c-9d88ae5bd0c9`: no blockers; confirmed all #320 acceptance criteria are covered