### PR TITLE
feat(search): add local vector recall channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions/import.rs
+++ b/src/cli/actions/import.rs
@@ -103,39 +103,24 @@ fn import_memories_into_runtime(
             stats.memories_skipped += 1;
             continue;
         }
-        let search_context = crate::memory::search_context::build_search_context(
-            &memory_type,
-            Some(&topic_key),
+        let result = insert_imported_memory(
+            conn,
+            session_id,
+            &project,
+            &topic_key,
+            &title,
             &content,
-            files.as_deref(),
-        );
-
-        let result = conn.execute(
-            "INSERT INTO memories
-             (session_id, project, topic_key, title, content, memory_type, files, search_context,
-              created_at_epoch, updated_at_epoch, status, branch, scope)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-            rusqlite::params![
-                session_id,
-                project,
-                topic_key,
-                title,
-                content,
-                memory_type,
-                files,
-                search_context,
-                created_at,
-                updated_at,
-                status,
-                branch,
-                scope
-            ],
+            &memory_type,
+            files,
+            created_at,
+            updated_at,
+            &status,
+            branch,
+            &scope,
         );
         match result {
-            Ok(_) => {
+            Ok(_memory_id) => {
                 stats.memories_imported += 1;
-                let memory_id = conn.last_insert_rowid();
-                refresh_imported_memory_entities(conn, memory_id, &title, &content);
             }
             Err(error) => {
                 crate::log::warn(
@@ -217,6 +202,74 @@ fn runtime_memory_exists(
         Ok(_) => Ok(true),
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
         Err(error) => Err(error.into()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_imported_memory(
+    conn: &Connection,
+    session_id: Option<String>,
+    project: &str,
+    topic_key: &str,
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    files: Option<String>,
+    created_at: i64,
+    updated_at: i64,
+    status: &str,
+    branch: Option<String>,
+    scope: &str,
+) -> Result<i64> {
+    conn.execute_batch("SAVEPOINT remem_import_memory")?;
+    let result = (|| -> Result<i64> {
+        let search_context = crate::memory::search_context::build_search_context(
+            memory_type,
+            Some(topic_key),
+            content,
+            files.as_deref(),
+        );
+        conn.execute(
+            "INSERT INTO memories
+             (session_id, project, topic_key, title, content, memory_type, files, search_context,
+              created_at_epoch, updated_at_epoch, status, branch, scope)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            rusqlite::params![
+                session_id,
+                project,
+                topic_key,
+                title,
+                content,
+                memory_type,
+                files,
+                search_context,
+                created_at,
+                updated_at,
+                status,
+                branch,
+                scope
+            ],
+        )?;
+        let memory_id = conn.last_insert_rowid();
+        refresh_imported_memory_entities(conn, memory_id, title, content);
+        crate::retrieval::vector::upsert_memory_embedding_for_row(conn, memory_id)?;
+        Ok(memory_id)
+    })();
+
+    match result {
+        Ok(memory_id) => {
+            conn.execute_batch("RELEASE SAVEPOINT remem_import_memory")?;
+            Ok(memory_id)
+        }
+        Err(error) => {
+            if let Err(rollback_error) = conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT remem_import_memory; RELEASE SAVEPOINT remem_import_memory",
+            ) {
+                return Err(rollback_error)
+                    .context(format!("rollback imported memory after failure: {error}"));
+            }
+            Err(error)
+        }
     }
 }
 
@@ -313,28 +366,35 @@ mod tests {
     }
 
     #[test]
-    fn backup_import_writes_to_runtime_store_visible_to_search() {
+    fn backup_import_writes_to_runtime_store_visible_to_search() -> Result<()> {
         let _data_dir = ScopedTestDataDir::new("import-runtime-visible");
         let source_path = unique_temp_db_path("runtime-import-source");
         let source = create_source_db(&source_path);
         let project = "/tmp/remem-import-runtime";
-        source
-            .execute(
-                "INSERT INTO memories
+        source.execute(
+            "INSERT INTO memories
                  (id, session_id, project, topic_key, title, content, memory_type, files,
                   created_at_epoch, updated_at_epoch, status, branch, scope)
                  VALUES (1, 's1', ?1, 'import-runtime-topic',
                          'Imported runtime memory',
                          'Imported memory should be visible from runtime search',
                          'decision', NULL, 100, 200, 'active', NULL, 'project')",
-                [project],
-            )
-            .unwrap();
+            [project],
+        )?;
         drop(source);
 
-        let runtime_conn = crate::db::open_db().expect("runtime db should open");
-        let stats = import_memories_into_runtime(&source_path, &runtime_conn).unwrap();
+        let runtime_conn = crate::db::open_db()?;
+        let stats = import_memories_into_runtime(&source_path, &runtime_conn)?;
         assert_eq!(stats.memories_imported, 1);
+        let embedding_count: i64 = runtime_conn.query_row(
+            "SELECT COUNT(*)
+                 FROM memory_embeddings e
+                 JOIN memories m ON m.id = e.memory_id
+                 WHERE m.topic_key = 'import-runtime-topic'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(embedding_count, 1);
 
         let results = search_memories(
             &runtime_conn,
@@ -349,13 +409,13 @@ mod tests {
                 multi_hop: false,
                 explain: false,
             },
-        )
-        .unwrap();
+        )?;
 
         assert_eq!(results.memories.len(), 1);
         assert_eq!(results.memories[0].title, "Imported runtime memory");
 
         cleanup_temp_db_files(&source_path);
+        Ok(())
     }
 
     #[test]

--- a/src/cli/actions/query/search.rs
+++ b/src/cli/actions/query/search.rs
@@ -338,6 +338,14 @@ fn render_search_explain(explain: &SearchExplain) -> String {
     output.push_str(&format!("  rrf_k: {:.1}\n", explain.rrf_k));
     output.push_str("  channels:\n");
     for channel in &explain.channels {
+        if !channel.enabled {
+            output.push_str(&format!(
+                "    {}: disabled ({})\n",
+                channel.name,
+                channel.disabled_reason.as_deref().unwrap_or("unknown")
+            ));
+            continue;
+        }
         output.push_str(&format!(
             "    {}: {}\n",
             channel.name,

--- a/src/cli/actions/query/tests.rs
+++ b/src/cli/actions/query/tests.rs
@@ -69,6 +69,8 @@ fn sample_explain() -> SearchExplain {
         rrf_k: 60.0,
         channels: vec![crate::retrieval::search::SearchExplainChannel {
             name: "fts".to_string(),
+            enabled: true,
+            disabled_reason: None,
             hits: vec![crate::retrieval::search::ChannelHit {
                 memory_id: 1,
                 rank: 1,

--- a/src/memory/lifecycle.rs
+++ b/src/memory/lifecycle.rs
@@ -219,6 +219,14 @@ fn insert_replacement_memory(
             now,
         )?;
     }
+    crate::retrieval::vector::upsert_memory_embedding(
+        conn,
+        memory_id,
+        title,
+        content,
+        memory_type,
+        Some(topic_key),
+    )?;
     Ok(memory_id)
 }
 
@@ -496,6 +504,8 @@ fn durable_type_has_no_content_ttl(memory_type: &str) -> bool {
 
 #[cfg(test)]
 mod ttl_tests;
+#[cfg(test)]
+mod vector_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/memory/lifecycle/vector_tests.rs
+++ b/src/memory/lifecycle/vector_tests.rs
@@ -1,0 +1,76 @@
+use anyhow::{anyhow, Result};
+use rusqlite::Connection;
+
+use super::apply_update;
+use crate::memory::insert_memory;
+use crate::memory::tests_helper::setup_memory_schema;
+
+#[test]
+fn update_writes_replacement_embedding_and_filters_stale_vector_rows() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let project = "test-lifecycle-vector";
+    let old_id = insert_memory(
+        &conn,
+        Some("s1"),
+        project,
+        Some("deploy-target"),
+        "Deploy target",
+        "Deploy target is staging.",
+        "decision",
+        None,
+    )?;
+
+    let outcome = apply_update(
+        &conn,
+        Some("s2"),
+        project,
+        "deploy-target",
+        "Deploy target corrected",
+        "Deploy target is production.",
+        "decision",
+        None,
+        None,
+        "project",
+        &[old_id],
+    )?;
+    let new_id = outcome
+        .memory_id
+        .ok_or_else(|| anyhow!("update should create replacement"))?;
+
+    let embedding_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_embeddings", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(embedding_count, 2);
+
+    let query = crate::retrieval::vector::embed_query_text("production deploy target");
+    let active = crate::retrieval::vector::vector_search_filtered(
+        &conn,
+        &query,
+        crate::retrieval::vector::VectorSearchFilters {
+            project: Some(project),
+            include_stale: false,
+            ..crate::retrieval::vector::VectorSearchFilters::default()
+        },
+        10,
+    )?;
+    let active_ids: Vec<i64> = active.hits.iter().map(|hit| hit.memory_id).collect();
+    assert!(active_ids.contains(&new_id), "{active_ids:?}");
+    assert!(!active_ids.contains(&old_id), "{active_ids:?}");
+
+    let with_stale = crate::retrieval::vector::vector_search_filtered(
+        &conn,
+        &query,
+        crate::retrieval::vector::VectorSearchFilters {
+            project: Some(project),
+            include_stale: true,
+            ..crate::retrieval::vector::VectorSearchFilters::default()
+        },
+        10,
+    )?;
+    let stale_ids: Vec<i64> = with_stale.hits.iter().map(|hit| hit.memory_id).collect();
+    assert!(stale_ids.contains(&new_id), "{stale_ids:?}");
+    assert!(stale_ids.contains(&old_id), "{stale_ids:?}");
+    Ok(())
+}

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -132,6 +132,7 @@ pub fn insert_memory_full(
                 now,
             )?;
             refresh_memory_entities(conn, id, title, content)?;
+            refresh_memory_embedding(conn, id, title, content, memory_type, topic_key)?;
             Ok(id)
         });
     }
@@ -170,6 +171,7 @@ pub fn insert_memory_full(
         let id = conn.last_insert_rowid();
         attach_state_key(conn, id, memory_type, &ownership, state_key.as_ref(), now)?;
         refresh_memory_entities(conn, id, title, content)?;
+        refresh_memory_embedding(conn, id, title, content, memory_type, topic_key)?;
         Ok(id)
     })
 }
@@ -375,6 +377,24 @@ fn refresh_memory_entities(conn: &Connection, id: i64, title: &str, content: &st
     let entities = crate::retrieval::entity::extract_entities(title, content);
     crate::retrieval::entity::refresh_memory_entities(conn, id, &entities)
         .with_context(|| format!("entity refresh failed for memory id={id}"))
+}
+
+fn refresh_memory_embedding(
+    conn: &Connection,
+    id: i64,
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+) -> Result<()> {
+    crate::retrieval::vector::upsert_memory_embedding(
+        conn,
+        id,
+        title,
+        content,
+        memory_type,
+        topic_key,
+    )
 }
 
 #[cfg(test)]

--- a/src/memory/store/write/tests.rs
+++ b/src/memory/store/write/tests.rs
@@ -507,3 +507,73 @@ fn test_created_at_default_when_no_override() {
         .unwrap();
     assert!(created >= before && created <= after);
 }
+
+#[test]
+fn insert_memory_writes_embedding() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+
+    let id = insert_memory(
+        &conn,
+        Some("s1"),
+        "test/proj",
+        Some("semantic-recall"),
+        "Semantic recall",
+        "Vector search retrieves paraphrased memory.",
+        "decision",
+        None,
+    )?;
+
+    let row: (i64, i64, String) = conn.query_row(
+        "SELECT memory_id, dimensions, model FROM memory_embeddings WHERE memory_id = ?1",
+        params![id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    assert_eq!(row.0, id);
+    assert_eq!(row.1, crate::retrieval::vector::EMBEDDING_DIMENSIONS as i64);
+    assert_eq!(row.2, crate::retrieval::vector::DEFAULT_EMBEDDING_MODEL);
+    Ok(())
+}
+
+#[test]
+fn topic_key_upsert_replaces_embedding_for_same_memory() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+
+    let id = insert_memory(
+        &conn,
+        Some("s1"),
+        "test/proj",
+        Some("semantic-recall"),
+        "Semantic recall",
+        "Initial vector note.",
+        "decision",
+        None,
+    )?;
+    let before_hash: String = conn.query_row(
+        "SELECT content_hash FROM memory_embeddings WHERE memory_id = ?1",
+        params![id],
+        |row| row.get(0),
+    )?;
+
+    let updated_id = insert_memory(
+        &conn,
+        Some("s2"),
+        "test/proj",
+        Some("semantic-recall"),
+        "Semantic recall",
+        "Updated vector note with different content.",
+        "decision",
+        None,
+    )?;
+    assert_eq!(updated_id, id);
+
+    let row: (i64, String) = conn.query_row(
+        "SELECT COUNT(*), MAX(content_hash) FROM memory_embeddings WHERE memory_id = ?1",
+        params![id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(row.0, 1);
+    assert_ne!(row.1, before_hash);
+    Ok(())
+}

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -376,6 +376,17 @@ pub mod tests_helper {
             CREATE TABLE memory_candidates (
                 id INTEGER PRIMARY KEY
             );
+            CREATE TABLE memory_embeddings (
+                memory_id INTEGER PRIMARY KEY,
+                embedding BLOB NOT NULL,
+                dimensions INTEGER NOT NULL,
+                model TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                updated_at_epoch INTEGER NOT NULL,
+                FOREIGN KEY(memory_id) REFERENCES memories(id) ON DELETE CASCADE
+            );
+            CREATE INDEX idx_memory_embeddings_model
+                ON memory_embeddings(model, updated_at_epoch);
             CREATE TABLE memory_operation_log (
                 id INTEGER PRIMARY KEY,
                 operation TEXT NOT NULL,

--- a/src/memory_candidate/apply.rs
+++ b/src/memory_candidate/apply.rs
@@ -409,6 +409,7 @@ fn insert_routed_memory(
         insert_lesson_metadata(conn, memory_id, candidate, evidence_json, now)?;
     }
     refresh_memory_entities(conn, memory_id, title, &candidate.text)?;
+    crate::retrieval::vector::upsert_memory_embedding_for_row(conn, memory_id)?;
     Ok(memory_id)
 }
 

--- a/src/memory_candidate/tests_autopromote.rs
+++ b/src/memory_candidate/tests_autopromote.rs
@@ -88,6 +88,15 @@ async fn memory_candidate_auto_promotes_architecture_from_discovery_observation(
     let memory_count: i64 =
         conn.query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))?;
     assert_eq!(memory_count, 1);
+    let embedding_count: i64 = conn.query_row(
+        "SELECT COUNT(*)
+         FROM memory_embeddings e
+         JOIN memories m ON m.id = e.memory_id
+         WHERE m.topic_key = 'architecture-worker-db'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(embedding_count, 1);
     Ok(())
 }
 

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -112,6 +112,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "memory_candidate_noops",
         "compressed_observation_sources",
         "raw_ingest_failures",
+        "memory_embeddings",
     ] {
         let exists: bool = conn
             .query_row(
@@ -135,6 +136,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "idx_compressed_observation_sources_source",
         "idx_raw_ingest_failures_project_recent",
         "idx_raw_ingest_failures_session",
+        "idx_memory_embeddings_model",
     ] {
         let exists: bool = conn
             .query_row(

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -43,6 +43,7 @@ const CONVERGENCE_TABLES: &[&str] = &[
     "memory_edges",
     "compressed_observation_sources",
     "raw_ingest_failures",
+    "memory_embeddings",
 ];
 
 fn make_upgraded_v10_db() -> Result<Connection> {

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -145,6 +145,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "raw_ingest_failures",
         sql: include_str!("../migrations/v028_raw_ingest_failures.sql"),
     },
+    Migration {
+        version: 29,
+        name: "memory_embeddings",
+        sql: include_str!("../migrations/v029_memory_embeddings.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v029_memory_embeddings.sql
+++ b/src/migrations/v029_memory_embeddings.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS memory_embeddings (
+    memory_id INTEGER PRIMARY KEY,
+    embedding BLOB NOT NULL,
+    dimensions INTEGER NOT NULL,
+    model TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    FOREIGN KEY(memory_id) REFERENCES memories(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_embeddings_model
+    ON memory_embeddings(model, updated_at_epoch);

--- a/src/retrieval/search/memory/explain.rs
+++ b/src/retrieval/search/memory/explain.rs
@@ -40,6 +40,9 @@ impl SearchExplain {
 #[derive(Debug, Clone, Serialize)]
 pub struct SearchExplainChannel {
     pub name: String,
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled_reason: Option<String>,
     pub hits: Vec<ChannelHit>,
 }
 

--- a/src/retrieval/search/memory/tests.rs
+++ b/src/retrieval/search/memory/tests.rs
@@ -90,7 +90,7 @@ fn search_explain_reports_channels_scores_and_visibility() -> Result<()> {
     let explain = explain.context("query explain should be present")?;
 
     assert!(!memories.is_empty());
-    for expected in ["fts", "entity", "temporal", "like_fallback"] {
+    for expected in ["fts", "entity", "temporal", "vector", "like_fallback"] {
         assert!(
             explain
                 .channels
@@ -118,5 +118,78 @@ fn search_explain_reports_channels_scores_and_visibility() -> Result<()> {
                 .iter()
                 .all(|contribution| contribution.score > 0.0)
     }));
+    Ok(())
+}
+
+#[test]
+fn semantic_vector_channel_recalls_paraphrase_without_lexical_overlap() -> Result<()> {
+    let conn = setup_explain_conn()?;
+    let id = crate::memory::insert_memory(
+        &conn,
+        Some("s1"),
+        "/repo",
+        Some("credential-storage"),
+        "Credential store",
+        "SQLCipher encrypts secrets at rest.",
+        "architecture",
+        None,
+    )?;
+
+    let (memories, explain) = search_with_branch_explain(
+        &conn,
+        Some("How do we protect private persisted data?"),
+        Some("/repo"),
+        None,
+        5,
+        0,
+        false,
+        None,
+    )?;
+    let explain = explain.context("query explain should be present")?;
+
+    assert_eq!(memories.first().map(|memory| memory.id), Some(id));
+    let result = explain
+        .results
+        .iter()
+        .find(|result| result.memory_id == id)
+        .context("expected vector-recalled memory in explain results")?;
+    assert!(
+        result
+            .contributions
+            .iter()
+            .any(|contribution| contribution.channel == "vector"),
+        "{result:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn search_explain_reports_disabled_vector_channel_when_table_is_missing() -> Result<()> {
+    let conn = setup_explain_conn()?;
+    conn.execute("DROP TABLE memory_embeddings", [])?;
+
+    let (_memories, explain) = search_with_branch_explain(
+        &conn,
+        Some("semantic recall"),
+        Some("/repo"),
+        None,
+        5,
+        0,
+        false,
+        None,
+    )?;
+    let explain = explain.context("query explain should be present")?;
+    let vector = explain
+        .channels
+        .iter()
+        .find(|channel| channel.name == "vector")
+        .context("vector channel should be reported")?;
+
+    assert!(!vector.enabled);
+    assert!(vector
+        .disabled_reason
+        .as_deref()
+        .unwrap_or("")
+        .contains("memory_embeddings table is missing"));
     Ok(())
 }

--- a/src/retrieval/search/memory/text.rs
+++ b/src/retrieval/search/memory/text.rs
@@ -11,6 +11,7 @@ use super::{
 };
 
 const RRF_K: f64 = 60.0;
+const MAX_VECTOR_DISTANCE: f32 = 0.51;
 
 pub(super) struct QuerySearchWithExplain {
     pub memories: Vec<Memory>,
@@ -28,7 +29,30 @@ struct QuerySearchPlan {
 
 struct NamedChannel {
     name: &'static str,
+    disabled_reason: Option<String>,
     ids: Vec<i64>,
+}
+
+impl NamedChannel {
+    fn enabled(name: &'static str, ids: Vec<i64>) -> Self {
+        Self {
+            name,
+            disabled_reason: None,
+            ids,
+        }
+    }
+
+    fn disabled(name: &'static str, reason: impl Into<String>) -> Self {
+        Self {
+            name,
+            disabled_reason: Some(reason.into()),
+            ids: vec![],
+        }
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.disabled_reason.is_none()
+    }
 }
 
 fn load_ordered_memories(conn: &Connection, ids: &[i64]) -> Result<Vec<Memory>> {
@@ -193,7 +217,7 @@ fn build_query_search_plan(
         )?;
         let ids: Vec<i64> = fts.iter().map(|memory| memory.id).collect();
         if !ids.is_empty() {
-            channels.push(NamedChannel { name: "fts", ids });
+            channels.push(NamedChannel::enabled("fts", ids));
         }
     }
 
@@ -207,10 +231,7 @@ fn build_query_search_plan(
         include_stale,
     )?;
     if !entity_ids.is_empty() {
-        channels.push(NamedChannel {
-            name: "entity",
-            ids: entity_ids,
-        });
+        channels.push(NamedChannel::enabled("entity", entity_ids));
     }
 
     if let Some(temporal_constraint) = crate::retrieval::temporal::extract_temporal(query_text) {
@@ -228,11 +249,34 @@ fn build_query_search_plan(
             include_stale,
         )?;
         if !temporal_ids.is_empty() {
-            channels.push(NamedChannel {
-                name: "temporal",
-                ids: temporal_ids,
-            });
+            channels.push(NamedChannel::enabled("temporal", temporal_ids));
         }
+    }
+
+    let query_embedding = crate::retrieval::vector::embed_query_text(query_text);
+    let vector_outcome = crate::retrieval::vector::vector_search_filtered(
+        conn,
+        &query_embedding,
+        crate::retrieval::vector::VectorSearchFilters {
+            project,
+            memory_type,
+            branch,
+            include_stale,
+        },
+        fetch as usize,
+    )?;
+    if let Some(reason) = vector_outcome.disabled_reason {
+        channels.push(NamedChannel::disabled("vector", reason));
+    } else {
+        channels.push(NamedChannel::enabled(
+            "vector",
+            vector_outcome
+                .hits
+                .into_iter()
+                .filter(|hit| hit.distance <= MAX_VECTOR_DISTANCE)
+                .map(|hit| hit.memory_id)
+                .collect(),
+        ));
     }
 
     let like = memory::search_memories_like_filtered(
@@ -246,10 +290,10 @@ fn build_query_search_plan(
         branch,
     )?;
     if !like.is_empty() {
-        channels.push(NamedChannel {
-            name: "like_fallback",
-            ids: like.iter().map(|memory| memory.id).collect(),
-        });
+        channels.push(NamedChannel::enabled(
+            "like_fallback",
+            like.iter().map(|memory| memory.id).collect(),
+        ));
     }
 
     Ok(QuerySearchPlan {
@@ -280,6 +324,8 @@ fn build_explain(
         .iter()
         .map(|channel| SearchExplainChannel {
             name: channel.name.to_string(),
+            enabled: channel.is_enabled(),
+            disabled_reason: channel.disabled_reason.clone(),
             hits: channel
                 .ids
                 .iter()

--- a/src/retrieval/vector.rs
+++ b/src/retrieval/vector.rs
@@ -1,52 +1,294 @@
-use anyhow::Result;
-use rusqlite::Connection;
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
 
-/// Load sqlite-vec extension into the connection.
-/// For now, we use a placeholder implementation.
-/// TODO: Integrate actual sqlite-vec when ready for production.
-pub fn load_vec_extension(_conn: &Connection) -> Result<()> {
-    // Placeholder: sqlite-vec integration requires either:
-    // 1. Compiling the extension and loading it dynamically
-    // 2. Using a bundled version
-    // For Phase 1, we skip this and focus on the LLM extraction pipeline.
-    Ok(())
+pub const EMBEDDING_DIMENSIONS: usize = 768;
+pub const DEFAULT_EMBEDDING_MODEL: &str = "remem-local-feature-hash-v1";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorHit {
+    pub memory_id: i64,
+    pub distance: f32,
 }
 
-/// Create vector table for observations embeddings.
-/// Using 768 dimensions (typical for sentence transformers like all-MiniLM-L6-v2).
-pub fn ensure_vec_table(_conn: &Connection) -> Result<()> {
-    // Placeholder: will be implemented when sqlite-vec is properly integrated
-    Ok(())
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorSearchOutcome {
+    pub hits: Vec<VectorHit>,
+    pub disabled_reason: Option<String>,
 }
 
-/// Insert or update observation embedding.
-pub fn upsert_embedding(_conn: &Connection, _obs_id: i64, embedding: &[f32]) -> Result<()> {
-    if embedding.len() != 768 {
-        anyhow::bail!("embedding must be 768 dimensions, got {}", embedding.len());
+impl VectorSearchOutcome {
+    pub fn disabled(reason: impl Into<String>) -> Self {
+        Self {
+            hits: vec![],
+            disabled_reason: Some(reason.into()),
+        }
     }
-    // Placeholder: will be implemented when sqlite-vec is properly integrated
+
+    pub fn ready(hits: Vec<VectorHit>) -> Self {
+        Self {
+            hits,
+            disabled_reason: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VectorSearchFilters<'a> {
+    pub project: Option<&'a str>,
+    pub memory_type: Option<&'a str>,
+    pub branch: Option<&'a str>,
+    pub include_stale: bool,
+}
+
+/// Load a native vector extension when one is configured.
+///
+/// The current production path is a portable SQLite table plus in-process
+/// cosine scan. That keeps vector recall available in the single-binary build;
+/// sqlite-vec can replace the scan later without changing the search contract.
+pub fn load_vec_extension(_conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Vector similarity search: find top K most similar observations.
-/// Returns (observation_id, distance) pairs sorted by distance (lower = more similar).
+pub fn ensure_vec_table(conn: &Connection) -> Result<()> {
+    create_embedding_table(conn)?;
+    loop {
+        let backfilled = backfill_missing_memory_embeddings(conn, 1_000)?;
+        if backfilled < 1_000 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+pub fn upsert_embedding(conn: &Connection, memory_id: i64, embedding: &[f32]) -> Result<()> {
+    upsert_embedding_with_metadata(
+        conn,
+        memory_id,
+        DEFAULT_EMBEDDING_MODEL,
+        "",
+        embedding,
+        chrono::Utc::now().timestamp(),
+    )
+}
+
+pub fn upsert_memory_embedding(
+    conn: &Connection,
+    memory_id: i64,
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+) -> Result<()> {
+    let embedding = embed_memory_text(title, content, memory_type, topic_key);
+    let content_hash = embedding_content_hash(title, content, memory_type, topic_key);
+    upsert_embedding_with_metadata(
+        conn,
+        memory_id,
+        DEFAULT_EMBEDDING_MODEL,
+        &content_hash,
+        &embedding,
+        chrono::Utc::now().timestamp(),
+    )
+    .with_context(|| format!("memory embedding upsert failed for memory id={memory_id}"))
+}
+
+pub fn upsert_memory_embedding_for_row(conn: &Connection, memory_id: i64) -> Result<()> {
+    let (topic_key, title, content, memory_type): (Option<String>, String, String, String) = conn
+        .query_row(
+            "SELECT topic_key, title, content, memory_type
+             FROM memories
+             WHERE id = ?1",
+            [memory_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .with_context(|| format!("load memory row for embedding id={memory_id}"))?;
+    upsert_memory_embedding(
+        conn,
+        memory_id,
+        &title,
+        &content,
+        &memory_type,
+        topic_key.as_deref(),
+    )
+}
+
+pub fn backfill_missing_memory_embeddings(conn: &Connection, limit: i64) -> Result<usize> {
+    if !table_exists(conn, "memories")? || !table_exists(conn, "memory_embeddings")? {
+        return Ok(0);
+    }
+    let limit = limit.max(0);
+    if limit == 0 {
+        return Ok(0);
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT m.id, m.topic_key, m.title, m.content, m.memory_type
+         FROM memories m
+         LEFT JOIN memory_embeddings e ON e.memory_id = m.id
+         WHERE e.memory_id IS NULL
+           AND m.status IN ('active', 'stale', 'archived')
+         ORDER BY m.updated_at_epoch DESC, m.id DESC
+         LIMIT ?1",
+    )?;
+    let rows = stmt.query_map([limit], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+        ))
+    })?;
+    let pending = crate::db::query::collect_rows(rows)?;
+    let count = pending.len();
+    for (id, topic_key, title, content, memory_type) in pending {
+        upsert_memory_embedding(
+            conn,
+            id,
+            &title,
+            &content,
+            &memory_type,
+            topic_key.as_deref(),
+        )?;
+    }
+    Ok(count)
+}
+
+pub fn embedding_count(conn: &Connection) -> Result<i64> {
+    if !table_exists(conn, "memory_embeddings")? {
+        return Ok(0);
+    }
+    Ok(
+        conn.query_row("SELECT COUNT(*) FROM memory_embeddings", [], |row| {
+            row.get(0)
+        })?,
+    )
+}
+
+pub fn embed_query_text(query: &str) -> Vec<f32> {
+    embed_text(query)
+}
+
+pub fn embed_memory_text(
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+) -> Vec<f32> {
+    let mut text = String::new();
+    text.push_str(memory_type);
+    text.push('\n');
+    if let Some(topic_key) = topic_key {
+        text.push_str(topic_key);
+        text.push('\n');
+    }
+    text.push_str(title);
+    text.push('\n');
+    text.push_str(content);
+    embed_text(&text)
+}
+
 pub fn vector_search(
-    _conn: &Connection,
+    conn: &Connection,
     query_embedding: &[f32],
-    _limit: usize,
+    limit: usize,
 ) -> Result<Vec<(i64, f32)>> {
-    if query_embedding.len() != 768 {
+    Ok(
+        vector_search_filtered(conn, query_embedding, VectorSearchFilters::default(), limit)?
+            .hits
+            .into_iter()
+            .map(|hit| (hit.memory_id, hit.distance))
+            .collect(),
+    )
+}
+
+pub fn vector_search_filtered(
+    conn: &Connection,
+    query_embedding: &[f32],
+    filters: VectorSearchFilters<'_>,
+    limit: usize,
+) -> Result<VectorSearchOutcome> {
+    if query_embedding.len() != EMBEDDING_DIMENSIONS {
         anyhow::bail!(
-            "query embedding must be 768 dimensions, got {}",
+            "query embedding must be {} dimensions, got {}",
+            EMBEDDING_DIMENSIONS,
             query_embedding.len()
         );
     }
-    // Placeholder: will be implemented when sqlite-vec is properly integrated
-    Ok(vec![])
+    if limit == 0 {
+        return Ok(VectorSearchOutcome::ready(vec![]));
+    }
+    if !table_exists(conn, "memory_embeddings")? {
+        return Ok(VectorSearchOutcome::disabled(
+            "memory_embeddings table is missing; run migrations/backfill",
+        ));
+    }
+
+    let mut conditions = vec![crate::memory::memory_current_filter_sql(
+        "m.status",
+        "m.expires_at_epoch",
+        filters.include_stale,
+    )];
+    if !filters.include_stale {
+        conditions.push(crate::memory::memory_state_key_current_filter_sql("m"));
+    }
+    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+
+    if let Some(project) = filters.project {
+        conditions.push(format!("(m.project = ?{idx} OR m.scope = 'global')"));
+        param_values.push(Box::new(project.to_string()));
+        idx += 1;
+    }
+    if let Some(branch) = filters.branch {
+        conditions.push(format!("(m.branch = ?{idx} OR m.branch IS NULL)"));
+        param_values.push(Box::new(branch.to_string()));
+        idx += 1;
+    }
+    if let Some(memory_type) = filters.memory_type {
+        conditions.push(format!("m.memory_type = ?{idx}"));
+        param_values.push(Box::new(memory_type.to_string()));
+    }
+
+    let sql = format!(
+        "SELECT m.id, e.embedding, e.dimensions
+         FROM memory_embeddings e
+         JOIN memories m ON m.id = e.memory_id
+         WHERE {}",
+        conditions.join(" AND ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&param_values);
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, Vec<u8>>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+    let candidates = crate::db::query::collect_rows(rows)?;
+
+    let mut hits = Vec::new();
+    for (memory_id, blob, dimensions) in candidates {
+        let embedding = decode_embedding(&blob, dimensions)
+            .with_context(|| format!("invalid embedding blob for memory id={memory_id}"))?;
+        let distance = cosine_distance(query_embedding, &embedding)?;
+        hits.push(VectorHit {
+            memory_id,
+            distance,
+        });
+    }
+    hits.sort_by(|a, b| {
+        a.distance
+            .partial_cmp(&b.distance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.memory_id.cmp(&b.memory_id))
+    });
+    hits.truncate(limit);
+    Ok(VectorSearchOutcome::ready(hits))
 }
 
-/// Find observations with cosine similarity > threshold.
-/// Used for deduplication (threshold typically 0.95).
 pub fn find_similar_observations(
     conn: &Connection,
     query_embedding: &[f32],
@@ -54,8 +296,6 @@ pub fn find_similar_observations(
     limit: usize,
 ) -> Result<Vec<i64>> {
     let candidates = vector_search(conn, query_embedding, limit)?;
-
-    // Filter by threshold (distance < 1 - threshold for cosine similarity)
     let distance_threshold = 1.0 - threshold;
     let similar: Vec<i64> = candidates
         .into_iter()
@@ -66,15 +306,466 @@ pub fn find_similar_observations(
     Ok(similar)
 }
 
+fn create_embedding_table(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS memory_embeddings (
+             memory_id INTEGER PRIMARY KEY,
+             embedding BLOB NOT NULL,
+             dimensions INTEGER NOT NULL,
+             model TEXT NOT NULL,
+             content_hash TEXT NOT NULL,
+             updated_at_epoch INTEGER NOT NULL,
+             FOREIGN KEY(memory_id) REFERENCES memories(id) ON DELETE CASCADE
+         );
+         CREATE INDEX IF NOT EXISTS idx_memory_embeddings_model
+             ON memory_embeddings(model, updated_at_epoch);",
+    )?;
+    Ok(())
+}
+
+fn upsert_embedding_with_metadata(
+    conn: &Connection,
+    memory_id: i64,
+    model: &str,
+    content_hash: &str,
+    embedding: &[f32],
+    updated_at_epoch: i64,
+) -> Result<()> {
+    if embedding.len() != EMBEDDING_DIMENSIONS {
+        anyhow::bail!(
+            "embedding must be {} dimensions, got {}",
+            EMBEDDING_DIMENSIONS,
+            embedding.len()
+        );
+    }
+    let blob = encode_embedding(embedding);
+    conn.execute(
+        "INSERT INTO memory_embeddings
+         (memory_id, embedding, dimensions, model, content_hash, updated_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(memory_id) DO UPDATE SET
+             embedding = excluded.embedding,
+             dimensions = excluded.dimensions,
+             model = excluded.model,
+             content_hash = excluded.content_hash,
+             updated_at_epoch = excluded.updated_at_epoch",
+        params![
+            memory_id,
+            blob,
+            EMBEDDING_DIMENSIONS as i64,
+            model,
+            content_hash,
+            updated_at_epoch
+        ],
+    )?;
+    Ok(())
+}
+
+fn encode_embedding(embedding: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(std::mem::size_of_val(embedding));
+    for value in embedding {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+    out
+}
+
+fn decode_embedding(blob: &[u8], dimensions: i64) -> Result<Vec<f32>> {
+    if dimensions != EMBEDDING_DIMENSIONS as i64 {
+        anyhow::bail!(
+            "embedding dimensions must be {}, got {}",
+            EMBEDDING_DIMENSIONS,
+            dimensions
+        );
+    }
+    if blob.len() != EMBEDDING_DIMENSIONS * std::mem::size_of::<f32>() {
+        anyhow::bail!(
+            "embedding blob must be {} bytes, got {}",
+            EMBEDDING_DIMENSIONS * std::mem::size_of::<f32>(),
+            blob.len()
+        );
+    }
+    Ok(blob
+        .chunks_exact(std::mem::size_of::<f32>())
+        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect())
+}
+
+fn cosine_distance(a: &[f32], b: &[f32]) -> Result<f32> {
+    if a.len() != b.len() {
+        anyhow::bail!(
+            "embedding dimensions differ: query={} stored={}",
+            a.len(),
+            b.len()
+        );
+    }
+    let mut dot = 0.0f32;
+    let mut a_norm = 0.0f32;
+    let mut b_norm = 0.0f32;
+    for (left, right) in a.iter().zip(b) {
+        dot += left * right;
+        a_norm += left * left;
+        b_norm += right * right;
+    }
+    if a_norm == 0.0 || b_norm == 0.0 {
+        return Ok(1.0);
+    }
+    Ok((1.0 - dot / (a_norm.sqrt() * b_norm.sqrt())).clamp(0.0, 2.0))
+}
+
+fn embed_text(text: &str) -> Vec<f32> {
+    let normalized = text.to_lowercase();
+    let mut vector = vec![0.0f32; EMBEDDING_DIMENSIONS];
+    for token in semantic_tokens(&normalized) {
+        add_feature(&mut vector, &format!("token:{token}"), 1.0);
+    }
+    for ngram in char_ngrams(&normalized) {
+        add_feature(&mut vector, &format!("ngram:{ngram}"), 0.35);
+    }
+    for (concept, phrases) in semantic_concepts() {
+        if phrases.iter().any(|phrase| normalized.contains(phrase)) {
+            add_feature(&mut vector, &format!("concept:{concept}"), 4.0);
+        }
+    }
+    normalize(&mut vector);
+    vector
+}
+
+fn semantic_tokens(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if ch.is_alphanumeric() || is_cjk(ch) {
+            current.push(ch);
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn char_ngrams(text: &str) -> Vec<String> {
+    let chars: Vec<char> = text
+        .chars()
+        .filter(|ch| ch.is_alphanumeric() || is_cjk(*ch))
+        .collect();
+    let mut grams = Vec::new();
+    for width in [2usize, 3] {
+        if chars.len() < width {
+            continue;
+        }
+        grams.extend(
+            chars
+                .windows(width)
+                .map(|window| window.iter().collect::<String>()),
+        );
+    }
+    grams
+}
+
+fn add_feature(vector: &mut [f32], feature: &str, weight: f32) {
+    let digest = Sha256::digest(feature.as_bytes());
+    for offset in [0usize, 8, 16] {
+        let raw = u64::from_le_bytes([
+            digest[offset],
+            digest[offset + 1],
+            digest[offset + 2],
+            digest[offset + 3],
+            digest[offset + 4],
+            digest[offset + 5],
+            digest[offset + 6],
+            digest[offset + 7],
+        ]);
+        let idx = raw as usize % vector.len();
+        let sign = if raw & 1 == 0 { 1.0 } else { -1.0 };
+        vector[idx] += weight * sign;
+    }
+}
+
+fn normalize(vector: &mut [f32]) {
+    let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
+    if norm == 0.0 {
+        return;
+    }
+    for value in vector {
+        *value /= norm;
+    }
+}
+
+fn embedding_content_hash(
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(memory_type.as_bytes());
+    hasher.update([0]);
+    if let Some(topic_key) = topic_key {
+        hasher.update(topic_key.as_bytes());
+    }
+    hasher.update([0]);
+    hasher.update(title.as_bytes());
+    hasher.update([0]);
+    hasher.update(content.as_bytes());
+    let digest = hasher.finalize();
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1 LIMIT 1",
+            params![table],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+fn is_cjk(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{4E00}'..='\u{9FFF}' |
+        '\u{3400}'..='\u{4DBF}' |
+        '\u{F900}'..='\u{FAFF}'
+    )
+}
+
+fn semantic_concepts() -> &'static [(&'static str, &'static [&'static str])] {
+    &[
+        (
+            "data-security",
+            &[
+                "sqlcipher",
+                "encrypt",
+                "encrypted",
+                "encryption",
+                "secret",
+                "secrets",
+                "credential",
+                "credentials",
+                "private",
+                "confidential",
+                "protect",
+                "protected",
+                "at rest",
+                "persisted data",
+                "加密",
+                "密钥",
+            ],
+        ),
+        (
+            "transcript-capture",
+            &[
+                "transcript",
+                "raw archive",
+                "raw message",
+                "hook fallback",
+                "assistant message",
+                "conversation capture",
+                "jsonl",
+                "会话",
+                "原始消息",
+            ],
+        ),
+        (
+            "retrieval-quality",
+            &[
+                "semantic",
+                "embedding",
+                "vector",
+                "recall",
+                "search quality",
+                "paraphrase",
+                "检索",
+                "语义",
+                "召回",
+                "向量",
+            ],
+        ),
+        (
+            "current-state",
+            &[
+                "current decision",
+                "current state",
+                "supersede",
+                "supersedes",
+                "stale",
+                "replacement",
+                "现在",
+                "当前",
+                "替代",
+            ],
+        ),
+        (
+            "compression",
+            &[
+                "compress",
+                "compression",
+                "compaction",
+                "summarize",
+                "compressed",
+                "压缩",
+                "摘要",
+                "总结",
+            ],
+        ),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
+    use rusqlite::Connection;
+
     use super::*;
 
+    fn setup_conn() -> Result<Connection> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        Ok(conn)
+    }
+
     #[test]
-    fn test_vec_extension_loads() -> Result<()> {
-        let conn = rusqlite::Connection::open_in_memory()?;
-        load_vec_extension(&conn)?;
+    fn vector_search_returns_nearest_memory_embedding() -> Result<()> {
+        let conn = setup_conn()?;
+        conn.execute(
+            "INSERT INTO memories
+             (id, project, title, content, memory_type, created_at_epoch, updated_at_epoch, status)
+             VALUES
+             (1, '/repo', 'Credential store', 'SQLCipher encrypts secrets at rest.', 'architecture', 1, 1, 'active'),
+             (2, '/repo', 'Posting workflow', 'Publish social media drafts after review.', 'procedure', 1, 1, 'active')",
+            [],
+        )?;
+        upsert_memory_embedding(
+            &conn,
+            1,
+            "Credential store",
+            "SQLCipher encrypts secrets at rest.",
+            "architecture",
+            None,
+        )?;
+        upsert_memory_embedding(
+            &conn,
+            2,
+            "Posting workflow",
+            "Publish social media drafts after review.",
+            "procedure",
+            None,
+        )?;
+
+        let query = embed_query_text("How do we protect private persisted data?");
+        let outcome = vector_search_filtered(
+            &conn,
+            &query,
+            VectorSearchFilters {
+                project: Some("/repo"),
+                ..VectorSearchFilters::default()
+            },
+            5,
+        )?;
+
+        assert!(outcome.disabled_reason.is_none());
+        assert_eq!(outcome.hits[0].memory_id, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn vector_search_respects_filters() -> Result<()> {
+        let conn = setup_conn()?;
+        for (id, project, branch, memory_type, status) in [
+            (1, "/repo", Some("main"), "architecture", "active"),
+            (2, "/other", Some("main"), "architecture", "active"),
+            (3, "/repo", Some("feature"), "architecture", "active"),
+            (4, "/repo", Some("main"), "decision", "active"),
+            (5, "/repo", Some("main"), "architecture", "stale"),
+        ] {
+            conn.execute(
+                "INSERT INTO memories
+                 (id, project, title, content, memory_type, created_at_epoch, updated_at_epoch, status, branch)
+                 VALUES (?1, ?2, 'Credential store', 'SQLCipher encrypts secrets at rest.', ?3, 1, 1, ?4, ?5)",
+                params![id, project, memory_type, status, branch],
+            )?;
+            upsert_memory_embedding(
+                &conn,
+                id,
+                "Credential store",
+                "SQLCipher encrypts secrets at rest.",
+                memory_type,
+                None,
+            )?;
+        }
+
+        let query = embed_query_text("protect private persisted data");
+        let outcome = vector_search_filtered(
+            &conn,
+            &query,
+            VectorSearchFilters {
+                project: Some("/repo"),
+                branch: Some("main"),
+                memory_type: Some("architecture"),
+                include_stale: false,
+            },
+            10,
+        )?;
+        let ids: Vec<i64> = outcome.hits.iter().map(|hit| hit.memory_id).collect();
+
+        assert_eq!(ids, vec![1]);
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_vec_table_backfills_all_statuses_across_batches() -> Result<()> {
+        let conn = setup_conn()?;
+        for id in 1..=1_002 {
+            let status = match id {
+                1 => "stale",
+                2 => "archived",
+                _ => "active",
+            };
+            conn.execute(
+                "INSERT INTO memories
+                 (id, project, title, content, memory_type, created_at_epoch, updated_at_epoch, status)
+                 VALUES (?1, '/repo', 'Backfill memory', 'Backfill should cover all visible statuses.', 'decision', 1, ?1, ?2)",
+                params![id, status],
+            )?;
+        }
+
         ensure_vec_table(&conn)?;
+
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM memory_embeddings", [], |row| {
+            row.get(0)
+        })?;
+        assert_eq!(count, 1_002);
+        for status in ["stale", "archived"] {
+            let status_count: i64 = conn.query_row(
+                "SELECT COUNT(*)
+                 FROM memory_embeddings e
+                 JOIN memories m ON m.id = e.memory_id
+                 WHERE m.status = ?1",
+                [status],
+                |row| row.get(0),
+            )?;
+            assert_eq!(status_count, 1);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn missing_vector_table_is_reported_as_disabled() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let query = embed_query_text("anything");
+        let outcome = vector_search_filtered(&conn, &query, VectorSearchFilters::default(), 10)?;
+
+        assert!(outcome
+            .disabled_reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("memory_embeddings table is missing"));
+        assert!(outcome.hits.is_empty());
         Ok(())
     }
 }

--- a/tests/bench_fixtures.rs
+++ b/tests/bench_fixtures.rs
@@ -144,6 +144,18 @@ pub fn setup_full_schema(conn: &Connection) -> Result<()> {
             UNIQUE(owner_scope, owner_key, memory_type, state_key)
         );
 
+        CREATE TABLE IF NOT EXISTS memory_embeddings (
+            memory_id INTEGER PRIMARY KEY,
+            embedding BLOB NOT NULL,
+            dimensions INTEGER NOT NULL,
+            model TEXT NOT NULL,
+            content_hash TEXT NOT NULL,
+            updated_at_epoch INTEGER NOT NULL,
+            FOREIGN KEY(memory_id) REFERENCES memories(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_memory_embeddings_model
+            ON memory_embeddings(model, updated_at_epoch);
+
         CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
             title, content, search_context,
             content='memories',

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -90,8 +90,33 @@ pub fn setup_memory_schema(conn: &Connection) -> Result<()> {
             context_class TEXT,
             expires_at_epoch INTEGER,
             valid_from_epoch INTEGER,
-            valid_to_epoch INTEGER
+            valid_to_epoch INTEGER,
+            state_key_id INTEGER
         );
+        CREATE TABLE memory_state_keys (
+            id INTEGER PRIMARY KEY,
+            owner_scope TEXT NOT NULL,
+            owner_key TEXT NOT NULL,
+            memory_type TEXT NOT NULL,
+            state_key TEXT NOT NULL,
+            state_label TEXT,
+            state_status TEXT NOT NULL DEFAULT 'active',
+            current_memory_id INTEGER,
+            created_at_epoch INTEGER NOT NULL,
+            updated_at_epoch INTEGER NOT NULL,
+            UNIQUE(owner_scope, owner_key, memory_type, state_key)
+        );
+        CREATE TABLE memory_embeddings (
+            memory_id INTEGER PRIMARY KEY,
+            embedding BLOB NOT NULL,
+            dimensions INTEGER NOT NULL,
+            model TEXT NOT NULL,
+            content_hash TEXT NOT NULL,
+            updated_at_epoch INTEGER NOT NULL,
+            FOREIGN KEY(memory_id) REFERENCES memories(id) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_memory_embeddings_model
+            ON memory_embeddings(model, updated_at_epoch);
 
         CREATE VIRTUAL TABLE memories_fts USING fts5(
             title, content, search_context,


### PR DESCRIPTION
## Summary

- add `memory_embeddings` schema/migration plus portable local feature-hash embeddings for memories
- write embeddings on normal memory saves, lifecycle replacements, candidate auto-promotion, and backup import direct inserts
- backfill missing embeddings across active/stale/archived rows and fuse vector results into memory search/explain via RRF

## Notes

This is intentionally a first mergeable local baseline (`remem-local-feature-hash-v1`), not a neural embedding provider. It establishes the graph/search contract, storage, write hooks, filters, stale-history behavior, and explain surface so a later PR can swap in sqlite-vec/neural embeddings without changing the search API.

Closes #324

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test retrieval::vector`
- `cargo test retrieval::search::memory`
- `cargo test memory_candidate_auto_promotes_architecture_from_discovery_observation`
- `cargo test backup_import_writes_to_runtime_store_visible_to_search`
- `cargo test update_writes_replacement_embedding_and_filters_stale_vector_rows`
- `python3 scripts/ci/check_version_bump.py origin/codex/issue-320-raw-archive-ingest HEAD`
- `git diff --check origin/codex/issue-320-raw-archive-ingest..HEAD`

## Thread Review

- Independent reviewer Helmholtz found one blocker around `include_stale=true` still applying state-key current-view filtering.
- Fixed by applying `memory_state_key_current_filter_sql` only for current searches (`include_stale=false`) and changing the lifecycle vector regression to use the same topic/state key.
- Follow-up review reported no blocking or non-blocking findings.
