### PR TITLE
feat(dream): schedule durable consolidation decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions/maintenance.rs
+++ b/src/cli/actions/maintenance.rs
@@ -16,13 +16,14 @@ pub(in crate::cli) async fn run_dream(
         .unwrap_or_else(|| db::project_from_cwd(&cwd));
 
     if dry_run {
-        let clusters = crate::dream::list_clusters(&project)?;
+        let plan = crate::dream::list_cluster_plan(&project)?;
         println!(
-            "project={} clusters={} (dry-run, no changes)",
+            "project={} clusters={} suppressed={} (dry-run, no changes)",
             project,
-            clusters.len()
+            plan.eligible.len(),
+            plan.suppressed
         );
-        for (i, c) in clusters.iter().enumerate() {
+        for (i, c) in plan.eligible.iter().enumerate() {
             println!("  cluster[{}] size={}", i, c.members.len());
             for m in &c.members {
                 println!("    id={} title={}", m.id, m.title);

--- a/src/db/job.rs
+++ b/src/db/job.rs
@@ -7,7 +7,7 @@ mod tests;
 pub use crate::db::models::{Job, JobType};
 
 pub use claim::claim_next_job;
-pub use enqueue::enqueue_job;
+pub use enqueue::{enqueue_job, maybe_enqueue_dream_job};
 pub use state::{
     mark_job_done, mark_job_exhausted, mark_job_failed, mark_job_failed_or_retry,
     release_expired_job_leases, requeue_stuck_jobs,

--- a/src/db/job/enqueue.rs
+++ b/src/db/job/enqueue.rs
@@ -49,3 +49,91 @@ pub fn enqueue_job(
     )?;
     Ok(conn.last_insert_rowid())
 }
+
+pub fn maybe_enqueue_dream_job(
+    conn: &Connection,
+    host: &str,
+    project: &str,
+    payload_json: &str,
+    priority: i64,
+    cooldown_secs: i64,
+) -> Result<Option<i64>> {
+    let incoming_profile = dream_profile_key(payload_json);
+    let inflight: Option<(i64, String, String)> = conn
+        .query_row(
+            "SELECT id, state, payload_json FROM jobs
+             WHERE job_type = ?1
+               AND project = ?2
+               AND session_id IS NULL
+               AND state IN ('pending', 'processing')
+             ORDER BY CASE state WHEN 'pending' THEN 0 ELSE 1 END,
+                      updated_at_epoch DESC,
+                      id DESC
+             LIMIT 1",
+            params![JobType::Dream.as_str(), project],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()?;
+    if let Some((id, state, existing_payload)) = inflight {
+        if state == "pending"
+            && incoming_profile.is_some()
+            && dream_profile_key(&existing_payload) != incoming_profile
+        {
+            let now = chrono::Utc::now().timestamp();
+            conn.execute(
+                "UPDATE jobs
+                 SET host = ?1,
+                     payload_json = ?2,
+                     priority = CASE WHEN priority <= ?3 THEN priority ELSE ?3 END,
+                     updated_at_epoch = ?4
+                 WHERE id = ?5 AND state = 'pending'",
+                params![host, payload_json, priority, now, id],
+            )?;
+        }
+        return Ok(None);
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let cutoff = now - cooldown_secs.max(1);
+    let recent_done: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM jobs
+             WHERE job_type = ?1
+               AND project = ?2
+               AND session_id IS NULL
+               AND state = 'done'
+               AND updated_at_epoch >= ?3
+             ORDER BY updated_at_epoch DESC, id DESC
+             LIMIT 1",
+            params![JobType::Dream.as_str(), project, cutoff],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if recent_done.is_some() {
+        return Ok(None);
+    }
+
+    enqueue_job(
+        conn,
+        host,
+        JobType::Dream,
+        project,
+        None,
+        payload_json,
+        priority,
+    )
+    .map(Some)
+}
+
+fn dream_profile_key(payload_json: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(payload_json)
+        .ok()
+        .and_then(|value| {
+            value
+                .get(crate::runtime_config::MEMORY_AI_PROFILE_FIELD)
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|profile| !profile.is_empty())
+                .map(str::to_string)
+        })
+}

--- a/src/db/job/tests.rs
+++ b/src/db/job/tests.rs
@@ -1,6 +1,8 @@
 use rusqlite::{params, Connection};
 
-use super::{claim_next_job, enqueue_job, mark_job_failed_or_retry, JobType};
+use super::{
+    claim_next_job, enqueue_job, mark_job_failed_or_retry, maybe_enqueue_dream_job, JobType,
+};
 use crate::migrate::MIGRATIONS;
 
 fn setup_conn() -> Connection {
@@ -219,4 +221,183 @@ fn mark_job_failed_or_retry_marks_failed_when_exhausted() {
     assert_eq!(row.2, None);
     assert!(row.3 >= 0);
     assert_eq!(row.4.as_deref(), Some("fatal"));
+}
+
+#[test]
+fn maybe_enqueue_dream_job_dedups_inflight_job() {
+    let conn = setup_conn();
+    let first = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("first dream enqueue should succeed")
+        .expect("first dream enqueue should create a job");
+    let second = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("second dream enqueue should succeed");
+
+    assert_eq!(second, None);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM jobs", [], |row| row.get(0))
+        .expect("job count should load");
+    assert_eq!(count, 1);
+    let state: String = conn
+        .query_row(
+            "SELECT state FROM jobs WHERE id = ?1",
+            params![first],
+            |row| row.get(0),
+        )
+        .expect("state should load");
+    assert_eq!(state, "pending");
+}
+
+#[test]
+fn maybe_enqueue_dream_job_dedups_inflight_across_hosts_for_project() {
+    let conn = setup_conn();
+    maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("first dream enqueue should succeed")
+        .expect("first dream enqueue should create a job");
+    let second = maybe_enqueue_dream_job(&conn, "claude-code", "alpha", "{}", 300, 3600)
+        .expect("second dream enqueue should succeed");
+
+    assert_eq!(second, None);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM jobs", [], |row| row.get(0))
+        .expect("job count should load");
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn maybe_enqueue_dream_job_upgrades_pending_payload_for_profile_override() {
+    let conn = setup_conn();
+    let first = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("first dream enqueue should succeed")
+        .expect("first dream enqueue should create a job");
+    let profile_payload = r#"{"remem_ai_profile":"quality"}"#;
+
+    let second = maybe_enqueue_dream_job(&conn, "claude-code", "alpha", profile_payload, 100, 3600)
+        .expect("profile dream enqueue should succeed");
+
+    assert_eq!(second, None);
+    let row: (String, String, i64) = conn
+        .query_row(
+            "SELECT host, payload_json, priority FROM jobs WHERE id = ?1",
+            params![first],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("job row should load");
+    assert_eq!(row.0, "claude-code");
+    assert_eq!(row.1, profile_payload);
+    assert_eq!(row.2, 100);
+}
+
+#[test]
+fn maybe_enqueue_dream_job_skips_recent_done_job() {
+    let conn = setup_conn();
+    let first = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("first dream enqueue should succeed")
+        .expect("first dream enqueue should create a job");
+    conn.execute(
+        "UPDATE jobs SET state = 'done' WHERE id = ?1",
+        params![first],
+    )
+    .expect("job state should update");
+
+    let second = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("second dream enqueue should succeed");
+
+    assert_eq!(second, None);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM jobs", [], |row| row.get(0))
+        .expect("job count should load");
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn maybe_enqueue_dream_job_skips_recent_done_across_hosts_for_same_profile() {
+    let conn = setup_conn();
+    let first = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("first dream enqueue should succeed")
+        .expect("first dream enqueue should create a job");
+    conn.execute(
+        "UPDATE jobs SET state = 'done' WHERE id = ?1",
+        params![first],
+    )
+    .expect("job state should update");
+
+    let second = maybe_enqueue_dream_job(&conn, "claude-code", "alpha", "{}", 300, 3600)
+        .expect("second dream enqueue should succeed");
+
+    assert_eq!(second, None);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM jobs", [], |row| row.get(0))
+        .expect("job count should load");
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn maybe_enqueue_dream_job_skips_recent_done_with_different_profile_for_project_cooldown() {
+    let conn = setup_conn();
+    let first = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("first dream enqueue should succeed")
+        .expect("first dream enqueue should create a job");
+    conn.execute(
+        "UPDATE jobs SET state = 'done' WHERE id = ?1",
+        params![first],
+    )
+    .expect("job state should update");
+
+    let second = maybe_enqueue_dream_job(
+        &conn,
+        "claude-code",
+        "alpha",
+        r#"{"remem_ai_profile":"quality"}"#,
+        300,
+        3600,
+    )
+    .expect("profile dream enqueue should succeed");
+
+    assert_eq!(second, None);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM jobs", [], |row| row.get(0))
+        .expect("job count should load");
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn maybe_enqueue_dream_job_allows_old_done_job() {
+    let conn = setup_conn();
+    let first = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("first dream enqueue should succeed")
+        .expect("first dream enqueue should create a job");
+    conn.execute(
+        "UPDATE jobs SET state = 'done', updated_at_epoch = ?2 WHERE id = ?1",
+        params![first, chrono::Utc::now().timestamp() - 7200],
+    )
+    .expect("job state should update");
+
+    let second = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("second dream enqueue should succeed")
+        .expect("old done dream should not block new enqueue");
+
+    assert_ne!(first, second);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM jobs", [], |row| row.get(0))
+        .expect("job count should load");
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn maybe_enqueue_dream_job_allows_failed_job_retry_visibility() {
+    let conn = setup_conn();
+    let first = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("first dream enqueue should succeed")
+        .expect("first dream enqueue should create a job");
+    conn.execute(
+        "UPDATE jobs SET state = 'failed' WHERE id = ?1",
+        params![first],
+    )
+    .expect("job state should update");
+
+    let second = maybe_enqueue_dream_job(&conn, "codex-cli", "alpha", "{}", 300, 3600)
+        .expect("second dream enqueue should succeed")
+        .expect("failed dream should not block new enqueue");
+
+    assert_ne!(first, second);
 }

--- a/src/dream.rs
+++ b/src/dream.rs
@@ -1,19 +1,33 @@
 mod apply;
 mod candidates;
 mod constants;
+mod decisions;
 mod merge;
 
 use anyhow::{anyhow, Result};
 use candidates::load_clusters;
 pub(crate) use candidates::Cluster;
+pub(crate) use constants::DREAM_COOLDOWN_SECS;
+use decisions::{load_cluster_plan, record_failed, record_merged, record_no_merge};
 use merge::{merge_cluster, MergeDecision};
 use rusqlite::Connection;
 use std::future::Future;
 use std::pin::Pin;
 
-pub(crate) fn list_clusters(project: &str) -> Result<Vec<Cluster>> {
+#[derive(Debug)]
+pub(crate) struct DreamClusterPlan {
+    pub eligible: Vec<Cluster>,
+    pub suppressed: usize,
+}
+
+pub(crate) fn list_cluster_plan(project: &str) -> Result<DreamClusterPlan> {
     let conn = crate::db::open_db()?;
-    load_clusters(&conn, project)
+    let clusters = load_clusters(&conn, project)?;
+    let plan = decisions::load_cluster_plan(&conn, project, clusters)?;
+    Ok(DreamClusterPlan {
+        eligible: plan.eligible,
+        suppressed: plan.suppressed,
+    })
 }
 
 pub async fn process_dream_job(project: &str) -> Result<()> {
@@ -38,7 +52,17 @@ async fn process_dream_job_with_selection(
     let profile = profile.map(str::to_string);
     let mut conn = crate::db::open_db()?;
     let clusters = load_clusters(&conn, project)?;
-    process_clusters(project, &mut conn, &clusters, |cluster, project| {
+    let plan = load_cluster_plan(&conn, project, clusters)?;
+    if plan.suppressed > 0 {
+        crate::log::info(
+            "dream",
+            &format!(
+                "project={} suppressed={} cluster(s) by durable dream decisions",
+                project, plan.suppressed
+            ),
+        );
+    }
+    process_clusters(project, &mut conn, &plan.eligible, |cluster, project| {
         Box::pin(merge_cluster(
             cluster,
             project,
@@ -82,6 +106,15 @@ async fn process_clusters(
         let decision = match merge_fn(cluster, project).await {
             Ok(decision) => decision,
             Err(error) => {
+                record_failed(
+                    conn,
+                    project,
+                    cluster,
+                    &format!(
+                        "merge failed: {}",
+                        crate::db::truncate_str(&error.to_string(), 500)
+                    ),
+                )?;
                 merge_failures += 1;
                 crate::log::warn(
                     "dream",
@@ -98,12 +131,35 @@ async fn process_clusters(
             MergeDecision::Merge(result) => {
                 let topic_key = result.topic_key.clone();
                 let superseded = result.superseded_ids.len();
-                if let Err(error) = apply::apply(conn, project, &result) {
+                let outcome = match apply::apply(conn, project, &result) {
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        record_failed(
+                            conn,
+                            project,
+                            cluster,
+                            &format!(
+                                "apply failed: {}",
+                                crate::db::truncate_str(&error.to_string(), 500)
+                            ),
+                        )?;
+                        apply_failures += 1;
+                        crate::log::warn(
+                            "dream",
+                            &format!(
+                                "project={} cluster_size={} cluster_first_id={:?} topic_key={} apply failed: {}",
+                                project, cluster_size, cluster_first_id, topic_key, error
+                            ),
+                        );
+                        continue;
+                    }
+                };
+                if let Err(error) = record_merged(conn, project, cluster, outcome) {
                     apply_failures += 1;
                     crate::log::warn(
                         "dream",
                         &format!(
-                            "project={} cluster_size={} cluster_first_id={:?} topic_key={} apply failed: {}",
+                            "project={} cluster_size={} cluster_first_id={:?} topic_key={} decision record failed: {}",
                             project, cluster_size, cluster_first_id, topic_key, error
                         ),
                     );
@@ -115,7 +171,8 @@ async fn process_clusters(
                     &format!("merged topic_key={} superseded={}", topic_key, superseded),
                 );
             }
-            MergeDecision::NoMerge => {
+            MergeDecision::NoMerge { reason } => {
+                record_no_merge(conn, project, cluster, reason.as_deref())?;
                 skipped += 1;
             }
         }
@@ -253,6 +310,37 @@ mod tests {
             error.to_string().contains("all 2 cluster attempts failed"),
             "error should report total failure: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn process_clusters_persists_no_merge_decision() {
+        let mut conn = Connection::open_in_memory().expect("in-memory db");
+        setup_memory_schema(&conn);
+        let project = "test-dream-no-merge";
+        let clusters = vec![make_cluster([101, 102], ["topic-a", "topic-b"])];
+
+        process_clusters(project, &mut conn, &clusters, |_cluster, _project| {
+            Box::pin(async move {
+                Ok(MergeDecision::NoMerge {
+                    reason: Some("entries cover different decisions".to_string()),
+                })
+            })
+        })
+        .await
+        .expect("no-merge should persist and complete");
+
+        let row: (String, String, String) = conn
+            .query_row(
+                "SELECT decision, reason, member_ids_json
+                 FROM dream_cluster_decisions
+                 WHERE project = ?1",
+                params![project],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("decision row should load");
+        assert_eq!(row.0, "no_merge");
+        assert_eq!(row.1, "entries cover different decisions");
+        assert_eq!(row.2, "[101,102]");
     }
 
     #[tokio::test]

--- a/src/dream/apply.rs
+++ b/src/dream/apply.rs
@@ -5,7 +5,17 @@ use super::merge::MergeResult;
 use crate::memory::lifecycle::MemoryLifecycleOp;
 use crate::memory::operation::{insert_operation_log, MemoryOperationInput, MemoryOperationPlan};
 
-pub(super) fn apply(conn: &mut Connection, project: &str, result: &MergeResult) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ApplyOutcome {
+    pub merged_id: i64,
+    pub operation_id: i64,
+}
+
+pub(super) fn apply(
+    conn: &mut Connection,
+    project: &str,
+    result: &MergeResult,
+) -> Result<ApplyOutcome> {
     let tx = conn.transaction()?;
     let superseded_ids =
         validate_dream_superseded_ids(&tx, project, &result.memory_type, &result.superseded_ids)?;
@@ -82,7 +92,10 @@ pub(super) fn apply(conn: &mut Connection, project: &str, result: &MergeResult) 
     )?;
 
     tx.commit()?;
-    Ok(())
+    Ok(ApplyOutcome {
+        merged_id,
+        operation_id,
+    })
 }
 
 fn validate_dream_superseded_ids(

--- a/src/dream/constants.rs
+++ b/src/dream/constants.rs
@@ -11,7 +11,10 @@ pub(super) const TOPIC_KEY_PREFIX_LEN: usize = 20;
 
 /// dream job 最小触发间隔（秒）
 #[allow(dead_code)]
-pub(super) const DREAM_COOLDOWN_SECS: i64 = 3600;
+pub(crate) const DREAM_COOLDOWN_SECS: i64 = 3600;
+
+/// unchanged no-merge clusters are not reconsidered until this review window expires.
+pub(crate) const DREAM_NO_MERGE_REVIEW_SECS: i64 = 7 * 24 * 3600;
 
 /// 最近 N 秒内写入的记忆不参与合并（避免合并进行中的会话）
 pub(super) const DREAM_RECENCY_GUARD_SECS: i64 = 3600;

--- a/src/dream/decisions.rs
+++ b/src/dream/decisions.rs
@@ -1,0 +1,258 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::apply::ApplyOutcome;
+use super::candidates::Cluster;
+use super::constants::DREAM_NO_MERGE_REVIEW_SECS;
+
+#[derive(Debug)]
+pub(super) struct ClusterPlan {
+    pub eligible: Vec<Cluster>,
+    pub suppressed: usize,
+}
+
+pub(super) fn load_cluster_plan(
+    conn: &Connection,
+    project: &str,
+    clusters: Vec<Cluster>,
+) -> Result<ClusterPlan> {
+    let now = chrono::Utc::now().timestamp();
+    let mut eligible = Vec::new();
+    let mut suppressed = 0usize;
+    for cluster in clusters {
+        if is_suppressed(conn, project, &cluster, now)? {
+            suppressed += 1;
+        } else {
+            eligible.push(cluster);
+        }
+    }
+    Ok(ClusterPlan {
+        eligible,
+        suppressed,
+    })
+}
+
+pub(super) fn record_no_merge(
+    conn: &Connection,
+    project: &str,
+    cluster: &Cluster,
+    reason: Option<&str>,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    upsert_decision(
+        conn,
+        project,
+        cluster,
+        "no_merge",
+        reason.unwrap_or("no merge returned by dream"),
+        Some(now + DREAM_NO_MERGE_REVIEW_SECS),
+        None,
+    )
+}
+
+pub(super) fn record_failed(
+    conn: &Connection,
+    project: &str,
+    cluster: &Cluster,
+    reason: &str,
+) -> Result<()> {
+    upsert_decision(conn, project, cluster, "failed", reason, None, None)
+}
+
+pub(super) fn record_merged(
+    conn: &Connection,
+    project: &str,
+    cluster: &Cluster,
+    outcome: ApplyOutcome,
+) -> Result<()> {
+    upsert_decision(
+        conn,
+        project,
+        cluster,
+        "merged",
+        "dream consolidation merged cluster",
+        None,
+        Some(outcome),
+    )
+}
+
+fn is_suppressed(conn: &Connection, project: &str, cluster: &Cluster, now: i64) -> Result<bool> {
+    let Some(memory_type) = cluster_memory_type(cluster) else {
+        return Ok(false);
+    };
+    let signature = cluster_signature(project, cluster);
+    let row: Option<(String, Option<i64>)> = conn
+        .query_row(
+            "SELECT decision, next_review_epoch
+             FROM dream_cluster_decisions
+             WHERE project = ?1
+               AND memory_type = ?2
+               AND cluster_signature = ?3",
+            params![project, memory_type, signature],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    let Some((decision, next_review_epoch)) = row else {
+        return Ok(false);
+    };
+    Ok(matches!(decision.as_str(), "no_merge" | "defer")
+        && next_review_epoch.is_none_or(|epoch| epoch > now))
+}
+
+fn upsert_decision(
+    conn: &Connection,
+    project: &str,
+    cluster: &Cluster,
+    decision: &str,
+    reason: &str,
+    next_review_epoch: Option<i64>,
+    outcome: Option<ApplyOutcome>,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let Some(memory_type) = cluster_memory_type(cluster) else {
+        return Ok(());
+    };
+    let signature = cluster_signature(project, cluster);
+    let member_ids_json = serde_json::to_string(&cluster_member_ids(cluster))?;
+    conn.execute(
+        "INSERT INTO dream_cluster_decisions
+         (project, memory_type, cluster_signature, decision, reason, member_ids_json,
+          cluster_size, next_review_epoch, source_memory_id, source_operation_id,
+          created_at_epoch, updated_at_epoch, last_seen_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?11, ?11)
+         ON CONFLICT(project, memory_type, cluster_signature)
+         DO UPDATE SET
+             decision = excluded.decision,
+             reason = excluded.reason,
+             member_ids_json = excluded.member_ids_json,
+             cluster_size = excluded.cluster_size,
+             next_review_epoch = excluded.next_review_epoch,
+             source_memory_id = excluded.source_memory_id,
+             source_operation_id = excluded.source_operation_id,
+             updated_at_epoch = excluded.updated_at_epoch,
+             last_seen_epoch = excluded.last_seen_epoch",
+        params![
+            project,
+            memory_type,
+            signature,
+            decision,
+            crate::db::truncate_str(reason, 1000),
+            member_ids_json,
+            cluster.members.len() as i64,
+            next_review_epoch,
+            outcome.map(|value| value.merged_id),
+            outcome.map(|value| value.operation_id),
+            now
+        ],
+    )?;
+    Ok(())
+}
+
+fn cluster_memory_type(cluster: &Cluster) -> Option<&str> {
+    cluster
+        .members
+        .first()
+        .map(|member| member.memory_type.as_str())
+}
+
+fn cluster_member_ids(cluster: &Cluster) -> Vec<i64> {
+    let mut ids = cluster
+        .members
+        .iter()
+        .map(|member| member.id)
+        .collect::<Vec<_>>();
+    ids.sort_unstable();
+    ids
+}
+
+fn cluster_signature(project: &str, cluster: &Cluster) -> String {
+    let mut parts = cluster
+        .members
+        .iter()
+        .map(|member| format!("{}:{}", member.id, member.updated_at_epoch))
+        .collect::<Vec<_>>();
+    parts.sort();
+    let memory_type = cluster_memory_type(cluster).unwrap_or("unknown");
+    let raw = format!(
+        "dream-cluster-v1\0{}\0{}\0{}",
+        project,
+        memory_type,
+        parts.join("\0")
+    );
+    format!("{:016x}", crate::db::deterministic_hash(raw.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::tests_helper::setup_memory_schema;
+    use rusqlite::Connection;
+
+    fn member(id: i64, updated_at_epoch: i64) -> super::super::candidates::MemoryCandidate {
+        super::super::candidates::MemoryCandidate {
+            id,
+            topic_key: Some("shared-topic".to_string()),
+            title: format!("title-{id}"),
+            content: format!("content-{id}"),
+            memory_type: "decision".to_string(),
+            updated_at_epoch,
+        }
+    }
+
+    fn cluster(updated_at_epoch: i64) -> Cluster {
+        Cluster {
+            members: vec![member(1, updated_at_epoch), member(2, updated_at_epoch)],
+        }
+    }
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        setup_memory_schema(&conn);
+        conn
+    }
+
+    #[test]
+    fn no_merge_decision_suppresses_unchanged_cluster_until_review_epoch() -> Result<()> {
+        let conn = setup_conn();
+        let project = "test-project";
+        let cluster = cluster(100);
+
+        record_no_merge(&conn, project, &cluster, Some("different decisions"))?;
+        let plan = load_cluster_plan(&conn, project, vec![cluster])?;
+
+        assert_eq!(plan.eligible.len(), 0);
+        assert_eq!(plan.suppressed, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn changed_cluster_signature_is_eligible_again() -> Result<()> {
+        let conn = setup_conn();
+        let project = "test-project";
+
+        record_no_merge(&conn, project, &cluster(100), Some("different decisions"))?;
+        let plan = load_cluster_plan(&conn, project, vec![cluster(200)])?;
+
+        assert_eq!(plan.eligible.len(), 1);
+        assert_eq!(plan.suppressed, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn expired_no_merge_decision_is_eligible_again() -> Result<()> {
+        let conn = setup_conn();
+        let project = "test-project";
+        let cluster = cluster(100);
+        record_no_merge(&conn, project, &cluster, Some("different decisions"))?;
+        conn.execute(
+            "UPDATE dream_cluster_decisions SET next_review_epoch = 1",
+            [],
+        )?;
+
+        let plan = load_cluster_plan(&conn, project, vec![cluster])?;
+
+        assert_eq!(plan.eligible.len(), 1);
+        assert_eq!(plan.suppressed, 0);
+        Ok(())
+    }
+}

--- a/src/dream/merge.rs
+++ b/src/dream/merge.rs
@@ -6,7 +6,7 @@ use super::constants::DREAM_PROMPT;
 #[derive(Debug)]
 pub(super) enum MergeDecision {
     Merge(MergeResult),
-    NoMerge,
+    NoMerge { reason: Option<String> },
 }
 
 #[derive(Debug)]
@@ -63,7 +63,9 @@ fn filter_superseded_ids(decision: MergeDecision, cluster: &Cluster) -> MergeDec
             "dream",
             "rejecting merge with no valid superseded_id(s) after filtering",
         );
-        return MergeDecision::NoMerge;
+        return MergeDecision::NoMerge {
+            reason: Some("no valid superseded ids after filtering".to_string()),
+        };
     }
     MergeDecision::Merge(result)
 }
@@ -85,7 +87,9 @@ fn build_user_message(members: &[MemoryCandidate]) -> String {
 
 fn parse_response(response: &str) -> Result<MergeDecision> {
     if response.contains("<no_merge") {
-        return Ok(MergeDecision::NoMerge);
+        return Ok(MergeDecision::NoMerge {
+            reason: extract_no_merge_reason(response),
+        });
     }
 
     let topic_key = require_tag(response, "topic_key")?;
@@ -102,7 +106,9 @@ fn parse_response(response: &str) -> Result<MergeDecision> {
         .filter_map(|s| s.parse::<i64>().ok())
         .collect();
     if superseded_ids.is_empty() {
-        return Ok(MergeDecision::NoMerge);
+        return Ok(MergeDecision::NoMerge {
+            reason: Some("merge response had no superseded ids".to_string()),
+        });
     }
 
     Ok(MergeDecision::Merge(MergeResult {
@@ -136,6 +142,35 @@ fn extract_tag(text: &str, tag: &str) -> Option<String> {
     let start = text.find(&open)? + open.len();
     let end = text[start..].find(&close)? + start;
     Some(text[start..end].trim().to_owned())
+}
+
+fn extract_no_merge_reason(text: &str) -> Option<String> {
+    let start = text.find("<no_merge")?;
+    let tag = &text[start..];
+    let end = tag.find('>')?;
+    extract_attr(&tag[..=end], "reason")
+        .map(|reason| reason.trim().to_string())
+        .filter(|reason| !reason.is_empty())
+}
+
+fn extract_attr(tag: &str, name: &str) -> Option<String> {
+    let marker = format!("{name}=");
+    let start = tag.find(&marker)? + marker.len();
+    let quote = tag[start..].chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let value_start = start + quote.len_utf8();
+    let value_end = tag[value_start..].find(quote)? + value_start;
+    Some(xml_unescape(&tag[value_start..value_end]))
+}
+
+fn xml_unescape(s: &str) -> String {
+    s.replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
 }
 
 fn redact_excerpt(response: &str) -> String {
@@ -216,7 +251,7 @@ mod tests {
                 assert_eq!(r.memory_type, "decision");
                 assert_eq!(r.superseded_ids, vec![42, 17]);
             }
-            MergeDecision::NoMerge => panic!("expected Merge"),
+            MergeDecision::NoMerge { .. } => panic!("expected Merge"),
         }
     }
 
@@ -225,8 +260,19 @@ mod tests {
         let response = r#"<no_merge reason="entries cover different topics"/>"#;
         assert!(matches!(
             parse_response(response).expect("expected Ok"),
-            MergeDecision::NoMerge
+            MergeDecision::NoMerge { .. }
         ));
+    }
+
+    #[test]
+    fn test_parse_no_merge_reason() {
+        let response = r#"<no_merge reason="entries cover different topics"/>"#;
+        match parse_response(response).expect("expected Ok") {
+            MergeDecision::NoMerge { reason } => {
+                assert_eq!(reason.as_deref(), Some("entries cover different topics"));
+            }
+            MergeDecision::Merge(_) => panic!("expected no merge"),
+        }
     }
 
     #[test]
@@ -285,7 +331,7 @@ mod tests {
 </memory>"#;
         match parse_response(response).expect("expected Ok") {
             MergeDecision::Merge(r) => assert_eq!(r.memory_type, "discovery"),
-            MergeDecision::NoMerge => panic!("expected Merge"),
+            MergeDecision::NoMerge { .. } => panic!("expected Merge"),
         }
     }
 
@@ -321,7 +367,7 @@ mod tests {
         });
         match filter_superseded_ids(decision, &cluster) {
             MergeDecision::Merge(r) => assert_eq!(r.superseded_ids, vec![10, 20]),
-            MergeDecision::NoMerge => panic!("expected Merge"),
+            MergeDecision::NoMerge { .. } => panic!("expected Merge"),
         }
     }
 
@@ -346,7 +392,7 @@ mod tests {
         });
         assert!(matches!(
             filter_superseded_ids(decision, &cluster),
-            MergeDecision::NoMerge
+            MergeDecision::NoMerge { .. }
         ));
     }
 
@@ -354,8 +400,8 @@ mod tests {
     fn test_filter_superseded_ids_no_merge_passthrough() {
         let cluster = Cluster { members: vec![] };
         assert!(matches!(
-            filter_superseded_ids(MergeDecision::NoMerge, &cluster),
-            MergeDecision::NoMerge
+            filter_superseded_ids(MergeDecision::NoMerge { reason: None }, &cluster),
+            MergeDecision::NoMerge { .. }
         ));
     }
 
@@ -370,7 +416,7 @@ mod tests {
 </memory>"#;
         assert!(matches!(
             parse_response(response).expect("expected Ok"),
-            MergeDecision::NoMerge
+            MergeDecision::NoMerge { .. }
         ));
     }
 

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -434,6 +434,29 @@ pub mod tests_helper {
                 ON memory_edges(to_memory_id, edge_type);
             CREATE INDEX idx_memory_edges_state
                 ON memory_edges(state_key_id, edge_type, created_at_epoch);
+            CREATE TABLE dream_cluster_decisions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project TEXT NOT NULL,
+                memory_type TEXT NOT NULL,
+                cluster_signature TEXT NOT NULL,
+                decision TEXT NOT NULL CHECK(decision IN ('merged', 'no_merge', 'defer', 'failed')),
+                reason TEXT,
+                member_ids_json TEXT NOT NULL,
+                cluster_size INTEGER NOT NULL,
+                next_review_epoch INTEGER,
+                source_memory_id INTEGER,
+                source_operation_id INTEGER,
+                created_at_epoch INTEGER NOT NULL,
+                updated_at_epoch INTEGER NOT NULL,
+                last_seen_epoch INTEGER NOT NULL,
+                UNIQUE(project, memory_type, cluster_signature),
+                FOREIGN KEY(source_memory_id) REFERENCES memories(id),
+                FOREIGN KEY(source_operation_id) REFERENCES memory_operation_log(id)
+            );
+            CREATE INDEX idx_dream_cluster_decisions_review
+                ON dream_cluster_decisions(project, decision, next_review_epoch);
+            CREATE INDEX idx_dream_cluster_decisions_signature
+                ON dream_cluster_decisions(project, memory_type, cluster_signature);
             CREATE VIRTUAL TABLE memories_fts USING fts5(
                 title, content, search_context,
                 content='memories',

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -44,6 +44,7 @@ const CONVERGENCE_TABLES: &[&str] = &[
     "compressed_observation_sources",
     "raw_ingest_failures",
     "memory_embeddings",
+    "dream_cluster_decisions",
 ];
 
 fn make_upgraded_v10_db() -> Result<Connection> {

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -150,6 +150,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "memory_embeddings",
         sql: include_str!("../migrations/v029_memory_embeddings.sql"),
     },
+    Migration {
+        version: 30,
+        name: "dream_cluster_decisions",
+        sql: include_str!("../migrations/v030_dream_cluster_decisions.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v030_dream_cluster_decisions.sql
+++ b/src/migrations/v030_dream_cluster_decisions.sql
@@ -1,0 +1,27 @@
+-- v030_dream_cluster_decisions: durable Dream consolidation decisions.
+
+CREATE TABLE IF NOT EXISTS dream_cluster_decisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project TEXT NOT NULL,
+    memory_type TEXT NOT NULL,
+    cluster_signature TEXT NOT NULL,
+    decision TEXT NOT NULL CHECK(decision IN ('merged', 'no_merge', 'defer', 'failed')),
+    reason TEXT,
+    member_ids_json TEXT NOT NULL,
+    cluster_size INTEGER NOT NULL,
+    next_review_epoch INTEGER,
+    source_memory_id INTEGER,
+    source_operation_id INTEGER,
+    created_at_epoch INTEGER NOT NULL,
+    updated_at_epoch INTEGER NOT NULL,
+    last_seen_epoch INTEGER NOT NULL,
+    UNIQUE(project, memory_type, cluster_signature),
+    FOREIGN KEY(source_memory_id) REFERENCES memories(id),
+    FOREIGN KEY(source_operation_id) REFERENCES memory_operation_log(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dream_cluster_decisions_review
+    ON dream_cluster_decisions(project, decision, next_review_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_dream_cluster_decisions_signature
+    ON dream_cluster_decisions(project, memory_type, cluster_signature);

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -164,6 +164,14 @@ fn enqueue_summary_jobs(
         compress_input,
         200,
     )?;
+    db::maybe_enqueue_dream_job(
+        conn,
+        host,
+        project,
+        compress_input,
+        300,
+        crate::dream::DREAM_COOLDOWN_SECS,
+    )?;
     crate::log::info(
         "summarize",
         &format!(
@@ -444,7 +452,14 @@ mod tests {
 
         assert!(!captured);
         let jobs = job_types(&conn);
-        assert_eq!(jobs, vec!["summary".to_string(), "compress".to_string()]);
+        assert_eq!(
+            jobs,
+            vec![
+                "summary".to_string(),
+                "compress".to_string(),
+                "dream".to_string()
+            ]
+        );
     }
 
     #[test]
@@ -518,7 +533,14 @@ mod tests {
         .expect("summary jobs should enqueue");
 
         let jobs = job_types(&conn);
-        assert_eq!(jobs, vec!["summary".to_string(), "compress".to_string()]);
+        assert_eq!(
+            jobs,
+            vec![
+                "summary".to_string(),
+                "compress".to_string(),
+                "dream".to_string()
+            ]
+        );
     }
 
     #[test]
@@ -548,7 +570,46 @@ mod tests {
         .expect("summary jobs should enqueue");
 
         let jobs = job_types(&conn);
-        assert_eq!(jobs, vec!["summary".to_string(), "compress".to_string()]);
+        assert_eq!(
+            jobs,
+            vec![
+                "summary".to_string(),
+                "compress".to_string(),
+                "dream".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn enqueue_summary_jobs_dedups_dream_and_preserves_profile_payload() {
+        let _test_dir = ScopedTestDataDir::new("summary-dream-profile");
+        let conn = db::open_db().expect("db should open");
+        let payload = compress_payload(Some("custom")).expect("compress payload should serialize");
+
+        enqueue_summary_jobs(
+            &conn,
+            "codex-cli",
+            "sess-dream-a",
+            "/tmp/remem",
+            r#"{"session_id":"sess-dream-a"}"#,
+            &payload,
+        )
+        .expect("first summary jobs should enqueue");
+        enqueue_summary_jobs(
+            &conn,
+            "codex-cli",
+            "sess-dream-b",
+            "/tmp/remem",
+            r#"{"session_id":"sess-dream-b"}"#,
+            &payload,
+        )
+        .expect("second summary jobs should enqueue");
+
+        let dream_payloads = job_payloads(&conn, "dream");
+        assert_eq!(dream_payloads.len(), 1);
+        let dream_payload: serde_json::Value =
+            serde_json::from_str(&dream_payloads[0]).expect("dream payload should parse");
+        assert_eq!(dream_payload["remem_ai_profile"].as_str(), Some("custom"));
     }
 
     fn job_types(conn: &rusqlite::Connection) -> Vec<String> {
@@ -556,6 +617,16 @@ mod tests {
             .prepare("SELECT job_type FROM jobs ORDER BY id ASC")
             .expect("job query should prepare");
         stmt.query_map([], |row| row.get(0))
+            .expect("job query should run")
+            .collect::<rusqlite::Result<Vec<String>>>()
+            .expect("job rows should collect")
+    }
+
+    fn job_payloads(conn: &rusqlite::Connection, job_type: &str) -> Vec<String> {
+        let mut stmt = conn
+            .prepare("SELECT payload_json FROM jobs WHERE job_type = ?1 ORDER BY id ASC")
+            .expect("job query should prepare");
+        stmt.query_map([job_type], |row| row.get(0))
             .expect("job query should run")
             .collect::<rusqlite::Result<Vec<String>>>()
             .expect("job rows should collect")

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -61,7 +61,12 @@ async fn process_job(job: &db::Job) -> Result<()> {
             Ok(())
         }
         db::JobType::Dream => {
-            crate::dream::process_dream_job_with_host(&job.project, &job.host).await?;
+            let profile = job_profile(&job.payload_json);
+            if let Some(profile) = profile.as_deref() {
+                crate::dream::process_dream_job_with_profile(&job.project, Some(profile)).await?;
+            } else {
+                crate::dream::process_dream_job_with_host(&job.project, &job.host).await?;
+            }
             Ok(())
         }
     }


### PR DESCRIPTION
## Summary
- enqueue Dream jobs from the automatic summary hook with project-level cooldown and inflight dedupe
- persist Dream cluster decisions for merged, no_merge, and failed outcomes, including no-merge review cooldowns
- surface suppressed cluster counts in dry-run and preserve explicit profile payloads for pending Dream jobs

Closes #327

## Verification
- cargo fmt --check
- cargo check
- cargo clippy -- -D warnings
- cargo test maybe_enqueue_dream_job --lib -- --test-threads=1
- cargo test dream --lib -- --test-threads=1
- cargo test enqueue_summary_jobs --lib -- --test-threads=1
- cargo test
- python3 scripts/ci/check_version_bump.py origin/fix/issue-326-summary-state-keys HEAD
- git diff --check origin/fix/issue-326-summary-state-keys..HEAD

## Thread review
- read-only reviewer lane re-reviewed final diff: no blockers