### PR TITLE
feat(eval): expose deterministic retrieval diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Full [LoCoMo](https://github.com/snap-research/locomo) benchmark (10 conversatio
 ### Local QA Eval
 
 ```bash
-python3 eval/local/run_local_eval.py --n 20
+python3 eval/local/run_local_eval.py --db ~/.remem/remem.db --n 20
 ```
 
 | Metric | Score |
@@ -246,7 +246,7 @@ python3 eval/local/run_local_eval.py --n 20
 | Preference | 100% |
 | Source in top-20 | 90.0% |
 
-Requires `.env` with `OPENAI_API_KEY` (optional `OPENAI_BASE_URL`, `OPENAI_MODEL`).
+Requires explicit `--db` plus `.env` with `OPENAI_API_KEY` (optional `OPENAI_BASE_URL`, `OPENAI_MODEL`).
 
 ### Sandboxed E2E Eval
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -221,7 +221,7 @@ Query: "database encryption"
 ### 本地端到端 QA 评测
 
 ```bash
-python3 eval/local/run_local_eval.py --n 20
+python3 eval/local/run_local_eval.py --db ~/.remem/remem.db --n 20
 ```
 
 | 指标 | 分数 |
@@ -232,7 +232,7 @@ python3 eval/local/run_local_eval.py --n 20
 | Preference | 100% |
 | Source in top-20 | 90.0% |
 
-需要项目根目录 `.env` 中配置 `OPENAI_API_KEY`（可选 `OPENAI_BASE_URL`、`OPENAI_MODEL`）。
+需要显式传入 `--db`，并在项目根目录 `.env` 中配置 `OPENAI_API_KEY`（可选 `OPENAI_BASE_URL`、`OPENAI_MODEL`）。
 
 ## Token 使用量与费用统计
 

--- a/SPEC-benchmark.md
+++ b/SPEC-benchmark.md
@@ -24,7 +24,7 @@ eval/locomo/run_locomo.py    — LoCoMo 长对话记忆评估
 
 ```bash
 cargo test --test benchmark
-python3 eval/local/run_local_eval.py --n 20
+python3 eval/local/run_local_eval.py --db ~/.remem/remem.db --n 20
 cd eval/locomo && python3 run_locomo.py --remem-url http://127.0.0.1:7899
 ```
 

--- a/eval/local/run_local_eval.py
+++ b/eval/local/run_local_eval.py
@@ -13,8 +13,8 @@ Same pipeline as LoCoMo eval but against your actual memories:
 Usage:
   # Requires remem API running: remem api --port 5567
   # Reads REMEM_API_TOKEN or ~/.remem/.api-token for REST API auth.
-  python eval/local/run_local_eval.py
-  python eval/local/run_local_eval.py --n 50 --model gpt-5.4
+  python eval/local/run_local_eval.py --db ~/.remem/remem.db
+  python eval/local/run_local_eval.py --db ~/.remem/remem.db --n 50 --model gpt-5.4
 """
 
 import argparse
@@ -391,7 +391,11 @@ def print_report(type_scores, cat_scores):
 def main():
     parser = argparse.ArgumentParser(description="Local eval: real-data QA benchmark for remem")
     parser.add_argument("--remem-url", default="http://127.0.0.1:5567")
-    parser.add_argument("--db", default=str(Path.home() / ".remem" / "remem.db"))
+    parser.add_argument(
+        "--db",
+        required=True,
+        help="Explicit remem SQLite database path. Required to avoid accidental production-data eval.",
+    )
     _load_env_file(_PROJECT_ENV)
     parser.add_argument(
         "--model",

--- a/src/cli/actions/eval.rs
+++ b/src/cli/actions/eval.rs
@@ -9,10 +9,14 @@ pub(in crate::cli) fn run_eval_local() -> Result<()> {
     Ok(())
 }
 
-pub(in crate::cli) fn run_eval(dataset_path: &str, k: usize) -> Result<()> {
+pub(in crate::cli) fn run_eval(dataset_path: &str, k: usize, json: bool) -> Result<()> {
     let conn = db::open_db()?;
     let report = crate::eval::golden::run_dataset_path(&conn, dataset_path, k)?;
-    print!("{}", report);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", report);
+    }
     Ok(())
 }
 

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -219,7 +219,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             project,
             branch,
         } => run_why(id, project.as_deref(), branch.as_deref())?,
-        Commands::Eval { dataset, k } => run_eval(&dataset, k)?,
+        Commands::Eval { dataset, k, json } => run_eval(&dataset, k, json)?,
         Commands::EvalE2e {
             k,
             json,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,8 @@ mod cwd;
 mod dispatch;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_eval;
 mod types;
 
 use anyhow::Result;

--- a/src/cli/tests_eval.rs
+++ b/src/cli/tests_eval.rs
@@ -1,0 +1,24 @@
+use super::types::{Cli, Commands};
+use clap::Parser;
+
+#[test]
+fn cli_parses_eval_json_options() {
+    let cli = Cli::parse_from([
+        "remem",
+        "eval",
+        "--dataset",
+        "fixtures/golden.json",
+        "--json",
+        "-k",
+        "3",
+    ]);
+
+    match cli.command {
+        Commands::Eval { dataset, k, json } => {
+            assert_eq!(dataset, "fixtures/golden.json");
+            assert_eq!(k, 3);
+            assert!(json);
+        }
+        _ => panic!("expected eval command"),
+    }
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -371,6 +371,9 @@ pub(super) enum Commands {
         /// Number of results to evaluate per query.
         #[arg(long, short = 'k', default_value = "5")]
         k: usize,
+        /// Emit the deterministic retrieval report as JSON.
+        #[arg(long)]
+        json: bool,
     },
     /// Run end-to-end local API evaluation.
     EvalE2e {

--- a/src/eval/golden/display.rs
+++ b/src/eval/golden/display.rs
@@ -6,7 +6,7 @@ impl Display for GoldenEvalReport {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         writeln!(
             f,
-            "remem eval — {} queries, k={}, rank_k={}",
+            "remem eval — deterministic retrieval layer, {} queries, k={}, rank_k={}",
             self.total_queries, self.k, self.rank_k
         )?;
         if let Some(version) = self.version.as_deref() {
@@ -15,6 +15,23 @@ impl Display for GoldenEvalReport {
         if let Some(description) = self.description.as_deref() {
             writeln!(f, "{description}")?;
         }
+        writeln!(f)?;
+        writeln!(f, "--- Evaluation Layers ---")?;
+        writeln!(
+            f,
+            "  retrieval: {}",
+            self.evaluation_layers.retrieval.status
+        )?;
+        writeln!(
+            f,
+            "  answer_generation: {}",
+            self.evaluation_layers.answer_generation.status
+        )?;
+        writeln!(
+            f,
+            "  llm_judge: {}",
+            self.evaluation_layers.llm_judge.status
+        )?;
         writeln!(f)?;
 
         for query in &self.queries {
@@ -37,6 +54,14 @@ impl Display for GoldenEvalReport {
                     query.category,
                     query.query
                 )?;
+                write_failure_details(
+                    f,
+                    query.status,
+                    &query.retrieved_ids,
+                    &query.expected_relevant_ids,
+                    &query.missing_relevant_ids,
+                    query.missing_evidence_refs.len(),
+                )?;
             } else {
                 writeln!(
                     f,
@@ -49,13 +74,21 @@ impl Display for GoldenEvalReport {
                     query.category,
                     query.query
                 )?;
+                write_failure_details(
+                    f,
+                    query.status,
+                    &query.retrieved_ids,
+                    &query.expected_relevant_ids,
+                    &query.missing_relevant_ids,
+                    query.missing_evidence_refs.len(),
+                )?;
             }
         }
 
         writeln!(f)?;
         writeln!(
             f,
-            "--- Overall ({} scored, {} abstention, {} skipped) ---",
+            "--- Retrieval Overall ({} scored, {} abstention, {} skipped) ---",
             self.scored_queries, self.abstention_queries, self.skipped_queries
         )?;
         if let Some(metrics) = self.overall.as_ref() {
@@ -68,6 +101,10 @@ impl Display for GoldenEvalReport {
                 self.abstention_passed, self.abstention_queries
             )?;
         }
+
+        writeln!(f)?;
+        writeln!(f, "--- Answer/Judge Layer ---")?;
+        writeln!(f, "  not run in deterministic golden retrieval eval")?;
 
         if !self.by_category.is_empty() {
             writeln!(f)?;
@@ -89,6 +126,27 @@ impl Display for GoldenEvalReport {
         }
         Ok(())
     }
+}
+
+fn write_failure_details(
+    f: &mut Formatter<'_>,
+    status: super::types::QueryStatus,
+    retrieved_ids: &[i64],
+    expected_relevant_ids: &[i64],
+    missing_relevant_ids: &[i64],
+    missing_evidence_ref_count: usize,
+) -> FmtResult {
+    if !matches!(
+        status,
+        super::types::QueryStatus::Miss | super::types::QueryStatus::Fail
+    ) {
+        return Ok(());
+    }
+    writeln!(
+        f,
+        "       retrieved_ids={:?} expected_relevant_ids={:?} missing_relevant_ids={:?} missing_evidence_refs={}",
+        retrieved_ids, expected_relevant_ids, missing_relevant_ids, missing_evidence_ref_count
+    )
 }
 
 fn write_metrics(

--- a/src/eval/golden/run.rs
+++ b/src/eval/golden/run.rs
@@ -4,8 +4,8 @@ use anyhow::{anyhow, Context, Result};
 use rusqlite::Connection;
 
 use super::types::{
-    CategoryEvaluation, EvidenceRef, GoldenDataset, GoldenEvalReport, GoldenQuery, MetricSums,
-    QueryEvaluation, QueryMetrics, QueryStatus,
+    CategoryEvaluation, EvaluationLayers, EvidenceRef, GoldenDataset, GoldenEvalReport,
+    GoldenQuery, MetricSums, QueryEvaluation, QueryMetrics, QueryStatus,
 };
 
 const RANK_K: usize = 10;
@@ -84,6 +84,7 @@ pub fn evaluate_dataset(
     }
 
     Ok(GoldenEvalReport {
+        evaluation_layers: EvaluationLayers::deterministic_retrieval_only(),
         version: dataset.version.clone(),
         description: dataset.description.clone(),
         k,
@@ -168,6 +169,10 @@ fn evaluate_query(
                 QueryStatus::Fail
             },
             result_count: results.len(),
+            retrieved_ids: retrieved_ids(results, k),
+            expected_relevant_ids: expected_relevant_ids(&expected_refs),
+            missing_relevant_ids: Vec::new(),
+            missing_evidence_refs: Vec::new(),
             matched_refs: 0,
             expected_refs: expected_refs.len(),
             metrics: None,
@@ -181,6 +186,10 @@ fn evaluate_query(
             category: query.category.clone(),
             status: QueryStatus::Skip,
             result_count: results.len(),
+            retrieved_ids: retrieved_ids(results, k),
+            expected_relevant_ids: Vec::new(),
+            missing_relevant_ids: Vec::new(),
+            missing_evidence_refs: Vec::new(),
             matched_refs: 0,
             expected_refs: 0,
             metrics: None,
@@ -188,7 +197,10 @@ fn evaluate_query(
     }
 
     let metrics = score_results(results, &expected_refs, k);
-    let matched_refs = matched_ref_indexes(results, &expected_refs, k).len();
+    let matched_ref_indexes = matched_ref_indexes(results, &expected_refs, k);
+    let missing_evidence_refs = missing_evidence_refs(&expected_refs, &matched_ref_indexes);
+    let missing_relevant_ids = missing_relevant_ids(&missing_evidence_refs);
+    let matched_refs = matched_ref_indexes.len();
     let status = if metrics.hit_at_k > 0.0 {
         QueryStatus::Hit
     } else {
@@ -200,6 +212,10 @@ fn evaluate_query(
         category: query.category.clone(),
         status,
         result_count: results.len(),
+        retrieved_ids: retrieved_ids(results, k),
+        expected_relevant_ids: expected_relevant_ids(&expected_refs),
+        missing_relevant_ids,
+        missing_evidence_refs,
         matched_refs,
         expected_refs: expected_refs.len(),
         metrics: Some(metrics),
@@ -262,6 +278,37 @@ fn matched_ref_indexes(
         }
     }
     matched
+}
+
+fn retrieved_ids(results: &[crate::memory::Memory], k: usize) -> Vec<i64> {
+    results.iter().take(k).map(|memory| memory.id).collect()
+}
+
+fn expected_relevant_ids(expected_refs: &[EvidenceRef]) -> Vec<i64> {
+    expected_refs
+        .iter()
+        .filter_map(|evidence_ref| evidence_ref.memory_id)
+        .collect()
+}
+
+fn missing_evidence_refs(
+    expected_refs: &[EvidenceRef],
+    matched_ref_indexes: &HashSet<usize>,
+) -> Vec<EvidenceRef> {
+    expected_refs
+        .iter()
+        .enumerate()
+        .filter_map(|(index, evidence_ref)| {
+            (!matched_ref_indexes.contains(&index)).then_some(evidence_ref.clone())
+        })
+        .collect()
+}
+
+fn missing_relevant_ids(missing_evidence_refs: &[EvidenceRef]) -> Vec<i64> {
+    missing_evidence_refs
+        .iter()
+        .filter_map(|evidence_ref| evidence_ref.memory_id)
+        .collect()
 }
 
 fn reciprocal_rank_from_relevance(relevance: &[bool]) -> f64 {

--- a/src/eval/golden/tests.rs
+++ b/src/eval/golden/tests.rs
@@ -292,6 +292,74 @@ fn golden_eval_rejects_empty_evidence_refs() -> Result<()> {
 }
 
 #[test]
+fn golden_eval_miss_records_retrieved_and_missing_ids() -> Result<()> {
+    let conn = setup_conn()?;
+    let now = chrono::Utc::now().timestamp();
+    insert_memory(
+        &conn,
+        &TestMemory {
+            id: 1,
+            project: "/repo-a",
+            topic_key: "wrong-eval-result",
+            title: "Wrong eval result",
+            content: "wrong eval needle is retrievable but irrelevant",
+            memory_type: "discovery",
+            branch: Some("main"),
+            status: "active",
+            updated_at_epoch: now,
+        },
+    )?;
+
+    let dataset = GoldenDataset {
+        version: Some("1.2-test".to_string()),
+        description: None,
+        queries: vec![GoldenQuery {
+            id: "miss".to_string(),
+            query: "wrong eval needle".to_string(),
+            category: "single_hop".to_string(),
+            project: Some("/repo-a".to_string()),
+            branch: Some("main".to_string()),
+            memory_type: None,
+            relevant_ids: vec![42],
+            evidence_refs: vec![],
+            expect_abstain: false,
+            false_premise: false,
+            notes: None,
+        }],
+    };
+
+    let report = evaluate_dataset(&conn, &dataset, 5)?;
+    let query = &report.queries[0];
+
+    assert_eq!(query.status, QueryStatus::Miss);
+    assert_eq!(query.retrieved_ids, vec![1]);
+    assert_eq!(query.expected_relevant_ids, vec![42]);
+    assert_eq!(query.missing_relevant_ids, vec![42]);
+    assert_eq!(query.missing_evidence_refs.len(), 1);
+
+    let rendered = report.to_string();
+    assert!(rendered.contains("--- Evaluation Layers ---"));
+    assert!(rendered.contains("--- Retrieval Overall"));
+    assert!(rendered.contains("--- Answer/Judge Layer ---"));
+    assert!(rendered.contains("retrieved_ids=[1]"));
+    assert!(rendered.contains("missing_relevant_ids=[42]"));
+
+    let json = serde_json::to_value(&report)?;
+    assert_eq!(
+        json["evaluation_layers"]["retrieval"]["status"],
+        "deterministic"
+    );
+    assert_eq!(
+        json["evaluation_layers"]["answer_generation"]["status"],
+        "not_run"
+    );
+    assert_eq!(json["queries"][0]["status"], "MISS");
+    assert_eq!(json["queries"][0]["retrieved_ids"][0], 1);
+    assert_eq!(json["queries"][0]["missing_relevant_ids"][0], 42);
+    Ok(())
+}
+
+#[test]
 fn golden_eval_ndcg_counts_each_expected_ref_once() -> Result<()> {
     let conn = setup_conn()?;
     let now = chrono::Utc::now().timestamp();

--- a/src/eval/golden/types.rs
+++ b/src/eval/golden/types.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use crate::memory::Memory;
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct GoldenDataset {
     pub version: Option<String>,
     pub description: Option<String>,
@@ -10,7 +10,7 @@ pub struct GoldenDataset {
     pub queries: Vec<GoldenQuery>,
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct GoldenQuery {
     pub id: String,
     pub query: String,
@@ -46,7 +46,7 @@ impl GoldenQuery {
     }
 }
 
-#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
 pub struct EvidenceRef {
     pub memory_id: Option<i64>,
     pub topic_key: Option<String>,
@@ -122,8 +122,9 @@ fn contains_case_insensitive(haystack: &str, needle: &str) -> bool {
     haystack.to_lowercase().contains(&needle.to_lowercase())
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct GoldenEvalReport {
+    pub evaluation_layers: EvaluationLayers,
     pub version: Option<String>,
     pub description: Option<String>,
     pub k: usize,
@@ -138,7 +139,7 @@ pub struct GoldenEvalReport {
     pub queries: Vec<QueryEvaluation>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct CategoryEvaluation {
     pub total_queries: usize,
     pub scored_queries: usize,
@@ -147,24 +148,33 @@ pub struct CategoryEvaluation {
     pub metrics: Option<MetricAverages>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct QueryEvaluation {
     pub id: String,
     pub query: String,
     pub category: String,
     pub status: QueryStatus,
     pub result_count: usize,
+    pub retrieved_ids: Vec<i64>,
+    pub expected_relevant_ids: Vec<i64>,
+    pub missing_relevant_ids: Vec<i64>,
+    pub missing_evidence_refs: Vec<EvidenceRef>,
     pub matched_refs: usize,
     pub expected_refs: usize,
     pub metrics: Option<QueryMetrics>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum QueryStatus {
+    #[serde(rename = "HIT")]
     Hit,
+    #[serde(rename = "MISS")]
     Miss,
+    #[serde(rename = "PASS")]
     Pass,
+    #[serde(rename = "FAIL")]
     Fail,
+    #[serde(rename = "SKIP")]
     Skip,
 }
 
@@ -180,7 +190,41 @@ impl QueryStatus {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EvaluationLayers {
+    pub retrieval: LayerStatus,
+    pub answer_generation: LayerStatus,
+    pub llm_judge: LayerStatus,
+}
+
+impl EvaluationLayers {
+    pub fn deterministic_retrieval_only() -> Self {
+        Self {
+            retrieval: LayerStatus {
+                status: "deterministic",
+                description:
+                    "fixed golden retrieval metrics: Hit@K, Recall@K, MRR, nDCG, evidence recall",
+            },
+            answer_generation: LayerStatus {
+                status: "not_run",
+                description:
+                    "answer generation is intentionally excluded from golden retrieval eval",
+            },
+            llm_judge: LayerStatus {
+                status: "not_run",
+                description: "LLM judging is intentionally excluded from deterministic golden eval",
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LayerStatus {
+    pub status: &'static str,
+    pub description: &'static str,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct QueryMetrics {
     pub hit_at_k: f64,
     pub mrr_at_10: f64,
@@ -190,7 +234,7 @@ pub struct QueryMetrics {
     pub evidence_recall_at_k: f64,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct MetricAverages {
     pub count: usize,
     pub hit_at_k: f64,


### PR DESCRIPTION
## Summary
- make golden eval reports explicitly separate deterministic retrieval from answer generation and LLM judging
- add retrieved IDs, expected relevant IDs, missing relevant IDs, and missing evidence refs to per-query diagnostics
- add remem eval --json and require explicit --db for the real-data Python local QA eval

Closes #328

## Verification
- cargo test golden_eval --lib -- --test-threads=1
- cargo test cli_parses_eval --lib -- --test-threads=1
- cargo fmt --check
- cargo check
- cargo clippy -- -D warnings
- cargo test
- python3 -m py_compile eval/local/run_local_eval.py
- python3 eval/local/run_local_eval.py --help
- python3 scripts/ci/check_version_bump.py origin/codex/issue-327-dream-scheduling HEAD
- git diff --check origin/codex/issue-327-dream-scheduling..HEAD

## Thread review
- read-only planner identified existing golden eval as the right implementation point
- read-only reviewer found JSON status/docs gaps; fixed and re-reviewed: no blockers