### PR TITLE
feat: define graph contract and typed node refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -474,6 +474,11 @@ observations (memory_session_id, project, type, title, subtitle, narrative, fact
 memories (session_id, project, topic_key, title, content, memory_type, files, branch,
           created_at_epoch, updated_at_epoch, status, scope[project|global])
 
+-- Typed graph contract for future traversal; see docs/graph-contract.md
+graph_edges (edge_type, edge_trust, from_node_kind/from_node_id, to_node_kind/to_node_id,
+             source_event_ids, source_candidate_id, source_operation_id, confidence,
+             reason, valid_from_epoch, valid_to_epoch)
+
 -- Session summaries
 session_summaries (memory_session_id, project, request, completed, decisions, learned,
                    next_steps, preferences, discovery_tokens)

--- a/docs/graph-contract.md
+++ b/docs/graph-contract.md
@@ -1,0 +1,99 @@
+# Graph Contract
+
+remem keeps graph memory SQLite-first. The graph contract adds typed references
+and provenance rules without adopting a graph database or changing retrieval
+behavior.
+
+## Scope
+
+`memory_edges` remains the memory-to-memory lifecycle table. Existing APIs and
+queries keep using it for replacement, merge, split, duplicate, conflict, and
+provenance summaries on durable memories.
+
+`graph_edges` is the first-class cross-node contract for future traversal. It
+can connect memory, entity, fact, episode, state, and topic nodes, but this PR
+only defines storage and Rust insertion types. Search, context injection, and
+retrieval ranking do not read `graph_edges` yet.
+
+## Node References
+
+Graph node references are typed by `(node_kind, node_id)`.
+
+| Node kind | Backing table | Meaning |
+|---|---|---|
+| `memory` | `memories(id)` | Durable curated memory row. |
+| `entity` | `entities(id)` | Canonical extracted entity. |
+| `fact` | `memory_facts(id)` | Temporal fact with validity and provenance. |
+| `episode` | `captured_events(id)` | Raw capture-ledger event used as episode evidence. |
+| `state` | `memory_state_keys(id)` | Stable mutable-memory state slot. |
+| `topic` | `topic_segments(id)` | Topic Loom segment for continuity/evidence. |
+
+Rust code must construct refs through `GraphNodeRef` so invalid ids fail before
+SQL execution. The database also has insert/update triggers that reject missing
+backing rows for every node kind. This is intentional: ad hoc SQL should fail
+closed rather than leave dangling graph references.
+
+## Edge Storage
+
+Migration `v031_graph_edges` creates `graph_edges`:
+
+| Column | Meaning |
+|---|---|
+| `edge_type` | Fixed graph relation vocabulary. |
+| `edge_trust` | `trusted` or `diagnostic_hint`, derived from `edge_type`. |
+| `from_node_kind` / `from_node_id` | Typed source node ref. |
+| `to_node_kind` / `to_node_id` | Typed target node ref. |
+| `source_event_ids` | JSON array of `captured_events.id` evidence. |
+| `source_candidate_id` | Candidate row that proposed the trusted edge. |
+| `source_operation_id` | Operation log row that accepted/wrote the edge. |
+| `confidence` | Extractor/reviewer confidence, constrained to `0.0..=1.0`. |
+| `reason` | Human/auditable reason for the edge. |
+| `valid_from_epoch` / `valid_to_epoch` | Optional validity interval for relations whose truth changes. |
+| `created_at_epoch` | Insertion time. |
+
+Trusted edges require non-empty `source_event_ids`, `source_candidate_id`,
+`source_operation_id`, `confidence`, `reason`, and `created_at_epoch`.
+Diagnostic hints may omit provenance because they are not authoritative inputs
+to retrieval or memory truth.
+
+## Edge Types
+
+Trusted graph edges:
+
+| Edge type | Intended use |
+|---|---|
+| `supersedes` | Current node replaces an older node. |
+| `duplicates` | Nodes represent the same durable claim. |
+| `conflicts` | Nodes disagree and need review or temporal resolution. |
+| `derived_from` | Node was derived from another durable node. |
+| `merged_into` | Node was merged into a replacement. |
+| `split_from` | Node was split from a broader source. |
+| `extracted_from` | Fact/entity/state/topic was extracted from episode evidence. |
+| `mentions` | Memory or episode mentions an entity. |
+| `has_state` | Memory belongs to a stable state key. |
+| `has_topic` | Memory or episode belongs to a topic segment. |
+
+Diagnostic hints:
+
+| Edge type | Intended use |
+|---|---|
+| `similar_to` | Approximate similarity, embedding neighbor, or heuristic match. |
+| `candidate_hint` | Extractor candidate link that has not been promoted. |
+| `co_occurs_with` | Co-occurrence signal useful for debugging or review. |
+
+Diagnostic hints must not be treated as trusted retrieval edges without a later
+promotion operation that writes a trusted edge with full provenance.
+
+## Compatibility
+
+The graph contract is additive:
+
+- existing `memory_edges` writes and summaries continue unchanged
+- `memory_facts` remains the temporal fact table
+- `memory_state_keys` remains the mutable state identity table
+- `topic_segments` remains the topic continuity/evidence table
+- no search or context behavior reads `graph_edges` yet
+
+Future traversal work should build on `GraphNodeRef`, `GraphEdgeType`,
+`GraphEdgeProvenance`, and `insert_graph_edge` instead of writing stringly typed
+node refs or raw edge type strings in new code.

--- a/docs/graph-contract.md
+++ b/docs/graph-contract.md
@@ -30,8 +30,9 @@ Graph node references are typed by `(node_kind, node_id)`.
 
 Rust code must construct refs through `GraphNodeRef` so invalid ids fail before
 SQL execution. The database also has insert/update triggers that reject missing
-backing rows for every node kind. This is intentional: ad hoc SQL should fail
-closed rather than leave dangling graph references.
+backing rows for every node kind, plus delete triggers that remove graph edges
+when a referenced node is hard-deleted. This is intentional: ad hoc SQL should
+fail closed rather than leave dangling graph references.
 
 ## Edge Storage
 
@@ -43,7 +44,7 @@ Migration `v031_graph_edges` creates `graph_edges`:
 | `edge_trust` | `trusted` or `diagnostic_hint`, derived from `edge_type`. |
 | `from_node_kind` / `from_node_id` | Typed source node ref. |
 | `to_node_kind` / `to_node_id` | Typed target node ref. |
-| `source_event_ids` | JSON array of `captured_events.id` evidence. |
+| `source_event_ids` | JSON array of positive `captured_events.id` evidence. |
 | `source_candidate_id` | Candidate row that proposed the trusted edge. |
 | `source_operation_id` | Operation log row that accepted/wrote the edge. |
 | `confidence` | Extractor/reviewer confidence, constrained to `0.0..=1.0`. |
@@ -53,8 +54,25 @@ Migration `v031_graph_edges` creates `graph_edges`:
 
 Trusted edges require non-empty `source_event_ids`, `source_candidate_id`,
 `source_operation_id`, `confidence`, `reason`, and `created_at_epoch`.
+`source_event_ids` must be a non-empty JSON array of existing captured event
+ids. If a source event is later hard-deleted, graph edges using it as trusted
+evidence are removed with it.
 Diagnostic hints may omit provenance because they are not authoritative inputs
 to retrieval or memory truth.
+
+## Endpoint Constraints
+
+Each edge type has fixed endpoint kinds. Rust `insert_graph_edge` validates the
+same matrix that the schema enforces for raw SQL writers:
+
+| Edge types | Allowed endpoints |
+|---|---|
+| `supersedes`, `duplicates`, `conflicts`, `derived_from`, `merged_into`, `split_from` | Same node kind on both sides. |
+| `extracted_from` | `entity`, `fact`, `state`, or `topic` to `episode`. |
+| `mentions` | `memory` or `episode` to `entity`. |
+| `has_state` | `memory` to `state`. |
+| `has_topic` | `memory` or `episode` to `topic`. |
+| `similar_to`, `candidate_hint`, `co_occurs_with` | Same node kind on both sides. |
 
 ## Edge Types
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -5,6 +5,7 @@ pub mod events;
 pub mod facts;
 pub mod format;
 pub mod governance;
+pub mod graph_contract;
 pub mod lesson;
 pub mod lifecycle;
 pub mod operation;

--- a/src/memory/graph_contract.rs
+++ b/src/memory/graph_contract.rs
@@ -131,6 +131,52 @@ impl GraphEdgeType {
             | Self::HasTopic => GraphEdgeTrust::Trusted,
         }
     }
+
+    pub const fn allows_endpoints(self, from: GraphNodeKind, to: GraphNodeKind) -> bool {
+        match self {
+            Self::Supersedes
+            | Self::Duplicates
+            | Self::Conflicts
+            | Self::DerivedFrom
+            | Self::MergedInto
+            | Self::SplitFrom
+            | Self::SimilarTo
+            | Self::CandidateHint
+            | Self::CoOccursWith => same_graph_node_kind(from, to),
+            Self::ExtractedFrom => {
+                matches!(
+                    from,
+                    GraphNodeKind::Entity
+                        | GraphNodeKind::Fact
+                        | GraphNodeKind::State
+                        | GraphNodeKind::Topic
+                ) && matches!(to, GraphNodeKind::Episode)
+            }
+            Self::Mentions => {
+                matches!(from, GraphNodeKind::Memory | GraphNodeKind::Episode)
+                    && matches!(to, GraphNodeKind::Entity)
+            }
+            Self::HasState => {
+                matches!(from, GraphNodeKind::Memory) && matches!(to, GraphNodeKind::State)
+            }
+            Self::HasTopic => {
+                matches!(from, GraphNodeKind::Memory | GraphNodeKind::Episode)
+                    && matches!(to, GraphNodeKind::Topic)
+            }
+        }
+    }
+}
+
+const fn same_graph_node_kind(left: GraphNodeKind, right: GraphNodeKind) -> bool {
+    matches!(
+        (left, right),
+        (GraphNodeKind::Memory, GraphNodeKind::Memory)
+            | (GraphNodeKind::Entity, GraphNodeKind::Entity)
+            | (GraphNodeKind::Fact, GraphNodeKind::Fact)
+            | (GraphNodeKind::Episode, GraphNodeKind::Episode)
+            | (GraphNodeKind::State, GraphNodeKind::State)
+            | (GraphNodeKind::Topic, GraphNodeKind::Topic)
+    )
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -153,7 +199,7 @@ pub struct GraphEdgeInput<'a> {
 }
 
 pub fn insert_graph_edge(conn: &Connection, input: &GraphEdgeInput<'_>) -> Result<i64> {
-    validate_graph_edge(input)?;
+    validate_graph_edge(conn, input)?;
     let now = chrono::Utc::now().timestamp();
     let source_event_ids = serde_json::to_string(input.provenance.source_event_ids)
         .context("serialize graph edge source event ids")?;
@@ -184,9 +230,20 @@ pub fn insert_graph_edge(conn: &Connection, input: &GraphEdgeInput<'_>) -> Resul
     Ok(conn.last_insert_rowid())
 }
 
-fn validate_graph_edge(input: &GraphEdgeInput<'_>) -> Result<()> {
+fn validate_graph_edge(conn: &Connection, input: &GraphEdgeInput<'_>) -> Result<()> {
     if input.from_node == input.to_node {
         bail!("graph edge cannot link a node to itself");
+    }
+    if !input
+        .edge_type
+        .allows_endpoints(input.from_node.kind, input.to_node.kind)
+    {
+        bail!(
+            "graph edge type {} does not allow {} to {} endpoints",
+            input.edge_type.as_str(),
+            input.from_node.kind.as_str(),
+            input.to_node.kind.as_str()
+        );
     }
     if let (Some(valid_from), Some(valid_to)) = (input.valid_from_epoch, input.valid_to_epoch) {
         if valid_to < valid_from {
@@ -199,17 +256,32 @@ fn validate_graph_edge(input: &GraphEdgeInput<'_>) -> Result<()> {
         }
     }
     if input.edge_type.trust() == GraphEdgeTrust::Trusted {
-        validate_trusted_provenance(input.provenance)?;
+        validate_trusted_provenance(conn, input.provenance)?;
     }
     Ok(())
 }
 
-fn validate_trusted_provenance(provenance: GraphEdgeProvenance<'_>) -> Result<()> {
+fn validate_trusted_provenance(
+    conn: &Connection,
+    provenance: GraphEdgeProvenance<'_>,
+) -> Result<()> {
     if provenance.source_event_ids.is_empty() {
         bail!("trusted graph edge requires source event ids");
     }
     if provenance.source_event_ids.iter().any(|id| *id <= 0) {
         bail!("trusted graph edge source event ids must be positive");
+    }
+    for event_id in provenance.source_event_ids {
+        let exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM captured_events WHERE id = ?1)",
+                [event_id],
+                |row| row.get(0),
+            )
+            .with_context(|| format!("validate graph edge source event id {event_id}"))?;
+        if !exists {
+            bail!("trusted graph edge source event id {event_id} does not exist");
+        }
     }
     if provenance.source_candidate_id.is_none() {
         bail!("trusted graph edge requires source candidate id");
@@ -235,7 +307,9 @@ mod tests {
     struct GraphFixture {
         conn: Connection,
         memory_id: i64,
+        second_memory_id: i64,
         entity_id: i64,
+        second_entity_id: i64,
         fact_id: i64,
         episode_id: i64,
         state_id: i64,
@@ -293,12 +367,28 @@ mod tests {
             "decision",
             None,
         )?;
+        let second_memory_id = crate::memory::insert_memory(
+            &conn,
+            Some("session-a"),
+            "/tmp/remem-graph",
+            Some("graph-contract-2"),
+            "Graph contract follow-up",
+            "Typed graph refs keep endpoints constrained.",
+            "decision",
+            None,
+        )?;
         conn.execute(
             "INSERT INTO entities(canonical_name, entity_type, mention_count, created_at_epoch)
              VALUES ('Graph API', 'concept', 1, ?1)",
             [now],
         )?;
         let entity_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO entities(canonical_name, entity_type, mention_count, created_at_epoch)
+             VALUES ('Graph API Review', 'concept', 1, ?1)",
+            [now],
+        )?;
+        let second_entity_id = conn.last_insert_rowid();
         conn.execute(
             "INSERT INTO memory_state_keys(owner_scope, owner_key, memory_type, state_key,
                                            state_label, current_memory_id,
@@ -369,7 +459,9 @@ mod tests {
         Ok(GraphFixture {
             conn,
             memory_id,
+            second_memory_id,
             entity_id,
+            second_entity_id,
             fact_id,
             episode_id,
             state_id,
@@ -387,6 +479,27 @@ mod tests {
             confidence: Some(0.9),
             reason: Some("test provenance"),
         }
+    }
+
+    fn insert_raw_trusted_mention(
+        fixture: &GraphFixture,
+        source_event_ids: &str,
+    ) -> rusqlite::Result<usize> {
+        fixture.conn.execute(
+            "INSERT INTO graph_edges
+             (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+              source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
+              created_at_epoch)
+             VALUES ('mentions', 'trusted', 'memory', ?1, 'entity', ?2,
+                     ?3, ?4, ?5, 0.9, 'raw trusted provenance', 1)",
+            params![
+                fixture.memory_id,
+                fixture.entity_id,
+                source_event_ids,
+                fixture.candidate_id,
+                fixture.operation_id
+            ],
+        )
     }
 
     #[test]
@@ -475,7 +588,7 @@ mod tests {
             &GraphEdgeInput {
                 edge_type: GraphEdgeType::SimilarTo,
                 from_node: GraphNodeRef::memory(fixture.memory_id)?,
-                to_node: GraphNodeRef::entity(fixture.entity_id)?,
+                to_node: GraphNodeRef::memory(fixture.second_memory_id)?,
                 provenance: GraphEdgeProvenance::default(),
                 valid_from_epoch: None,
                 valid_to_epoch: None,
@@ -498,7 +611,7 @@ mod tests {
             &GraphEdgeInput {
                 edge_type: GraphEdgeType::SimilarTo,
                 from_node: GraphNodeRef::memory(fixture.memory_id)?,
-                to_node: GraphNodeRef::entity(99_999)?,
+                to_node: GraphNodeRef::memory(99_999)?,
                 provenance: GraphEdgeProvenance::default(),
                 valid_from_epoch: None,
                 valid_to_epoch: None,
@@ -507,7 +620,36 @@ mod tests {
         .expect_err("missing graph target must fail");
         assert!(err.to_string().contains("insert graph edge"));
         let chain = format!("{err:#}");
-        assert!(chain.contains("graph_edges to entity node missing"));
+        assert!(chain.contains("graph_edges to memory node missing"));
+        Ok(())
+    }
+
+    #[test]
+    fn trusted_edge_requires_existing_source_events() -> Result<()> {
+        let fixture = fixture()?;
+        let missing_event_id = 99_999_i64;
+        let source_event_ids = [missing_event_id];
+        let err = insert_graph_edge(
+            &fixture.conn,
+            &GraphEdgeInput {
+                edge_type: GraphEdgeType::Mentions,
+                from_node: GraphNodeRef::memory(fixture.memory_id)?,
+                to_node: GraphNodeRef::entity(fixture.entity_id)?,
+                provenance: GraphEdgeProvenance {
+                    source_event_ids: &source_event_ids,
+                    source_candidate_id: Some(fixture.candidate_id),
+                    source_operation_id: Some(fixture.operation_id),
+                    confidence: Some(0.9),
+                    reason: Some("missing event must fail"),
+                },
+                valid_from_epoch: None,
+                valid_to_epoch: None,
+            },
+        )
+        .expect_err("trusted graph edge with missing evidence must fail");
+        assert!(err
+            .to_string()
+            .contains("source event id 99999 does not exist"));
         Ok(())
     }
 
@@ -519,12 +661,122 @@ mod tests {
             .execute(
                 "INSERT INTO graph_edges
                  (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+                  source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
                   created_at_epoch)
-                 VALUES ('made_up', 'trusted', 'memory', ?1, 'entity', ?2, 1)",
-                params![fixture.memory_id, fixture.entity_id],
+                 VALUES ('made_up', 'trusted', 'memory', ?1, 'entity', ?2,
+                         ?3, ?4, ?5, 0.9, 'invalid edge type', 1)",
+                params![
+                    fixture.memory_id,
+                    fixture.entity_id,
+                    format!("[{}]", fixture.episode_id),
+                    fixture.candidate_id,
+                    fixture.operation_id
+                ],
             )
             .expect_err("invalid graph edge type must fail");
         assert!(err.to_string().contains("CHECK constraint failed"));
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_source_event_ids_fail_closed_at_schema_boundary() -> Result<()> {
+        let fixture = fixture()?;
+        for source_event_ids in ["[ ]", "not-json", "{\"id\":1}", "[\"event-a\"]", "[99999]"] {
+            assert!(
+                insert_raw_trusted_mention(&fixture, source_event_ids).is_err(),
+                "invalid source_event_ids {source_event_ids:?} must fail"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn edge_type_rejects_invalid_endpoint_kinds() -> Result<()> {
+        let fixture = fixture()?;
+        let err = insert_graph_edge(
+            &fixture.conn,
+            &GraphEdgeInput {
+                edge_type: GraphEdgeType::HasState,
+                from_node: GraphNodeRef::entity(fixture.entity_id)?,
+                to_node: GraphNodeRef::memory(fixture.memory_id)?,
+                provenance: trusted_provenance(&fixture),
+                valid_from_epoch: None,
+                valid_to_epoch: None,
+            },
+        )
+        .expect_err("has_state with entity to memory endpoints must fail");
+        assert!(err
+            .to_string()
+            .contains("graph edge type has_state does not allow entity to memory endpoints"));
+
+        let err = fixture
+            .conn
+            .execute(
+                "INSERT INTO graph_edges
+                 (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+                  source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
+                  created_at_epoch)
+                 VALUES ('has_state', 'trusted', 'entity', ?1, 'memory', ?2,
+                         ?3, ?4, ?5, 0.9, 'invalid endpoints', 1)",
+                params![
+                    fixture.entity_id,
+                    fixture.memory_id,
+                    format!("[{}]", fixture.episode_id),
+                    fixture.candidate_id,
+                    fixture.operation_id
+                ],
+            )
+            .expect_err("raw SQL invalid graph endpoints must fail");
+        assert!(err.to_string().contains("CHECK constraint failed"));
+        Ok(())
+    }
+
+    #[test]
+    fn parent_node_deletes_remove_graph_edges() -> Result<()> {
+        let fixture = fixture()?;
+        let entity_edge_id = insert_graph_edge(
+            &fixture.conn,
+            &GraphEdgeInput {
+                edge_type: GraphEdgeType::Mentions,
+                from_node: GraphNodeRef::memory(fixture.memory_id)?,
+                to_node: GraphNodeRef::entity(fixture.second_entity_id)?,
+                provenance: trusted_provenance(&fixture),
+                valid_from_epoch: None,
+                valid_to_epoch: None,
+            },
+        )?;
+        let state_edge_id = insert_graph_edge(
+            &fixture.conn,
+            &GraphEdgeInput {
+                edge_type: GraphEdgeType::HasState,
+                from_node: GraphNodeRef::memory(fixture.memory_id)?,
+                to_node: GraphNodeRef::state(fixture.state_id)?,
+                provenance: trusted_provenance(&fixture),
+                valid_from_epoch: None,
+                valid_to_epoch: None,
+            },
+        )?;
+        fixture.conn.execute(
+            "DELETE FROM entities WHERE id = ?1",
+            [fixture.second_entity_id],
+        )?;
+        let entity_edge_count: i64 = fixture.conn.query_row(
+            "SELECT COUNT(*) FROM graph_edges WHERE id = ?1",
+            [entity_edge_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(entity_edge_count, 0);
+
+        fixture.conn.execute(
+            "DELETE FROM memory_state_keys WHERE id = ?1",
+            [fixture.state_id],
+        )?;
+        let state_edge_count: i64 = fixture.conn.query_row(
+            "SELECT COUNT(*) FROM graph_edges WHERE id = ?1",
+            [state_edge_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state_edge_count, 0);
         Ok(())
     }
 }

--- a/src/memory/graph_contract.rs
+++ b/src/memory/graph_contract.rs
@@ -1,0 +1,530 @@
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphNodeKind {
+    Memory,
+    Entity,
+    Fact,
+    Episode,
+    State,
+    Topic,
+}
+
+impl GraphNodeKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Memory => "memory",
+            Self::Entity => "entity",
+            Self::Fact => "fact",
+            Self::Episode => "episode",
+            Self::State => "state",
+            Self::Topic => "topic",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GraphNodeRef {
+    pub kind: GraphNodeKind,
+    pub id: i64,
+}
+
+impl GraphNodeRef {
+    pub fn new(kind: GraphNodeKind, id: i64) -> Result<Self> {
+        if id <= 0 {
+            bail!("graph node id must be positive");
+        }
+        Ok(Self { kind, id })
+    }
+
+    pub fn memory(id: i64) -> Result<Self> {
+        Self::new(GraphNodeKind::Memory, id)
+    }
+
+    pub fn entity(id: i64) -> Result<Self> {
+        Self::new(GraphNodeKind::Entity, id)
+    }
+
+    pub fn fact(id: i64) -> Result<Self> {
+        Self::new(GraphNodeKind::Fact, id)
+    }
+
+    pub fn episode(id: i64) -> Result<Self> {
+        Self::new(GraphNodeKind::Episode, id)
+    }
+
+    pub fn state(id: i64) -> Result<Self> {
+        Self::new(GraphNodeKind::State, id)
+    }
+
+    pub fn topic(id: i64) -> Result<Self> {
+        Self::new(GraphNodeKind::Topic, id)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphEdgeTrust {
+    Trusted,
+    DiagnosticHint,
+}
+
+impl GraphEdgeTrust {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Trusted => "trusted",
+            Self::DiagnosticHint => "diagnostic_hint",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphEdgeType {
+    Supersedes,
+    Duplicates,
+    Conflicts,
+    DerivedFrom,
+    MergedInto,
+    SplitFrom,
+    ExtractedFrom,
+    Mentions,
+    HasState,
+    HasTopic,
+    SimilarTo,
+    CandidateHint,
+    CoOccursWith,
+}
+
+impl GraphEdgeType {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Supersedes => "supersedes",
+            Self::Duplicates => "duplicates",
+            Self::Conflicts => "conflicts",
+            Self::DerivedFrom => "derived_from",
+            Self::MergedInto => "merged_into",
+            Self::SplitFrom => "split_from",
+            Self::ExtractedFrom => "extracted_from",
+            Self::Mentions => "mentions",
+            Self::HasState => "has_state",
+            Self::HasTopic => "has_topic",
+            Self::SimilarTo => "similar_to",
+            Self::CandidateHint => "candidate_hint",
+            Self::CoOccursWith => "co_occurs_with",
+        }
+    }
+
+    pub const fn trust(self) -> GraphEdgeTrust {
+        match self {
+            Self::SimilarTo | Self::CandidateHint | Self::CoOccursWith => {
+                GraphEdgeTrust::DiagnosticHint
+            }
+            Self::Supersedes
+            | Self::Duplicates
+            | Self::Conflicts
+            | Self::DerivedFrom
+            | Self::MergedInto
+            | Self::SplitFrom
+            | Self::ExtractedFrom
+            | Self::Mentions
+            | Self::HasState
+            | Self::HasTopic => GraphEdgeTrust::Trusted,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct GraphEdgeProvenance<'a> {
+    pub source_event_ids: &'a [i64],
+    pub source_candidate_id: Option<i64>,
+    pub source_operation_id: Option<i64>,
+    pub confidence: Option<f64>,
+    pub reason: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphEdgeInput<'a> {
+    pub edge_type: GraphEdgeType,
+    pub from_node: GraphNodeRef,
+    pub to_node: GraphNodeRef,
+    pub provenance: GraphEdgeProvenance<'a>,
+    pub valid_from_epoch: Option<i64>,
+    pub valid_to_epoch: Option<i64>,
+}
+
+pub fn insert_graph_edge(conn: &Connection, input: &GraphEdgeInput<'_>) -> Result<i64> {
+    validate_graph_edge(input)?;
+    let now = chrono::Utc::now().timestamp();
+    let source_event_ids = serde_json::to_string(input.provenance.source_event_ids)
+        .context("serialize graph edge source event ids")?;
+    conn.execute(
+        "INSERT INTO graph_edges
+         (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+          source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
+          valid_from_epoch, valid_to_epoch, created_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        params![
+            input.edge_type.as_str(),
+            input.edge_type.trust().as_str(),
+            input.from_node.kind.as_str(),
+            input.from_node.id,
+            input.to_node.kind.as_str(),
+            input.to_node.id,
+            source_event_ids,
+            input.provenance.source_candidate_id,
+            input.provenance.source_operation_id,
+            input.provenance.confidence,
+            input.provenance.reason,
+            input.valid_from_epoch,
+            input.valid_to_epoch,
+            now
+        ],
+    )
+    .context("insert graph edge")?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn validate_graph_edge(input: &GraphEdgeInput<'_>) -> Result<()> {
+    if input.from_node == input.to_node {
+        bail!("graph edge cannot link a node to itself");
+    }
+    if let (Some(valid_from), Some(valid_to)) = (input.valid_from_epoch, input.valid_to_epoch) {
+        if valid_to < valid_from {
+            bail!("graph edge valid_to_epoch cannot be before valid_from_epoch");
+        }
+    }
+    if let Some(confidence) = input.provenance.confidence {
+        if !(0.0..=1.0).contains(&confidence) {
+            bail!("graph edge confidence out of range");
+        }
+    }
+    if input.edge_type.trust() == GraphEdgeTrust::Trusted {
+        validate_trusted_provenance(input.provenance)?;
+    }
+    Ok(())
+}
+
+fn validate_trusted_provenance(provenance: GraphEdgeProvenance<'_>) -> Result<()> {
+    if provenance.source_event_ids.is_empty() {
+        bail!("trusted graph edge requires source event ids");
+    }
+    if provenance.source_event_ids.iter().any(|id| *id <= 0) {
+        bail!("trusted graph edge source event ids must be positive");
+    }
+    if provenance.source_candidate_id.is_none() {
+        bail!("trusted graph edge requires source candidate id");
+    }
+    if provenance.source_operation_id.is_none() {
+        bail!("trusted graph edge requires source operation id");
+    }
+    if provenance.confidence.is_none() {
+        bail!("trusted graph edge requires confidence");
+    }
+    let reason = provenance.reason.unwrap_or_default().trim();
+    if reason.is_empty() {
+        bail!("trusted graph edge requires reason");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::facts::{insert_temporal_fact, FactPredicate, TemporalFactInput};
+
+    struct GraphFixture {
+        conn: Connection,
+        memory_id: i64,
+        entity_id: i64,
+        fact_id: i64,
+        episode_id: i64,
+        state_id: i64,
+        topic_id: i64,
+        candidate_id: i64,
+        operation_id: i64,
+    }
+
+    fn fixture() -> Result<GraphFixture> {
+        let mut conn = Connection::open_in_memory()?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        crate::migrate::run_migrations(&conn)?;
+
+        let now = 1_700_000_000_i64;
+        let host_id: i64 =
+            conn.query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |row| {
+                row.get(0)
+            })?;
+        conn.execute(
+            "INSERT INTO workspaces(root_path, git_remote, git_branch, created_at_epoch, updated_at_epoch)
+             VALUES ('/tmp/remem-graph', 'origin', 'main', ?1, ?1)",
+            [now],
+        )?;
+        let workspace_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO projects(workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
+             VALUES (?1, '/tmp/remem-graph', 'tmp-remem-graph', ?2, ?2)",
+            params![workspace_id, now],
+        )?;
+        let project_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO sessions(host_id, workspace_id, project_id, session_id, started_at_epoch,
+                                  last_seen_at_epoch, status)
+             VALUES (?1, ?2, ?3, 'session-a', ?4, ?4, 'active')",
+            params![host_id, workspace_id, project_id, now],
+        )?;
+        let session_row_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO captured_events(host_id, workspace_id, project_id, session_row_id,
+                                         session_id, event_id, event_type, content_hash,
+                                         retention_class, created_at_epoch, inserted_at_epoch)
+             VALUES (?1, ?2, ?3, ?4, 'session-a', 'event-a', 'message',
+                     'hash-a', 'default', ?5, ?5)",
+            params![host_id, workspace_id, project_id, session_row_id, now],
+        )?;
+        let episode_id = conn.last_insert_rowid();
+
+        let memory_id = crate::memory::insert_memory(
+            &conn,
+            Some("session-a"),
+            "/tmp/remem-graph",
+            Some("graph-contract"),
+            "Graph contract",
+            "Typed graph refs are available.",
+            "decision",
+            None,
+        )?;
+        conn.execute(
+            "INSERT INTO entities(canonical_name, entity_type, mention_count, created_at_epoch)
+             VALUES ('Graph API', 'concept', 1, ?1)",
+            [now],
+        )?;
+        let entity_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO memory_state_keys(owner_scope, owner_key, memory_type, state_key,
+                                           state_label, current_memory_id,
+                                           created_at_epoch, updated_at_epoch)
+             VALUES ('project', '/tmp/remem-graph', 'decision', 'graph-contract',
+                     'graph contract', ?1, ?2, ?2)",
+            params![memory_id, now],
+        )?;
+        let state_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO topic_segments(host_id, project_id, session_row_id, project, topic_key,
+                                        title, summary, status, segment_index,
+                                        covered_from_event_id, covered_to_event_id,
+                                        evidence_event_ids, confidence,
+                                        created_at_epoch, updated_at_epoch)
+             VALUES (?1, ?2, ?3, '/tmp/remem-graph', 'graph-contract',
+                     'Graph contract', 'Typed graph refs.', 'resolved', 0,
+                     ?4, ?4, ?5, 0.9, ?6, ?6)",
+            params![
+                host_id,
+                project_id,
+                session_row_id,
+                episode_id,
+                format!("[{episode_id}]"),
+                now
+            ],
+        )?;
+        let topic_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO memory_candidates(project_id, scope, memory_type, topic_key, text,
+                                           evidence_event_ids, confidence, risk_class,
+                                           review_status, created_at_epoch, updated_at_epoch)
+             VALUES (?1, 'project', 'decision', 'graph-contract', 'Typed graph refs.',
+                     ?2, 0.9, 'low', 'accepted', ?3, ?3)",
+            params![project_id, format!("[{episode_id}]"), now],
+        )?;
+        let candidate_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO memory_operation_log(operation, planner_version, actor, source,
+                                             owner_scope, owner_key, memory_type, state_key,
+                                             source_candidate_id, result_memory_id,
+                                             superseded_ids, conflicting_ids, confidence,
+                                             reason, created_at_epoch)
+             VALUES ('add', 'graph-contract-test', 'test', 'memory_candidate',
+                     'project', '/tmp/remem-graph', 'decision', 'graph-contract',
+                     ?1, ?2, '[]', '[]', 0.9, 'test provenance', ?3)",
+            params![candidate_id, memory_id, now],
+        )?;
+        let operation_id = conn.last_insert_rowid();
+        let fact_id = insert_temporal_fact(
+            &mut conn,
+            &TemporalFactInput {
+                project: "/tmp/remem-graph",
+                subject: "graph-contract",
+                predicate: FactPredicate::VerifiedBy,
+                object: "cargo test memory::graph",
+                valid_from_epoch: Some(now),
+                valid_to_epoch: None,
+                learned_at_epoch: Some(now),
+                source_memory_id: Some(memory_id),
+                source_observation_id: None,
+                source_event_ids: &[episode_id],
+                confidence: 0.9,
+                supersedes_fact_id: None,
+            },
+        )?;
+
+        Ok(GraphFixture {
+            conn,
+            memory_id,
+            entity_id,
+            fact_id,
+            episode_id,
+            state_id,
+            topic_id,
+            candidate_id,
+            operation_id,
+        })
+    }
+
+    fn trusted_provenance(fixture: &GraphFixture) -> GraphEdgeProvenance<'_> {
+        GraphEdgeProvenance {
+            source_event_ids: std::slice::from_ref(&fixture.episode_id),
+            source_candidate_id: Some(fixture.candidate_id),
+            source_operation_id: Some(fixture.operation_id),
+            confidence: Some(0.9),
+            reason: Some("test provenance"),
+        }
+    }
+
+    #[test]
+    fn graph_node_refs_use_stable_db_values() -> Result<()> {
+        assert_eq!(GraphNodeRef::memory(1)?.kind.as_str(), "memory");
+        assert_eq!(GraphNodeRef::entity(1)?.kind.as_str(), "entity");
+        assert_eq!(GraphNodeRef::fact(1)?.kind.as_str(), "fact");
+        assert_eq!(GraphNodeRef::episode(1)?.kind.as_str(), "episode");
+        assert_eq!(GraphNodeRef::state(1)?.kind.as_str(), "state");
+        assert_eq!(GraphNodeRef::topic(1)?.kind.as_str(), "topic");
+        assert!(GraphNodeRef::memory(0).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn trusted_edge_requires_complete_provenance() -> Result<()> {
+        let fixture = fixture()?;
+        let err = insert_graph_edge(
+            &fixture.conn,
+            &GraphEdgeInput {
+                edge_type: GraphEdgeType::Mentions,
+                from_node: GraphNodeRef::memory(fixture.memory_id)?,
+                to_node: GraphNodeRef::entity(fixture.entity_id)?,
+                provenance: GraphEdgeProvenance::default(),
+                valid_from_epoch: None,
+                valid_to_epoch: None,
+            },
+        )
+        .expect_err("trusted graph edge without provenance must fail");
+        assert!(err.to_string().contains("source event ids"));
+        Ok(())
+    }
+
+    #[test]
+    fn inserts_typed_graph_edges_for_supported_node_refs() -> Result<()> {
+        let fixture = fixture()?;
+        let edges = [
+            (
+                GraphEdgeType::Mentions,
+                GraphNodeRef::memory(fixture.memory_id)?,
+                GraphNodeRef::entity(fixture.entity_id)?,
+            ),
+            (
+                GraphEdgeType::ExtractedFrom,
+                GraphNodeRef::fact(fixture.fact_id)?,
+                GraphNodeRef::episode(fixture.episode_id)?,
+            ),
+            (
+                GraphEdgeType::HasState,
+                GraphNodeRef::memory(fixture.memory_id)?,
+                GraphNodeRef::state(fixture.state_id)?,
+            ),
+            (
+                GraphEdgeType::HasTopic,
+                GraphNodeRef::memory(fixture.memory_id)?,
+                GraphNodeRef::topic(fixture.topic_id)?,
+            ),
+        ];
+        for (edge_type, from_node, to_node) in edges {
+            let id = insert_graph_edge(
+                &fixture.conn,
+                &GraphEdgeInput {
+                    edge_type,
+                    from_node,
+                    to_node,
+                    provenance: trusted_provenance(&fixture),
+                    valid_from_epoch: Some(1_700_000_000),
+                    valid_to_epoch: None,
+                },
+            )?;
+            assert!(id > 0);
+        }
+
+        let count: i64 = fixture
+            .conn
+            .query_row("SELECT COUNT(*) FROM graph_edges", [], |row| row.get(0))?;
+        assert_eq!(count, 4);
+        Ok(())
+    }
+
+    #[test]
+    fn diagnostic_hint_can_be_written_without_trusted_provenance() -> Result<()> {
+        let fixture = fixture()?;
+        let id = insert_graph_edge(
+            &fixture.conn,
+            &GraphEdgeInput {
+                edge_type: GraphEdgeType::SimilarTo,
+                from_node: GraphNodeRef::memory(fixture.memory_id)?,
+                to_node: GraphNodeRef::entity(fixture.entity_id)?,
+                provenance: GraphEdgeProvenance::default(),
+                valid_from_epoch: None,
+                valid_to_epoch: None,
+            },
+        )?;
+        let trust: String = fixture.conn.query_row(
+            "SELECT edge_trust FROM graph_edges WHERE id = ?1",
+            [id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(trust, "diagnostic_hint");
+        Ok(())
+    }
+
+    #[test]
+    fn missing_target_node_fails_closed() -> Result<()> {
+        let fixture = fixture()?;
+        let err = insert_graph_edge(
+            &fixture.conn,
+            &GraphEdgeInput {
+                edge_type: GraphEdgeType::SimilarTo,
+                from_node: GraphNodeRef::memory(fixture.memory_id)?,
+                to_node: GraphNodeRef::entity(99_999)?,
+                provenance: GraphEdgeProvenance::default(),
+                valid_from_epoch: None,
+                valid_to_epoch: None,
+            },
+        )
+        .expect_err("missing graph target must fail");
+        assert!(err.to_string().contains("insert graph edge"));
+        let chain = format!("{err:#}");
+        assert!(chain.contains("graph_edges to entity node missing"));
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_edge_type_fails_closed_at_schema_boundary() -> Result<()> {
+        let fixture = fixture()?;
+        let err = fixture
+            .conn
+            .execute(
+                "INSERT INTO graph_edges
+                 (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+                  created_at_epoch)
+                 VALUES ('made_up', 'trusted', 'memory', ?1, 'entity', ?2, 1)",
+                params![fixture.memory_id, fixture.entity_id],
+            )
+            .expect_err("invalid graph edge type must fail");
+        assert!(err.to_string().contains("CHECK constraint failed"));
+        Ok(())
+    }
+}

--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use rusqlite::Connection;
 
-use super::schema_drift::repair_known_schema_drift;
+use super::schema_drift::{install_v031_state_delete_trigger, repair_known_schema_drift};
 use super::state::{applied_versions, ensure_migration_table, mark_applied};
 use super::transition::transition_from_old_system;
 use super::types::{MIGRATIONS, OLD_BASELINE_VERSION};
@@ -102,6 +102,11 @@ pub(super) fn run_post_migration_hook(conn: &Connection, version: i64, name: &st
             "migrate",
             &format!("rebuilt search_context for {rebuilt} memories"),
         );
+    }
+    if version == 31 {
+        install_v031_state_delete_trigger(conn).with_context(|| {
+            format!("migration v{version:03}_{name} failed to install graph edge cleanup triggers")
+        })?;
     }
     Ok(())
 }

--- a/src/migrate/schema_drift.rs
+++ b/src/migrate/schema_drift.rs
@@ -42,9 +42,28 @@ pub(super) fn repair_known_schema_drift(conn: &Connection, applied: &[i64]) -> R
             still_missing.join(", ")
         );
     }
+    install_v031_state_delete_trigger(conn)
+        .context("install v031 graph_edges memory_state_keys delete trigger")?;
 
     repaired.push(format!("v022_memory_state_keys ({})", missing.join(", ")));
     Ok(repaired)
+}
+
+pub(super) fn install_v031_state_delete_trigger(conn: &Connection) -> Result<()> {
+    if !table_exists(conn, "graph_edges")? || !table_exists(conn, "memory_state_keys")? {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE TRIGGER IF NOT EXISTS graph_edges_memory_state_keys_delete
+        AFTER DELETE ON memory_state_keys
+        BEGIN
+            DELETE FROM graph_edges
+            WHERE (from_node_kind = 'state' AND from_node_id = OLD.id)
+               OR (to_node_kind = 'state' AND to_node_id = OLD.id);
+        END;",
+    )?;
+    Ok(())
 }
 
 fn repair_v022_memory_state_keys(conn: &Connection) -> Result<()> {

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -113,6 +113,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "compressed_observation_sources",
         "raw_ingest_failures",
         "memory_embeddings",
+        "graph_edges",
     ] {
         let exists: bool = conn
             .query_row(
@@ -137,6 +138,9 @@ fn full_migration_on_empty_db() -> Result<()> {
         "idx_raw_ingest_failures_project_recent",
         "idx_raw_ingest_failures_session",
         "idx_memory_embeddings_model",
+        "idx_graph_edges_from",
+        "idx_graph_edges_to",
+        "idx_graph_edges_type",
     ] {
         let exists: bool = conn
             .query_row(

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -45,6 +45,7 @@ const CONVERGENCE_TABLES: &[&str] = &[
     "raw_ingest_failures",
     "memory_embeddings",
     "dream_cluster_decisions",
+    "graph_edges",
 ];
 
 fn make_upgraded_v10_db() -> Result<Connection> {

--- a/src/migrate/tests_schema.rs
+++ b/src/migrate/tests_schema.rs
@@ -236,6 +236,94 @@ fn memories_fts_indexes_all_statuses_after_v020() -> Result<()> {
 }
 
 #[test]
+fn graph_edges_reject_self_edges_at_schema_boundary() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+    run_migrations(&conn)?;
+
+    let now = 1_700_000_000_i64;
+    let host_id: i64 =
+        conn.query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |row| {
+            row.get(0)
+        })?;
+    conn.execute(
+        "INSERT INTO workspaces(root_path, git_remote, git_branch, created_at_epoch, updated_at_epoch)
+         VALUES ('/tmp/remem-graph-schema', 'origin', 'main', ?1, ?1)",
+        [now],
+    )?;
+    let workspace_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO projects(workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
+         VALUES (?1, '/tmp/remem-graph-schema', 'tmp-remem-graph-schema', ?2, ?2)",
+        params![workspace_id, now],
+    )?;
+    let project_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO sessions(host_id, workspace_id, project_id, session_id, started_at_epoch,
+                              last_seen_at_epoch, status)
+         VALUES (?1, ?2, ?3, 'session-a', ?4, ?4, 'active')",
+        params![host_id, workspace_id, project_id, now],
+    )?;
+    let session_row_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO captured_events(host_id, workspace_id, project_id, session_row_id,
+                                     session_id, event_id, event_type, content_hash,
+                                     retention_class, created_at_epoch, inserted_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, 'session-a', 'event-a', 'message',
+                 'hash-a', 'default', ?5, ?5)",
+        params![host_id, workspace_id, project_id, session_row_id, now],
+    )?;
+    let episode_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memories(project, topic_key, title, content, memory_type,
+                              created_at_epoch, updated_at_epoch, status)
+         VALUES ('/tmp/remem-graph-schema', 'graph-schema', 'Graph schema',
+                 'Schema rejects graph self-edges.', 'decision', ?1, ?1, 'active')",
+        [now],
+    )?;
+    let memory_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memory_candidates(project_id, scope, memory_type, topic_key, text,
+                                       evidence_event_ids, confidence, risk_class,
+                                       review_status, created_at_epoch, updated_at_epoch)
+         VALUES (?1, 'project', 'decision', 'graph-schema', 'Graph schema.',
+                 ?2, 0.9, 'low', 'accepted', ?3, ?3)",
+        params![project_id, format!("[{episode_id}]"), now],
+    )?;
+    let candidate_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memory_operation_log(operation, planner_version, actor, source,
+                                         source_candidate_id, result_memory_id,
+                                         confidence, reason, created_at_epoch)
+         VALUES ('add', 'graph-schema-test', 'test', 'memory_candidate',
+                 ?1, ?2, 0.9, 'test provenance', ?3)",
+        params![candidate_id, memory_id, now],
+    )?;
+    let operation_id = conn.last_insert_rowid();
+
+    let err = conn
+        .execute(
+            "INSERT INTO graph_edges
+             (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+              source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
+              created_at_epoch)
+             VALUES ('duplicates', 'trusted', 'memory', ?1, 'memory', ?1,
+                     ?2, ?3, ?4, 0.9, 'self edge', ?5)",
+            params![
+                memory_id,
+                format!("[{episode_id}]"),
+                candidate_id,
+                operation_id,
+                now
+            ],
+        )
+        .expect_err("raw SQL graph self-edge must fail");
+    assert!(err.to_string().contains("CHECK constraint failed"));
+
+    Ok(())
+}
+
+#[test]
 fn run_migrations_rejects_db_newer_than_binary() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     run_migrations(&conn)?;

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -155,6 +155,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "dream_cluster_decisions",
         sql: include_str!("../migrations/v030_dream_cluster_decisions.sql"),
     },
+    Migration {
+        version: 31,
+        name: "graph_edges",
+        sql: include_str!("../migrations/v031_graph_edges.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v031_graph_edges.sql
+++ b/src/migrations/v031_graph_edges.sql
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS graph_edges (
         OR valid_from_epoch IS NULL
         OR valid_to_epoch >= valid_from_epoch
     ),
+    CHECK (from_node_kind != to_node_kind OR from_node_id != to_node_id),
     CHECK (
         (
             edge_type IN (

--- a/src/migrations/v031_graph_edges.sql
+++ b/src/migrations/v031_graph_edges.sql
@@ -32,7 +32,10 @@ CREATE TABLE IF NOT EXISTS graph_edges (
         to_node_kind IN ('memory', 'entity', 'fact', 'episode', 'state', 'topic')
     ),
     to_node_id INTEGER NOT NULL CHECK (to_node_id > 0),
-    source_event_ids TEXT NOT NULL DEFAULT '[]',
+    source_event_ids TEXT NOT NULL DEFAULT '[]' CHECK (
+        json_valid(source_event_ids) = 1
+        AND json_type(source_event_ids) = 'array'
+    ),
     source_candidate_id INTEGER,
     source_operation_id INTEGER,
     confidence REAL CHECK (confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)),
@@ -67,11 +70,46 @@ CREATE TABLE IF NOT EXISTS graph_edges (
         )
     ),
     CHECK (
+        (
+            edge_type IN (
+                'supersedes',
+                'duplicates',
+                'conflicts',
+                'derived_from',
+                'merged_into',
+                'split_from',
+                'similar_to',
+                'candidate_hint',
+                'co_occurs_with'
+            )
+            AND from_node_kind = to_node_kind
+        )
+        OR (
+            edge_type = 'extracted_from'
+            AND from_node_kind IN ('entity', 'fact', 'state', 'topic')
+            AND to_node_kind = 'episode'
+        )
+        OR (
+            edge_type = 'mentions'
+            AND from_node_kind IN ('memory', 'episode')
+            AND to_node_kind = 'entity'
+        )
+        OR (
+            edge_type = 'has_state'
+            AND from_node_kind = 'memory'
+            AND to_node_kind = 'state'
+        )
+        OR (
+            edge_type = 'has_topic'
+            AND from_node_kind IN ('memory', 'episode')
+            AND to_node_kind = 'topic'
+        )
+    ),
+    CHECK (
         edge_trust != 'trusted'
         OR (
             source_event_ids IS NOT NULL
-            AND length(trim(source_event_ids)) > 2
-            AND source_event_ids != '[]'
+            AND json_array_length(source_event_ids) > 0
             AND source_candidate_id IS NOT NULL
             AND source_operation_id IS NOT NULL
             AND confidence IS NOT NULL
@@ -91,6 +129,58 @@ CREATE INDEX IF NOT EXISTS idx_graph_edges_to
 
 CREATE INDEX IF NOT EXISTS idx_graph_edges_type
     ON graph_edges(edge_type, edge_trust, created_at_epoch);
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_validate_source_events_insert
+BEFORE INSERT ON graph_edges
+WHEN NEW.edge_trust = 'trusted'
+BEGIN
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM json_each(NEW.source_event_ids) AS source_event
+            WHERE source_event.type != 'integer'
+               OR source_event.value <= 0
+        )
+        THEN RAISE(ABORT, 'graph_edges trusted source_event_ids must be positive integers')
+    END;
+
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM json_each(NEW.source_event_ids) AS source_event
+            WHERE NOT EXISTS (
+                SELECT 1 FROM captured_events WHERE id = source_event.value
+            )
+        )
+        THEN RAISE(ABORT, 'graph_edges trusted source event missing')
+    END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_validate_source_events_update
+BEFORE UPDATE OF edge_trust, source_event_ids ON graph_edges
+WHEN NEW.edge_trust = 'trusted'
+BEGIN
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM json_each(NEW.source_event_ids) AS source_event
+            WHERE source_event.type != 'integer'
+               OR source_event.value <= 0
+        )
+        THEN RAISE(ABORT, 'graph_edges trusted source_event_ids must be positive integers')
+    END;
+
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM json_each(NEW.source_event_ids) AS source_event
+            WHERE NOT EXISTS (
+                SELECT 1 FROM captured_events WHERE id = source_event.value
+            )
+        )
+        THEN RAISE(ABORT, 'graph_edges trusted source event missing')
+    END;
+END;
 
 CREATE TRIGGER IF NOT EXISTS graph_edges_validate_nodes_insert
 BEFORE INSERT ON graph_edges
@@ -136,6 +226,51 @@ BEGIN
              AND NOT EXISTS (SELECT 1 FROM topic_segments WHERE id = NEW.to_node_id)
         THEN RAISE(ABORT, 'graph_edges to topic node missing')
     END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_memories_delete
+AFTER DELETE ON memories
+BEGIN
+    DELETE FROM graph_edges
+    WHERE (from_node_kind = 'memory' AND from_node_id = OLD.id)
+       OR (to_node_kind = 'memory' AND to_node_id = OLD.id);
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_entities_delete
+AFTER DELETE ON entities
+BEGIN
+    DELETE FROM graph_edges
+    WHERE (from_node_kind = 'entity' AND from_node_id = OLD.id)
+       OR (to_node_kind = 'entity' AND to_node_id = OLD.id);
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_memory_facts_delete
+AFTER DELETE ON memory_facts
+BEGIN
+    DELETE FROM graph_edges
+    WHERE (from_node_kind = 'fact' AND from_node_id = OLD.id)
+       OR (to_node_kind = 'fact' AND to_node_id = OLD.id);
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_captured_events_delete
+AFTER DELETE ON captured_events
+BEGIN
+    DELETE FROM graph_edges
+    WHERE (from_node_kind = 'episode' AND from_node_id = OLD.id)
+       OR (to_node_kind = 'episode' AND to_node_id = OLD.id)
+       OR EXISTS (
+           SELECT 1
+           FROM json_each(graph_edges.source_event_ids) AS source_event
+           WHERE source_event.value = OLD.id
+       );
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_topic_segments_delete
+AFTER DELETE ON topic_segments
+BEGIN
+    DELETE FROM graph_edges
+    WHERE (from_node_kind = 'topic' AND from_node_id = OLD.id)
+       OR (to_node_kind = 'topic' AND to_node_id = OLD.id);
 END;
 
 CREATE TRIGGER IF NOT EXISTS graph_edges_validate_nodes_update

--- a/src/migrations/v031_graph_edges.sql
+++ b/src/migrations/v031_graph_edges.sql
@@ -1,0 +1,185 @@
+-- v031_graph_edges: first-class typed graph contract.
+--
+-- memory_edges remains the memory-to-memory lifecycle relation table. graph_edges
+-- is the typed cross-node contract for future traversal; this migration adds the
+-- storage contract only and does not change retrieval behavior.
+
+CREATE TABLE IF NOT EXISTS graph_edges (
+    id INTEGER PRIMARY KEY,
+    edge_type TEXT NOT NULL CHECK (
+        edge_type IN (
+            'supersedes',
+            'duplicates',
+            'conflicts',
+            'derived_from',
+            'merged_into',
+            'split_from',
+            'extracted_from',
+            'mentions',
+            'has_state',
+            'has_topic',
+            'similar_to',
+            'candidate_hint',
+            'co_occurs_with'
+        )
+    ),
+    edge_trust TEXT NOT NULL CHECK (edge_trust IN ('trusted', 'diagnostic_hint')),
+    from_node_kind TEXT NOT NULL CHECK (
+        from_node_kind IN ('memory', 'entity', 'fact', 'episode', 'state', 'topic')
+    ),
+    from_node_id INTEGER NOT NULL CHECK (from_node_id > 0),
+    to_node_kind TEXT NOT NULL CHECK (
+        to_node_kind IN ('memory', 'entity', 'fact', 'episode', 'state', 'topic')
+    ),
+    to_node_id INTEGER NOT NULL CHECK (to_node_id > 0),
+    source_event_ids TEXT NOT NULL DEFAULT '[]',
+    source_candidate_id INTEGER,
+    source_operation_id INTEGER,
+    confidence REAL CHECK (confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)),
+    reason TEXT,
+    valid_from_epoch INTEGER,
+    valid_to_epoch INTEGER,
+    created_at_epoch INTEGER NOT NULL,
+    CHECK (
+        valid_to_epoch IS NULL
+        OR valid_from_epoch IS NULL
+        OR valid_to_epoch >= valid_from_epoch
+    ),
+    CHECK (
+        (
+            edge_type IN (
+                'supersedes',
+                'duplicates',
+                'conflicts',
+                'derived_from',
+                'merged_into',
+                'split_from',
+                'extracted_from',
+                'mentions',
+                'has_state',
+                'has_topic'
+            )
+            AND edge_trust = 'trusted'
+        )
+        OR (
+            edge_type IN ('similar_to', 'candidate_hint', 'co_occurs_with')
+            AND edge_trust = 'diagnostic_hint'
+        )
+    ),
+    CHECK (
+        edge_trust != 'trusted'
+        OR (
+            source_event_ids IS NOT NULL
+            AND length(trim(source_event_ids)) > 2
+            AND source_event_ids != '[]'
+            AND source_candidate_id IS NOT NULL
+            AND source_operation_id IS NOT NULL
+            AND confidence IS NOT NULL
+            AND reason IS NOT NULL
+            AND length(trim(reason)) > 0
+        )
+    ),
+    FOREIGN KEY(source_candidate_id) REFERENCES memory_candidates(id),
+    FOREIGN KEY(source_operation_id) REFERENCES memory_operation_log(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_edges_from
+    ON graph_edges(from_node_kind, from_node_id, edge_type, created_at_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_graph_edges_to
+    ON graph_edges(to_node_kind, to_node_id, edge_type, created_at_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_graph_edges_type
+    ON graph_edges(edge_type, edge_trust, created_at_epoch);
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_validate_nodes_insert
+BEFORE INSERT ON graph_edges
+BEGIN
+    SELECT CASE
+        WHEN NEW.from_node_kind = 'memory'
+             AND NOT EXISTS (SELECT 1 FROM memories WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from memory node missing')
+        WHEN NEW.from_node_kind = 'entity'
+             AND NOT EXISTS (SELECT 1 FROM entities WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from entity node missing')
+        WHEN NEW.from_node_kind = 'fact'
+             AND NOT EXISTS (SELECT 1 FROM memory_facts WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from fact node missing')
+        WHEN NEW.from_node_kind = 'episode'
+             AND NOT EXISTS (SELECT 1 FROM captured_events WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from episode node missing')
+        WHEN NEW.from_node_kind = 'state'
+             AND NOT EXISTS (SELECT 1 FROM memory_state_keys WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from state node missing')
+        WHEN NEW.from_node_kind = 'topic'
+             AND NOT EXISTS (SELECT 1 FROM topic_segments WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from topic node missing')
+    END;
+
+    SELECT CASE
+        WHEN NEW.to_node_kind = 'memory'
+             AND NOT EXISTS (SELECT 1 FROM memories WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to memory node missing')
+        WHEN NEW.to_node_kind = 'entity'
+             AND NOT EXISTS (SELECT 1 FROM entities WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to entity node missing')
+        WHEN NEW.to_node_kind = 'fact'
+             AND NOT EXISTS (SELECT 1 FROM memory_facts WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to fact node missing')
+        WHEN NEW.to_node_kind = 'episode'
+             AND NOT EXISTS (SELECT 1 FROM captured_events WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to episode node missing')
+        WHEN NEW.to_node_kind = 'state'
+             AND NOT EXISTS (SELECT 1 FROM memory_state_keys WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to state node missing')
+        WHEN NEW.to_node_kind = 'topic'
+             AND NOT EXISTS (SELECT 1 FROM topic_segments WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to topic node missing')
+    END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_validate_nodes_update
+BEFORE UPDATE OF from_node_kind, from_node_id, to_node_kind, to_node_id ON graph_edges
+BEGIN
+    SELECT CASE
+        WHEN NEW.from_node_kind = 'memory'
+             AND NOT EXISTS (SELECT 1 FROM memories WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from memory node missing')
+        WHEN NEW.from_node_kind = 'entity'
+             AND NOT EXISTS (SELECT 1 FROM entities WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from entity node missing')
+        WHEN NEW.from_node_kind = 'fact'
+             AND NOT EXISTS (SELECT 1 FROM memory_facts WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from fact node missing')
+        WHEN NEW.from_node_kind = 'episode'
+             AND NOT EXISTS (SELECT 1 FROM captured_events WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from episode node missing')
+        WHEN NEW.from_node_kind = 'state'
+             AND NOT EXISTS (SELECT 1 FROM memory_state_keys WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from state node missing')
+        WHEN NEW.from_node_kind = 'topic'
+             AND NOT EXISTS (SELECT 1 FROM topic_segments WHERE id = NEW.from_node_id)
+        THEN RAISE(ABORT, 'graph_edges from topic node missing')
+    END;
+
+    SELECT CASE
+        WHEN NEW.to_node_kind = 'memory'
+             AND NOT EXISTS (SELECT 1 FROM memories WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to memory node missing')
+        WHEN NEW.to_node_kind = 'entity'
+             AND NOT EXISTS (SELECT 1 FROM entities WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to entity node missing')
+        WHEN NEW.to_node_kind = 'fact'
+             AND NOT EXISTS (SELECT 1 FROM memory_facts WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to fact node missing')
+        WHEN NEW.to_node_kind = 'episode'
+             AND NOT EXISTS (SELECT 1 FROM captured_events WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to episode node missing')
+        WHEN NEW.to_node_kind = 'state'
+             AND NOT EXISTS (SELECT 1 FROM memory_state_keys WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to state node missing')
+        WHEN NEW.to_node_kind = 'topic'
+             AND NOT EXISTS (SELECT 1 FROM topic_segments WHERE id = NEW.to_node_id)
+        THEN RAISE(ABORT, 'graph_edges to topic node missing')
+    END;
+END;


### PR DESCRIPTION
## Summary

- Add schema v31 `graph_edges` as a typed cross-node graph contract while leaving existing `memory_edges` behavior unchanged.
- Add Rust graph contract types for node refs, edge types/trust, provenance, and fail-closed insertion validation.
- Document the graph contract and bump remem to 0.5.11 for the schema-impacting change.

Closes #330

## Validation

- `cargo fmt -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check origin/main..HEAD`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`