### PR TITLE
fix(install): add Claude PreCompact hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.16"
+version = "0.5.17"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -297,7 +297,13 @@ fn display_mcp_paths(paths: &[PathBuf]) -> String {
 fn expected_hook_events(host: &str) -> &'static [&'static str] {
     match host {
         "codex" => &["SessionStart", "Stop"],
-        _ => &["PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"],
+        _ => &[
+            "PostToolUse",
+            "PreCompact",
+            "Stop",
+            "SessionStart",
+            "UserPromptSubmit",
+        ],
     }
 }
 
@@ -525,13 +531,13 @@ mod tests {
         .unwrap();
 
         let check = probe_hooks(HostProbe {
-            name: "codex",
+            name: "claude",
             hooks_path,
             mcp_paths: vec![dir.join("config.toml")],
         });
 
         assert!(matches!(check.status, Status::Warn));
-        assert!(check.detail.contains("1/2 registered"), "{}", check.detail);
+        assert!(check.detail.contains("1/5 registered"), "{}", check.detail);
     }
 
     #[test]

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -15,6 +15,17 @@ impl HookStrategy {
         matches!(self, Self::ClaudeCode)
     }
 
+    fn include_pre_compact(self) -> bool {
+        matches!(self, Self::ClaudeCode)
+    }
+
+    fn session_start_matcher(self) -> Option<&'static str> {
+        match self {
+            Self::ClaudeCode => Some("startup|clear|compact"),
+            Self::Codex => None,
+        }
+    }
+
     fn include_observe(self) -> bool {
         matches!(self, Self::ClaudeCode)
     }
@@ -65,11 +76,15 @@ fn shell_quote(value: &str) -> String {
 pub(in crate::install) fn build_hooks(bin: &str, strategy: HookStrategy) -> Value {
     let mut hooks = serde_json::Map::new();
 
+    let mut session_start = json!({
+        "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "context"), "timeout": 15000 }]
+    });
+    if let Some(matcher) = strategy.session_start_matcher() {
+        session_start["matcher"] = json!(matcher);
+    }
     hooks.insert(
         "SessionStart".to_string(),
-        json!([{
-            "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "context"), "timeout": 15000 }]
-        }]),
+        Value::Array(vec![session_start]),
     );
 
     if strategy.include_session_init() {
@@ -87,6 +102,15 @@ pub(in crate::install) fn build_hooks(bin: &str, strategy: HookStrategy) -> Valu
             json!([{
                 "matcher": strategy.observe_matcher(),
                 "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "observe"), "timeout": strategy.observe_timeout_ms() }]
+            }]),
+        );
+    }
+
+    if strategy.include_pre_compact() {
+        hooks.insert(
+            "PreCompact".to_string(),
+            json!([{
+                "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "summarize"), "timeout": 120000 }]
             }]),
         );
     }

--- a/src/install/hosts/claude.rs
+++ b/src/install/hosts/claude.rs
@@ -87,7 +87,7 @@ impl InstallHost for ClaudeHost {
                 claude_json_path().display()
             ),
             format!(
-                "  hooks  -> {} (SessionStart/UserPromptSubmit/PostToolUse/Stop)",
+                "  hooks  -> {} (SessionStart/UserPromptSubmit/PostToolUse/PreCompact/Stop)",
                 settings_path().display()
             ),
             format!("  binary -> {}", bin),

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -9,6 +9,7 @@ fn build_hooks_contains_expected_claude_commands() {
         hooks["SessionStart"][0]["hooks"][0]["command"],
         "/tmp/remem context --host claude-code"
     );
+    assert_eq!(hooks["SessionStart"][0]["matcher"], "startup|clear|compact");
     assert_eq!(
         hooks["UserPromptSubmit"][0]["hooks"][0]["command"],
         "/tmp/remem session-init --host claude-code"
@@ -25,6 +26,10 @@ fn build_hooks_contains_expected_claude_commands() {
         hooks["Stop"][0]["hooks"][0]["command"],
         "/tmp/remem summarize --host claude-code"
     );
+    assert_eq!(
+        hooks["PreCompact"][0]["hooks"][0]["command"],
+        "/tmp/remem summarize --host claude-code"
+    );
 }
 
 #[test]
@@ -34,8 +39,10 @@ fn build_hooks_contains_expected_codex_commands() {
         hooks["SessionStart"][0]["hooks"][0]["command"],
         "/tmp/remem context --host codex-cli"
     );
+    assert!(hooks["SessionStart"][0].get("matcher").is_none());
     assert!(hooks.get("UserPromptSubmit").is_none());
     assert!(hooks.get("PostToolUse").is_none());
+    assert!(hooks.get("PreCompact").is_none());
     assert_eq!(
         hooks["Stop"][0]["hooks"][0]["command"],
         "/tmp/remem summarize --host codex-cli"


### PR DESCRIPTION
Closes #375.

## Summary
- add Claude Code `PreCompact` hook that reuses `remem summarize --host claude-code` before compaction
- constrain Claude `SessionStart` hook with `startup|clear|compact` matcher
- update doctor expected hook events and install tests while keeping Codex hook shape unchanged

## Verification
- `cargo fmt`
- `git diff --check`
- `cargo test install::tests`
- `cargo test doctor::environment::tests`
- `cargo check`
- `cargo test`

## Review
- independent read-only reviewer thread: no blocking findings
