### PR TITLE
[codex] Add Remem plugin runtime foundation

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "remem-local",
+  "interface": {
+    "displayName": "Remem Local"
+  },
+  "plugins": [
+    {
+      "name": "remem",
+      "source": {
+        "source": "local",
+        "path": "./plugins/remem"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+      - name: Test plugin runtime scripts
+        run: node --test plugins/remem/scripts/remem-runtime.test.js
       - name: Check version bump
         if: github.event_name == 'pull_request'
         run: python3 scripts/ci/check_version_bump.py "${{ github.event.pull_request.base.sha }}" HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.17"
+version = "0.5.18"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,26 @@ Codex uses strict duplicate-injection gating via
 `SessionStart` repeat stays silent after the first injection for the same
 session. It does not install high-frequency Bash observation by default.
 
+### Codex Plugin
+
+This repository includes a local Codex plugin wrapper in `plugins/remem`.
+The plugin exposes `remem mcp` and a Remem skill while keeping hook activation
+explicit. To try it from a local checkout:
+
+```bash
+codex plugin marketplace add .
+codex plugin add remem@remem-local
+```
+
+After installing the plugin, start a new Codex thread. To enable automatic
+SessionStart context injection and Stop summarization, run:
+
+```bash
+cargo build --release
+node plugins/remem/scripts/activate-codex.js --dry-run
+node plugins/remem/scripts/activate-codex.js
+```
+
 ## Distribution Channels
 
 Currently published:

--- a/README.md
+++ b/README.md
@@ -135,7 +135,10 @@ session. It does not install high-frequency Bash observation by default.
 
 This repository includes a local Codex plugin wrapper in `plugins/remem`.
 The plugin exposes `remem mcp` and a Remem skill while keeping hook activation
-explicit. To try it from a local checkout:
+explicit. The complete product direction is documented in
+[`docs/spec-codex-plugin-complete-design.md`](docs/spec-codex-plugin-complete-design.md);
+the current plugin is the local development foundation, not the final
+self-contained plugin experience. To try it from a local checkout:
 
 ```bash
 codex plugin marketplace add .

--- a/docs/spec-codex-plugin-complete-design.md
+++ b/docs/spec-codex-plugin-complete-design.md
@@ -1,0 +1,490 @@
+# Remem Complete Codex Plugin Design
+
+## Summary
+
+The current Remem Codex plugin is a wrapper. It exposes a skill and a bundled
+MCP server config, but it still depends on a separately installed `remem`
+binary. That makes the plugin useful for local development, but weak as a
+product: installing the plugin alone does not create a working memory system.
+
+The complete plugin should be a self-contained local runtime first, and an
+Apps SDK GUI app second.
+
+The target user experience is:
+
+1. Install Remem from the Codex plugin directory.
+2. Start a new thread.
+3. Ask Remem to check memory status, search memory, save a memory, or open the
+   memory dashboard.
+4. If the runtime is missing, the plugin installs or downloads a matching
+   Remem runtime into plugin-managed storage.
+5. Automatic context injection and session summarization remain explicit,
+   reviewable, and trusted by the user before hooks run.
+
+## Problem
+
+The current plugin does not satisfy the expected plugin contract. Official
+plugins observed locally follow one of these useful shapes:
+
+- Connector plugins, such as GitHub and Gmail, provide an app connector via
+  `.app.json` and use skills as workflow guidance.
+- Runtime plugins, such as Documents and Spreadsheets, bundle their own
+  scripts and resources so installation immediately enables useful work.
+- Local control plugins, such as Browser and Chrome, bundle runtime scripts,
+  docs, assets, and host integration code.
+
+The current Remem plugin is different:
+
+```text
+Codex plugin -> skill + .mcp.json -> node wrapper -> system remem binary
+```
+
+If the machine has no compatible `remem` binary, the plugin cannot do the work
+it advertises. This creates a bad first-run experience and makes the plugin
+feel like an empty shell.
+
+## Goals
+
+- Installing the plugin alone should be enough to use manual memory features.
+- The plugin should not rely on `remem` being installed on `PATH`.
+- The plugin should manage a version-matched runtime under plugin-controlled
+  storage.
+- Existing global Remem installs should be detected and adopted only with an
+  explicit user choice.
+- Hook-based automatic capture should be opt-in and reviewable.
+- The design should keep local memory data local by default.
+- The design should support a future GUI dashboard through Apps SDK without
+  blocking the local runtime MVP.
+
+## Non-goals
+
+- Do not silently modify `~/.codex/config.toml` or `~/.codex/hooks.json` during
+  plugin installation.
+- Do not depend on a user-managed Homebrew, cargo, npm, or manual binary
+  install for the baseline plugin experience.
+- Do not make the Apps SDK app id a prerequisite for the local plugin runtime.
+- Do not ship destructive memory governance without dry-run and confirmation.
+
+## Architecture
+
+### Layer 1: Codex plugin package
+
+The package remains under `plugins/remem`:
+
+```text
+plugins/remem/
+  .codex-plugin/plugin.json
+  .mcp.json
+  README.md
+  assets/
+  hooks/hooks.json
+  scripts/
+    remem-mcp.js
+    remem-hook.js
+    remem-runtime.js
+    remem-download.js
+    remem-status.js
+  skills/remem/SKILL.md
+  runtimes/remem-releases.json
+```
+
+Responsibilities:
+
+- present Remem in the Codex plugin directory
+- expose Remem skill workflows
+- expose the Remem MCP server
+- manage runtime discovery, download, checksum validation, and version checks
+- provide optional plugin-bundled hooks for automatic memory capture
+
+### Layer 2: plugin-managed runtime
+
+The plugin should prefer a plugin-managed binary:
+
+```text
+$PLUGIN_DATA/bin/remem
+```
+
+Resolution order:
+
+1. `REMEM_BINARY`, for explicit development override only.
+2. `$PLUGIN_DATA/bin/remem`, installed by the plugin runtime manager.
+3. repository `target/release/remem`, for local checkout development.
+4. system `remem` on `PATH`, only as an adoptable external install.
+
+The default production path should be `PLUGIN_DATA`, not `PATH`. A stale
+system binary should be reported as an external install, not selected silently.
+
+Runtime metadata lives in:
+
+```text
+$PLUGIN_DATA/runtime.json
+```
+
+Example:
+
+```json
+{
+  "version": "0.5.17",
+  "schema": 34,
+  "source": "github-release",
+  "binary": "/Users/example/.codex/plugin-data/remem/bin/remem",
+  "installed_at": "2026-06-11T00:00:00Z",
+  "sha256": "..."
+}
+```
+
+### Layer 3: MCP server
+
+The plugin MCP wrapper should guarantee that `remem mcp` starts with a
+version-matched runtime.
+
+Startup behavior:
+
+1. Read plugin version from `.codex-plugin/plugin.json`.
+2. Resolve or install a matching runtime.
+3. Run `remem doctor --json` and `remem status --json` when requested by tools,
+   not on every MCP startup.
+4. Start `remem mcp` over stdio.
+5. Fail closed with a structured message if runtime installation or checksum
+   validation fails.
+
+The existing Rust MCP tools remain the core model interface:
+
+- `search`
+- `get_observations`
+- `search_raw`
+- `current_state`
+- `timeline`
+- `lookup_commit`
+- `commits_for_session`
+- `save_memory`
+- `govern_memory`
+- `timeline_report`
+- `workstreams`
+- `update_workstream`
+
+Add plugin-facing utility tools or commands:
+
+- `plugin_status`: show runtime, data, hook, and schema state
+- `ensure_runtime`: install or repair the plugin-managed runtime
+- `activation_plan`: show hook changes before activation
+- `activate_hooks`: enable automatic capture after explicit approval
+
+### Layer 4: hooks
+
+Automatic memory capture should use plugin-bundled hooks where possible:
+
+```text
+plugins/remem/hooks/hooks.json
+```
+
+The hook commands should call a plugin script, not a global binary:
+
+```text
+node ${PLUGIN_ROOT}/scripts/remem-hook.js session-start
+node ${PLUGIN_ROOT}/scripts/remem-hook.js stop
+```
+
+`remem-hook.js` resolves the plugin-managed runtime and then delegates to:
+
+```text
+remem session-init
+remem summarize
+```
+
+Important behavior:
+
+- Plugin hooks are not trusted automatically. The user must review and trust
+  the current hook definition before they run.
+- The first-run UI and skill should explain this explicitly.
+- If hooks are not trusted, manual MCP tools still work.
+- Hook failures must be visible in `plugin_status` and `doctor --json`.
+
+This removes the need for the plugin to edit global Codex hook config for the
+common path. The existing `remem install --target codex` path can remain as a
+legacy or advanced installation mode.
+
+### Layer 5: Apps SDK GUI
+
+The GUI is a separate Apps SDK app surface. It should not block the local
+runtime MVP.
+
+Proposed layout:
+
+```text
+apps/remem/
+  package.json
+  src/server.ts
+  src/tools/
+  src/ui/
+  src/remem-client.ts
+```
+
+The Apps SDK server provides:
+
+- HTTP MCP endpoint at `/mcp`
+- tool descriptors for Remem operations
+- iframe UI resources
+- structured tool results for the model
+- `_meta` data for the widget
+
+Codex plugin integration adds `.app.json` only after an app or connector id
+exists:
+
+```json
+{
+  "apps": {
+    "remem": {
+      "id": "asdk_app_..."
+    }
+  }
+}
+```
+
+The local plugin runtime and the Apps SDK app can share the same Rust backend.
+The GUI should call structured APIs, not parse human CLI output.
+
+## First-run experience
+
+### Fresh machine, no Remem installed
+
+1. User installs Remem plugin from Codex.
+2. User starts a new Codex thread.
+3. User asks `@remem status` or invokes Remem.
+4. Plugin reports `runtime_missing`.
+5. User approves runtime installation.
+6. Plugin downloads a platform-specific Remem binary, verifies checksum, and
+   stores it in `$PLUGIN_DATA/bin/remem`.
+7. Plugin initializes local data directory.
+8. Manual MCP tools work immediately.
+9. Plugin offers optional hook trust for automatic capture.
+
+### Existing Remem install
+
+1. Plugin detects system `remem`.
+2. If the version matches, it offers to adopt the existing install.
+3. If the version is stale, it defaults to plugin-managed runtime and reports
+   the stale system path.
+4. It never silently chooses a mismatched binary.
+
+### Hook activation
+
+1. User asks to enable automatic memory.
+2. Plugin shows an activation plan.
+3. User reviews hook definitions in Codex.
+4. After trust, SessionStart and Stop hooks run through `remem-hook.js`.
+5. `plugin_status` reports hooks as active/trusted.
+
+## GUI product design
+
+The Apps SDK GUI should expose the parts of Remem that users need to inspect
+and control, not just a marketing panel.
+
+### Dashboard
+
+- runtime version and schema version
+- database path and active project
+- memory count, observation count, raw archive count
+- pending queue health
+- worker state
+- hook trust and activation state
+- stale binary or duplicate install warnings
+
+### Search
+
+- query box
+- project filter
+- branch filter
+- memory type filter
+- include stale toggle
+- multi-hop toggle
+- compact result list
+- detail panel using `get_observations`
+- raw archive fallback section clearly marked as recall evidence
+
+### Save
+
+- title
+- memory text
+- type
+- project
+- topic key
+- scope
+- branch
+- related files
+- local-copy status
+- claim status
+- result verification link
+
+### Governance
+
+- selected memory IDs
+- action: stale, reject, delete
+- dry-run preview
+- explicit reason
+- destructive confirmation
+- audit result
+
+### Workstreams
+
+- active, paused, completed, abandoned filters
+- next action and blockers
+- status update action
+
+### Timeline
+
+- project timeline report
+- anchor/query timeline
+- commit lookup
+- session-to-commit links
+
+## Security and trust
+
+- Runtime downloads require pinned version metadata and SHA-256 verification.
+- Checksum mismatch is fatal.
+- No hardcoded credentials.
+- Local database paths must stay local unless the user explicitly exports or
+  shares data.
+- Governance mutations require dry-run first and explicit confirmation for the
+  actual mutation.
+- Hook activation requires explicit user trust.
+- Plugin-managed runtime should not shadow `PATH` globally.
+- App UI must not expose raw archive content by default without user action,
+  because raw chat history can contain sensitive information.
+
+## Implementation plan
+
+### Phase 0: current wrapper
+
+Already implemented in the draft plugin:
+
+- plugin manifest
+- repo marketplace entry
+- Remem skill
+- `.mcp.json`
+- node wrapper for `remem mcp`
+- explicit activation script
+- stale binary guard
+
+This phase is useful for local development but not sufficient as the final
+plugin product.
+
+### Phase 1: self-contained local runtime
+
+Deliverables:
+
+- `scripts/remem-runtime.js`
+- `scripts/remem-download.js`
+- `$PLUGIN_DATA/bin/remem` install path
+- `runtimes/remem-releases.json` with platform artifacts and checksums
+- `plugin_status` and `ensure_runtime` flow
+- tests using temp `PLUGIN_DATA` and empty `PATH`
+
+Acceptance:
+
+- With no `remem` on `PATH`, installing the plugin and invoking `@remem status`
+  can install or repair a runtime.
+- The plugin does not select stale system binaries silently.
+- MCP starts from the plugin-managed runtime.
+
+### Phase 2: plugin-bundled hooks
+
+Deliverables:
+
+- `hooks/hooks.json`
+- `scripts/remem-hook.js`
+- hook trust/status reporting
+- migration guidance from global `remem install --target codex`
+
+Acceptance:
+
+- Manual MCP works without hook trust.
+- Automatic SessionStart/Stop works after hook trust.
+- Hook commands resolve the plugin-managed runtime.
+- No silent global config edits are required for the normal path.
+
+### Phase 3: Apps SDK GUI
+
+Deliverables:
+
+- `apps/remem` app server
+- HTTP MCP endpoint
+- dashboard/search/save/governance UI
+- structured tool results and widget `_meta`
+- developer-mode smoke test
+
+Acceptance:
+
+- App tools list in MCP Inspector or ChatGPT Developer Mode.
+- Dashboard renders with local Remem status.
+- Search, detail, save, and governance dry-run work end to end.
+- `.app.json` is added only after the app id exists.
+
+### Phase 4: distribution
+
+Deliverables:
+
+- signed or checksummed release artifacts
+- marketplace metadata
+- icons and screenshots
+- privacy and security notes
+- upgrade flow
+
+Acceptance:
+
+- Fresh install works without a preinstalled `remem`.
+- Upgrade replaces the plugin-managed runtime safely.
+- Existing user data is preserved.
+
+## Testing matrix
+
+| Scenario | Expected result |
+| --- | --- |
+| Empty machine, no `remem` on `PATH` | plugin installs runtime into `PLUGIN_DATA` |
+| Stale system binary on `PATH` | plugin reports stale binary and uses managed runtime |
+| Matching system binary exists | plugin can adopt it after explicit choice |
+| Offline runtime install | plugin reports actionable offline error |
+| Checksum mismatch | install fails closed |
+| Manual MCP without hooks | search/save/status work |
+| Hooks untrusted | automatic capture does not run, manual MCP still works |
+| Hooks trusted | SessionStart injection and Stop summarization work |
+| Governance mutation without dry-run/reason | rejected |
+| Apps SDK app without app id | app remains local developer-mode only |
+
+## Required verification
+
+For implementation PRs:
+
+```bash
+python3 /Users/lifcc/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/remem
+cargo check
+cargo test
+```
+
+For plugin runtime tests:
+
+```bash
+PLUGIN_DATA="$(mktemp -d)" PATH="/usr/bin:/bin" node plugins/remem/scripts/remem-runtime.js status
+PLUGIN_DATA="$(mktemp -d)" PATH="/usr/bin:/bin" node plugins/remem/scripts/remem-mcp.js --self-test
+```
+
+For Apps SDK tests:
+
+```bash
+cd apps/remem
+npm test
+npm run build
+```
+
+Then run MCP Inspector or ChatGPT Developer Mode against the local `/mcp`
+endpoint.
+
+## Key decisions
+
+- The final plugin should be plugin-managed by default, not PATH-managed.
+- Existing `remem install --target codex` remains a supported advanced path,
+  but it is not the primary plugin experience.
+- Automatic capture uses trusted plugin-bundled hooks where Codex supports
+  them.
+- Apps SDK GUI is a later layer and must not block manual memory usefulness.
+- `.app.json` should not be added until a real app or connector id exists.

--- a/docs/spec-codex-plugin-complete-design.md
+++ b/docs/spec-codex-plugin-complete-design.md
@@ -373,12 +373,11 @@ plugin product.
 
 Deliverables:
 
-- `scripts/remem-runtime.js`
-- `scripts/remem-download.js`
-- `$PLUGIN_DATA/bin/remem` install path
-- `runtimes/remem-releases.json` with platform artifacts and checksums
-- `plugin_status` and `ensure_runtime` flow
-- tests using temp `PLUGIN_DATA` and empty `PATH`
+- `scripts/remem-runtime.js` for runtime status, install, and path resolution
+- `$PLUGIN_DATA/bin/remem` or `REMEM_PLUGIN_DATA/bin/remem` install path
+- local checkout adoption from `target/release/remem` or `target/debug/remem`
+- `runtimes/remem-releases.json` for future platform artifacts and checksums
+- tests using temp plugin data and isolated `PATH`
 
 Acceptance:
 
@@ -386,6 +385,8 @@ Acceptance:
   can install or repair a runtime.
 - The plugin does not select stale system binaries silently.
 - MCP starts from the plugin-managed runtime.
+- Release download remains checksum-gated; if no manifest entry exists for the
+  plugin version, the installer fails closed with an actionable message.
 
 ### Phase 2: plugin-bundled hooks
 
@@ -466,6 +467,7 @@ For plugin runtime tests:
 ```bash
 PLUGIN_DATA="$(mktemp -d)" PATH="/usr/bin:/bin" node plugins/remem/scripts/remem-runtime.js status
 PLUGIN_DATA="$(mktemp -d)" PATH="/usr/bin:/bin" node plugins/remem/scripts/remem-mcp.js --self-test
+node --test plugins/remem/scripts/remem-runtime.test.js
 ```
 
 For Apps SDK tests:

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "remem",
+  "version": "0.5.17",
+  "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
+  "author": {
+    "name": "majiayu000",
+    "url": "https://github.com/majiayu000"
+  },
+  "homepage": "https://github.com/majiayu000/remem",
+  "repository": "https://github.com/majiayu000/remem",
+  "license": "MIT",
+  "keywords": ["codex", "memory", "mcp", "remem"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Remem",
+    "shortDescription": "Persistent project memory for Codex",
+    "longDescription": "Remem lets Codex search, save, govern, and activate project memory through the remem MCP server. Automatic context injection and Stop summarization stay behind an explicit activation script.",
+    "developerName": "majiayu000",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://github.com/majiayu000/remem",
+    "defaultPrompt": [
+      "Search remem for prior project context",
+      "Save this decision to remem",
+      "Activate remem hooks for Codex"
+    ]
+  }
+}

--- a/plugins/remem/.mcp.json
+++ b/plugins/remem/.mcp.json
@@ -1,9 +1,8 @@
 {
   "mcpServers": {
     "remem": {
-      "cwd": ".",
       "command": "node",
-      "args": ["./scripts/remem-mcp.js"],
+      "args": ["${PLUGIN_ROOT}/scripts/remem-mcp.js"],
       "note": "Starts `remem mcp` through the plugin runtime manager. Set REMEM_BINARY to an absolute remem binary path only for explicit local debugging."
     }
   }

--- a/plugins/remem/.mcp.json
+++ b/plugins/remem/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "remem": {
+      "cwd": ".",
+      "command": "node",
+      "args": ["./scripts/remem-mcp.js"],
+      "note": "Starts `remem mcp`. Set REMEM_BINARY to an absolute remem binary path to override auto-detection."
+    }
+  }
+}

--- a/plugins/remem/.mcp.json
+++ b/plugins/remem/.mcp.json
@@ -4,7 +4,7 @@
       "cwd": ".",
       "command": "node",
       "args": ["./scripts/remem-mcp.js"],
-      "note": "Starts `remem mcp`. Set REMEM_BINARY to an absolute remem binary path to override auto-detection."
+      "note": "Starts `remem mcp` through the plugin runtime manager. Set REMEM_BINARY to an absolute remem binary path only for explicit local debugging."
     }
   }
 }

--- a/plugins/remem/README.md
+++ b/plugins/remem/README.md
@@ -50,6 +50,10 @@ release manifest exists for the plugin version, fresh installs outside a local
 checkout must provide `REMEM_BINARY` or use a published plugin build that
 includes checked runtime assets.
 
+Plugin MCP startup leaves the server cwd as the active Codex workspace. The
+wrapper is invoked by plugin-root path so repo-scoped memory operations can use
+the caller workspace instead of the plugin checkout.
+
 ## Hook Activation
 
 MCP tools work without hook activation. To enable automatic memory injection and Stop summarization for Codex:
@@ -64,7 +68,8 @@ remem status
 The activation script delegates to:
 
 ```bash
-remem install --target codex
+remem install --target codex --hooks-only
 ```
 
-That command updates `~/.codex/config.toml`, `~/.codex/hooks.json`, and `~/.remem/config.toml`.
+That command enables Codex hooks without adding another global `remem` MCP
+server entry, because the plugin already provides MCP through `.mcp.json`.

--- a/plugins/remem/README.md
+++ b/plugins/remem/README.md
@@ -4,10 +4,11 @@ This directory contains a local Codex plugin wrapper for remem.
 
 The plugin exposes `remem mcp` to Codex and provides a Remem skill for retrieval, saving, governance, and activation workflows. It does not silently install hooks. Automatic SessionStart context injection and Stop summarization require an explicit activation step.
 
-This is a development foundation, not the final plugin experience. A complete
-plugin should manage its own version-matched remem runtime under plugin storage
-and should work even when the user has not installed remem separately. See
-`../../docs/spec-codex-plugin-complete-design.md` for the target design.
+This is a development foundation, not the final Apps SDK GUI experience. The
+plugin now manages a version-matched local runtime under plugin storage for
+local checkout testing, so it no longer needs to select a stale `remem` from
+`PATH`. See `../../docs/spec-codex-plugin-complete-design.md` for the target
+design.
 
 ## Local Install
 
@@ -20,24 +21,34 @@ codex plugin add remem@remem-local
 
 Start a new Codex thread after installing the plugin.
 
-## Binary Resolution
+## Runtime Resolution
 
-The MCP wrapper looks for the remem binary in this order:
+The MCP wrapper resolves the remem runtime in this order:
 
 1. `REMEM_BINARY`
-2. `target/release/remem`
-3. `target/debug/remem`
-4. `remem` on `PATH`
+2. `PLUGIN_DATA/bin/remem` or `REMEM_PLUGIN_DATA/bin/remem`
+3. `target/release/remem`
+4. `target/debug/remem`
+5. `remem` on `PATH`, reported but not silently adopted
 
+When a matching repo binary exists, the runtime manager copies it into plugin
+storage. PATH binaries are never adopted silently; use `REMEM_BINARY` for
+explicit development overrides or `--adopt-path` for a deliberate local copy.
 By default, the selected binary must report the same version as the plugin
-manifest. Set `REMEM_ALLOW_VERSION_MISMATCH=1` only for explicit local
-debugging.
+manifest. Set `REMEM_ALLOW_VERSION_MISMATCH=1` only for explicit local debugging.
 
 Build from source when testing directly from this repository:
 
 ```bash
 cargo build --release
+node plugins/remem/scripts/remem-runtime.js install
+node plugins/remem/scripts/remem-runtime.js status
 ```
+
+Release download support is intentionally checksum-gated. Until a matching
+release manifest exists for the plugin version, fresh installs outside a local
+checkout must provide `REMEM_BINARY` or use a published plugin build that
+includes checked runtime assets.
 
 ## Hook Activation
 

--- a/plugins/remem/README.md
+++ b/plugins/remem/README.md
@@ -4,6 +4,11 @@ This directory contains a local Codex plugin wrapper for remem.
 
 The plugin exposes `remem mcp` to Codex and provides a Remem skill for retrieval, saving, governance, and activation workflows. It does not silently install hooks. Automatic SessionStart context injection and Stop summarization require an explicit activation step.
 
+This is a development foundation, not the final plugin experience. A complete
+plugin should manage its own version-matched remem runtime under plugin storage
+and should work even when the user has not installed remem separately. See
+`../../docs/spec-codex-plugin-complete-design.md` for the target design.
+
 ## Local Install
 
 From the repository root:

--- a/plugins/remem/README.md
+++ b/plugins/remem/README.md
@@ -1,0 +1,54 @@
+# Remem Codex Plugin
+
+This directory contains a local Codex plugin wrapper for remem.
+
+The plugin exposes `remem mcp` to Codex and provides a Remem skill for retrieval, saving, governance, and activation workflows. It does not silently install hooks. Automatic SessionStart context injection and Stop summarization require an explicit activation step.
+
+## Local Install
+
+From the repository root:
+
+```bash
+codex plugin marketplace add .
+codex plugin add remem@remem-local
+```
+
+Start a new Codex thread after installing the plugin.
+
+## Binary Resolution
+
+The MCP wrapper looks for the remem binary in this order:
+
+1. `REMEM_BINARY`
+2. `target/release/remem`
+3. `target/debug/remem`
+4. `remem` on `PATH`
+
+By default, the selected binary must report the same version as the plugin
+manifest. Set `REMEM_ALLOW_VERSION_MISMATCH=1` only for explicit local
+debugging.
+
+Build from source when testing directly from this repository:
+
+```bash
+cargo build --release
+```
+
+## Hook Activation
+
+MCP tools work without hook activation. To enable automatic memory injection and Stop summarization for Codex:
+
+```bash
+node plugins/remem/scripts/activate-codex.js --dry-run
+node plugins/remem/scripts/activate-codex.js
+remem doctor
+remem status
+```
+
+The activation script delegates to:
+
+```bash
+remem install --target codex
+```
+
+That command updates `~/.codex/config.toml`, `~/.codex/hooks.json`, and `~/.remem/config.toml`.

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,0 +1,8 @@
+{
+  "versions": {
+    "0.5.17": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.17",
+      "assets": {}
+    }
+  }
+}

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.17": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.17",
+    "0.5.18": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.18",
       "assets": {}
     }
   }

--- a/plugins/remem/scripts/activate-codex.js
+++ b/plugins/remem/scripts/activate-codex.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+"use strict";
+
+const { runRemem } = require("./remem-binary");
+
+try {
+  const extraArgs = process.argv.slice(2);
+  process.exit(runRemem(["install", "--target", "codex", ...extraArgs]));
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+}

--- a/plugins/remem/scripts/activate-codex.js
+++ b/plugins/remem/scripts/activate-codex.js
@@ -5,7 +5,7 @@ const { runRemem } = require("./remem-binary");
 
 try {
   const extraArgs = process.argv.slice(2);
-  process.exit(runRemem(["install", "--target", "codex", ...extraArgs]));
+  process.exit(runRemem(["install", "--target", "codex", "--hooks-only", ...extraArgs]));
 } catch (error) {
   process.stderr.write(`${error.message}\n`);
   process.exit(1);

--- a/plugins/remem/scripts/activate-codex.js
+++ b/plugins/remem/scripts/activate-codex.js
@@ -1,12 +1,20 @@
 #!/usr/bin/env node
 "use strict";
 
-const { runRemem } = require("./remem-binary");
+const { runRememAsync } = require("./remem-runtime");
 
-try {
+async function main() {
   const extraArgs = process.argv.slice(2);
-  process.exit(runRemem(["install", "--target", "codex", "--hooks-only", ...extraArgs]));
-} catch (error) {
-  process.stderr.write(`${error.message}\n`);
-  process.exit(1);
+  const dryRun = extraArgs.includes("--dry-run");
+  return runRememAsync(["install", "--target", "codex", "--hooks-only", ...extraArgs], {
+    allowDownload: !dryRun,
+    adoptLocal: !dryRun
+  });
 }
+
+main()
+  .then((status) => process.exit(status))
+  .catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  });

--- a/plugins/remem/scripts/remem-binary.js
+++ b/plugins/remem/scripts/remem-binary.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const VERSION_RE = /remem\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s]+)?)\s+\(schema v([0-9]+)\)/;
+
+function isExecutable(candidate) {
+  if (!candidate) return false;
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function pluginRoot() {
+  return path.resolve(__dirname, "..");
+}
+
+function expectedVersion() {
+  const manifestPath = path.join(pluginRoot(), ".codex-plugin", "plugin.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (!manifest.version) {
+    throw new Error(`Plugin manifest is missing version: ${manifestPath}`);
+  }
+  return manifest.version;
+}
+
+function inspectVersion(candidate) {
+  const result = spawnSync(candidate, ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 3000
+  });
+  if (result.error) {
+    return {
+      ok: false,
+      reason: result.error.message
+    };
+  }
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      reason: (result.stderr || result.stdout || `exit ${result.status}`).trim()
+    };
+  }
+  const output = (result.stdout || result.stderr || "").trim();
+  const match = VERSION_RE.exec(output);
+  if (!match) {
+    return {
+      ok: false,
+      reason: `unexpected version output: ${output}`
+    };
+  }
+  return {
+    ok: true,
+    version: match[1],
+    schemaVersion: Number(match[2]),
+    output
+  };
+}
+
+function pathCandidates() {
+  const names = process.platform === "win32" ? ["remem.exe", "remem"] : ["remem"];
+  return (process.env.PATH || "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .flatMap((dir) => names.map((name) => path.join(dir, name)));
+}
+
+function repoCandidates() {
+  const repoRoot = path.resolve(pluginRoot(), "..", "..");
+  return [
+    path.join(repoRoot, "target", "release", process.platform === "win32" ? "remem.exe" : "remem"),
+    path.join(repoRoot, "target", "debug", process.platform === "win32" ? "remem.exe" : "remem")
+  ];
+}
+
+function findRememBinary() {
+  const expected = expectedVersion();
+  const allowMismatch = process.env.REMEM_ALLOW_VERSION_MISMATCH === "1";
+  const explicit = process.env.REMEM_BINARY;
+  if (explicit) {
+    if (!isExecutable(explicit)) {
+      throw new Error(`REMEM_BINARY is set but is not executable: ${explicit}`);
+    }
+    const version = inspectVersion(explicit);
+    if (allowMismatch || (version.ok && version.version === expected)) return explicit;
+    throw new Error(versionMismatchMessage(explicit, expected, version));
+  }
+
+  const rejected = [];
+  for (const candidate of [...repoCandidates(), ...pathCandidates()]) {
+    if (!isExecutable(candidate)) continue;
+    const version = inspectVersion(candidate);
+    if (allowMismatch || (version.ok && version.version === expected)) return candidate;
+    rejected.push(versionMismatchMessage(candidate, expected, version));
+  }
+
+  throw new Error(
+    [
+      `Unable to find remem ${expected}.`,
+      "Build the matching binary with `cargo build --release`, install the same remem version on PATH,",
+      "or set REMEM_BINARY=/absolute/path/to/remem.",
+      "Set REMEM_ALLOW_VERSION_MISMATCH=1 only for explicit local debugging.",
+      rejected.length ? `Rejected candidates: ${rejected.join(" | ")}` : "No executable candidates were found."
+    ].join(" ")
+  );
+}
+
+function versionMismatchMessage(candidate, expected, version) {
+  if (!version.ok) {
+    return `${candidate}: ${version.reason}`;
+  }
+  return `${candidate}: found remem ${version.version} (schema v${version.schemaVersion}), expected ${expected}`;
+}
+
+function runRemem(args, options = {}) {
+  const bin = findRememBinary();
+  const result = spawnSync(bin, args, {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      REMEM_PLUGIN_ROOT: pluginRoot()
+    },
+    ...options
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  return result.status === null ? 1 : result.status;
+}
+
+module.exports = {
+  findRememBinary,
+  runRemem
+};
+
+if (require.main === module) {
+  try {
+    process.exit(runRemem(process.argv.slice(2)));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
+}

--- a/plugins/remem/scripts/remem-binary.js
+++ b/plugins/remem/scripts/remem-binary.js
@@ -1,143 +1,31 @@
 #!/usr/bin/env node
 "use strict";
 
-const fs = require("node:fs");
-const path = require("node:path");
-const { spawnSync } = require("node:child_process");
-
-const VERSION_RE = /remem\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s]+)?)\s+\(schema v([0-9]+)\)/;
-
-function isExecutable(candidate) {
-  if (!candidate) return false;
-  try {
-    fs.accessSync(candidate, fs.constants.X_OK);
-    return true;
-  } catch (_error) {
-    return false;
-  }
-}
-
-function pluginRoot() {
-  return path.resolve(__dirname, "..");
-}
-
-function expectedVersion() {
-  const manifestPath = path.join(pluginRoot(), ".codex-plugin", "plugin.json");
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-  if (!manifest.version) {
-    throw new Error(`Plugin manifest is missing version: ${manifestPath}`);
-  }
-  return manifest.version;
-}
-
-function inspectVersion(candidate) {
-  const result = spawnSync(candidate, ["--version"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: 3000
-  });
-  if (result.error) {
-    return {
-      ok: false,
-      reason: result.error.message
-    };
-  }
-  if (result.status !== 0) {
-    return {
-      ok: false,
-      reason: (result.stderr || result.stdout || `exit ${result.status}`).trim()
-    };
-  }
-  const output = (result.stdout || result.stderr || "").trim();
-  const match = VERSION_RE.exec(output);
-  if (!match) {
-    return {
-      ok: false,
-      reason: `unexpected version output: ${output}`
-    };
-  }
-  return {
-    ok: true,
-    version: match[1],
-    schemaVersion: Number(match[2]),
-    output
-  };
-}
-
-function pathCandidates() {
-  const names = process.platform === "win32" ? ["remem.exe", "remem"] : ["remem"];
-  return (process.env.PATH || "")
-    .split(path.delimiter)
-    .filter(Boolean)
-    .flatMap((dir) => names.map((name) => path.join(dir, name)));
-}
-
-function repoCandidates() {
-  const repoRoot = path.resolve(pluginRoot(), "..", "..");
-  return [
-    path.join(repoRoot, "target", "release", process.platform === "win32" ? "remem.exe" : "remem"),
-    path.join(repoRoot, "target", "debug", process.platform === "win32" ? "remem.exe" : "remem")
-  ];
-}
+const {
+  ensureRuntimeSync,
+  expectedVersion,
+  inspectVersion,
+  isExecutable,
+  pathCandidates,
+  pluginRoot,
+  repoCandidates,
+  runRemem,
+  versionMismatchMessage
+} = require("./remem-runtime");
 
 function findRememBinary() {
-  const expected = expectedVersion();
-  const allowMismatch = process.env.REMEM_ALLOW_VERSION_MISMATCH === "1";
-  const explicit = process.env.REMEM_BINARY;
-  if (explicit) {
-    if (!isExecutable(explicit)) {
-      throw new Error(`REMEM_BINARY is set but is not executable: ${explicit}`);
-    }
-    const version = inspectVersion(explicit);
-    if (allowMismatch || (version.ok && version.version === expected)) return explicit;
-    throw new Error(versionMismatchMessage(explicit, expected, version));
-  }
-
-  const rejected = [];
-  for (const candidate of [...repoCandidates(), ...pathCandidates()]) {
-    if (!isExecutable(candidate)) continue;
-    const version = inspectVersion(candidate);
-    if (allowMismatch || (version.ok && version.version === expected)) return candidate;
-    rejected.push(versionMismatchMessage(candidate, expected, version));
-  }
-
-  throw new Error(
-    [
-      `Unable to find remem ${expected}.`,
-      "Build the matching binary with `cargo build --release`, install the same remem version on PATH,",
-      "or set REMEM_BINARY=/absolute/path/to/remem.",
-      "Set REMEM_ALLOW_VERSION_MISMATCH=1 only for explicit local debugging.",
-      rejected.length ? `Rejected candidates: ${rejected.join(" | ")}` : "No executable candidates were found."
-    ].join(" ")
-  );
-}
-
-function versionMismatchMessage(candidate, expected, version) {
-  if (!version.ok) {
-    return `${candidate}: ${version.reason}`;
-  }
-  return `${candidate}: found remem ${version.version} (schema v${version.schemaVersion}), expected ${expected}`;
-}
-
-function runRemem(args, options = {}) {
-  const bin = findRememBinary();
-  const result = spawnSync(bin, args, {
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      REMEM_PLUGIN_ROOT: pluginRoot()
-    },
-    ...options
-  });
-
-  if (result.error) {
-    throw result.error;
-  }
-  return result.status === null ? 1 : result.status;
+  return ensureRuntimeSync();
 }
 
 module.exports = {
+  expectedVersion,
   findRememBinary,
+  inspectVersion,
+  isExecutable,
+  pathCandidates,
+  pluginRoot,
+  repoCandidates,
+  versionMismatchMessage,
   runRemem
 };
 

--- a/plugins/remem/scripts/remem-mcp.js
+++ b/plugins/remem/scripts/remem-mcp.js
@@ -2,20 +2,24 @@
 "use strict";
 
 const { inspectVersion } = require("./remem-binary");
-const { ensureRuntimeSync, runRemem } = require("./remem-runtime");
+const { ensureRuntime, runRememAsync } = require("./remem-runtime");
 
-try {
+async function main() {
   if (process.argv.includes("--self-test")) {
-    const bin = ensureRuntimeSync();
+    const bin = await ensureRuntime();
     const version = inspectVersion(bin);
     if (!version.ok) {
       throw new Error(version.reason);
     }
     process.stdout.write(`${version.output}\n`);
-    process.exit(0);
+    return 0;
   }
-  process.exit(runRemem(["mcp"]));
-} catch (error) {
-  process.stderr.write(`${error.message}\n`);
-  process.exit(1);
+  return runRememAsync(["mcp"]);
 }
+
+main()
+  .then((status) => process.exit(status))
+  .catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  });

--- a/plugins/remem/scripts/remem-mcp.js
+++ b/plugins/remem/scripts/remem-mcp.js
@@ -1,9 +1,19 @@
 #!/usr/bin/env node
 "use strict";
 
-const { runRemem } = require("./remem-binary");
+const { inspectVersion } = require("./remem-binary");
+const { ensureRuntimeSync, runRemem } = require("./remem-runtime");
 
 try {
+  if (process.argv.includes("--self-test")) {
+    const bin = ensureRuntimeSync();
+    const version = inspectVersion(bin);
+    if (!version.ok) {
+      throw new Error(version.reason);
+    }
+    process.stdout.write(`${version.output}\n`);
+    process.exit(0);
+  }
   process.exit(runRemem(["mcp"]));
 } catch (error) {
   process.stderr.write(`${error.message}\n`);

--- a/plugins/remem/scripts/remem-mcp.js
+++ b/plugins/remem/scripts/remem-mcp.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+"use strict";
+
+const { runRemem } = require("./remem-binary");
+
+try {
+  process.exit(runRemem(["mcp"]));
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+}

--- a/plugins/remem/scripts/remem-runtime.js
+++ b/plugins/remem/scripts/remem-runtime.js
@@ -181,14 +181,40 @@ function versionMismatchMessage(candidate, expected, version) {
   return `${candidate}: found remem ${version.version} (schema v${version.schemaVersion}), expected ${expected}`;
 }
 
+function shouldCodesignRuntime(options = {}) {
+  return (options.platformKey || platformKey()) === "darwin-arm64";
+}
+
+function codesignRuntimeIfNeeded(candidate, options = {}) {
+  if (!shouldCodesignRuntime(options)) return;
+  const result = spawnSync("codesign", ["--force", "--sign", "-", candidate], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 5000
+  });
+  if (result.error) {
+    throw new Error(`codesign failed for ${candidate}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const reason = (result.stderr || result.stdout || `exit ${result.status}`).trim();
+    throw new Error(`codesign failed for ${candidate}: ${reason}`);
+  }
+}
+
 function copyRuntime(source, options = {}) {
   const dest = managedBinaryPath(options);
   fs.mkdirSync(path.dirname(dest), { recursive: true, mode: 0o755 });
   fs.copyFileSync(source, dest);
   fs.chmodSync(dest, 0o755);
+  codesignRuntimeIfNeeded(dest, options);
   const version = inspectVersion(dest);
   if (!version.ok) {
     throw new Error(`Copied runtime is not executable: ${version.reason}`);
+  }
+  const expected = expectedVersion(options);
+  const allowMismatch = (options.env || process.env).REMEM_ALLOW_VERSION_MISMATCH === "1";
+  if (!allowMismatch && version.version !== expected) {
+    throw new Error(versionMismatchMessage(dest, expected, version));
   }
   const metadata = {
     version: version.version,
@@ -389,16 +415,45 @@ async function installRuntime(options = {}) {
   const matchingPath = status.candidates.find((candidate) => candidate.ok && candidate.source === "path");
   if (matchingPath && adoptPath) return copyRuntime(matchingPath.path, options).path;
 
+  if (!options.allowDownload) {
+    throw new Error(runtimeMissingMessage(status));
+  }
+
   return downloadRuntime(options).then((installed) => installed.path);
 }
 
-function runRemem(args, options = {}) {
-  const env = {
+function runtimeEnv(options = {}) {
+  return {
     ...process.env,
+    ...(options.env || {}),
     REMEM_PLUGIN_ROOT: pluginRoot(options),
     REMEM_PLUGIN_DATA: pluginDataDir(options)
   };
+}
+
+function runRemem(args, options = {}) {
+  const env = runtimeEnv(options);
   const bin = options.binary || fs.realpathSync(ensureRuntimeSync(options));
+  const result = spawnSync(bin, args, {
+    stdio: "inherit",
+    env,
+    ...options.spawnOptions
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  return result.status === null ? 1 : result.status;
+}
+
+async function runRememAsync(args, options = {}) {
+  const env = runtimeEnv(options);
+  const runtimeOptions = {
+    ...options,
+    allowDownload: options.allowDownload !== false
+  };
+  const resolved = options.binary || (await ensureRuntime(runtimeOptions));
+  const bin = fs.realpathSync(resolved);
   const result = spawnSync(bin, args, {
     stdio: "inherit",
     env,
@@ -479,10 +534,12 @@ async function main(argv) {
 module.exports = {
   binaryName,
   candidateEntries,
+  codesignRuntimeIfNeeded,
   copyRuntime,
   ensureRuntime,
   ensureRuntimeSync,
   expectedVersion,
+  installRuntime,
   inspectRuntime,
   inspectVersion,
   isExecutable,
@@ -493,7 +550,9 @@ module.exports = {
   repoCandidates,
   repoRoot,
   runRemem,
+  runRememAsync,
   runtimeMetadataPath,
+  shouldCodesignRuntime,
   versionMismatchMessage
 };
 

--- a/plugins/remem/scripts/remem-runtime.js
+++ b/plugins/remem/scripts/remem-runtime.js
@@ -1,0 +1,507 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const https = require("node:https");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const VERSION_RE = /remem\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s]+)?)\s+\(schema v([0-9]+)\)/;
+
+function binaryName() {
+  return process.platform === "win32" ? "remem.exe" : "remem";
+}
+
+function pluginRoot(options = {}) {
+  return path.resolve(options.pluginRoot || path.join(__dirname, ".."));
+}
+
+function repoRoot(options = {}) {
+  return path.resolve(options.repoRoot || path.join(pluginRoot(options), "..", ".."));
+}
+
+function expectedVersion(options = {}) {
+  if (options.expectedVersion) return options.expectedVersion;
+  const manifestPath = path.join(pluginRoot(options), ".codex-plugin", "plugin.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (!manifest.version) {
+    throw new Error(`Plugin manifest is missing version: ${manifestPath}`);
+  }
+  return manifest.version;
+}
+
+function defaultPluginDataDir() {
+  if (process.env.REMEM_PLUGIN_DATA) return process.env.REMEM_PLUGIN_DATA;
+  if (process.env.PLUGIN_DATA) return process.env.PLUGIN_DATA;
+  const home = os.homedir();
+  if (process.platform === "win32") {
+    return path.join(process.env.LOCALAPPDATA || home, "remem", "codex-plugin");
+  }
+  return path.join(home, ".remem", "codex-plugin");
+}
+
+function pluginDataDir(options = {}) {
+  return path.resolve(options.pluginData || defaultPluginDataDir());
+}
+
+function managedBinaryPath(options = {}) {
+  return path.join(pluginDataDir(options), "bin", binaryName());
+}
+
+function runtimeMetadataPath(options = {}) {
+  return path.join(pluginDataDir(options), "runtime.json");
+}
+
+function isExecutable(candidate) {
+  if (!candidate) return false;
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function inspectVersion(candidate) {
+  const result = spawnSync(candidate, ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 3000
+  });
+  if (result.error) {
+    return {
+      ok: false,
+      reason: result.error.message
+    };
+  }
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      reason: (result.stderr || result.stdout || `exit ${result.status}`).trim()
+    };
+  }
+  const output = (result.stdout || result.stderr || "").trim();
+  const match = VERSION_RE.exec(output);
+  if (!match) {
+    return {
+      ok: false,
+      reason: `unexpected version output: ${output}`
+    };
+  }
+  return {
+    ok: true,
+    version: match[1],
+    schemaVersion: Number(match[2]),
+    output
+  };
+}
+
+function pathCandidates(env = process.env) {
+  const names = process.platform === "win32" ? ["remem.exe", "remem"] : ["remem"];
+  return (env.PATH || "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .flatMap((dir) => names.map((name) => path.join(dir, name)));
+}
+
+function repoCandidates(options = {}) {
+  const root = repoRoot(options);
+  return [
+    path.join(root, "target", "release", binaryName()),
+    path.join(root, "target", "debug", binaryName())
+  ];
+}
+
+function candidateEntries(options = {}) {
+  const env = options.env || process.env;
+  const entries = [];
+  if (env.REMEM_BINARY) {
+    entries.push({ source: "explicit", path: env.REMEM_BINARY, adoptable: true });
+  }
+  entries.push({ source: "managed", path: managedBinaryPath(options), adoptable: true });
+  for (const candidate of repoCandidates(options)) {
+    entries.push({ source: "repo", path: candidate, adoptable: true });
+  }
+  for (const candidate of pathCandidates(env)) {
+    entries.push({ source: "path", path: candidate, adoptable: false });
+  }
+  return entries;
+}
+
+function inspectCandidate(entry, expected, allowMismatch) {
+  if (!isExecutable(entry.path)) {
+    return {
+      ...entry,
+      exists: fs.existsSync(entry.path),
+      executable: false,
+      ok: false,
+      reason: "not executable"
+    };
+  }
+  const version = inspectVersion(entry.path);
+  const versionOk = version.ok && (allowMismatch || version.version === expected);
+  return {
+    ...entry,
+    exists: true,
+    executable: true,
+    ok: versionOk,
+    version: version.version,
+    schemaVersion: version.schemaVersion,
+    output: version.output,
+    reason: versionOk ? undefined : versionMismatchMessage(entry.path, expected, version)
+  };
+}
+
+function inspectRuntime(options = {}) {
+  const expected = expectedVersion(options);
+  const allowMismatch = (options.env || process.env).REMEM_ALLOW_VERSION_MISMATCH === "1";
+  const candidates = candidateEntries(options).map((entry) =>
+    inspectCandidate(entry, expected, allowMismatch)
+  );
+  const selected = candidates.find((candidate) => candidate.ok && candidate.adoptable);
+  const pathMatch = candidates.find((candidate) => candidate.ok && !candidate.adoptable);
+  return {
+    expectedVersion: expected,
+    pluginRoot: pluginRoot(options),
+    pluginData: pluginDataDir(options),
+    managedBinary: managedBinaryPath(options),
+    metadataPath: runtimeMetadataPath(options),
+    selected,
+    pathMatch,
+    candidates
+  };
+}
+
+function versionMismatchMessage(candidate, expected, version) {
+  if (!version.ok) {
+    return `${candidate}: ${version.reason}`;
+  }
+  return `${candidate}: found remem ${version.version} (schema v${version.schemaVersion}), expected ${expected}`;
+}
+
+function copyRuntime(source, options = {}) {
+  const dest = managedBinaryPath(options);
+  fs.mkdirSync(path.dirname(dest), { recursive: true, mode: 0o755 });
+  fs.copyFileSync(source, dest);
+  fs.chmodSync(dest, 0o755);
+  const version = inspectVersion(dest);
+  if (!version.ok) {
+    throw new Error(`Copied runtime is not executable: ${version.reason}`);
+  }
+  const metadata = {
+    version: version.version,
+    schema: version.schemaVersion,
+    source: "local-copy",
+    source_path: source,
+    binary: dest,
+    installed_at: new Date().toISOString()
+  };
+  writeMetadata(metadata, options);
+  return {
+    path: dest,
+    version,
+    metadata
+  };
+}
+
+function writeMetadata(metadata, options = {}) {
+  const metadataPath = runtimeMetadataPath(options);
+  fs.mkdirSync(path.dirname(metadataPath), { recursive: true, mode: 0o755 });
+  fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, { mode: 0o600 });
+}
+
+function readReleaseManifest(options = {}) {
+  const manifestPath = path.join(pluginRoot(options), "runtimes", "remem-releases.json");
+  if (!fs.existsSync(manifestPath)) return null;
+  return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+}
+
+function platformKey() {
+  const platform = os.platform();
+  const arch = os.arch();
+  if (platform === "darwin" && arch === "arm64") return "darwin-arm64";
+  if (platform === "darwin" && arch === "x64") return "darwin-x64";
+  if (platform === "linux" && arch === "arm64") return "linux-arm64";
+  if (platform === "linux" && arch === "x64") return "linux-x64";
+  throw new Error(`Unsupported platform: ${platform}/${arch}`);
+}
+
+function releaseAssetForCurrentPlatform(options = {}) {
+  const manifest = readReleaseManifest(options);
+  if (!manifest) return null;
+  const expected = expectedVersion(options);
+  const release = manifest.versions && manifest.versions[expected];
+  if (!release) return null;
+  const asset = release.assets && release.assets[platformKey()];
+  if (!asset) return null;
+  const baseUrl = release.base_url || `https://github.com/majiayu000/remem/releases/download/v${expected}`;
+  return {
+    ...asset,
+    url: asset.url || `${baseUrl}/${asset.file}`
+  };
+}
+
+function download(url, dest, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if (
+        response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        response.headers.location
+      ) {
+        response.resume();
+        if (redirects >= 5) {
+          reject(new Error(`Too many redirects while downloading ${url}`));
+          return;
+        }
+        const next = new URL(response.headers.location, url).toString();
+        resolve(download(next, dest, redirects + 1));
+        return;
+      }
+
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`Download failed with HTTP ${response.statusCode}: ${url}`));
+        return;
+      }
+
+      const output = fs.createWriteStream(dest, { mode: 0o600 });
+      response.pipe(output);
+      output.on("finish", () => output.close(resolve));
+      output.on("error", reject);
+    });
+    request.on("error", reject);
+  });
+}
+
+function sha256(file) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(file));
+  return hash.digest("hex");
+}
+
+async function downloadRuntime(options = {}) {
+  const asset = releaseAssetForCurrentPlatform(options);
+  if (!asset) {
+    throw new Error(
+      `No checked release asset is available for remem ${expectedVersion(options)} on ${platformKey()}`
+    );
+  }
+  if (!asset.sha256 || !/^[0-9a-f]{64}$/i.test(asset.sha256)) {
+    throw new Error(`Release asset is missing a valid sha256: ${asset.file || asset.url}`);
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "remem-plugin-"));
+  const archive = path.join(tmpDir, asset.file || "remem.tar.gz");
+  const extractDir = path.join(tmpDir, "extract");
+  try {
+    await download(asset.url, archive);
+    const actual = sha256(archive);
+    if (actual !== asset.sha256) {
+      throw new Error(`Checksum mismatch for ${asset.file}: expected ${asset.sha256}, got ${actual}`);
+    }
+    fs.mkdirSync(extractDir, { recursive: true, mode: 0o755 });
+    const tar = spawnSync("tar", ["-xzf", archive, "-C", extractDir], {
+      stdio: "ignore"
+    });
+    if (tar.error) throw tar.error;
+    if (tar.status !== 0) throw new Error(`tar exited with status ${tar.status}`);
+    const extracted = path.join(extractDir, binaryName());
+    if (!isExecutable(extracted)) {
+      throw new Error(`Release archive did not contain executable ${binaryName()}`);
+    }
+    const installed = copyRuntime(extracted, options);
+    installed.metadata.source = "github-release";
+    installed.metadata.url = asset.url;
+    installed.metadata.sha256 = asset.sha256;
+    writeMetadata(installed.metadata, options);
+    return installed;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function ensureRuntime(options = {}) {
+  const status = inspectRuntime(options);
+  if (status.selected && status.selected.source === "managed") {
+    return status.selected.path;
+  }
+  if (status.selected && status.selected.source === "explicit") {
+    return status.selected.path;
+  }
+
+  const localCandidate = status.candidates.find(
+    (candidate) => candidate.ok && candidate.adoptable && candidate.source === "repo"
+  );
+  if (localCandidate) {
+    return copyRuntime(localCandidate.path, options).path;
+  }
+
+  if (options.allowDownload) {
+    const downloaded = await downloadRuntime(options);
+    return downloaded.path;
+  }
+
+  if (status.pathMatch) {
+    throw new Error(
+      [
+        `A matching remem ${status.expectedVersion} exists on PATH at ${status.pathMatch.path},`,
+        "but the plugin does not adopt PATH binaries silently.",
+        "Run `node plugins/remem/scripts/remem-runtime.js install --adopt-path` to copy it into plugin storage,",
+        "or set REMEM_BINARY explicitly for development."
+      ].join(" ")
+    );
+  }
+
+  throw new Error(runtimeMissingMessage(status));
+}
+
+function runtimeMissingMessage(status) {
+  const rejected = status.candidates
+    .filter((candidate) => candidate.executable && !candidate.ok)
+    .map((candidate) => candidate.reason)
+    .filter(Boolean);
+  return [
+    `Unable to find plugin-managed remem ${status.expectedVersion}.`,
+    `Plugin data: ${status.pluginData}.`,
+    "Build this checkout with `cargo build --release`, then run `node plugins/remem/scripts/remem-runtime.js install`,",
+    "or publish checked release assets in `plugins/remem/runtimes/remem-releases.json`.",
+    rejected.length ? `Rejected candidates: ${rejected.join(" | ")}` : "No executable candidates were found."
+  ].join(" ");
+}
+
+async function installRuntime(options = {}) {
+  const status = inspectRuntime(options);
+  const adoptPath = options.adoptPath === true;
+  const matchingManaged = status.candidates.find(
+    (candidate) => candidate.ok && candidate.source === "managed"
+  );
+  if (matchingManaged && !options.force) return matchingManaged.path;
+
+  const explicit = status.candidates.find((candidate) => candidate.ok && candidate.source === "explicit");
+  if (explicit) return copyRuntime(explicit.path, options).path;
+
+  const local = status.candidates.find((candidate) => candidate.ok && candidate.source === "repo");
+  if (local) return copyRuntime(local.path, options).path;
+
+  const matchingPath = status.candidates.find((candidate) => candidate.ok && candidate.source === "path");
+  if (matchingPath && adoptPath) return copyRuntime(matchingPath.path, options).path;
+
+  return downloadRuntime(options).then((installed) => installed.path);
+}
+
+function runRemem(args, options = {}) {
+  const env = {
+    ...process.env,
+    REMEM_PLUGIN_ROOT: pluginRoot(options),
+    REMEM_PLUGIN_DATA: pluginDataDir(options)
+  };
+  const bin = options.binary || fs.realpathSync(ensureRuntimeSync(options));
+  const result = spawnSync(bin, args, {
+    stdio: "inherit",
+    env,
+    ...options.spawnOptions
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  return result.status === null ? 1 : result.status;
+}
+
+function ensureRuntimeSync(options = {}) {
+  const status = inspectRuntime(options);
+  if (status.selected && ["managed", "explicit"].includes(status.selected.source)) {
+    return status.selected.path;
+  }
+  const localCandidate = status.candidates.find(
+    (candidate) => candidate.ok && candidate.adoptable && candidate.source === "repo"
+  );
+  if (localCandidate) {
+    return copyRuntime(localCandidate.path, options).path;
+  }
+  throw new Error(runtimeMissingMessage(status));
+}
+
+function humanStatus(status) {
+  const lines = [
+    `expected: remem ${status.expectedVersion}`,
+    `plugin_root: ${status.pluginRoot}`,
+    `plugin_data: ${status.pluginData}`,
+    `managed_binary: ${status.managedBinary}`,
+    `selected: ${status.selected ? `${status.selected.source} ${status.selected.path}` : "none"}`
+  ];
+  for (const candidate of status.candidates) {
+    if (!candidate.executable && !candidate.exists) continue;
+    const state = candidate.ok ? "ok" : "rejected";
+    lines.push(`${state}: ${candidate.source} ${candidate.path}${candidate.reason ? ` (${candidate.reason})` : ""}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function main(argv) {
+  const [command = "status", ...args] = argv;
+  const options = {
+    force: args.includes("--force"),
+    adoptPath: args.includes("--adopt-path"),
+    allowDownload: !args.includes("--no-download")
+  };
+  if (command === "status") {
+    const status = inspectRuntime();
+    if (args.includes("--json")) {
+      process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+    } else {
+      process.stdout.write(humanStatus(status));
+    }
+    return 0;
+  }
+  if (command === "install") {
+    const installed = await installRuntime(options);
+    process.stdout.write(`${installed}\n`);
+    return 0;
+  }
+  if (command === "path") {
+    process.stdout.write(`${ensureRuntimeSync()}\n`);
+    return 0;
+  }
+  if (command === "self-test") {
+    const installed = ensureRuntimeSync();
+    const version = inspectVersion(installed);
+    if (!version.ok) throw new Error(version.reason);
+    process.stdout.write(`${version.output}\n`);
+    return 0;
+  }
+  throw new Error(`Unknown remem runtime command: ${command}`);
+}
+
+module.exports = {
+  binaryName,
+  candidateEntries,
+  copyRuntime,
+  ensureRuntime,
+  ensureRuntimeSync,
+  expectedVersion,
+  inspectRuntime,
+  inspectVersion,
+  isExecutable,
+  managedBinaryPath,
+  pathCandidates,
+  pluginDataDir,
+  pluginRoot,
+  repoCandidates,
+  repoRoot,
+  runRemem,
+  runtimeMetadataPath,
+  versionMismatchMessage
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2))
+    .then((status) => process.exit(status))
+    .catch((error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/remem/scripts/remem-runtime.js
+++ b/plugins/remem/scripts/remem-runtime.js
@@ -182,7 +182,8 @@ function versionMismatchMessage(candidate, expected, version) {
 }
 
 function shouldCodesignRuntime(options = {}) {
-  return (options.platformKey || platformKey()) === "darwin-arm64";
+  if (options.platformKey) return options.platformKey === "darwin-arm64";
+  return os.platform() === "darwin" && os.arch() === "arm64";
 }
 
 function codesignRuntimeIfNeeded(candidate, options = {}) {
@@ -362,6 +363,7 @@ async function ensureRuntime(options = {}) {
     (candidate) => candidate.ok && candidate.adoptable && candidate.source === "repo"
   );
   if (localCandidate) {
+    if (options.adoptLocal === false) return localCandidate.path;
     return copyRuntime(localCandidate.path, options).path;
   }
 
@@ -475,6 +477,7 @@ function ensureRuntimeSync(options = {}) {
     (candidate) => candidate.ok && candidate.adoptable && candidate.source === "repo"
   );
   if (localCandidate) {
+    if (options.adoptLocal === false) return localCandidate.path;
     return copyRuntime(localCandidate.path, options).path;
   }
   throw new Error(runtimeMissingMessage(status));

--- a/plugins/remem/scripts/remem-runtime.test.js
+++ b/plugins/remem/scripts/remem-runtime.test.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  ensureRuntimeSync,
+  inspectRuntime,
+  managedBinaryPath,
+  pluginDataDir,
+  runtimeMetadataPath
+} = require("./remem-runtime");
+
+function tempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeFakeRemem(file, version) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    [
+      "#!/usr/bin/env sh",
+      "if [ \"$1\" = \"--version\" ]; then",
+      `  printf 'remem ${version} (schema v34)\\n'`,
+      "  exit 0",
+      "fi",
+      "exit 0",
+      ""
+    ].join("\n")
+  );
+  fs.chmodSync(file, 0o755);
+}
+
+function fixture(options = {}) {
+  const root = tempDir("remem-plugin-root-");
+  const repo = tempDir("remem-plugin-repo-");
+  const data = tempDir("remem-plugin-data-");
+  writeJson(path.join(root, ".codex-plugin", "plugin.json"), {
+    name: "remem",
+    version: "0.5.17"
+  });
+  return {
+    pluginRoot: root,
+    repoRoot: repo,
+    pluginData: data,
+    env: {
+      PATH: options.path || "",
+      REMEM_ALLOW_VERSION_MISMATCH: options.allowMismatch || ""
+    }
+  };
+}
+
+test("plugin data prefers explicit override", () => {
+  const data = tempDir("remem-plugin-data-");
+  assert.equal(pluginDataDir({ pluginData: data }), data);
+});
+
+test("ensureRuntimeSync copies matching repo binary into plugin data", () => {
+  const fx = fixture();
+  const source = path.join(fx.repoRoot, "target", "release", "remem");
+  writeFakeRemem(source, "0.5.17");
+
+  const installed = ensureRuntimeSync(fx);
+
+  assert.equal(installed, managedBinaryPath(fx));
+  assert.equal(fs.existsSync(installed), true);
+  assert.equal(fs.existsSync(runtimeMetadataPath(fx)), true);
+  const status = inspectRuntime(fx);
+  assert.equal(status.selected.source, "managed");
+});
+
+test("matching PATH binary is reported but not silently adopted", () => {
+  const pathDir = tempDir("remem-plugin-path-");
+  writeFakeRemem(path.join(pathDir, "remem"), "0.5.17");
+  const fx = fixture({ path: pathDir });
+
+  assert.throws(() => ensureRuntimeSync(fx), /does not adopt PATH binaries silently|Unable to find/);
+  const status = inspectRuntime(fx);
+  assert.equal(status.pathMatch.path, path.join(pathDir, "remem"));
+  assert.equal(fs.existsSync(managedBinaryPath(fx)), false);
+});
+
+test("mismatched managed binary is rejected", () => {
+  const fx = fixture();
+  writeFakeRemem(managedBinaryPath(fx), "0.5.11");
+
+  const status = inspectRuntime(fx);
+
+  assert.equal(status.selected, undefined);
+  assert.match(status.candidates[0].reason, /expected 0.5.17/);
+});

--- a/plugins/remem/scripts/remem-runtime.test.js
+++ b/plugins/remem/scripts/remem-runtime.test.js
@@ -8,6 +8,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+  codesignRuntimeIfNeeded,
   copyRuntime,
   ensureRuntimeSync,
   ensureRuntime,
@@ -58,6 +59,7 @@ function fixture(options = {}) {
     pluginRoot: root,
     repoRoot: repo,
     pluginData: data,
+    platformKey: options.platformKey || "linux-x64",
     env: {
       PATH: options.path || "",
       REMEM_ALLOW_VERSION_MISMATCH: options.allowMismatch || ""
@@ -150,9 +152,30 @@ test("ensureRuntime can use local runtime without adopting it", async () => {
   assert.equal(fs.existsSync(runtimeMetadataPath(fx)), false);
 });
 
+test("activation dry-run uses local runtime without writing plugin runtime files", async () => {
+  const fx = fixture();
+  const source = path.join(fx.repoRoot, "target", "release", "remem");
+  writeFakeRemem(source, "0.5.17");
+
+  const status = await runRememAsync(
+    ["install", "--target", "codex", "--hooks-only", "--dry-run"],
+    { ...fx, adoptLocal: false, allowDownload: false }
+  );
+
+  assert.equal(status, 0);
+  assert.equal(fs.existsSync(managedBinaryPath(fx)), false);
+  assert.equal(fs.existsSync(runtimeMetadataPath(fx)), false);
+});
+
 test("darwin arm64 runtimes require ad-hoc codesign", () => {
   assert.equal(shouldCodesignRuntime({ platformKey: "darwin-arm64" }), true);
   assert.equal(shouldCodesignRuntime({ platformKey: "darwin-x64" }), false);
   assert.equal(shouldCodesignRuntime({ platformKey: "linux-arm64" }), false);
   assert.equal(shouldCodesignRuntime({ platformKey: "win32-x64" }), false);
+});
+
+test("codesign is skipped without throwing on non-darwin-arm64 platforms", () => {
+  assert.doesNotThrow(() => codesignRuntimeIfNeeded("unused", { platformKey: "win32-x64" }));
+  assert.doesNotThrow(() => codesignRuntimeIfNeeded("unused", { platformKey: "linux-x64" }));
+  assert.doesNotThrow(() => codesignRuntimeIfNeeded("unused", { platformKey: "freebsd-x64" }));
 });

--- a/plugins/remem/scripts/remem-runtime.test.js
+++ b/plugins/remem/scripts/remem-runtime.test.js
@@ -8,11 +8,15 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+  copyRuntime,
   ensureRuntimeSync,
+  installRuntime,
   inspectRuntime,
   managedBinaryPath,
   pluginDataDir,
-  runtimeMetadataPath
+  runRememAsync,
+  runtimeMetadataPath,
+  shouldCodesignRuntime
 } = require("./remem-runtime");
 
 function tempDir(prefix) {
@@ -29,7 +33,7 @@ function writeFakeRemem(file, version) {
   fs.writeFileSync(
     file,
     [
-      "#!/usr/bin/env sh",
+      "#!/bin/sh",
       "if [ \"$1\" = \"--version\" ]; then",
       `  printf 'remem ${version} (schema v34)\\n'`,
       "  exit 0",
@@ -98,4 +102,43 @@ test("mismatched managed binary is rejected", () => {
 
   assert.equal(status.selected, undefined);
   assert.match(status.candidates[0].reason, /expected 0.5.17/);
+});
+
+test("copyRuntime rejects mismatched source version", () => {
+  const fx = fixture();
+  const source = path.join(fx.repoRoot, "target", "release", "remem");
+  writeFakeRemem(source, "0.5.11");
+
+  assert.throws(() => copyRuntime(source, fx), /expected 0.5.17/);
+  assert.equal(fs.existsSync(runtimeMetadataPath(fx)), false);
+});
+
+test("installRuntime honors no-download fallback", async () => {
+  const fx = fixture();
+
+  await assert.rejects(
+    () => installRuntime({ ...fx, allowDownload: false }),
+    (error) => {
+      assert.match(error.message, /Unable to find plugin-managed remem 0.5.17/);
+      assert.doesNotMatch(error.message, /No checked release asset/);
+      return true;
+    }
+  );
+});
+
+test("runRememAsync resolves local runtime before executing", async () => {
+  const fx = fixture();
+  const source = path.join(fx.repoRoot, "target", "release", "remem");
+  writeFakeRemem(source, "0.5.17");
+
+  const status = await runRememAsync(["mcp"], fx);
+
+  assert.equal(status, 0);
+  assert.equal(fs.existsSync(managedBinaryPath(fx)), true);
+});
+
+test("darwin arm64 runtimes require ad-hoc codesign", () => {
+  assert.equal(shouldCodesignRuntime({ platformKey: "darwin-arm64" }), true);
+  assert.equal(shouldCodesignRuntime({ platformKey: "darwin-x64" }), false);
+  assert.equal(shouldCodesignRuntime({ platformKey: "linux-arm64" }), false);
 });

--- a/plugins/remem/scripts/remem-runtime.test.js
+++ b/plugins/remem/scripts/remem-runtime.test.js
@@ -10,6 +10,7 @@ const test = require("node:test");
 const {
   copyRuntime,
   ensureRuntimeSync,
+  ensureRuntime,
   installRuntime,
   inspectRuntime,
   managedBinaryPath,
@@ -137,8 +138,21 @@ test("runRememAsync resolves local runtime before executing", async () => {
   assert.equal(fs.existsSync(managedBinaryPath(fx)), true);
 });
 
+test("ensureRuntime can use local runtime without adopting it", async () => {
+  const fx = fixture();
+  const source = path.join(fx.repoRoot, "target", "release", "remem");
+  writeFakeRemem(source, "0.5.17");
+
+  const resolved = await ensureRuntime({ ...fx, adoptLocal: false, allowDownload: false });
+
+  assert.equal(resolved, source);
+  assert.equal(fs.existsSync(managedBinaryPath(fx)), false);
+  assert.equal(fs.existsSync(runtimeMetadataPath(fx)), false);
+});
+
 test("darwin arm64 runtimes require ad-hoc codesign", () => {
   assert.equal(shouldCodesignRuntime({ platformKey: "darwin-arm64" }), true);
   assert.equal(shouldCodesignRuntime({ platformKey: "darwin-x64" }), false);
   assert.equal(shouldCodesignRuntime({ platformKey: "linux-arm64" }), false);
+  assert.equal(shouldCodesignRuntime({ platformKey: "win32-x64" }), false);
 });

--- a/plugins/remem/skills/remem/SKILL.md
+++ b/plugins/remem/skills/remem/SKILL.md
@@ -23,7 +23,7 @@ Save a durable memory after:
 - important project discoveries with future implications
 - explicit user preferences that should affect future sessions
 
-Use a stable `topic_key` so repeated saves update the same memory instead of creating duplicates.
+Use the active repo/workspace `project` plus a stable `topic_key` so repeated saves update the same memory instead of creating duplicates.
 For project memories, pass `project` as the active repo/workspace path and pass
 `branch` when it is known. Use `scope: "global"` only for explicit cross-project
 user preferences.

--- a/plugins/remem/skills/remem/SKILL.md
+++ b/plugins/remem/skills/remem/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: remem
+description: Use when the user asks Codex to recall prior project context, save durable decisions or bug fixes, inspect remem memory health, or activate remem automatic memory hooks from the Codex plugin.
+---
+
+# Remem
+
+Remem gives Codex durable project memory through the `remem` MCP server. Use it when the answer depends on prior sessions, project preferences, saved decisions, workstreams, or memory health.
+
+## Retrieval
+
+- Search remem before answering questions about prior project context, remembered preferences, older bug fixes, workstreams, or "what did we decide before".
+- Use compact `search` results first, then call `get_observations` for selected IDs when exact content is needed.
+- Use `search_raw` only when curated search misses an exact phrase or chat transcript detail.
+- Treat memory as evidence, not current truth. Verify live repo, GitHub, filesystem, and command output when the fact can drift.
+
+## Saving Memory
+
+Save a durable memory after:
+
+- architecture decisions, including what was chosen and what was rejected
+- bug fixes with a verified root cause, fix, and prevention
+- important project discoveries with future implications
+- explicit user preferences that should affect future sessions
+
+Use a stable `topic_key` so repeated saves update the same memory instead of creating duplicates.
+
+## Activation
+
+The plugin exposes MCP tools as soon as Codex loads `.mcp.json`. Automatic context injection and Stop summarization require explicit hook activation because they modify `~/.codex/config.toml` and `~/.codex/hooks.json`.
+
+For a local repo checkout, activate with:
+
+```bash
+node plugins/remem/scripts/activate-codex.js --dry-run
+node plugins/remem/scripts/activate-codex.js
+remem doctor
+remem status
+```
+
+If the plugin cannot find the binary, build or install remem first:
+
+```bash
+cargo build --release
+REMEM_BINARY="$PWD/target/release/remem" node plugins/remem/scripts/activate-codex.js --dry-run
+```
+
+The wrapper rejects stale remem binaries by default. Use `REMEM_ALLOW_VERSION_MISMATCH=1` only for explicit local debugging.
+
+After installing or updating the plugin, start a new Codex thread so skills and MCP tools are reloaded.

--- a/plugins/remem/skills/remem/SKILL.md
+++ b/plugins/remem/skills/remem/SKILL.md
@@ -27,18 +27,23 @@ Use a stable `topic_key` so repeated saves update the same memory instead of cre
 
 ## Activation
 
-The plugin exposes MCP tools as soon as Codex loads `.mcp.json`. Automatic context injection and Stop summarization require explicit hook activation because they modify `~/.codex/config.toml` and `~/.codex/hooks.json`.
+The plugin exposes MCP tools as soon as Codex loads `.mcp.json` and the runtime
+manager can resolve a matching `remem` binary. Automatic context injection and
+Stop summarization require explicit hook activation because they modify
+`~/.codex/config.toml` and `~/.codex/hooks.json`.
 
 For a local repo checkout, activate with:
 
 ```bash
+cargo build --release
+node plugins/remem/scripts/remem-runtime.js install
 node plugins/remem/scripts/activate-codex.js --dry-run
 node plugins/remem/scripts/activate-codex.js
 remem doctor
 remem status
 ```
 
-If the plugin cannot find the binary, build or install remem first:
+If the plugin cannot find the binary, build or explicitly point at remem first:
 
 ```bash
 cargo build --release

--- a/plugins/remem/skills/remem/SKILL.md
+++ b/plugins/remem/skills/remem/SKILL.md
@@ -24,6 +24,9 @@ Save a durable memory after:
 - explicit user preferences that should affect future sessions
 
 Use a stable `topic_key` so repeated saves update the same memory instead of creating duplicates.
+For project memories, pass `project` as the active repo/workspace path and pass
+`branch` when it is known. Use `scope: "global"` only for explicit cross-project
+user preferences.
 
 ## Activation
 

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -63,7 +63,11 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         }
         Commands::Worker { once } => worker::run(once, 2000).await?,
         Commands::Mcp => mcp::run_mcp_server().await?,
-        Commands::Install { target, dry_run } => install::install(target, dry_run)?,
+        Commands::Install {
+            target,
+            hooks_only,
+            dry_run,
+        } => install::install(target, dry_run, hooks_only)?,
         Commands::Uninstall { target, dry_run } => install::uninstall(target, dry_run)?,
         Commands::Cleanup { dry_run, json } => run_cleanup(dry_run, json)?,
         Commands::SyncMemory { cwd } => {

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -95,6 +95,9 @@ pub(super) enum Commands {
         /// Which host(s) to install into.
         #[arg(long, value_enum, default_value = "auto")]
         target: InstallTarget,
+        /// Install automatic capture hooks without registering MCP servers.
+        #[arg(long)]
+        hooks_only: bool,
         /// Print what would be written without touching disk.
         #[arg(long)]
         dry_run: bool,

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -69,6 +69,10 @@ impl InstallHost for CodexHost {
                 SERVER_KEY
             ),
             format!(
+                "  config -> {} (set [features].hooks = true)",
+                codex_config_path().display()
+            ),
+            format!(
                 "  hooks  -> {} (SessionStart/Stop)",
                 codex_hooks_path().display()
             ),
@@ -302,6 +306,16 @@ codex_hooks = true
             hooks["Stop"][0]["hooks"][0]["command"],
             "/tmp/remem summarize --host codex-cli"
         );
+    }
+
+    #[test]
+    fn dry_run_plan_discloses_hooks_feature_config_write() {
+        let host = CodexHost;
+        let plan = host.dry_run_plan("/tmp/remem").join("\n");
+
+        assert!(plan.contains("MCP"), "{plan}");
+        assert!(plan.contains("set [features].hooks = true"), "{plan}");
+        assert!(plan.contains("SessionStart/Stop"), "{plan}");
     }
 
     #[test]

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -49,6 +49,10 @@ impl InstallHost for CodexHost {
     }
 
     fn install_hooks(&self, bin: &str) -> Result<HookSupport> {
+        let config_path = codex_config_path();
+        let mut doc = read_toml_doc(&config_path)?;
+        enable_codex_hooks(&mut doc)?;
+        write_toml_doc(&config_path, &doc)?;
         apply_codex_hooks_json(&codex_hooks_path(), bin)?;
         Ok(HookSupport::Installed)
     }

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -5,7 +5,7 @@ use crate::install::host::{HookSupport, InstallTarget};
 use crate::install::hosts::resolve_hosts;
 use crate::install::paths::{binary_path, old_hooks_path, remem_data_dir};
 
-pub fn install(target: InstallTarget, dry_run: bool) -> Result<()> {
+pub fn install(target: InstallTarget, dry_run: bool, hooks_only: bool) -> Result<()> {
     let bin = binary_path()?;
     let hosts = resolve_hosts(target);
     if hosts.is_empty() {
@@ -16,10 +16,18 @@ pub fn install(target: InstallTarget, dry_run: bool) -> Result<()> {
     }
 
     if dry_run {
-        eprintln!("remem install (dry-run) — 以下写入不会被执行:");
+        if hooks_only {
+            eprintln!("remem install --hooks-only (dry-run) — 以下写入不会被执行:");
+        } else {
+            eprintln!("remem install (dry-run) — 以下写入不会被执行:");
+        }
         for host in &hosts {
             eprintln!("→ {}", host.name());
-            for line in host.dry_run_plan(&bin) {
+            let plan = host.dry_run_plan(&bin);
+            for line in plan
+                .iter()
+                .filter(|line| !hooks_only || !line.contains("MCP"))
+            {
                 eprintln!("{line}");
             }
         }
@@ -32,7 +40,11 @@ pub fn install(target: InstallTarget, dry_run: bool) -> Result<()> {
         return Ok(());
     }
 
-    eprintln!("remem install:");
+    if hooks_only {
+        eprintln!("remem install --hooks-only:");
+    } else {
+        eprintln!("remem install:");
+    }
     let runtime_hosts = hosts
         .iter()
         .map(|host| runtime_host_name(host.name()))
@@ -41,8 +53,12 @@ pub fn install(target: InstallTarget, dry_run: bool) -> Result<()> {
     eprintln!("  config -> {}", config_path.display());
     for host in &hosts {
         eprintln!("→ {}", host.name());
-        host.install_mcp(&bin)?;
-        eprintln!("  MCP    -> {}", host.config_path().display());
+        if hooks_only {
+            eprintln!("  MCP    skipped (hooks-only)");
+        } else {
+            host.install_mcp(&bin)?;
+            eprintln!("  MCP    -> {}", host.config_path().display());
+        }
         match host.install_hooks(&bin)? {
             HookSupport::Installed => eprintln!("  hooks  ✓"),
             HookSupport::Skipped(reason) => eprintln!("  hooks  skipped: {reason}"),


### PR DESCRIPTION
Closes #388.

## Summary

- Add a repo-local Codex marketplace entry for the remem plugin.
- Add `plugins/remem` with `.codex-plugin/plugin.json`, `.mcp.json`, a Remem skill, and Node wrappers for `remem mcp` plus explicit Codex hook activation.
- Add version guarding in the wrapper so stale remem binaries are rejected by default unless `REMEM_ALLOW_VERSION_MISMATCH=1` is set for local debugging.
- Document local plugin install and activation in the root README and plugin README.

## Why

remem already has the right core shape for Codex plugin packaging: a single binary, an MCP server, and existing Codex install logic. The plugin should expose MCP tools directly while keeping hook writes explicit because activation modifies user-level Codex config and hooks.

## Validation

- `python3 /Users/lifcc/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/remem`
- `python3 -m json.tool plugins/remem/.codex-plugin/plugin.json`
- `python3 -m json.tool plugins/remem/.mcp.json`
- `python3 -m json.tool .agents/plugins/marketplace.json`
- `node plugins/remem/scripts/remem-binary.js --version` -> `remem 0.5.17 (schema v34)`
- `node plugins/remem/scripts/activate-codex.js --dry-run`
- `REMEM_BINARY=/opt/homebrew/bin/remem node plugins/remem/scripts/remem-binary.js --version` fails with `found remem 0.5.11 (schema v31), expected 0.5.17`
- `rg -n "console\." plugins/remem -S || true`
- `cargo build --release`
- `cargo check`
- `cargo test` -> 971 lib tests plus integration/doc tests passed

## Notes

The activation dry run reported local stale installs at `/opt/homebrew/bin/remem` and `~/.local/bin/remem` on my machine. The wrapper intentionally selected the matching repo release binary and rejects stale binaries by default.
