### PR TITLE
fix(doctor): warn on empty temporal facts table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.17"
+version = "0.5.18"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -221,7 +221,8 @@ pub fn query_memory_facts_stats(conn: &Connection) -> Result<MemoryFactsStats> {
              JOIN memories m ON m.id = f.source_memory_id
              WHERE f.status = 'active'
                AND f.valid_from_epoch IS NOT NULL
-               AND m.status = 'active'",
+               AND m.status = 'active'
+               AND (m.expires_at_epoch IS NULL OR m.expires_at_epoch > strftime('%s', 'now'))",
             [],
             |row| row.get(0),
         )?

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -47,6 +47,9 @@ pub struct SystemStats {
 pub struct MemoryFactsStats {
     pub table_exists: bool,
     pub total: i64,
+    pub retrieval_eligible: i64,
+    pub active_memories: i64,
+    pub captured_events: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -203,15 +206,48 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
 }
 
 pub fn query_memory_facts_stats(conn: &Connection) -> Result<MemoryFactsStats> {
-    let table_exists = table_exists(conn, "memory_facts")?;
-    let total = if table_exists {
+    let memory_facts_exists = table_exists(conn, "memory_facts")?;
+    let memories_exists = table_exists(conn, "memories")?;
+    let captured_events_exists = table_exists(conn, "captured_events")?;
+    let total = if memory_facts_exists {
         conn.query_row("SELECT COUNT(*) FROM memory_facts", [], |row| row.get(0))?
     } else {
         0
     };
+    let retrieval_eligible = if memory_facts_exists && memories_exists {
+        conn.query_row(
+            "SELECT COUNT(*)
+             FROM memory_facts f
+             JOIN memories m ON m.id = f.source_memory_id
+             WHERE f.status = 'active'
+               AND f.valid_from_epoch IS NOT NULL
+               AND m.status = 'active'",
+            [],
+            |row| row.get(0),
+        )?
+    } else {
+        0
+    };
+    let active_memories = if memories_exists {
+        conn.query_row(
+            "SELECT COUNT(*) FROM memories WHERE status = 'active'",
+            [],
+            |row| row.get(0),
+        )?
+    } else {
+        0
+    };
+    let captured_events = if captured_events_exists {
+        conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))?
+    } else {
+        0
+    };
     Ok(MemoryFactsStats {
-        table_exists,
+        table_exists: memory_facts_exists,
         total,
+        retrieval_eligible,
+        active_memories,
+        captured_events,
     })
 }
 

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -44,6 +44,12 @@ pub struct SystemStats {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryFactsStats {
+    pub table_exists: bool,
+    pub total: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DailyActivityStats {
     pub memories: i64,
     pub observations: i64,
@@ -193,6 +199,19 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
         worker_daemon_healthy,
         worker_heartbeat_owner: worker_heartbeat.map(|heartbeat| heartbeat.owner),
         worker_heartbeat_age_secs,
+    })
+}
+
+pub fn query_memory_facts_stats(conn: &Connection) -> Result<MemoryFactsStats> {
+    let table_exists = table_exists(conn, "memory_facts")?;
+    let total = if table_exists {
+        conn.query_row("SELECT COUNT(*) FROM memory_facts", [], |row| row.get(0))?
+    } else {
+        0
+    };
+    Ok(MemoryFactsStats {
+        table_exists,
+        total,
     })
 }
 

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -167,6 +167,56 @@ pub(super) fn check_raw_archive_ingest() -> Check {
     }
 }
 
+pub(super) fn check_temporal_facts() -> Check {
+    let conn = match db::open_db_read_only() {
+        Ok(conn) => conn,
+        Err(_) => {
+            return Check {
+                name: "Temporal facts",
+                status: Status::Warn,
+                detail: "cannot open database".to_string(),
+            };
+        }
+    };
+
+    let stats = match db::query_memory_facts_stats(&conn) {
+        Ok(stats) => stats,
+        Err(err) => {
+            return Check {
+                name: "Temporal facts",
+                status: Status::Warn,
+                detail: format!("cannot load fact stats: {}", err),
+            };
+        }
+    };
+
+    if !stats.table_exists {
+        return Check {
+            name: "Temporal facts",
+            status: Status::Ok,
+            detail: "memory_facts table not present; temporal retrieval uses created_at fallback"
+                .to_string(),
+        };
+    }
+
+    if stats.total == 0 {
+        return Check {
+            name: "Temporal facts",
+            status: Status::Warn,
+            detail: "temporal retrieval can read memory_facts, but the table is empty; production fact extraction is not populating event-time facts yet".to_string(),
+        };
+    }
+
+    Check {
+        name: "Temporal facts",
+        status: Status::Ok,
+        detail: format!(
+            "{} memory fact(s) available for event-time retrieval",
+            stats.total
+        ),
+    }
+}
+
 pub(super) fn check_worker_daemon() -> Check {
     let conn = match db::open_db_read_only() {
         Ok(conn) => conn,

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -199,11 +199,24 @@ pub(super) fn check_temporal_facts() -> Check {
         };
     }
 
-    if stats.total == 0 {
+    if stats.retrieval_eligible == 0 && stats.active_memories == 0 && stats.captured_events == 0 {
+        return Check {
+            name: "Temporal facts",
+            status: Status::Ok,
+            detail:
+                "memory_facts table is empty because this store has no memories or captured events yet"
+                    .to_string(),
+        };
+    }
+
+    if stats.retrieval_eligible == 0 {
         return Check {
             name: "Temporal facts",
             status: Status::Warn,
-            detail: "temporal retrieval can read memory_facts, but the table is empty; production fact extraction is not populating event-time facts yet".to_string(),
+            detail: format!(
+                "temporal retrieval can read memory_facts, but 0 of {} fact row(s) are linked active event-time facts; production fact extraction is not populating retrievable facts yet",
+                stats.total
+            ),
         };
     }
 
@@ -211,8 +224,8 @@ pub(super) fn check_temporal_facts() -> Check {
         name: "Temporal facts",
         status: Status::Ok,
         detail: format!(
-            "{} memory fact(s) available for event-time retrieval",
-            stats.total
+            "{} linked active memory fact(s) available for event-time retrieval",
+            stats.retrieval_eligible
         ),
     }
 }

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use super::database::{
     check_database, check_disk_space, check_pending_queue, check_raw_archive_ingest,
-    check_worker_daemon,
+    check_temporal_facts, check_worker_daemon,
 };
 use super::environment::{check_binary, check_hooks, check_install_paths, check_mcp};
 use super::native_memory::check_native_memory_sync;
@@ -55,6 +55,7 @@ fn collect_checks() -> Vec<Check> {
     checks.extend(check_hooks());
     checks.extend(check_mcp());
     checks.push(check_raw_archive_ingest());
+    checks.push(check_temporal_facts());
     checks.push(check_worker_daemon());
     checks.push(check_pending_queue());
     checks.push(check_native_memory_sync());

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -315,6 +315,50 @@ fn check_temporal_facts_warns_when_rows_are_not_retrievable() -> anyhow::Result<
 }
 
 #[test]
+fn check_temporal_facts_warns_when_source_memory_is_expired() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-expired");
+    let conn = db::open_db()?;
+    let memory_id = memory::insert_memory(
+        &conn,
+        Some("session-1"),
+        "proj-a",
+        None,
+        "expired memory",
+        "A source memory exists with an expired temporal fact.",
+        "decision",
+        None,
+    )?;
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "UPDATE memories SET expires_at_epoch = ?1 WHERE id = ?2",
+        params![now - 1, memory_id],
+    )?;
+    conn.execute(
+        "INSERT INTO memory_facts
+         (project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
+          learned_at_epoch, source_memory_id, source_event_ids, confidence, status,
+          created_at_epoch, updated_at_epoch)
+         VALUES ('proj-a', 'deploy', 'affects_project', 'prod', ?1, NULL,
+                 ?1, ?2, '[]', 0.9, 'active', ?1, ?1)",
+        params![now, memory_id],
+    )?;
+    let stats = db::query_memory_facts_stats(&conn)?;
+    drop(conn);
+
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.retrieval_eligible, 0);
+
+    let check = check_temporal_facts();
+    assert_eq!(check.icon(), "WARN");
+    assert!(
+        check.detail.contains("0 of 1 fact row(s)"),
+        "{}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
 fn check_temporal_facts_is_ok_when_fact_table_has_rows() -> anyhow::Result<()> {
     let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-present");
     let conn = db::open_db()?;

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -215,11 +215,22 @@ fn check_raw_archive_ingest_warns_on_recorded_failures() -> anyhow::Result<()> {
 fn check_temporal_facts_warns_when_fact_table_is_empty() -> anyhow::Result<()> {
     let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-empty");
     let conn = db::open_db()?;
+    memory::insert_memory(
+        &conn,
+        Some("session-1"),
+        "proj-a",
+        None,
+        "source memory",
+        "A source memory exists without temporal facts.",
+        "decision",
+        None,
+    )?;
     let stats = db::query_memory_facts_stats(&conn)?;
     drop(conn);
 
     assert!(stats.table_exists);
     assert_eq!(stats.total, 0);
+    assert_eq!(stats.retrieval_eligible, 0);
 
     let check = check_temporal_facts();
     assert_eq!(check.icon(), "WARN");
@@ -241,24 +252,104 @@ fn check_temporal_facts_warns_when_fact_table_is_empty() -> anyhow::Result<()> {
 }
 
 #[test]
-fn check_temporal_facts_is_ok_when_fact_table_has_rows() -> anyhow::Result<()> {
-    let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-present");
+fn check_temporal_facts_is_ok_when_store_has_no_source_data() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-empty-store");
     let conn = db::open_db()?;
-    conn.execute(
-        "INSERT INTO memory_facts
-         (project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
-          learned_at_epoch, source_event_ids, confidence, status, created_at_epoch,
-          updated_at_epoch)
-         VALUES ('proj-a', 'deploy', 'affects_project', 'prod', ?1, NULL,
-                 ?1, '[]', 0.9, 'active', ?1, ?1)",
-        params![chrono::Utc::now().timestamp()],
-    )?;
+    let stats = db::query_memory_facts_stats(&conn)?;
     drop(conn);
+
+    assert!(stats.table_exists);
+    assert_eq!(stats.total, 0);
+    assert_eq!(stats.retrieval_eligible, 0);
+    assert_eq!(stats.active_memories, 0);
+    assert_eq!(stats.captured_events, 0);
 
     let check = check_temporal_facts();
     assert_eq!(check.icon(), "ok");
     assert!(
-        check.detail.contains("1 memory fact(s) available"),
+        check.detail.contains("no memories or captured events yet"),
+        "{}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
+fn check_temporal_facts_warns_when_rows_are_not_retrievable() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-unlinked");
+    let conn = db::open_db()?;
+    memory::insert_memory(
+        &conn,
+        Some("session-1"),
+        "proj-a",
+        None,
+        "source memory",
+        "A source memory exists with an unlinked temporal fact.",
+        "decision",
+        None,
+    )?;
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "INSERT INTO memory_facts
+         (project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
+          learned_at_epoch, source_memory_id, source_event_ids, confidence, status,
+          created_at_epoch, updated_at_epoch)
+         VALUES ('proj-a', 'deploy', 'affects_project', 'prod', ?1, NULL,
+                 ?1, NULL, '[]', 0.9, 'active', ?1, ?1)",
+        params![now],
+    )?;
+    let stats = db::query_memory_facts_stats(&conn)?;
+    drop(conn);
+
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.retrieval_eligible, 0);
+
+    let check = check_temporal_facts();
+    assert_eq!(check.icon(), "WARN");
+    assert!(
+        check.detail.contains("0 of 1 fact row(s)"),
+        "{}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
+fn check_temporal_facts_is_ok_when_fact_table_has_rows() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-present");
+    let conn = db::open_db()?;
+    let memory_id = memory::insert_memory(
+        &conn,
+        Some("session-1"),
+        "proj-a",
+        None,
+        "source memory",
+        "A source memory exists with a retrievable temporal fact.",
+        "decision",
+        None,
+    )?;
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "INSERT INTO memory_facts
+         (project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
+          learned_at_epoch, source_memory_id, source_event_ids, confidence, status,
+          created_at_epoch, updated_at_epoch)
+         VALUES ('proj-a', 'deploy', 'affects_project', 'prod', ?1, NULL,
+                 ?1, ?2, '[]', 0.9, 'active', ?1, ?1)",
+        params![now, memory_id],
+    )?;
+    let stats = db::query_memory_facts_stats(&conn)?;
+    drop(conn);
+
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.retrieval_eligible, 1);
+
+    let check = check_temporal_facts();
+    assert_eq!(check.icon(), "ok");
+    assert!(
+        check
+            .detail
+            .contains("1 linked active memory fact(s) available"),
         "{}",
         check.detail
     );

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -4,7 +4,8 @@ use crate::db::test_support::ScopedTestDataDir;
 use crate::{db, memory};
 
 use super::database::{
-    check_database, check_pending_queue, check_raw_archive_ingest, check_worker_daemon,
+    check_database, check_pending_queue, check_raw_archive_ingest, check_temporal_facts,
+    check_worker_daemon,
 };
 use super::health_action::{queue_actions, render_action_block};
 use super::report::{run_doctor_with_writer, DoctorOptions};
@@ -207,6 +208,60 @@ fn check_raw_archive_ingest_warns_on_recorded_failures() -> anyhow::Result<()> {
     assert!(check.detail.contains("1 failure"), "{}", check.detail);
     assert!(check.detail.contains("read_error"), "{}", check.detail);
     assert!(check.detail.contains("/bad/path.jsonl"), "{}", check.detail);
+    Ok(())
+}
+
+#[test]
+fn check_temporal_facts_warns_when_fact_table_is_empty() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-empty");
+    let conn = db::open_db()?;
+    let stats = db::query_memory_facts_stats(&conn)?;
+    drop(conn);
+
+    assert!(stats.table_exists);
+    assert_eq!(stats.total, 0);
+
+    let check = check_temporal_facts();
+    assert_eq!(check.icon(), "WARN");
+    assert!(
+        check
+            .detail
+            .contains("temporal retrieval can read memory_facts"),
+        "{}",
+        check.detail
+    );
+    assert!(
+        check
+            .detail
+            .contains("production fact extraction is not populating"),
+        "{}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
+fn check_temporal_facts_is_ok_when_fact_table_has_rows() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-present");
+    let conn = db::open_db()?;
+    conn.execute(
+        "INSERT INTO memory_facts
+         (project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
+          learned_at_epoch, source_event_ids, confidence, status, created_at_epoch,
+          updated_at_epoch)
+         VALUES ('proj-a', 'deploy', 'affects_project', 'prod', ?1, NULL,
+                 ?1, '[]', 0.9, 'active', ?1, ?1)",
+        params![chrono::Utc::now().timestamp()],
+    )?;
+    drop(conn);
+
+    let check = check_temporal_facts();
+    assert_eq!(check.icon(), "ok");
+    assert!(
+        check.detail.contains("1 memory fact(s) available"),
+        "{}",
+        check.detail
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Refs #359.

## Summary
- Add shared memory_facts table stats.
- Add a doctor check that warns when temporal retrieval can read `memory_facts` but the table is empty.
- Keep this scoped to visibility only; this does not implement the full temporal fact writer.

## Validation
- `cargo test doctor`
- `cargo test retrieval::temporal`
- `cargo check`
- `cargo test --quiet`
