### PR TITLE
fix(context): gate Claude duplicate injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.17"
+version = "0.5.18"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -8,7 +8,7 @@ use super::invocation::ContextInvocation;
 
 mod delta;
 
-const DEFAULT_GATE_HOSTS: &str = "codex-cli";
+const DEFAULT_GATE_HOSTS: &str = "codex-cli,claude-code";
 const DEFAULT_SUPPRESSED_SOURCES: &str = "compact";
 const DEFAULT_FALLBACK_COOLDOWN_SECS: i64 = 900;
 const DEFAULT_RETENTION_DAYS: i64 = 30;

--- a/src/context/injection_gate/tests.rs
+++ b/src/context/injection_gate/tests.rs
@@ -25,6 +25,12 @@ fn gate_invocation(session_id: Option<&str>) -> ContextInvocation {
     }
 }
 
+fn claude_gate_invocation(session_id: Option<&str>) -> ContextInvocation {
+    let mut invocation = gate_invocation(session_id);
+    invocation.host = HostKind::ClaudeCode;
+    invocation
+}
+
 #[test]
 fn fingerprint_ignores_header_timestamp() {
     let a = "# [/tmp/remem] context 2026-05-25 1:00pm\nBody\n";
@@ -247,6 +253,61 @@ fn compact_source_force_bypasses_suppression() {
     assert_eq!(forced.action, ContextGateAction::EmittedFull);
     assert_eq!(forced.reason, "first_or_forced");
     assert_eq!(forced.output, output);
+}
+
+#[test]
+fn claude_code_resume_suppresses_same_session_same_hash_by_default() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-claude-resume");
+    let invocation = claude_gate_invocation(Some("claude-session-1"));
+    let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+    let first = apply_context_gate(&invocation, output.clone());
+    assert_eq!(first.action, ContextGateAction::EmittedFull);
+    assert_eq!(first.reason, "first_or_forced");
+    assert_eq!(first.output, output);
+    assert!(first
+        .key
+        .as_deref()
+        .is_some_and(|key| key.contains("claude-session-1")));
+
+    let second = apply_context_gate(&invocation, output);
+    assert_eq!(second.action, ContextGateAction::Suppressed);
+    assert_eq!(second.reason, "same_hash");
+    assert!(second.output.is_empty());
+}
+
+#[test]
+fn claude_code_compact_session_start_suppresses_same_hash_by_default() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-claude-compact");
+    let mut invocation = claude_gate_invocation(Some("claude-session-compact"));
+    let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+    let first = apply_context_gate(&invocation, output.clone());
+    assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+    invocation.source = Some("compact".to_string());
+    let second = apply_context_gate(&invocation, output);
+    assert_eq!(second.action, ContextGateAction::Suppressed);
+    assert_eq!(second.reason, "suppressed_source");
+    assert!(second.output.is_empty());
+}
+
+#[test]
+fn unknown_host_remains_ungated_by_default() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-unknown-host");
+    let mut invocation = gate_invocation(Some("unknown-session"));
+    invocation.host = HostKind::Unknown;
+    let output = "# [/tmp/remem] context now\nBody\n".to_string();
+
+    let first = apply_context_gate(&invocation, output.clone());
+    assert_eq!(first.action, ContextGateAction::Bypassed);
+    assert_eq!(first.reason, "host_not_gated");
+    assert_eq!(first.output, output);
+
+    let second = apply_context_gate(&invocation, output.clone());
+    assert_eq!(second.action, ContextGateAction::Bypassed);
+    assert_eq!(second.reason, "host_not_gated");
+    assert_eq!(second.output, output);
 }
 
 #[test]

--- a/src/context/injection_gate/tests.rs
+++ b/src/context/injection_gate/tests.rs
@@ -293,6 +293,28 @@ fn claude_code_compact_session_start_suppresses_same_hash_by_default() {
 }
 
 #[test]
+fn claude_code_compact_changed_hash_emits_delta_by_default() {
+    let _data_dir =
+        crate::db::test_support::ScopedTestDataDir::new("context-gate-claude-compact-changed");
+    let mut invocation = claude_gate_invocation(Some("claude-session-compact-changed"));
+
+    let first = apply_context_gate(
+        &invocation,
+        "# [/tmp/remem] context now\nBody A\n".to_string(),
+    );
+    assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+    invocation.source = Some("compact".to_string());
+    let second = apply_context_gate(
+        &invocation,
+        "# [/tmp/remem] context now\nBody B\n".to_string(),
+    );
+    assert_eq!(second.action, ContextGateAction::EmittedDelta);
+    assert_eq!(second.reason, "changed_hash");
+    assert!(second.output.contains("context delta"));
+}
+
+#[test]
 fn unknown_host_remains_ungated_by_default() {
     let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-unknown-host");
     let mut invocation = gate_invocation(Some("unknown-session"));

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -268,7 +268,7 @@ fn ensure_host_config(hosts: &mut Table, host: &str) -> Result<()> {
         }
         CLAUDE_HOST => {
             set_str_if_missing(table, "memory_profile", "claude");
-            set_str_if_missing(table, "context_gate", "strict");
+            set_str_if_missing_or_legacy_value(table, "context_gate", "auto", "off");
             set_bool_if_missing(table, "context_color", true);
             set_str_if_missing(table, "capture_adapter", CLAUDE_HOST);
         }
@@ -395,6 +395,22 @@ fn child_table_mut<'a>(table: &'a mut Table, key: &str) -> Result<&'a mut Table>
 
 fn set_str_if_missing(table: &mut Table, key: &str, value_str: &str) {
     if table.get(key).is_none() {
+        table[key] = value(value_str);
+    }
+}
+
+fn set_str_if_missing_or_legacy_value(
+    table: &mut Table,
+    key: &str,
+    value_str: &str,
+    legacy_value: &str,
+) {
+    let should_set = table
+        .get(key)
+        .and_then(Item::as_str)
+        .map(|current| current.trim().eq_ignore_ascii_case(legacy_value))
+        .unwrap_or(true);
+    if should_set {
         table[key] = value(value_str);
     }
 }
@@ -555,16 +571,35 @@ mod tests {
     }
 
     #[test]
-    fn claude_host_defaults_to_context_gate_strict() -> Result<()> {
+    fn claude_host_defaults_to_context_gate_auto() -> Result<()> {
         let path = temp_config_path("runtime-claude-context");
         with_config_path(&path, || -> Result<()> {
             init_config()?;
             let host = resolve_host_runtime_config(Some("claude-code"))?;
 
             assert_eq!(host.host, CLAUDE_HOST);
-            assert_eq!(host.context_gate.as_deref(), Some("strict"));
+            assert_eq!(host.context_gate.as_deref(), Some("auto"));
             assert!(host.context_color);
             assert_eq!(host.capture_adapter, CLAUDE_HOST);
+            Ok(())
+        })?;
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn claude_host_migrates_legacy_context_gate_off_to_auto() -> Result<()> {
+        let path = temp_config_path("runtime-claude-context-migrate");
+        with_config_path(&path, || -> Result<()> {
+            std::fs::write(
+                &path,
+                "[memory_ai.hosts.claude-code]\nmemory_profile = \"claude\"\ncontext_gate = \"off\"\n",
+            )?;
+            init_config()?;
+            let host = resolve_host_runtime_config(Some("claude-code"))?;
+
+            assert_eq!(host.host, CLAUDE_HOST);
+            assert_eq!(host.context_gate.as_deref(), Some("auto"));
             Ok(())
         })?;
         std::fs::remove_file(path)?;

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -51,12 +51,6 @@ pub struct HostRuntimeConfig {
     pub capture_adapter: String,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ConfigDefaultMode {
-    PreserveUserValues,
-    MigrateLegacyDefaults,
-}
-
 pub fn config_path() -> PathBuf {
     std::env::var("REMEM_CONFIG")
         .ok()
@@ -68,12 +62,8 @@ pub fn config_path() -> PathBuf {
 
 pub fn default_config_text() -> String {
     let mut doc = DocumentMut::new();
-    ensure_config_defaults_with_mode(
-        &mut doc,
-        &[CLAUDE_HOST, CODEX_HOST],
-        ConfigDefaultMode::MigrateLegacyDefaults,
-    )
-    .expect("default runtime config should be valid");
+    ensure_config_defaults(&mut doc, &[CLAUDE_HOST, CODEX_HOST])
+        .expect("default runtime config should be valid");
     doc.to_string()
 }
 
@@ -86,11 +76,7 @@ pub fn show_config_text() -> Result<String> {
 pub fn init_config() -> Result<PathBuf> {
     let path = config_path();
     let mut doc = read_config_doc_or_default()?;
-    ensure_config_defaults_with_mode(
-        &mut doc,
-        &[CLAUDE_HOST, CODEX_HOST],
-        ConfigDefaultMode::MigrateLegacyDefaults,
-    )?;
+    ensure_config_defaults(&mut doc, &[CLAUDE_HOST, CODEX_HOST])?;
     write_config_doc(&path, &doc)?;
     Ok(path)
 }
@@ -98,7 +84,7 @@ pub fn init_config() -> Result<PathBuf> {
 pub fn ensure_config_for_hosts(hosts: &[&str]) -> Result<PathBuf> {
     let path = config_path();
     let mut doc = read_config_doc_or_default()?;
-    ensure_config_defaults_with_mode(&mut doc, hosts, ConfigDefaultMode::MigrateLegacyDefaults)?;
+    ensure_config_defaults(&mut doc, hosts)?;
     write_config_doc(&path, &doc)?;
     Ok(path)
 }
@@ -106,11 +92,7 @@ pub fn ensure_config_for_hosts(hosts: &[&str]) -> Result<PathBuf> {
 pub fn set_config_value(key: &str, raw_value: &str) -> Result<PathBuf> {
     let path = config_path();
     let mut doc = read_config_doc_or_default()?;
-    ensure_config_defaults_with_mode(
-        &mut doc,
-        &[CLAUDE_HOST, CODEX_HOST],
-        ConfigDefaultMode::MigrateLegacyDefaults,
-    )?;
+    ensure_config_defaults(&mut doc, &[CLAUDE_HOST, CODEX_HOST])?;
 
     let segments = key
         .split('.')
@@ -217,14 +199,6 @@ fn write_config_doc(path: &PathBuf, doc: &DocumentMut) -> Result<()> {
 }
 
 fn ensure_config_defaults(doc: &mut DocumentMut, hosts: &[&str]) -> Result<()> {
-    ensure_config_defaults_with_mode(doc, hosts, ConfigDefaultMode::PreserveUserValues)
-}
-
-fn ensure_config_defaults_with_mode(
-    doc: &mut DocumentMut,
-    hosts: &[&str],
-    mode: ConfigDefaultMode,
-) -> Result<()> {
     if doc.get("version").is_none() {
         doc["version"] = value(1);
     }
@@ -247,11 +221,11 @@ fn ensure_config_defaults_with_mode(
 
     {
         let hosts_table = child_table_mut(memory_ai, "hosts")?;
-        ensure_host_config(hosts_table, &default_host, mode)?;
+        ensure_host_config(hosts_table, &default_host)?;
         for host in hosts {
             let host = normalize_host(host);
             if !host.is_empty() && host != default_host {
-                ensure_host_config(hosts_table, &host, mode)?;
+                ensure_host_config(hosts_table, &host)?;
             }
         }
     }
@@ -283,7 +257,7 @@ fn ensure_http_profile(profiles: &mut Table) -> Result<()> {
     Ok(())
 }
 
-fn ensure_host_config(hosts: &mut Table, host: &str, mode: ConfigDefaultMode) -> Result<()> {
+fn ensure_host_config(hosts: &mut Table, host: &str) -> Result<()> {
     let table = child_table_mut(hosts, host)?;
     match host {
         CODEX_HOST => {
@@ -294,11 +268,7 @@ fn ensure_host_config(hosts: &mut Table, host: &str, mode: ConfigDefaultMode) ->
         }
         CLAUDE_HOST => {
             set_str_if_missing(table, "memory_profile", "claude");
-            if mode == ConfigDefaultMode::MigrateLegacyDefaults {
-                set_str_if_missing_or_legacy_value(table, "context_gate", "auto", "off");
-            } else {
-                set_str_if_missing(table, "context_gate", "auto");
-            }
+            set_str_if_missing(table, "context_gate", "auto");
             set_bool_if_missing(table, "context_color", true);
             set_str_if_missing(table, "capture_adapter", CLAUDE_HOST);
         }
@@ -425,22 +395,6 @@ fn child_table_mut<'a>(table: &'a mut Table, key: &str) -> Result<&'a mut Table>
 
 fn set_str_if_missing(table: &mut Table, key: &str, value_str: &str) {
     if table.get(key).is_none() {
-        table[key] = value(value_str);
-    }
-}
-
-fn set_str_if_missing_or_legacy_value(
-    table: &mut Table,
-    key: &str,
-    value_str: &str,
-    legacy_value: &str,
-) {
-    let should_set = table
-        .get(key)
-        .and_then(Item::as_str)
-        .map(|current| current.trim().eq_ignore_ascii_case(legacy_value))
-        .unwrap_or(true);
-    if should_set {
         table[key] = value(value_str);
     }
 }
@@ -618,18 +572,65 @@ mod tests {
     }
 
     #[test]
-    fn claude_host_migrates_legacy_context_gate_off_to_auto() -> Result<()> {
-        let path = temp_config_path("runtime-claude-context-migrate");
+    fn init_config_preserves_explicit_claude_context_gate_off() -> Result<()> {
+        let path = temp_config_path("runtime-claude-context-init-explicit-off");
         with_config_path(&path, || -> Result<()> {
             std::fs::write(
                 &path,
                 "[memory_ai.hosts.claude-code]\nmemory_profile = \"claude\"\ncontext_gate = \"off\"\n",
             )?;
             init_config()?;
+            let text = std::fs::read_to_string(&path)?;
             let host = resolve_host_runtime_config(Some("claude-code"))?;
 
             assert_eq!(host.host, CLAUDE_HOST);
-            assert_eq!(host.context_gate.as_deref(), Some("auto"));
+            assert_eq!(host.context_gate.as_deref(), Some("off"));
+            assert!(text.contains("context_gate = \"off\""), "{text}");
+            Ok(())
+        })?;
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_config_for_hosts_preserves_explicit_claude_context_gate_off() -> Result<()> {
+        let path = temp_config_path("runtime-claude-context-ensure-explicit-off");
+        with_config_path(&path, || -> Result<()> {
+            std::fs::write(
+                &path,
+                "[memory_ai.hosts.claude-code]\nmemory_profile = \"claude\"\ncontext_gate = \"off\"\n",
+            )?;
+            ensure_config_for_hosts(&[CLAUDE_HOST])?;
+            let text = std::fs::read_to_string(&path)?;
+            let host = resolve_host_runtime_config(Some("claude-code"))?;
+
+            assert_eq!(host.host, CLAUDE_HOST);
+            assert_eq!(host.context_gate.as_deref(), Some("off"));
+            assert!(text.contains("context_gate = \"off\""), "{text}");
+            Ok(())
+        })?;
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unrelated_config_set_preserves_explicit_claude_context_gate_off() -> Result<()> {
+        let path = temp_config_path("runtime-claude-context-set-explicit-off");
+        with_config_path(&path, || -> Result<()> {
+            init_config()?;
+            set_config_value("memory_ai.hosts.claude-code.context_gate", "off")?;
+            set_config_value("memory_ai.profiles.codex.model", "custom-mini")?;
+            let text = std::fs::read_to_string(&path)?;
+            let host = resolve_host_runtime_config(Some("claude-code"))?;
+            let profile = resolve_memory_ai_profile(MemoryAiSelection {
+                host: Some(CODEX_HOST),
+                profile: None,
+            })?;
+
+            assert_eq!(host.host, CLAUDE_HOST);
+            assert_eq!(host.context_gate.as_deref(), Some("off"));
+            assert_eq!(profile.model.as_deref(), Some("custom-mini"));
+            assert!(text.contains("context_gate = \"off\""), "{text}");
             Ok(())
         })?;
         std::fs::remove_file(path)?;

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -51,6 +51,12 @@ pub struct HostRuntimeConfig {
     pub capture_adapter: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConfigDefaultMode {
+    PreserveUserValues,
+    MigrateLegacyDefaults,
+}
+
 pub fn config_path() -> PathBuf {
     std::env::var("REMEM_CONFIG")
         .ok()
@@ -62,8 +68,12 @@ pub fn config_path() -> PathBuf {
 
 pub fn default_config_text() -> String {
     let mut doc = DocumentMut::new();
-    ensure_config_defaults(&mut doc, &[CLAUDE_HOST, CODEX_HOST])
-        .expect("default runtime config should be valid");
+    ensure_config_defaults_with_mode(
+        &mut doc,
+        &[CLAUDE_HOST, CODEX_HOST],
+        ConfigDefaultMode::MigrateLegacyDefaults,
+    )
+    .expect("default runtime config should be valid");
     doc.to_string()
 }
 
@@ -76,7 +86,11 @@ pub fn show_config_text() -> Result<String> {
 pub fn init_config() -> Result<PathBuf> {
     let path = config_path();
     let mut doc = read_config_doc_or_default()?;
-    ensure_config_defaults(&mut doc, &[CLAUDE_HOST, CODEX_HOST])?;
+    ensure_config_defaults_with_mode(
+        &mut doc,
+        &[CLAUDE_HOST, CODEX_HOST],
+        ConfigDefaultMode::MigrateLegacyDefaults,
+    )?;
     write_config_doc(&path, &doc)?;
     Ok(path)
 }
@@ -84,7 +98,7 @@ pub fn init_config() -> Result<PathBuf> {
 pub fn ensure_config_for_hosts(hosts: &[&str]) -> Result<PathBuf> {
     let path = config_path();
     let mut doc = read_config_doc_or_default()?;
-    ensure_config_defaults(&mut doc, hosts)?;
+    ensure_config_defaults_with_mode(&mut doc, hosts, ConfigDefaultMode::MigrateLegacyDefaults)?;
     write_config_doc(&path, &doc)?;
     Ok(path)
 }
@@ -92,7 +106,11 @@ pub fn ensure_config_for_hosts(hosts: &[&str]) -> Result<PathBuf> {
 pub fn set_config_value(key: &str, raw_value: &str) -> Result<PathBuf> {
     let path = config_path();
     let mut doc = read_config_doc_or_default()?;
-    ensure_config_defaults(&mut doc, &[CLAUDE_HOST, CODEX_HOST])?;
+    ensure_config_defaults_with_mode(
+        &mut doc,
+        &[CLAUDE_HOST, CODEX_HOST],
+        ConfigDefaultMode::MigrateLegacyDefaults,
+    )?;
 
     let segments = key
         .split('.')
@@ -199,6 +217,14 @@ fn write_config_doc(path: &PathBuf, doc: &DocumentMut) -> Result<()> {
 }
 
 fn ensure_config_defaults(doc: &mut DocumentMut, hosts: &[&str]) -> Result<()> {
+    ensure_config_defaults_with_mode(doc, hosts, ConfigDefaultMode::PreserveUserValues)
+}
+
+fn ensure_config_defaults_with_mode(
+    doc: &mut DocumentMut,
+    hosts: &[&str],
+    mode: ConfigDefaultMode,
+) -> Result<()> {
     if doc.get("version").is_none() {
         doc["version"] = value(1);
     }
@@ -221,11 +247,11 @@ fn ensure_config_defaults(doc: &mut DocumentMut, hosts: &[&str]) -> Result<()> {
 
     {
         let hosts_table = child_table_mut(memory_ai, "hosts")?;
-        ensure_host_config(hosts_table, &default_host)?;
+        ensure_host_config(hosts_table, &default_host, mode)?;
         for host in hosts {
             let host = normalize_host(host);
             if !host.is_empty() && host != default_host {
-                ensure_host_config(hosts_table, &host)?;
+                ensure_host_config(hosts_table, &host, mode)?;
             }
         }
     }
@@ -257,7 +283,7 @@ fn ensure_http_profile(profiles: &mut Table) -> Result<()> {
     Ok(())
 }
 
-fn ensure_host_config(hosts: &mut Table, host: &str) -> Result<()> {
+fn ensure_host_config(hosts: &mut Table, host: &str, mode: ConfigDefaultMode) -> Result<()> {
     let table = child_table_mut(hosts, host)?;
     match host {
         CODEX_HOST => {
@@ -268,7 +294,11 @@ fn ensure_host_config(hosts: &mut Table, host: &str) -> Result<()> {
         }
         CLAUDE_HOST => {
             set_str_if_missing(table, "memory_profile", "claude");
-            set_str_if_missing_or_legacy_value(table, "context_gate", "auto", "off");
+            if mode == ConfigDefaultMode::MigrateLegacyDefaults {
+                set_str_if_missing_or_legacy_value(table, "context_gate", "auto", "off");
+            } else {
+                set_str_if_missing(table, "context_gate", "auto");
+            }
             set_bool_if_missing(table, "context_color", true);
             set_str_if_missing(table, "capture_adapter", CLAUDE_HOST);
         }
@@ -600,6 +630,24 @@ mod tests {
 
             assert_eq!(host.host, CLAUDE_HOST);
             assert_eq!(host.context_gate.as_deref(), Some("auto"));
+            Ok(())
+        })?;
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn claude_host_resolve_preserves_explicit_context_gate_off() -> Result<()> {
+        let path = temp_config_path("runtime-claude-context-explicit-off");
+        with_config_path(&path, || -> Result<()> {
+            std::fs::write(
+                &path,
+                "[memory_ai.hosts.claude-code]\nmemory_profile = \"claude\"\ncontext_gate = \"off\"\n",
+            )?;
+            let host = resolve_host_runtime_config(Some("claude-code"))?;
+
+            assert_eq!(host.host, CLAUDE_HOST);
+            assert_eq!(host.context_gate.as_deref(), Some("off"));
             Ok(())
         })?;
         std::fs::remove_file(path)?;

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -268,7 +268,7 @@ fn ensure_host_config(hosts: &mut Table, host: &str) -> Result<()> {
         }
         CLAUDE_HOST => {
             set_str_if_missing(table, "memory_profile", "claude");
-            set_str_if_missing(table, "context_gate", "off");
+            set_str_if_missing(table, "context_gate", "strict");
             set_bool_if_missing(table, "context_color", true);
             set_str_if_missing(table, "capture_adapter", CLAUDE_HOST);
         }
@@ -552,6 +552,23 @@ mod tests {
             assert_eq!(host.capture_adapter, CODEX_HOST);
         });
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn claude_host_defaults_to_context_gate_strict() -> Result<()> {
+        let path = temp_config_path("runtime-claude-context");
+        with_config_path(&path, || -> Result<()> {
+            init_config()?;
+            let host = resolve_host_runtime_config(Some("claude-code"))?;
+
+            assert_eq!(host.host, CLAUDE_HOST);
+            assert_eq!(host.context_gate.as_deref(), Some("strict"));
+            assert!(host.context_color);
+            assert_eq!(host.capture_adapter, CLAUDE_HOST);
+            Ok(())
+        })?;
+        std::fs::remove_file(path)?;
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Refs #378.

## Summary
- Add `claude-code` to the default context injection gate hosts.
- Default missing Claude host config to `context_gate = "auto"` so fresh installs use the gate.
- Preserve explicit `context_gate = "off"` opt-outs during init, reinstall, and unrelated config writes because existing configs have no provenance bit to distinguish generated legacy values from deliberate user choices.
- Add regressions for Claude resume suppression, Claude compact suppression, unknown-host bypass behavior, and explicit opt-out preservation.

## Validation
- `cargo test context::injection_gate`
- `cargo test runtime_config`
- `cargo check`
- `git diff --check`
- GitHub CI `check`

## Remaining #378 work

This does not close #378. A safe legacy migration path for old generated Claude `off` configs still needs explicit provenance or a user-visible migration command.