### PR TITLE
feat(search): expose explain via MCP and API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.17"
+version = "0.5.18"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/api/handlers/search.rs
+++ b/src/api/handlers/search.rs
@@ -35,6 +35,20 @@ pub(in crate::api) async fn handle_search(
     State(_state): State<DbState>,
     Query(params): Query<SearchParams>,
 ) -> impl IntoResponse {
+    if params.explain.unwrap_or(false)
+        && !params
+            .query
+            .as_deref()
+            .is_some_and(|query| !query.trim().is_empty())
+    {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_search_request",
+            "explain requires a non-empty query; set query or explain=false",
+        )
+        .into_response();
+    }
+
     if params.multi_hop.unwrap_or(false) && params.explain.unwrap_or(false) {
         return error_response(
             StatusCode::BAD_REQUEST,
@@ -206,6 +220,32 @@ mod tests {
             "{}",
             json
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn handle_search_rejects_explain_without_query() -> Result<()> {
+        for query in [None, Some("")] {
+            let mut params = base_search_params(Some(true));
+            params.query = query.map(str::to_string);
+
+            let response = handle_search(State(DbState), Query(params))
+                .await
+                .into_response();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = to_bytes(response.into_body(), usize::MAX).await?;
+            let json: Value = serde_json::from_slice(&body)?;
+
+            assert_eq!(json["error"]["code"], "invalid_search_request");
+            assert!(
+                json["error"]["message"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("non-empty query"),
+                "{}",
+                json
+            );
+        }
         Ok(())
     }
 }

--- a/src/api/handlers/search.rs
+++ b/src/api/handlers/search.rs
@@ -27,7 +27,7 @@ pub(in crate::api) fn search_request_from_params(params: SearchParams) -> servic
             .unwrap_or_else(service::default_include_stale),
         branch: params.branch,
         multi_hop: params.multi_hop.unwrap_or(false),
-        explain: false,
+        explain: params.explain.unwrap_or(false),
     }
 }
 
@@ -76,6 +76,7 @@ pub(in crate::api) async fn handle_search(
                     entities_discovered: meta.entities_discovered,
                 }),
                 raw_hits,
+                explain: results.explain,
             })
             .into_response()
         }
@@ -85,5 +86,86 @@ pub(in crate::api) async fn handle_search(
             &err.to_string(),
         )
         .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use axum::{
+        body::to_bytes,
+        extract::{Query, State},
+        response::IntoResponse,
+    };
+    use serde_json::Value;
+
+    use super::*;
+    use crate::db::test_support::ScopedTestDataDir;
+    use crate::memory;
+
+    fn base_search_params(explain: Option<bool>) -> SearchParams {
+        SearchParams {
+            query: Some("aurora".to_string()),
+            project: Some("/repo".to_string()),
+            memory_type: None,
+            limit: Some(5),
+            offset: Some(0),
+            include_stale: Some(true),
+            branch: None,
+            multi_hop: Some(false),
+            explain,
+        }
+    }
+
+    #[test]
+    fn search_request_from_params_keeps_explain_default_false() {
+        let request = search_request_from_params(base_search_params(None));
+
+        assert!(!request.explain);
+    }
+
+    #[test]
+    fn search_request_from_params_passes_explain_true() {
+        let request = search_request_from_params(base_search_params(Some(true)));
+
+        assert!(request.explain);
+    }
+
+    #[tokio::test]
+    async fn handle_search_emits_explain_only_when_requested() -> Result<()> {
+        let _dir = ScopedTestDataDir::new("api-search-explain");
+        let conn = crate::db::open_db()?;
+        let memory_id = memory::insert_memory(
+            &conn,
+            Some("session-1"),
+            "/repo",
+            Some("aurora-contract"),
+            "Aurora contract decision",
+            "The aurora recall contract keeps search compact before expansion.",
+            "decision",
+            None,
+        )?;
+        drop(conn);
+
+        let default_response = handle_search(State(DbState), Query(base_search_params(None)))
+            .await
+            .into_response();
+        let default_body = to_bytes(default_response.into_body(), usize::MAX).await?;
+        let default_json: Value = serde_json::from_slice(&default_body)?;
+        assert!(default_json.get("explain").is_none());
+
+        let explain_response = handle_search(State(DbState), Query(base_search_params(Some(true))))
+            .await
+            .into_response();
+        let explain_body = to_bytes(explain_response.into_body(), usize::MAX).await?;
+        let explain_json: Value = serde_json::from_slice(&explain_body)?;
+
+        assert_eq!(explain_json["data"][0]["id"], memory_id);
+        assert_eq!(explain_json["explain"]["query"], "aurora");
+        assert_eq!(
+            explain_json["explain"]["results"][0]["memory_id"],
+            memory_id
+        );
+        Ok(())
     }
 }

--- a/src/api/handlers/search.rs
+++ b/src/api/handlers/search.rs
@@ -35,6 +35,15 @@ pub(in crate::api) async fn handle_search(
     State(_state): State<DbState>,
     Query(params): Query<SearchParams>,
 ) -> impl IntoResponse {
+    if params.multi_hop.unwrap_or(false) && params.explain.unwrap_or(false) {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_search_request",
+            "explain is not supported with multi_hop search yet; set multi_hop=false or explain=false",
+        )
+        .into_response();
+    }
+
     let conn = match open_request_db() {
         Ok(conn) => conn,
         Err(response) => return response,
@@ -117,6 +126,14 @@ mod tests {
         }
     }
 
+    fn multi_hop_explain_params() -> SearchParams {
+        SearchParams {
+            multi_hop: Some(true),
+            explain: Some(true),
+            ..base_search_params(None)
+        }
+    }
+
     #[test]
     fn search_request_from_params_keeps_explain_default_false() {
         let request = search_request_from_params(base_search_params(None));
@@ -165,6 +182,29 @@ mod tests {
         assert_eq!(
             explain_json["explain"]["results"][0]["memory_id"],
             memory_id
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn handle_search_rejects_multi_hop_explain() -> Result<()> {
+        let _dir = ScopedTestDataDir::new("api-search-explain-multi-hop");
+
+        let response = handle_search(State(DbState), Query(multi_hop_explain_params()))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX).await?;
+        let json: Value = serde_json::from_slice(&body)?;
+
+        assert_eq!(json["error"]["code"], "invalid_search_request");
+        assert!(
+            json["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("multi_hop"),
+            "{}",
+            json
         );
         Ok(())
     }

--- a/src/api/handlers/search.rs
+++ b/src/api/handlers/search.rs
@@ -36,10 +36,10 @@ pub(in crate::api) async fn handle_search(
     Query(params): Query<SearchParams>,
 ) -> impl IntoResponse {
     if params.explain.unwrap_or(false)
-        && !params
+        && params
             .query
             .as_deref()
-            .is_some_and(|query| !query.trim().is_empty())
+            .is_none_or(|query| query.trim().is_empty())
     {
         return error_response(
             StatusCode::BAD_REQUEST,

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -40,6 +40,7 @@ fn search_request_from_params_clamps_limit_and_offset() {
         include_stale: None,
         branch: None,
         multi_hop: None,
+        explain: None,
     });
 
     assert_eq!(request.limit, 100);
@@ -47,6 +48,7 @@ fn search_request_from_params_clamps_limit_and_offset() {
     // Canonical default for `include_stale` is `true` so MCP and REST agree.
     assert!(request.include_stale);
     assert!(!request.multi_hop);
+    assert!(!request.explain);
 }
 
 #[test]
@@ -60,6 +62,7 @@ fn search_request_from_params_preserves_filters() {
         include_stale: Some(true),
         branch: Some("main".to_string()),
         multi_hop: Some(true),
+        explain: Some(true),
     });
 
     assert_eq!(request.query.as_deref(), Some("hello"));
@@ -70,6 +73,7 @@ fn search_request_from_params_preserves_filters() {
     assert!(request.include_stale);
     assert_eq!(request.branch.as_deref(), Some("main"));
     assert!(request.multi_hop);
+    assert!(request.explain);
 }
 
 #[tokio::test]

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -14,6 +14,7 @@ pub(super) struct SearchParams {
     pub include_stale: Option<bool>,
     pub branch: Option<String>,
     pub multi_hop: Option<bool>,
+    pub explain: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -26,6 +27,8 @@ pub(super) struct SearchResponse {
     /// Only present when the underlying service returned non-empty raw_hits.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub raw_hits: Vec<RawHitItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explain: Option<crate::retrieval::search::SearchExplain>,
 }
 
 #[derive(Serialize)]

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -50,6 +50,17 @@ impl MemoryServer {
         let start = std::time::Instant::now();
         let requested_multi_hop = params.multi_hop.unwrap_or(false);
         let requested_explain = params.explain.unwrap_or(false);
+        if requested_explain
+            && !params
+                .query
+                .as_deref()
+                .is_some_and(|query| !query.trim().is_empty())
+        {
+            return Err(McpToolError::invalid_request(
+                TOOL,
+                "explain requires a non-empty query; set query or explain=false",
+            ));
+        }
         if requested_multi_hop && requested_explain {
             return Err(McpToolError::invalid_request(
                 TOOL,
@@ -289,6 +300,33 @@ mod tests {
             "{}",
             json
         );
+        Ok(())
+    }
+
+    #[test]
+    fn search_rejects_explain_without_query() -> Result<()> {
+        let _dir = ScopedTestDataDir::new("mcp-search-explain-missing-query");
+        let server = MemoryServer::new()?;
+
+        for query in [None, Some("")] {
+            let mut params = base_search_params(Some(true));
+            params.query = query.map(str::to_string);
+
+            let err = server
+                .search(Parameters(params))
+                .expect_err("queryless explain should be rejected");
+            let json: Value = serde_json::from_str(&err.to_string())?;
+
+            assert_eq!(json["error"]["code"], "invalid_request");
+            assert!(
+                json["error"]["message"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("non-empty query"),
+                "{}",
+                json
+            );
+        }
         Ok(())
     }
 }

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -51,10 +51,10 @@ impl MemoryServer {
         let requested_multi_hop = params.multi_hop.unwrap_or(false);
         let requested_explain = params.explain.unwrap_or(false);
         if requested_explain
-            && !params
+            && params
                 .query
                 .as_deref()
-                .is_some_and(|query| !query.trim().is_empty())
+                .is_none_or(|query| query.trim().is_empty())
         {
             return Err(McpToolError::invalid_request(
                 TOOL,

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -49,6 +49,13 @@ impl MemoryServer {
         const TOOL: &str = "search";
         let start = std::time::Instant::now();
         let requested_multi_hop = params.multi_hop.unwrap_or(false);
+        let requested_explain = params.explain.unwrap_or(false);
+        if requested_multi_hop && requested_explain {
+            return Err(McpToolError::invalid_request(
+                TOOL,
+                "explain is not supported with multi_hop search yet; set multi_hop=false or explain=false",
+            ));
+        }
         crate::log::info(
             "mcp",
             &format!(
@@ -74,7 +81,7 @@ impl MemoryServer {
                     .unwrap_or_else(service::default_include_stale),
                 branch: params.branch.clone(),
                 multi_hop: requested_multi_hop,
-                explain: params.explain.unwrap_or(false),
+                explain: requested_explain,
             };
             let search_set = service::search_memories(conn, &req).map_err(|e| {
                 crate::log::warn("mcp", &format!("search failed: {}", e));
@@ -218,6 +225,14 @@ mod tests {
         }
     }
 
+    fn multi_hop_explain_params() -> SearchParams {
+        SearchParams {
+            multi_hop: Some(true),
+            explain: Some(true),
+            ..base_search_params(None)
+        }
+    }
+
     #[test]
     fn search_emits_explain_only_when_requested() -> Result<()> {
         let _dir = ScopedTestDataDir::new("mcp-search-explain");
@@ -251,6 +266,28 @@ mod tests {
         assert_eq!(
             explain_json["explain"]["results"][0]["memory_id"],
             memory_id
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn search_rejects_multi_hop_explain() -> Result<()> {
+        let _dir = ScopedTestDataDir::new("mcp-search-explain-multi-hop");
+        let server = MemoryServer::new()?;
+
+        let err = server
+            .search(Parameters(multi_hop_explain_params()))
+            .expect_err("multi-hop explain should be rejected");
+        let json: Value = serde_json::from_str(&err.to_string())?;
+
+        assert_eq!(json["error"]["code"], "invalid_request");
+        assert!(
+            json["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("multi_hop"),
+            "{}",
+            json
         );
         Ok(())
     }

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -74,7 +74,7 @@ impl MemoryServer {
                     .unwrap_or_else(service::default_include_stale),
                 branch: params.branch.clone(),
                 multi_hop: requested_multi_hop,
-                explain: false,
+                explain: params.explain.unwrap_or(false),
             };
             let search_set = service::search_memories(conn, &req).map_err(|e| {
                 crate::log::warn("mcp", &format!("search failed: {}", e));
@@ -86,7 +86,7 @@ impl MemoryServer {
                 memories,
                 multi_hop,
                 has_more,
-                explain: _,
+                explain,
                 raw_hits,
             } = search_set;
 
@@ -185,7 +185,73 @@ impl MemoryServer {
                 response["has_more"] = serde_json::Value::Bool(true);
                 response["next_offset"] = serde_json::Value::from(req_offset + req_limit);
             }
+            if let Some(explain) = explain {
+                response["explain"] = errors::to_json_value(TOOL, &explain)?;
+            }
             errors::to_json_pretty(TOOL, &response)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use rmcp::handler::server::wrapper::Parameters;
+    use serde_json::Value;
+
+    use super::*;
+    use crate::db::test_support::ScopedTestDataDir;
+    use crate::mcp::types::SearchParams;
+    use crate::memory;
+
+    fn base_search_params(explain: Option<bool>) -> SearchParams {
+        SearchParams {
+            query: Some("aurora".to_string()),
+            limit: Some(5),
+            project: Some("/repo".to_string()),
+            r#type: None,
+            offset: Some(0),
+            include_stale: Some(true),
+            branch: None,
+            multi_hop: Some(false),
+            explain,
+        }
+    }
+
+    #[test]
+    fn search_emits_explain_only_when_requested() -> Result<()> {
+        let _dir = ScopedTestDataDir::new("mcp-search-explain");
+        let conn = crate::db::open_db()?;
+        let memory_id = memory::insert_memory(
+            &conn,
+            Some("session-1"),
+            "/repo",
+            Some("aurora-contract"),
+            "Aurora contract decision",
+            "The aurora recall contract keeps search compact before expansion.",
+            "decision",
+            None,
+        )?;
+        drop(conn);
+
+        let server = MemoryServer::new()?;
+        let default_response = server
+            .search(Parameters(base_search_params(None)))
+            .map_err(anyhow::Error::msg)?;
+        let default_json: Value = serde_json::from_str(&default_response)?;
+        assert!(default_json.get("explain").is_none());
+
+        let explain_response = server
+            .search(Parameters(base_search_params(Some(true))))
+            .map_err(anyhow::Error::msg)?;
+        let explain_json: Value = serde_json::from_str(&explain_response)?;
+
+        assert_eq!(explain_json["results"][0]["id"], memory_id);
+        assert_eq!(explain_json["explain"]["query"], "aurora");
+        assert_eq!(
+            explain_json["explain"]["results"][0]["memory_id"],
+            memory_id
+        );
+        Ok(())
     }
 }

--- a/src/mcp/server/tests.rs
+++ b/src/mcp/server/tests.rs
@@ -74,6 +74,7 @@ fn search_reopens_database_after_file_removal() {
         include_stale: Some(true),
         branch: None,
         multi_hop: Some(false),
+        explain: None,
     }));
     assert!(first.is_ok());
     assert!(test_dir.db_path().exists());
@@ -90,6 +91,7 @@ fn search_reopens_database_after_file_removal() {
         include_stale: Some(true),
         branch: None,
         multi_hop: Some(false),
+        explain: None,
     }));
     assert!(second.is_ok());
     assert!(test_dir.db_path().exists());
@@ -406,6 +408,7 @@ fn search_returns_stable_compact_envelope_with_expansion_hint() {
             include_stale: Some(true),
             branch: None,
             multi_hop: Some(false),
+            explain: None,
         }))
         .expect("search succeeds");
     let json: Value = serde_json::from_str(&response).expect("search returns json");
@@ -541,6 +544,7 @@ fn search_labels_sparse_result_raw_fallback_as_raw_archive() {
             include_stale: Some(true),
             branch: Some("main".to_string()),
             multi_hop: Some(false),
+            explain: None,
         }))
         .expect("search succeeds");
     let json: Value = serde_json::from_str(&response).expect("search returns json");
@@ -569,6 +573,7 @@ fn search_preserves_multi_hop_metadata_in_compact_envelope() {
             include_stale: Some(true),
             branch: None,
             multi_hop: Some(true),
+            explain: None,
         }))
         .expect("search succeeds");
     let json: Value = serde_json::from_str(&response).expect("search returns json");
@@ -704,6 +709,7 @@ fn mcp_tool_errors_report_db_open_failure_as_retryable() {
         include_stale: Some(true),
         branch: None,
         multi_hop: Some(false),
+        explain: None,
     }));
 
     if let Err(err) = std::fs::remove_file(&test_dir.path) {

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -24,7 +24,7 @@ pub(super) struct SearchParams {
     )]
     pub multi_hop: Option<bool>,
     #[schemars(
-        description = "Include retrieval scoring and visibility explanation (default false)"
+        description = "Include retrieval scoring and visibility explanation for standard search (default false). Not supported with multi_hop=true."
     )]
     pub explain: Option<bool>,
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -23,6 +23,10 @@ pub(super) struct SearchParams {
         description = "Enable multi-hop search (default false). When true, performs entity graph expansion: finds entities in first-hop results, then searches for memories mentioning those entities. Use for questions that span multiple topics/people, e.g. 'What do Melanie\\'s kids like?' or 'What events has Caroline participated in?'"
     )]
     pub multi_hop: Option<bool>,
+    #[schemars(
+        description = "Include retrieval scoring and visibility explanation (default false)"
+    )]
+    pub explain: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]


### PR DESCRIPTION
Refs #380.

## Summary
- Add `explain` request parameters to the MCP and HTTP search surfaces.
- Pass `explain=true` through to the existing search service.
- Include explain payloads only when requested, preserving default compact behavior.

## Validation
- `cargo test api::`
- `cargo test mcp::server::`
- `cargo check`
- `cargo test --quiet`
