### PR TITLE
fix(memory): harden candidate support safety fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.18"
+version = "0.5.19"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -645,3 +645,5 @@ fn build_candidate_prompt(task: &db::ExtractionTask, batch: &ObservationBatch) -
 pub(super) mod tests;
 #[cfg(test)]
 mod tests_autopromote;
+#[cfg(test)]
+mod tests_autopromote_safety;

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -20,7 +20,7 @@ use apply::{
 use parse::{normalize_memory_type, normalize_scope, normalize_topic_key};
 use parse::{parse_defer_reason, parse_memory_candidates};
 pub(super) use route::{route_candidate, CandidateRoute};
-use support::has_conservative_support_token_overlap;
+use support::has_conservative_source_support;
 
 const MEMORY_CANDIDATE_SYSTEM: &str = "\
 Generate durable memory candidates from extracted observations.
@@ -583,8 +583,7 @@ fn is_supported_by_source_observation(
             return false;
         }
         let observation_text = normalize_evidence_text(&observation.text);
-        observation_text.contains(&candidate_text)
-            || has_conservative_support_token_overlap(&candidate_text, &observation_text)
+        has_conservative_source_support(&candidate_text, &observation_text)
     })
 }
 

--- a/src/memory_candidate/support.rs
+++ b/src/memory_candidate/support.rs
@@ -21,11 +21,12 @@ struct SupportWindow {
 const SUPPORT_RISK_TOKENS: &[&str] = &[
     "allow", "allowed", "allows", "cannot", "cant", "could", "couldn", "delete", "deleted",
     "deletes", "deny", "denied", "denies", "didn", "disable", "disabled", "disables", "doesn", "don",
-    "enable", "enabled", "enables", "fail", "failed", "failing", "fails", "hadn", "hasn",
+    "enable", "enabled", "enables", "fail", "failed", "failing", "fails", "failure", "failures", "hadn", "hasn",
     "haven", "if", "ignore", "ignored", "ignores", "isn", "may", "might", "must", "never",
-    "no", "not", "prevent", "prevented", "prevents", "reject", "rejected", "rejects",
-    "remove", "removed", "removes", "should", "shouldn", "skip", "skipped", "skips",
-    "succeed", "succeeded", "succeeds", "success", "unless", "wasn", "weren", "without",
+    "no", "not", "pass", "passed", "passes", "passing", "plan", "planned", "planning", "plans",
+    "prevent", "prevented", "prevents", "reject", "rejected", "rejects",
+    "remove", "removed", "removes", "shall", "should", "shouldn", "skip", "skipped", "skips",
+    "succeed", "succeeded", "succeeds", "success", "unless", "wasn", "weren", "will", "without",
     "won", "wouldn",
 ];
 
@@ -187,13 +188,14 @@ fn support_token(token: &str) -> Option<SupportToken> {
     if is_support_stop_token(token) {
         return None;
     }
-    let required = is_required_support_identifier(token);
-    if !required && token.chars().count() < SUPPORT_TOKEN_MIN_CHARS {
+    let required_identifier = is_required_support_identifier(token);
+    if !required_identifier && token.chars().count() < SUPPORT_TOKEN_MIN_CHARS {
         return None;
     }
+    let text = normalize_support_token(token);
     Some(SupportToken {
-        text: normalize_support_token(token),
-        required,
+        required: required_identifier || !is_optional_support_token(&text),
+        text,
     })
 }
 
@@ -202,6 +204,10 @@ fn is_required_support_identifier(token: &str) -> bool {
         token,
         "api" | "cli" | "db" | "jwt" | "llm" | "mcp" | "sql" | "ssh" | "ssl" | "tls" | "ui"
     )
+}
+
+fn is_optional_support_token(token: &str) -> bool {
+    matches!(token, "review")
 }
 
 fn normalize_support_token(token: &str) -> String {

--- a/src/memory_candidate/support.rs
+++ b/src/memory_candidate/support.rs
@@ -9,14 +9,6 @@ struct SupportToken {
     required: bool,
 }
 
-#[derive(Clone, Copy)]
-struct SupportWindow {
-    matched: usize,
-    required_matched: usize,
-    start: usize,
-    end: usize,
-}
-
 #[rustfmt::skip]
 const SUPPORT_RISK_TOKENS: &[&str] = &[
     "allow", "allowed", "allows", "cannot", "cant", "could", "couldn", "delete", "deleted",
@@ -30,7 +22,7 @@ const SUPPORT_RISK_TOKENS: &[&str] = &[
     "won", "wouldn",
 ];
 
-pub(super) fn has_conservative_support_token_overlap(
+pub(super) fn has_conservative_source_support(
     candidate_text: &str,
     observation_text: &str,
 ) -> bool {
@@ -38,6 +30,11 @@ pub(super) fn has_conservative_support_token_overlap(
     {
         return false;
     }
+    observation_text.contains(candidate_text)
+        || has_conservative_support_token_overlap(candidate_text, observation_text)
+}
+
+fn has_conservative_support_token_overlap(candidate_text: &str, observation_text: &str) -> bool {
     let candidate_tokens = support_tokens(candidate_text);
     if candidate_tokens.len() < MIN_SUPPORT_TOKEN_OVERLAP {
         return false;
@@ -49,21 +46,18 @@ pub(super) fn has_conservative_support_token_overlap(
     support_token_segments(observation_text)
         .into_iter()
         .any(|observation_tokens| {
-            ordered_support_window(&candidate_tokens, &observation_tokens).is_some_and(|window| {
-                window.matched >= MIN_SUPPORT_TOKEN_OVERLAP
-                    && window.required_matched == candidate_required
-                    && (window.matched as f64 / candidate_tokens.len() as f64)
-                        >= MIN_SUPPORT_TOKEN_RATIO
-            })
+            has_ordered_support_window(&candidate_tokens, &observation_tokens, candidate_required)
         })
 }
 
-fn ordered_support_window(
+fn has_ordered_support_window(
     candidate_tokens: &[SupportToken],
     observation_tokens: &[SupportToken],
-) -> Option<SupportWindow> {
-    let first_candidate = candidate_tokens.first()?;
-    let mut best = None;
+    candidate_required: usize,
+) -> bool {
+    let Some(first_candidate) = candidate_tokens.first() else {
+        return false;
+    };
     for (candidate_start, observation) in observation_tokens.iter().enumerate() {
         if observation.text != first_candidate.text {
             continue;
@@ -92,23 +86,14 @@ fn ordered_support_window(
         }
         let window_len = end.saturating_sub(candidate_start) + 1;
         if window_len <= candidate_tokens.len() + MAX_SUPPORT_TOKEN_WINDOW_EXTRA
-            && best
-                .map(|best| is_better_support_window(matched, candidate_start, end, best))
-                .unwrap_or(true)
+            && matched >= MIN_SUPPORT_TOKEN_OVERLAP
+            && required_matched == candidate_required
+            && (matched as f64 / candidate_tokens.len() as f64) >= MIN_SUPPORT_TOKEN_RATIO
         {
-            best = Some(SupportWindow {
-                matched,
-                required_matched,
-                start: candidate_start,
-                end,
-            });
+            return true;
         }
     }
-    best
-}
-
-fn is_better_support_window(matched: usize, start: usize, end: usize, best: SupportWindow) -> bool {
-    matched > best.matched || (matched == best.matched && end - start < best.end - best.start)
+    false
 }
 
 fn support_tokens(text: &str) -> Vec<SupportToken> {
@@ -202,7 +187,21 @@ fn support_token(token: &str) -> Option<SupportToken> {
 fn is_required_support_identifier(token: &str) -> bool {
     matches!(
         token,
-        "api" | "cli" | "db" | "jwt" | "llm" | "mcp" | "sql" | "ssh" | "ssl" | "tls" | "ui"
+        "aes"
+            | "api"
+            | "cli"
+            | "db"
+            | "jwt"
+            | "kms"
+            | "llm"
+            | "mcp"
+            | "rsa"
+            | "s3"
+            | "sql"
+            | "ssh"
+            | "ssl"
+            | "tls"
+            | "ui"
     )
 }
 

--- a/src/memory_candidate/tests_autopromote.rs
+++ b/src/memory_candidate/tests_autopromote.rs
@@ -6,7 +6,7 @@ use crate::db;
 use super::tests::{setup_conn, setup_task};
 use super::{process_with_generator, MemoryCandidateResult};
 
-fn insert_source_observation_typed(
+pub(super) fn insert_source_observation_typed(
     conn: &Connection,
     task: &db::ExtractionTask,
     observation_type: &str,

--- a/src/memory_candidate/tests_autopromote_safety.rs
+++ b/src/memory_candidate/tests_autopromote_safety.rs
@@ -158,3 +158,132 @@ async fn memory_candidate_keeps_future_tense_observation_pending() -> Result<()>
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn memory_candidate_keeps_exact_future_tense_candidate_pending() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-exact-future-tense")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "The ingestion worker will persist durable memory candidates from summarized observations.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>discovery</type><topic_key>discovery-exact-future-tense</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>The ingestion worker will persist durable memory candidates from summarized observations.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1,
+            to_event_id: task
+                .high_watermark_event_id
+                .ok_or_else(|| anyhow::anyhow!("task watermark"))?
+        }
+    );
+    let (review_status, block_reason): (String, Option<String>) = conn.query_row(
+        "SELECT review_status, auto_promote_block_reason FROM memory_candidates",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(review_status, "pending_review");
+    assert_eq!(
+        block_reason.as_deref(),
+        Some("no_supporting_source_observation")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_requires_support_for_short_security_modifiers() -> Result<()> {
+    for modifier in ["AES", "KMS", "RSA", "S3"] {
+        assert_short_security_modifier_pending(modifier).await?;
+    }
+    Ok(())
+}
+
+async fn assert_short_security_modifier_pending(modifier: &str) -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(
+        &mut conn,
+        &format!(
+            "sess-candidate-short-security-modifier-{}",
+            modifier.to_ascii_lowercase()
+        ),
+    )?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "API gateway stores JWT auth keys inside the Redis cache layer for operator login flows.",
+    )?;
+
+    let topic_key = format!("discovery-{}-jwt-cache", modifier.to_ascii_lowercase());
+    let response = format!(
+        "<memory_candidate><scope>project</scope><type>discovery</type><topic_key>{topic_key}</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>API gateway stores {modifier} JWT auth keys in Redis cache layer.</text></memory_candidate>"
+    );
+    let result = process_with_generator(&mut conn, &task, |_prompt| async { Ok(response) }).await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1,
+            to_event_id: task
+                .high_watermark_event_id
+                .ok_or_else(|| anyhow::anyhow!("task watermark"))?
+        }
+    );
+    let (review_status, block_reason): (String, Option<String>) = conn.query_row(
+        "SELECT review_status, auto_promote_block_reason FROM memory_candidates",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(review_status, "pending_review");
+    assert_eq!(
+        block_reason.as_deref(),
+        Some("no_supporting_source_observation")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_auto_promotes_later_required_support_window() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-later-required-window")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "The worker lifecycle records auto promote block reasons in memory candidate review notes, the worker lifecycle records auto promote block reasons in memory candidate diagnostics.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>discovery</type><topic_key>discovery-later-required-window</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>Worker lifecycle records auto promote block reasons for memory candidate review diagnostics.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0,
+            to_event_id: task
+                .high_watermark_event_id
+                .ok_or_else(|| anyhow::anyhow!("task watermark"))?
+        }
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(review_status, "auto_promoted");
+    Ok(())
+}

--- a/src/memory_candidate/tests_autopromote_safety.rs
+++ b/src/memory_candidate/tests_autopromote_safety.rs
@@ -1,0 +1,160 @@
+use anyhow::Result;
+
+use super::tests::{setup_conn, setup_task};
+use super::tests_autopromote::insert_source_observation_typed;
+use super::{process_with_generator, MemoryCandidateResult};
+
+#[tokio::test]
+async fn memory_candidate_keeps_failure_pass_polarity_pending() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-failure-pass-polarity")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "Source evidence validation failures for condensed memory candidate promotion are visible in diagnostics.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>discovery</type><topic_key>discovery-validation-passes</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>Source evidence validation passes for condensed memory candidate promotion.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1,
+            to_event_id: task
+                .high_watermark_event_id
+                .ok_or_else(|| anyhow::anyhow!("task watermark"))?
+        }
+    );
+    let (review_status, block_reason): (String, Option<String>) = conn.query_row(
+        "SELECT review_status, auto_promote_block_reason FROM memory_candidates",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(review_status, "pending_review");
+    assert_eq!(
+        block_reason.as_deref(),
+        Some("no_supporting_source_observation")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_requires_support_for_security_modifier() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-security-modifier")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "API gateway stores JWT auth keys inside the Redis cache layer for operator login flows.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>discovery</type><topic_key>discovery-encrypted-jwt-cache</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>API gateway stores encrypted JWT auth keys in Redis cache layer.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1,
+            to_event_id: task
+                .high_watermark_event_id
+                .ok_or_else(|| anyhow::anyhow!("task watermark"))?
+        }
+    );
+    let (review_status, block_reason): (String, Option<String>) = conn.query_row(
+        "SELECT review_status, auto_promote_block_reason FROM memory_candidates",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(review_status, "pending_review");
+    assert_eq!(
+        block_reason.as_deref(),
+        Some("no_supporting_source_observation")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_auto_promotes_supported_security_modifier() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-supported-security-modifier")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "The API gateway stores encrypted JWT auth keys inside the Redis cache layer for operator login flows.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>discovery</type><topic_key>discovery-encrypted-jwt-cache-supported</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>API gateway stores encrypted JWT auth key in Redis cache layer.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0,
+            to_event_id: task
+                .high_watermark_event_id
+                .ok_or_else(|| anyhow::anyhow!("task watermark"))?
+        }
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(review_status, "auto_promoted");
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_keeps_future_tense_observation_pending() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-future-tense")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "The ingestion worker will persist durable memory candidates from summarized observations.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>discovery</type><topic_key>discovery-future-tense</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>Ingestion worker persists durable memory candidates from summarized observations.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1,
+            to_event_id: task
+                .high_watermark_event_id
+                .ok_or_else(|| anyhow::anyhow!("task watermark"))?
+        }
+    );
+    let (review_status, block_reason): (String, Option<String>) = conn.query_row(
+        "SELECT review_status, auto_promote_block_reason FROM memory_candidates",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(review_status, "pending_review");
+    assert_eq!(
+        block_reason.as_deref(),
+        Some("no_supporting_source_observation")
+    );
+    Ok(())
+}


### PR DESCRIPTION
Refs #357.
Follow-up to #391 post-merge auto-review.

## Summary
- Treat failure/pass polarity and future/planned wording as unsafe for overlap auto-promotion.
- Require every non-optional candidate support token to be present in the source window, while keeping the existing `review` optional-token path so the condensed partial-support case remains useful.
- Add a dedicated safety regression module for candidate support fallback edge cases, reusing the existing typed-observation helper instead of duplicating it.

## Review Threads Addressed
- #391 `Block failure/pass polarity before overlap promotion`
- #391 `Require support for candidate-only security modifiers`
- #391 `Block future-tense observations before factual promotion`

## Validation
- `cargo fmt --check`
- `cargo test memory_candidate`
- `cargo clippy -- -D warnings`
- `cargo check`
- `cargo test`

## Remaining #357 Work
This still does not close #357. The issue continues to track promotion metrics and model-provided observation confidence.