### PR TITLE
fix(memory): narrow exact support risk segmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.19"
+version = "0.5.20"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/memory_candidate/support.rs
+++ b/src/memory_candidate/support.rs
@@ -13,7 +13,7 @@ struct SupportToken {
 const SUPPORT_RISK_TOKENS: &[&str] = &[
     "allow", "allowed", "allows", "cannot", "cant", "could", "couldn", "delete", "deleted",
     "deletes", "deny", "denied", "denies", "didn", "disable", "disabled", "disables", "doesn", "don",
-    "enable", "enabled", "enables", "fail", "failed", "failing", "fails", "failure", "failures", "hadn", "hasn",
+    "enable", "enabled", "enables", "fail", "failed", "failing", "fails", "hadn", "hasn",
     "haven", "if", "ignore", "ignored", "ignores", "isn", "may", "might", "must", "never",
     "no", "not", "pass", "passed", "passes", "passing", "plan", "planned", "planning", "plans",
     "prevent", "prevented", "prevents", "reject", "rejected", "rejects",
@@ -26,12 +26,17 @@ pub(super) fn has_conservative_source_support(
     candidate_text: &str,
     observation_text: &str,
 ) -> bool {
-    if contains_support_risk_token(candidate_text) || contains_support_risk_token(observation_text)
-    {
+    if contains_support_risk_token(candidate_text) {
         return false;
     }
-    observation_text.contains(candidate_text)
+    has_conservative_exact_support(candidate_text, observation_text)
         || has_conservative_support_token_overlap(candidate_text, observation_text)
+}
+
+fn has_conservative_exact_support(candidate_text: &str, observation_text: &str) -> bool {
+    support_sentence_segments(observation_text)
+        .into_iter()
+        .any(|segment| !contains_support_risk_token(&segment) && segment.contains(candidate_text))
 }
 
 fn has_conservative_support_token_overlap(candidate_text: &str, observation_text: &str) -> bool {
@@ -43,11 +48,25 @@ fn has_conservative_support_token_overlap(candidate_text: &str, observation_text
         .iter()
         .filter(|token| token.required)
         .count();
-    support_token_segments(observation_text)
+    support_text_segments(observation_text)
         .into_iter()
-        .any(|observation_tokens| {
-            has_ordered_support_window(&candidate_tokens, &observation_tokens, candidate_required)
+        .any(|segment| {
+            !contains_support_risk_token(&segment)
+                && has_conservative_support_token_overlap_segment(
+                    &candidate_tokens,
+                    &segment,
+                    candidate_required,
+                )
         })
+}
+
+fn has_conservative_support_token_overlap_segment(
+    candidate_tokens: &[SupportToken],
+    observation_text: &str,
+    candidate_required: usize,
+) -> bool {
+    let observation_tokens = support_tokens(observation_text);
+    has_ordered_support_window(candidate_tokens, &observation_tokens, candidate_required)
 }
 
 fn has_ordered_support_window(
@@ -102,49 +121,69 @@ fn support_tokens(text: &str) -> Vec<SupportToken> {
         .collect()
 }
 
-fn support_token_segments(text: &str) -> Vec<Vec<SupportToken>> {
+fn support_sentence_segments(text: &str) -> Vec<String> {
     let mut segments = Vec::new();
-    let mut current = Vec::new();
-    let mut token = String::new();
-    for ch in text.chars() {
-        if ch.is_ascii_alphanumeric() {
-            token.push(ch.to_ascii_lowercase());
-            continue;
-        }
-        flush_support_segment_token(&mut token, &mut current, &mut segments);
-        if is_support_clause_boundary_char(ch) {
-            finish_support_segment(&mut current, &mut segments);
+    let mut segment_start = 0;
+    for (index, ch) in text.char_indices() {
+        if is_support_sentence_boundary_char(ch) {
+            push_support_text_segment(text, segment_start, index + ch.len_utf8(), &mut segments);
+            segment_start = index + ch.len_utf8();
         }
     }
-    flush_support_segment_token(&mut token, &mut current, &mut segments);
-    finish_support_segment(&mut current, &mut segments);
+    push_support_text_segment(text, segment_start, text.len(), &mut segments);
     segments
 }
 
-fn flush_support_segment_token(
-    token: &mut String,
-    current: &mut Vec<SupportToken>,
-    segments: &mut Vec<Vec<SupportToken>>,
-) {
-    if token.is_empty() {
-        return;
+fn support_text_segments(text: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut segment_start = 0;
+    let mut token_start = None;
+    for (index, ch) in text.char_indices() {
+        if ch.is_ascii_alphanumeric() {
+            if token_start.is_none() {
+                token_start = Some(index);
+            }
+        } else {
+            if let Some(start) = token_start.take() {
+                let token = text[start..index].to_ascii_lowercase();
+                if is_support_clause_boundary_token(&token) {
+                    push_support_text_segment(text, segment_start, start, &mut segments);
+                    segment_start = index + ch.len_utf8();
+                }
+            }
+            if is_support_clause_boundary_char(ch) {
+                push_support_text_segment(text, segment_start, index, &mut segments);
+                segment_start = index + ch.len_utf8();
+            }
+        }
     }
-    if is_support_clause_boundary_token(token) {
-        finish_support_segment(current, segments);
-    } else if let Some(token) = support_token(token) {
-        current.push(token);
+    if let Some(start) = token_start {
+        let token = text[start..].to_ascii_lowercase();
+        if is_support_clause_boundary_token(&token) {
+            push_support_text_segment(text, segment_start, start, &mut segments);
+            segment_start = text.len();
+        }
     }
-    token.clear();
+    push_support_text_segment(text, segment_start, text.len(), &mut segments);
+    segments
 }
 
-fn finish_support_segment(current: &mut Vec<SupportToken>, segments: &mut Vec<Vec<SupportToken>>) {
-    if !current.is_empty() {
-        segments.push(std::mem::take(current));
+fn push_support_text_segment(text: &str, start: usize, end: usize, segments: &mut Vec<String>) {
+    if start >= end {
+        return;
+    }
+    let segment = text[start..end].trim();
+    if !segment.is_empty() {
+        segments.push(segment.to_string());
     }
 }
 
 fn is_support_clause_boundary_char(ch: char) -> bool {
     matches!(ch, '.' | ';' | ':' | '?' | '!')
+}
+
+fn is_support_sentence_boundary_char(ch: char) -> bool {
+    matches!(ch, '.' | ';' | '?' | '!')
 }
 
 fn is_support_clause_boundary_token(token: &str) -> bool {

--- a/src/memory_candidate/tests_autopromote_safety.rs
+++ b/src/memory_candidate/tests_autopromote_safety.rs
@@ -45,6 +45,76 @@ async fn memory_candidate_keeps_failure_pass_polarity_pending() -> Result<()> {
 }
 
 #[tokio::test]
+async fn memory_candidate_auto_promotes_exact_fact_with_unrelated_risk_segment() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-unrelated-risk-segment")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "No migration is needed. The extraction worker uses one writer SQLite connection for memory writes.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>discovery</type><topic_key>discovery-exact-supported-risk-segment</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>The extraction worker uses one writer SQLite connection for memory writes.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0,
+            to_event_id: task
+                .high_watermark_event_id
+                .ok_or_else(|| anyhow::anyhow!("task watermark"))?
+        }
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(review_status, "auto_promoted");
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_candidate_auto_promotes_exact_failure_diagnostic_fact() -> Result<()> {
+    let mut conn = setup_conn();
+    let task = setup_task(&mut conn, "sess-candidate-exact-failure-diagnostic")?;
+    insert_source_observation_typed(
+        &conn,
+        &task,
+        "feature",
+        "Source evidence validation failures are visible in memory candidate diagnostics.",
+    )?;
+
+    let result = process_with_generator(&mut conn, &task, |_prompt| async {
+        Ok("<memory_candidate><scope>project</scope><type>discovery</type><topic_key>discovery-exact-failure-diagnostic</topic_key><risk_class>low</risk_class><confidence>0.92</confidence><text>Source evidence validation failures are visible in memory candidate diagnostics.</text></memory_candidate>".to_string())
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        MemoryCandidateResult::Written {
+            candidates: 1,
+            promoted: 1,
+            pending_review: 0,
+            to_event_id: task
+                .high_watermark_event_id
+                .ok_or_else(|| anyhow::anyhow!("task watermark"))?
+        }
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(review_status, "auto_promoted");
+    Ok(())
+}
+
+#[tokio::test]
 async fn memory_candidate_requires_support_for_security_modifier() -> Result<()> {
     let mut conn = setup_conn();
     let task = setup_task(&mut conn, "sess-candidate-security-modifier")?;


### PR DESCRIPTION
Refs #357.
Follow-up to #395 post-merge review.

## Summary
- Keep candidate-level risk tokens as fail-closed, but evaluate observation risk only on the segment that actually supports the candidate.
- Split exact-match support at sentence boundaries instead of global observation text, so unrelated risky sentences do not block factual exact support.
- Keep overlap support on the stricter clause/window segmentation path.
- Stop treating `failure`/`failures` nouns as inherently unsafe so exact diagnostic facts can still auto-promote while polarity swaps remain blocked by `pass`/`passes` etc.
- Bump version to `0.5.20`.

## Review Threads Addressed
- #395 `Limit risk checks to the supporting clause`
- #395 `Allow exact supported failure-diagnostic facts`

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test memory_candidate::tests_autopromote_safety`
- `cargo test memory_candidate`
- `cargo test`

## Remaining #357 Work
This still does not close #357. The issue continues to track promotion metrics and model-provided observation confidence.