### PR TITLE
[codex] Add SessionStart injection eval baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.20"
+version = "0.5.21"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.20"
+version = "0.5.21"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,4 +18,5 @@ mod tests;
 mod types;
 
 pub(crate) use render::governance_eval_snapshot;
+pub(crate) use render::session_start_eval_snapshot;
 pub use render::{generate_context, generate_context_from_cli};

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -108,6 +108,7 @@ fn load_project_memories(
         conn,
         project,
         None,
+        current_branch,
         excluded_types,
         policy.limits.candidate_fetch_limit as i64,
     )
@@ -129,6 +130,7 @@ fn load_project_memories(
         conn,
         project,
         Some(project_query),
+        current_branch,
         excluded_types,
         BASENAME_SEARCH_LIMIT,
     ) {
@@ -213,6 +215,7 @@ fn query_owner_included_memory_rows(
     conn: &Connection,
     project: &str,
     query: Option<&str>,
+    current_branch: Option<&str>,
     excluded_types: &[&str],
     limit: i64,
 ) -> Result<Vec<ContextMemoryRow>> {
@@ -232,6 +235,11 @@ fn query_owner_included_memory_rows(
     conditions.push(crate::memory::memory_state_key_current_filter_sql(
         "memories",
     ));
+    if let Some(branch) = current_branch.filter(|branch| !branch.trim().is_empty()) {
+        conditions.push(format!("(branch = ?{idx} OR branch IS NULL)"));
+        params.push(Box::new(branch.to_string()));
+        idx += 1;
+    }
 
     if let Some(query) = query {
         let like_pattern = format!("%{query}%");

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -84,6 +84,51 @@ pub(crate) fn governance_eval_snapshot(
     })
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionStartEvalSnapshot {
+    pub rendered_output: String,
+    pub output_chars: usize,
+    pub memories_loaded: usize,
+    pub core_count: usize,
+    pub index_count: usize,
+    pub lesson_count: usize,
+    pub preference_count: usize,
+    pub session_count: usize,
+    pub workstream_count: usize,
+    pub truncated: bool,
+}
+
+pub(crate) fn session_start_eval_snapshot(
+    cwd: &str,
+    project: &str,
+    current_branch: Option<&str>,
+    host: &str,
+) -> Result<SessionStartEvalSnapshot> {
+    let request = ContextRequest {
+        cwd: cwd.to_string(),
+        project: project.to_string(),
+        session_id: Some("eval-session-start".to_string()),
+        hook_source: Some("SessionStart".to_string()),
+        current_branch: current_branch.map(str::to_string),
+        host: super::host::resolve_host_kind(Some(host)),
+        use_colors: false,
+    };
+    let policy = ContextPolicy::from_limits(ContextLimits::default());
+    let rendered = render_context_output_with_policy(&request, false, policy)?;
+    Ok(SessionStartEvalSnapshot {
+        rendered_output: rendered.output,
+        output_chars: rendered.stats.output_chars,
+        memories_loaded: rendered.stats.memories_loaded,
+        core_count: rendered.stats.core.count,
+        index_count: rendered.stats.index.count,
+        lesson_count: rendered.stats.lessons.count,
+        preference_count: rendered.stats.preferences.count,
+        session_count: rendered.stats.sessions.count,
+        workstream_count: rendered.stats.workstreams.count,
+        truncated: rendered.stats.truncated,
+    })
+}
+
 fn render_loaded_context_for_eval(
     conn: &rusqlite::Connection,
     project: &str,
@@ -257,7 +302,15 @@ pub(in crate::context) fn render_context_output(
     debug: bool,
 ) -> Result<RenderedContext> {
     let profile = resolve_profile(request.host);
-    let policy = profile.default_policy();
+    render_context_output_with_policy(request, debug, profile.default_policy())
+}
+
+fn render_context_output_with_policy(
+    request: &ContextRequest,
+    debug: bool,
+    policy: ContextPolicy,
+) -> Result<RenderedContext> {
+    let profile = resolve_profile(request.host);
     let conn = match db::open_db() {
         Ok(connection) => connection,
         Err(error) => {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,5 +1,6 @@
 pub mod e2e;
 pub mod golden;
 pub mod governance;
+pub mod injection;
 pub mod local;
 pub mod metrics;

--- a/src/eval/governance/types.rs
+++ b/src/eval/governance/types.rs
@@ -52,7 +52,7 @@ pub struct RateMetric {
 }
 
 impl RateMetric {
-    pub(super) fn new(passed: usize, total: usize) -> Self {
+    pub fn new(passed: usize, total: usize) -> Self {
         Self {
             passed,
             total,
@@ -64,7 +64,7 @@ impl RateMetric {
         }
     }
 
-    pub(super) fn is_perfect(&self) -> bool {
+    pub fn is_perfect(&self) -> bool {
         self.total > 0 && self.passed == self.total
     }
 }

--- a/src/eval/injection.rs
+++ b/src/eval/injection.rs
@@ -1,0 +1,10 @@
+mod run;
+#[cfg(test)]
+mod tests;
+mod types;
+
+pub use run::run_sandbox_eval;
+pub use types::{
+    InjectionCaseReport, InjectionEvalMetadata, InjectionEvalOptions, InjectionEvalReport,
+    InjectionMetricSummary, InjectionRateMetric,
+};

--- a/src/eval/injection/run.rs
+++ b/src/eval/injection/run.rs
@@ -1,0 +1,320 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+
+use super::types::{
+    InjectionCaseReport, InjectionEvalMetadata, InjectionEvalOptions, InjectionEvalReport,
+    InjectionMetricSummary, InjectionRateMetric, CORPUS_NAME,
+};
+
+const PROJECT: &str = "/tmp/remem-injection-eval/repo";
+const OTHER_PROJECT: &str = "/tmp/remem-injection-eval/other";
+const HOST: &str = "codex-cli";
+const CURRENT_BRANCH: &str = "main";
+
+#[derive(Clone, Copy)]
+struct FixtureMemory {
+    id: i64,
+    project: &'static str,
+    topic_key: &'static str,
+    title: &'static str,
+    content: &'static str,
+    memory_type: &'static str,
+    branch: Option<&'static str>,
+    status: &'static str,
+    updated_offset: i64,
+    expected: InjectionExpectation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InjectionExpectation {
+    Expected,
+    Forbidden,
+    Filler,
+}
+
+const FIXTURE_MEMORIES: &[FixtureMemory] = &[
+    FixtureMemory {
+        id: 1,
+        project: PROJECT,
+        topic_key: "inject-migration-locking",
+        title: "Migration locking fix",
+        content: "Root cause: startup migrations raced. Fix: serialize migration execution and verify with cargo test migrate::tests.",
+        memory_type: "bugfix",
+        branch: Some(CURRENT_BRANCH),
+        status: "active",
+        updated_offset: 0,
+        expected: InjectionExpectation::Expected,
+    },
+    FixtureMemory {
+        id: 2,
+        project: PROJECT,
+        topic_key: "inject-api-token-handling",
+        title: "API token handling decision",
+        content: "Keep API tokens in the temp data directory and avoid reading user-level state during sandboxed evals.",
+        memory_type: "decision",
+        branch: None,
+        status: "active",
+        updated_offset: -1,
+        expected: InjectionExpectation::Expected,
+    },
+    FixtureMemory {
+        id: 3,
+        project: PROJECT,
+        topic_key: "inject-branch-mismatch",
+        title: "Feature branch wasm snapshot",
+        content: "This feature-only memory must not appear when the SessionStart branch is main.",
+        memory_type: "decision",
+        branch: Some("feature/wasm"),
+        status: "active",
+        updated_offset: 10,
+        expected: InjectionExpectation::Filler,
+    },
+    FixtureMemory {
+        id: 4,
+        project: OTHER_PROJECT,
+        topic_key: "inject-cross-project",
+        title: "Other project migration shortcut",
+        content: "A different project memory must not leak into this repo's SessionStart context.",
+        memory_type: "bugfix",
+        branch: None,
+        status: "active",
+        updated_offset: 20,
+        expected: InjectionExpectation::Forbidden,
+    },
+    FixtureMemory {
+        id: 5,
+        project: PROJECT,
+        topic_key: "inject-deleted-advice",
+        title: "Deleted project advice",
+        content: "Deleted memories must not be rendered by the injection path.",
+        memory_type: "discovery",
+        branch: None,
+        status: "deleted",
+        updated_offset: 30,
+        expected: InjectionExpectation::Forbidden,
+    },
+    FixtureMemory {
+        id: 6,
+        project: PROJECT,
+        topic_key: "inject-filler-telemetry",
+        title: "Telemetry fixture filler",
+        content: "Filler memory keeps the fixture realistic without affecting pass/fail expectations.",
+        memory_type: "discovery",
+        branch: None,
+        status: "active",
+        updated_offset: -2,
+        expected: InjectionExpectation::Filler,
+    },
+];
+
+pub fn run_sandbox_eval(options: InjectionEvalOptions) -> Result<InjectionEvalReport> {
+    let temp_data_dir = TempDataDir::new()?;
+    let data_dir = temp_data_dir.path.clone();
+    let result = crate::db::core::with_data_dir(&data_dir, || {
+        crate::log::with_log_dir(&data_dir, || run_sandbox_eval_inner(options, &data_dir))
+    });
+    cleanup_data_dir_after_eval(temp_data_dir, options.keep_data_dir, result)
+}
+
+fn run_sandbox_eval_inner(
+    options: InjectionEvalOptions,
+    data_dir: &Path,
+) -> Result<InjectionEvalReport> {
+    let mut conn = crate::db::open_db().context("open sandbox injection eval DB")?;
+    seed_fixture(&mut conn).context("seed injection eval fixture")?;
+    drop(conn);
+
+    let snapshot =
+        crate::context::session_start_eval_snapshot(PROJECT, PROJECT, Some(CURRENT_BRANCH), HOST)
+            .context("render SessionStart injection context")?;
+
+    let expected_cases = evaluate_cases(&snapshot.rendered_output, InjectionExpectation::Expected);
+    let forbidden_cases =
+        evaluate_cases(&snapshot.rendered_output, InjectionExpectation::Forbidden);
+    let expected_memory_recall = InjectionRateMetric::new(
+        expected_cases.iter().filter(|case| case.matched).count(),
+        expected_cases.len(),
+    );
+    let forbidden_memory_exclusion = InjectionRateMetric::new(
+        forbidden_cases.iter().filter(|case| case.matched).count(),
+        forbidden_cases.len(),
+    );
+    let all_checks_passed =
+        expected_memory_recall.is_perfect() && forbidden_memory_exclusion.is_perfect();
+    let mut failing_examples = Vec::new();
+    for case in expected_cases.iter().filter(|case| !case.matched) {
+        failing_examples.push(format!("missing expected memory: {}", case.title));
+    }
+    for case in forbidden_cases.iter().filter(|case| !case.matched) {
+        failing_examples.push(format!("rendered forbidden memory: {}", case.title));
+    }
+
+    let mut cases = expected_cases;
+    cases.extend(forbidden_cases);
+    Ok(InjectionEvalReport {
+        metadata: InjectionEvalMetadata {
+            corpus: CORPUS_NAME.to_string(),
+            boundary: "context::render_context_output".to_string(),
+            storage: "temporary sqlite".to_string(),
+            data_dir: data_dir.display().to_string(),
+            data_dir_kept: options.keep_data_dir,
+            real_db_touched: false,
+            project: PROJECT.to_string(),
+            host: HOST.to_string(),
+            branch: CURRENT_BRANCH.to_string(),
+            output_chars: snapshot.output_chars,
+            memories_loaded: snapshot.memories_loaded,
+            core_count: snapshot.core_count,
+            index_count: snapshot.index_count,
+            lesson_count: snapshot.lesson_count,
+            preference_count: snapshot.preference_count,
+            session_count: snapshot.session_count,
+            workstream_count: snapshot.workstream_count,
+            truncated: snapshot.truncated,
+        },
+        metrics: InjectionMetricSummary {
+            expected_memory_recall,
+            forbidden_memory_exclusion,
+            all_checks_passed,
+        },
+        cases,
+        failing_examples,
+    })
+}
+
+fn evaluate_cases(output: &str, expectation: InjectionExpectation) -> Vec<InjectionCaseReport> {
+    FIXTURE_MEMORIES
+        .iter()
+        .filter(|memory| memory.expected == expectation)
+        .map(|memory| {
+            let present = output.contains(memory.title);
+            let matched = match expectation {
+                InjectionExpectation::Expected => present,
+                InjectionExpectation::Forbidden => !present,
+                InjectionExpectation::Filler => true,
+            };
+            InjectionCaseReport {
+                id: memory.id.to_string(),
+                expectation: expectation.as_str().to_string(),
+                title: memory.title.to_string(),
+                topic_key: memory.topic_key.to_string(),
+                matched,
+            }
+        })
+        .collect()
+}
+
+impl InjectionExpectation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Expected => "expected",
+            Self::Forbidden => "forbidden",
+            Self::Filler => "filler",
+        }
+    }
+}
+
+fn seed_fixture(conn: &mut Connection) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let tx = conn.transaction()?;
+    for memory in FIXTURE_MEMORIES {
+        tx.execute(
+            "INSERT INTO memories
+             (id, session_id, project, topic_key, title, content, memory_type, files,
+              created_at_epoch, updated_at_epoch, status, branch, scope)
+             VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?7, ?8, ?9, 'project')",
+            params![
+                memory.id,
+                memory.project,
+                memory.topic_key,
+                memory.title,
+                memory.content,
+                memory.memory_type,
+                now + memory.updated_offset,
+                memory.status,
+                memory.branch,
+            ],
+        )?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+fn unique_temp_data_dir() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "remem-injection-eval-{}-{}",
+        std::process::id(),
+        nanos
+    ))
+}
+
+struct TempDataDir {
+    path: PathBuf,
+    cleaned: bool,
+}
+
+impl TempDataDir {
+    fn new() -> Result<Self> {
+        let path = unique_temp_data_dir();
+        std::fs::create_dir_all(&path)
+            .with_context(|| format!("create injection eval data dir {}", path.display()))?;
+        crate::db::core::with_data_dir(&path, crate::db::generate_cipher_key)
+            .context("create injection eval database key")?;
+        Ok(Self {
+            path,
+            cleaned: false,
+        })
+    }
+
+    fn cleanup(&mut self) -> Result<()> {
+        std::fs::remove_dir_all(&self.path)
+            .with_context(|| format!("remove injection eval data dir {}", self.path.display()))?;
+        self.cleaned = true;
+        Ok(())
+    }
+}
+
+impl Drop for TempDataDir {
+    fn drop(&mut self) {
+        if self.cleaned {
+            return;
+        }
+        if let Err(cleanup_err) = std::fs::remove_dir_all(&self.path) {
+            crate::log::warn(
+                "eval-injection",
+                &format!("cleanup failed during drop: {}", cleanup_err),
+            );
+        }
+    }
+}
+
+fn cleanup_data_dir_after_eval<T>(
+    mut temp_data_dir: TempDataDir,
+    keep_data_dir: bool,
+    result: Result<T>,
+) -> Result<T> {
+    if keep_data_dir {
+        temp_data_dir.cleaned = true;
+        return result;
+    }
+    let cleanup = temp_data_dir.cleanup();
+    match (result, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(err)) => Err(err),
+        (Err(err), Ok(())) => Err(err),
+        (Err(err), Err(cleanup_err)) => {
+            crate::log::warn(
+                "eval-injection",
+                &format!("cleanup failed after eval error: {}", cleanup_err),
+            );
+            Err(err)
+        }
+    }
+}

--- a/src/eval/injection/run.rs
+++ b/src/eval/injection/run.rs
@@ -70,7 +70,7 @@ const FIXTURE_MEMORIES: &[FixtureMemory] = &[
         branch: Some("feature/wasm"),
         status: "active",
         updated_offset: 10,
-        expected: InjectionExpectation::Filler,
+        expected: InjectionExpectation::Forbidden,
     },
     FixtureMemory {
         id: 4,

--- a/src/eval/injection/tests.rs
+++ b/src/eval/injection/tests.rs
@@ -1,0 +1,73 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::types::CORPUS_NAME;
+use super::{
+    run_sandbox_eval, InjectionEvalMetadata, InjectionEvalOptions, InjectionEvalReport,
+    InjectionMetricSummary, InjectionRateMetric,
+};
+
+#[test]
+fn injection_eval_exercises_session_start_render_path() -> Result<()> {
+    let report = run_sandbox_eval(InjectionEvalOptions::default())?;
+
+    assert!(!report.metadata.real_db_touched);
+    assert_eq!(report.metadata.boundary, "context::render_context_output");
+    assert!(
+        report.metrics.expected_memory_recall.is_perfect(),
+        "{:#?}",
+        report
+    );
+    assert!(
+        report.metrics.forbidden_memory_exclusion.is_perfect(),
+        "{:#?}",
+        report
+    );
+    assert!(report.metrics.all_checks_passed, "{:#?}", report);
+    assert!(report.metadata.memories_loaded > 0);
+    assert!(report.metadata.core_count > 0 || report.metadata.index_count > 0);
+    assert!(report.failing_examples.is_empty());
+    assert!(!Path::new(&report.metadata.data_dir).exists());
+    Ok(())
+}
+
+#[test]
+fn injection_eval_display_includes_metrics() {
+    let report = InjectionEvalReport {
+        metadata: InjectionEvalMetadata {
+            corpus: CORPUS_NAME.to_string(),
+            boundary: "context::render_context_output".to_string(),
+            storage: "temporary sqlite".to_string(),
+            data_dir: "/tmp/example".to_string(),
+            data_dir_kept: false,
+            real_db_touched: false,
+            project: "/tmp/remem-injection-eval/repo".to_string(),
+            host: "codex-cli".to_string(),
+            branch: "main".to_string(),
+            output_chars: 100,
+            memories_loaded: 2,
+            core_count: 1,
+            index_count: 1,
+            lesson_count: 0,
+            preference_count: 0,
+            session_count: 0,
+            workstream_count: 0,
+            truncated: false,
+        },
+        metrics: InjectionMetricSummary {
+            expected_memory_recall: InjectionRateMetric::new(2, 2),
+            forbidden_memory_exclusion: InjectionRateMetric::new(3, 3),
+            all_checks_passed: true,
+        },
+        cases: vec![],
+        failing_examples: vec![],
+    };
+
+    let rendered = format!("{report}");
+
+    assert!(rendered.contains("=== remem eval-injection"));
+    assert!(rendered.contains("expected_memory_recall: 2/2"));
+    assert!(rendered.contains("forbidden_memory_exclusion: 3/3"));
+    assert!(rendered.contains("all_checks_passed: true"));
+}

--- a/src/eval/injection/types.rs
+++ b/src/eval/injection/types.rs
@@ -1,0 +1,102 @@
+use std::fmt::{self, Display};
+
+use serde::Serialize;
+
+pub use crate::eval::governance::RateMetric as InjectionRateMetric;
+
+pub(super) const CORPUS_NAME: &str = "builtin-session-start-injection-v1";
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct InjectionEvalOptions {
+    pub keep_data_dir: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InjectionEvalReport {
+    pub metadata: InjectionEvalMetadata,
+    pub metrics: InjectionMetricSummary,
+    pub cases: Vec<InjectionCaseReport>,
+    pub failing_examples: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InjectionEvalMetadata {
+    pub corpus: String,
+    pub boundary: String,
+    pub storage: String,
+    pub data_dir: String,
+    pub data_dir_kept: bool,
+    pub real_db_touched: bool,
+    pub project: String,
+    pub host: String,
+    pub branch: String,
+    pub output_chars: usize,
+    pub memories_loaded: usize,
+    pub core_count: usize,
+    pub index_count: usize,
+    pub lesson_count: usize,
+    pub preference_count: usize,
+    pub session_count: usize,
+    pub workstream_count: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InjectionMetricSummary {
+    pub expected_memory_recall: InjectionRateMetric,
+    pub forbidden_memory_exclusion: InjectionRateMetric,
+    pub all_checks_passed: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InjectionCaseReport {
+    pub id: String,
+    pub expectation: String,
+    pub title: String,
+    pub topic_key: String,
+    pub matched: bool,
+}
+
+impl Display for InjectionEvalReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "=== remem eval-injection ({}) ===", self.metadata.corpus)?;
+        writeln!(f, "boundary: {}", self.metadata.boundary)?;
+        writeln!(
+            f,
+            "storage: {}; real_db_touched={}",
+            self.metadata.storage, self.metadata.real_db_touched
+        )?;
+        writeln!(
+            f,
+            "expected_memory_recall: {}/{} ({:.1}%)",
+            self.metrics.expected_memory_recall.passed,
+            self.metrics.expected_memory_recall.total,
+            self.metrics.expected_memory_recall.rate * 100.0
+        )?;
+        writeln!(
+            f,
+            "forbidden_memory_exclusion: {}/{} ({:.1}%)",
+            self.metrics.forbidden_memory_exclusion.passed,
+            self.metrics.forbidden_memory_exclusion.total,
+            self.metrics.forbidden_memory_exclusion.rate * 100.0
+        )?;
+        writeln!(
+            f,
+            "rendered: memories_loaded={} core={} index={} chars={} truncated={}",
+            self.metadata.memories_loaded,
+            self.metadata.core_count,
+            self.metadata.index_count,
+            self.metadata.output_chars,
+            self.metadata.truncated
+        )?;
+        writeln!(f, "all_checks_passed: {}", self.metrics.all_checks_passed)?;
+        if self.failing_examples.is_empty() {
+            return Ok(());
+        }
+        writeln!(f, "failures:")?;
+        for failure in &self.failing_examples {
+            writeln!(f, "- {failure}")?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- add a sandboxed `eval::injection` suite that seeds a temporary Remem database and exercises the real SessionStart render path through `context::render_context_output`
- assert expected project memories are injected while cross-project, other-branch, and deleted rows stay out of the rendered context
- filter SessionStart context memory loading to the current branch or branchless memories so non-current branch decisions do not leak into injection output
- add a fixed-policy eval snapshot wrapper so this baseline is not affected by caller `REMEM_CONTEXT_*` environment settings
- bump `remem-ai` to `0.5.21` for the binary-impacting eval/render changes

Refs #362

## Notes

This is the #362-A baseline only. It intentionally does not close #362 because the larger issue still tracks the expanded 50+ query golden set and trajectory/channel assertions.

## Validation

- `cargo fmt --check`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `git diff --check`
- `cargo test eval::injection`
- `cargo test context::tests::load`
- `cargo test eval::governance`
- `cargo test context::tests::render`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`