### PR TITLE
Add Claude gate legacy migration command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.21"
+version = "0.5.22"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.21"
+version = "0.5.22"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/src/cli/actions/config_command.rs
+++ b/src/cli/actions/config_command.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
+use serde_json::json;
 
 use crate::cli::types::ConfigAction;
+use crate::runtime_config::LegacyClaudeGateMigration;
 
 pub(in crate::cli) fn run_config(action: ConfigAction) -> Result<()> {
     match action {
@@ -18,6 +20,54 @@ pub(in crate::cli) fn run_config(action: ConfigAction) -> Result<()> {
             let path = crate::runtime_config::set_config_value(&key, &value)?;
             println!("config -> {}", path.display());
         }
+        ConfigAction::MigrateClaudeGate { dry_run, json } => {
+            let migration = crate::runtime_config::migrate_legacy_claude_context_gate(dry_run)?;
+            if json {
+                print_migration_json(&migration);
+            } else {
+                print_migration_human(&migration);
+            }
+        }
     }
     Ok(())
+}
+
+fn print_migration_human(migration: &LegacyClaudeGateMigration) {
+    println!("Config: {}", migration.config_path.display());
+    println!("Host: {}", migration.host);
+    if migration.dry_run {
+        println!("Mode: dry-run (no files written)");
+    }
+    if migration.changed {
+        println!(
+            "context_gate: {} -> {}",
+            quote_or_dash(migration.old_gate.as_deref()),
+            quote_or_dash(migration.new_gate.as_deref())
+        );
+    } else {
+        println!(
+            "context_gate: {} (no migration needed)",
+            quote_or_dash(migration.new_gate.as_deref())
+        );
+    }
+}
+
+fn print_migration_json(migration: &LegacyClaudeGateMigration) {
+    println!(
+        "{}",
+        json!({
+            "config_path": migration.config_path,
+            "host": migration.host,
+            "old_gate": migration.old_gate,
+            "new_gate": migration.new_gate,
+            "changed": migration.changed,
+            "dry_run": migration.dry_run
+        })
+    );
+}
+
+fn quote_or_dash(value: Option<&str>) -> String {
+    value
+        .map(|value| format!("\"{value}\""))
+        .unwrap_or_else(|| "-".to_string())
 }

--- a/src/cli/config_types.rs
+++ b/src/cli/config_types.rs
@@ -1,0 +1,22 @@
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum ConfigAction {
+    /// Print the active config file path.
+    Path,
+    /// Print the resolved config text, including built-in defaults.
+    Show,
+    /// Create or update the config file with default sections.
+    Init,
+    /// Set one scalar config key, for example memory_ai.profiles.codex.model.
+    Set { key: String, value: String },
+    /// Explicitly migrate legacy Claude context_gate = "off" to "auto".
+    MigrateClaudeGate {
+        /// Print the planned migration without writing the config file.
+        #[arg(long)]
+        dry_run: bool,
+        /// Emit a single JSON object with stable fields for scripts.
+        #[arg(long)]
+        json: bool,
+    },
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,8 +1,11 @@
 mod actions;
+mod config_types;
 mod cwd;
 mod dispatch;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_config;
 #[cfg(test)]
 mod tests_eval;
 #[cfg(test)]

--- a/src/cli/tests_config.rs
+++ b/src/cli/tests_config.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+
+use super::types::{Cli, Commands, ConfigAction};
+
+#[test]
+fn cli_parses_config_migrate_claude_gate_options() {
+    let cli = Cli::parse_from([
+        "remem",
+        "config",
+        "migrate-claude-gate",
+        "--dry-run",
+        "--json",
+    ]);
+
+    match cli.command {
+        Commands::Config {
+            action: ConfigAction::MigrateClaudeGate { dry_run, json },
+        } => {
+            assert!(dry_run);
+            assert!(json);
+        }
+        _ => panic!("expected config migrate-claude-gate command"),
+    }
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
+pub(in crate::cli) use super::config_types::ConfigAction;
 pub(super) use crate::install::InstallTarget;
 
 #[derive(Parser)]
@@ -487,18 +488,6 @@ pub(in crate::cli) enum ContextGateAction {
         #[arg(long)]
         json: bool,
     },
-}
-
-#[derive(Subcommand)]
-pub(in crate::cli) enum ConfigAction {
-    /// Print the active config file path.
-    Path,
-    /// Print the resolved config text, including built-in defaults.
-    Show,
-    /// Create or update the config file with default sections.
-    Init,
-    /// Set one scalar config key, for example memory_ai.profiles.codex.model.
-    Set { key: String, value: String },
 }
 
 #[derive(Subcommand)]

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use anyhow::{bail, Context, Result};
 use toml_edit::{value, DocumentMut, Item, Table};
 
+#[cfg(test)]
+mod migration_tests;
 mod model;
 pub use model::{
     model_status, model_statuses, rollback_model_config, set_model, ModelChange, ModelPreset,
@@ -49,6 +51,16 @@ pub struct HostRuntimeConfig {
     pub context_gate: Option<String>,
     pub context_color: bool,
     pub capture_adapter: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LegacyClaudeGateMigration {
+    pub config_path: PathBuf,
+    pub host: String,
+    pub old_gate: Option<String>,
+    pub new_gate: Option<String>,
+    pub changed: bool,
+    pub dry_run: bool,
 }
 
 pub fn config_path() -> PathBuf {
@@ -111,6 +123,33 @@ pub fn set_config_value(key: &str, raw_value: &str) -> Result<PathBuf> {
     current[leaf] = cli_value(raw_value);
     write_config_doc(&path, &doc)?;
     Ok(path)
+}
+
+pub fn migrate_legacy_claude_context_gate(dry_run: bool) -> Result<LegacyClaudeGateMigration> {
+    let path = config_path();
+    let mut doc = read_config_doc_or_default()?;
+    ensure_config_defaults(&mut doc, &[CLAUDE_HOST, CODEX_HOST])?;
+
+    let old_gate = context_gate_from_doc(&doc, CLAUDE_HOST);
+    let changed = old_gate
+        .as_deref()
+        .is_some_and(|gate| gate.eq_ignore_ascii_case("off"));
+
+    if changed {
+        set_host_context_gate(&mut doc, CLAUDE_HOST, "auto")?;
+        if !dry_run {
+            write_config_doc(&path, &doc)?;
+        }
+    }
+
+    Ok(LegacyClaudeGateMigration {
+        config_path: path,
+        host: CLAUDE_HOST.to_string(),
+        old_gate,
+        new_gate: context_gate_from_doc(&doc, CLAUDE_HOST),
+        changed,
+        dry_run,
+    })
 }
 
 pub fn normalize_host(raw: &str) -> String {
@@ -285,6 +324,24 @@ fn ensure_host_config(hosts: &mut Table, host: &str) -> Result<()> {
             set_str_if_missing(table, "capture_adapter", host);
         }
     }
+    Ok(())
+}
+
+fn context_gate_from_doc(doc: &DocumentMut, host: &str) -> Option<String> {
+    doc.get("memory_ai")
+        .and_then(Item::as_table)
+        .and_then(|table| table.get("hosts"))
+        .and_then(Item::as_table)
+        .and_then(|hosts| hosts.get(host))
+        .and_then(Item::as_table)
+        .and_then(|table| optional_str(table, "context_gate"))
+}
+
+fn set_host_context_gate(doc: &mut DocumentMut, host: &str, gate: &str) -> Result<()> {
+    let memory_ai = top_table_mut(doc, "memory_ai")?;
+    let hosts = child_table_mut(memory_ai, "hosts")?;
+    let table = child_table_mut(hosts, host)?;
+    table["context_gate"] = value(gate);
     Ok(())
 }
 

--- a/src/runtime_config/migration_tests.rs
+++ b/src/runtime_config/migration_tests.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+fn with_migration_config_path<T>(path: &std::path::Path, f: impl FnOnce() -> T) -> T {
+    let _guard = TEST_ENV_LOCK.lock().expect("env lock should acquire");
+    let old = std::env::var("REMEM_CONFIG").ok();
+    unsafe { std::env::set_var("REMEM_CONFIG", path) };
+    let result = f();
+    match old {
+        Some(value) => unsafe { std::env::set_var("REMEM_CONFIG", value) },
+        None => unsafe { std::env::remove_var("REMEM_CONFIG") },
+    }
+    result
+}
+
+fn migration_temp_config_path(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "remem-{label}-{}-{}.toml",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ))
+}
+
+fn legacy_claude_gate_config() -> &'static str {
+    "[memory_ai.hosts.claude-code]\nmemory_profile = \"claude\"\ncontext_gate = \"off\"\n"
+}
+
+#[test]
+fn migrate_legacy_claude_context_gate_dry_run_does_not_write() -> Result<()> {
+    let path = migration_temp_config_path("runtime-claude-gate-migrate-dry-run");
+    with_migration_config_path(&path, || -> Result<()> {
+        std::fs::write(&path, legacy_claude_gate_config())?;
+
+        let migration = migrate_legacy_claude_context_gate(true)?;
+        let text = std::fs::read_to_string(&path)?;
+        let host = resolve_host_runtime_config(Some("claude-code"))?;
+
+        assert!(migration.changed);
+        assert!(migration.dry_run);
+        assert_eq!(migration.old_gate.as_deref(), Some("off"));
+        assert_eq!(migration.new_gate.as_deref(), Some("auto"));
+        assert_eq!(host.context_gate.as_deref(), Some("off"));
+        assert!(text.contains("context_gate = \"off\""), "{text}");
+        Ok(())
+    })?;
+    std::fs::remove_file(path)?;
+    Ok(())
+}
+
+#[test]
+fn migrate_legacy_claude_context_gate_applies_explicit_user_command() -> Result<()> {
+    let path = migration_temp_config_path("runtime-claude-gate-migrate-apply");
+    with_migration_config_path(&path, || -> Result<()> {
+        std::fs::write(&path, legacy_claude_gate_config())?;
+
+        let migration = migrate_legacy_claude_context_gate(false)?;
+        let text = std::fs::read_to_string(&path)?;
+        let host = resolve_host_runtime_config(Some("claude-code"))?;
+
+        assert!(migration.changed);
+        assert!(!migration.dry_run);
+        assert_eq!(migration.old_gate.as_deref(), Some("off"));
+        assert_eq!(migration.new_gate.as_deref(), Some("auto"));
+        assert_eq!(host.context_gate.as_deref(), Some("auto"));
+        assert!(text.contains("context_gate = \"auto\""), "{text}");
+        Ok(())
+    })?;
+    std::fs::remove_file(path)?;
+    Ok(())
+}
+
+#[test]
+fn migrate_legacy_claude_context_gate_leaves_current_config_unchanged() -> Result<()> {
+    let path = migration_temp_config_path("runtime-claude-gate-migrate-current");
+    with_migration_config_path(&path, || -> Result<()> {
+        init_config()?;
+
+        let migration = migrate_legacy_claude_context_gate(false)?;
+        let host = resolve_host_runtime_config(Some("claude-code"))?;
+
+        assert!(!migration.changed);
+        assert_eq!(migration.old_gate.as_deref(), Some("auto"));
+        assert_eq!(migration.new_gate.as_deref(), Some("auto"));
+        assert_eq!(host.context_gate.as_deref(), Some("auto"));
+        Ok(())
+    })?;
+    std::fs::remove_file(path)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #378 by adding an explicit, user-run migration path for legacy Claude Code configs that were generated with `context_gate = "off"` before Claude became gated by default.

This intentionally preserves the existing safe behavior for normal config loading and initialization:
- fresh/default Claude config remains `context_gate = "auto"`
- explicit `context_gate = "off"` is still respected by runtime resolution and `init_config`
- migration happens only when the user runs `remem config migrate-claude-gate`

## Changes

- Add `migrate_legacy_claude_context_gate(dry_run)` in runtime config.
- Add `remem config migrate-claude-gate [--dry-run] [--json]`.
- Split new CLI/config tests into small modules to keep existing large files under the 800-line rule.
- Bump package version to `0.5.22` for the binary-impacting change.
- Cover dry-run, apply, no-op current config, and CLI parsing.

## Verification

- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
