### PR TITLE
Check plugin version sync in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+      - name: Check plugin version sync
+        run: python3 scripts/ci/check_plugin_version_sync.py
       - name: Test plugin runtime scripts
         run: node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js
       - name: Check version bump

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.18",
+  "version": "0.5.22",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/README.md
+++ b/plugins/remem/README.md
@@ -51,6 +51,10 @@ release manifest exists for the plugin version, fresh installs outside a local
 checkout must provide `REMEM_BINARY` or use a published plugin build that
 includes checked runtime assets.
 
+CI enforces that `Cargo.toml`, `Cargo.lock`,
+`.codex-plugin/plugin.json`, and `runtimes/remem-releases.json` carry the same
+Remem version. Bump those files together whenever the binary version changes.
+
 Plugin MCP startup leaves the server cwd as the active Codex workspace. The
 wrapper is invoked by plugin-root path so repo-scoped memory operations can use
 the caller workspace instead of the plugin checkout.

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.18": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.18",
+    "0.5.22": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.22",
       "assets": {}
     }
   }

--- a/scripts/ci/check_plugin_version_sync.py
+++ b/scripts/ci/check_plugin_version_sync.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Require the Codex plugin runtime version metadata to match Cargo.toml."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CARGO_TOML = ROOT / "Cargo.toml"
+CARGO_LOCK = ROOT / "Cargo.lock"
+PLUGIN_JSON = ROOT / "plugins/remem/.codex-plugin/plugin.json"
+RELEASES_JSON = ROOT / "plugins/remem/runtimes/remem-releases.json"
+
+
+def read_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return value
+
+
+def read_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def cargo_package_version() -> str:
+    version = read_toml(CARGO_TOML).get("package", {}).get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError("Cargo.toml is missing package.version")
+    return version
+
+
+def lock_version() -> str | None:
+    packages = read_toml(CARGO_LOCK).get("package", [])
+    matches = [
+        package.get("version")
+        for package in packages
+        if isinstance(package, dict) and package.get("name") == "remem-ai"
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"Cargo.lock must contain exactly one remem-ai package, found {len(matches)}")
+    version = matches[0]
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError("Cargo.lock remem-ai package is missing version")
+    return version
+
+
+def plugin_version() -> str:
+    version = read_json(PLUGIN_JSON).get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError("plugins/remem/.codex-plugin/plugin.json is missing version")
+    return version
+
+
+def release_versions() -> tuple[set[str], str | None]:
+    manifest = read_json(RELEASES_JSON)
+    versions = manifest.get("versions")
+    if not isinstance(versions, dict):
+        raise ValueError("plugins/remem/runtimes/remem-releases.json is missing versions object")
+    keys = {str(key) for key in versions.keys()}
+    if len(keys) != 1:
+        return keys, None
+    key = next(iter(keys))
+    release = versions.get(key)
+    if not isinstance(release, dict):
+        raise ValueError(f"release entry for {key} must be an object")
+    base_url = release.get("base_url")
+    if base_url is not None and not isinstance(base_url, str):
+        raise ValueError(f"release entry for {key} has non-string base_url")
+    assets = release.get("assets")
+    if assets is not None and not isinstance(assets, dict):
+        raise ValueError(f"release entry for {key} has non-object assets")
+    return keys, base_url
+
+
+def main() -> int:
+    cargo = cargo_package_version()
+    locked = lock_version()
+    plugin = plugin_version()
+    releases, base_url = release_versions()
+
+    errors: list[str] = []
+    if locked != cargo:
+        errors.append(f"Cargo.lock remem-ai version is {locked}, expected {cargo}")
+    if plugin != cargo:
+        errors.append(f"plugin.json version is {plugin}, expected {cargo}")
+    if releases != {cargo}:
+        rendered = ", ".join(sorted(releases)) or "<none>"
+        errors.append(f"remem-releases.json versions are {{{rendered}}}, expected only {{{cargo}}}")
+    expected_suffix = f"/releases/download/v{cargo}"
+    if base_url is None:
+        errors.append(f"remem-releases.json entry for {cargo} is missing base_url")
+    elif not base_url.endswith(expected_suffix):
+        errors.append(f"release base_url is {base_url}, expected suffix {expected_suffix}")
+
+    if errors:
+        print("plugin version sync check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        print(
+            "Update Cargo.toml, Cargo.lock, plugins/remem/.codex-plugin/plugin.json, "
+            "and plugins/remem/runtimes/remem-releases.json together.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "plugin version sync: "
+        f"{cargo} across Cargo.toml, Cargo.lock, plugin.json, and remem-releases.json"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a CI gate that checks `Cargo.toml`, `Cargo.lock`, `plugins/remem/.codex-plugin/plugin.json`, and `plugins/remem/runtimes/remem-releases.json` stay on the same Remem version.
- Update the plugin manifest/runtime release index from `0.5.18` to the current runtime version `0.5.22`.
- Document the release-time version sync rule in the plugin README.

## Why

PR #398 left `main` with Cargo/runtime newer than the plugin manifest and release index. PR #400 then bumped the runtime to `0.5.22`. This PR makes that mismatch fail in CI instead of relying on manual review.

## Validation

- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 -m py_compile scripts/ci/check_plugin_version_sync.py`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `git diff --check origin/main..HEAD`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
