### PR TITLE
feat(plugin): add governance dry-run app preview

### DIFF
--- a/plugins/remem/apps/remem/README.md
+++ b/plugins/remem/apps/remem/README.md
@@ -8,6 +8,7 @@ This app surface provides:
 - project memory dashboard: memory, observation, raw archive, and queue counts
 - search: compact results with detail drill-down
 - save memory: explicit decision, bugfix, architecture, discovery, or preference save
+- governance: stale, reject, or delete dry-run preview with affected IDs and status transitions
 - activation: hooks-only dry-run plan without writing Codex config
 
 Run locally:

--- a/plugins/remem/apps/remem/governance.js
+++ b/plugins/remem/apps/remem/governance.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const GOVERNANCE_ACTIONS = new Set(["delete", "reject", "stale"]);
+
+function cleanOptionalString(value) {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value).trim();
+  return text ? text : undefined;
+}
+
+function cleanOptionalInteger(value, fallback, { min = 0, max = Number.MAX_SAFE_INTEGER } = {}) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < min || number > max) {
+    throw Object.assign(new Error(`Expected integer between ${min} and ${max}`), {
+      statusCode: 400
+    });
+  }
+  return number;
+}
+
+function cleanRequiredInteger(value, { min = 0, max = Number.MAX_SAFE_INTEGER } = {}) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < min || number > max) {
+    throw Object.assign(new Error(`Expected integer between ${min} and ${max}`), {
+      statusCode: 400
+    });
+  }
+  return number;
+}
+
+function normalizeGovernancePreviewInput(input = {}) {
+  const action = cleanOptionalString(input.action) || "stale";
+  if (!GOVERNANCE_ACTIONS.has(action)) {
+    throw Object.assign(new Error("Governance action must be delete, reject, or stale"), {
+      statusCode: 400
+    });
+  }
+  const rawIds = Array.isArray(input.ids)
+    ? input.ids
+    : input.id !== undefined && input.id !== null
+      ? [input.id]
+      : [];
+  const ids = rawIds.map((id) => cleanRequiredInteger(id, { min: 1 }));
+  const query = cleanOptionalString(input.query);
+  const memoryType = cleanOptionalString(input.memory_type || input.type);
+  const status = cleanOptionalString(input.status);
+  const project = cleanOptionalString(input.project);
+  const limit = cleanOptionalInteger(input.limit, 50, { min: 1, max: 200 });
+  const offset = cleanOptionalInteger(input.offset, 0, { min: 0, max: 1_000_000 });
+  const hasSelector = Boolean(query || memoryType || status);
+  if (!ids.length && !hasSelector) {
+    throw Object.assign(
+      new Error("Governance preview requires memory IDs or a selector"),
+      { statusCode: 400 }
+    );
+  }
+  return {
+    action,
+    actor: cleanOptionalString(input.actor),
+    ids,
+    limit,
+    memory_type: memoryType,
+    offset,
+    project,
+    query,
+    reason: cleanOptionalString(input.reason),
+    status
+  };
+}
+
+function pushOptionalArg(args, name, value) {
+  if (value !== undefined && value !== null && value !== "") {
+    args.push(name, String(value));
+  }
+}
+
+function governancePreviewArgs(input = {}) {
+  const requested = normalizeGovernancePreviewInput(input);
+  const args = ["govern", "--action", requested.action, "--dry-run", "--json"];
+  pushOptionalArg(args, "--project", requested.project);
+  pushOptionalArg(args, "--reason", requested.reason);
+  pushOptionalArg(args, "--actor", requested.actor);
+  pushOptionalArg(args, "--query", requested.query);
+  pushOptionalArg(args, "--memory-type", requested.memory_type);
+  pushOptionalArg(args, "--status", requested.status);
+  pushOptionalArg(args, "--limit", requested.limit);
+  pushOptionalArg(args, "--offset", requested.offset);
+  for (const id of requested.ids) args.push(String(id));
+  return { args, requested };
+}
+
+module.exports = {
+  governancePreviewArgs,
+  normalizeGovernancePreviewInput
+};

--- a/plugins/remem/apps/remem/public/widget.html
+++ b/plugins/remem/apps/remem/public/widget.html
@@ -20,9 +20,7 @@
       font-family: Avenir Next, ui-sans-serif, system-ui, sans-serif;
       letter-spacing: 0;
     }
-
     * { box-sizing: border-box; }
-
     body {
       margin: 0;
       background: var(--paper);
@@ -30,12 +28,10 @@
       font-size: 14px;
       line-height: 1.45;
     }
-
     button, input, textarea, select {
       font: inherit;
       letter-spacing: 0;
     }
-
     button {
       border: 1px solid var(--line);
       background: #fff;
@@ -45,11 +41,9 @@
       padding: 6px 10px;
       cursor: pointer;
     }
-
     button:hover { border-color: #9fb0ad; }
     button.primary { background: var(--ink); color: #fff; border-color: var(--ink); }
     button.icon { width: 34px; padding: 0; }
-
     input, textarea, select {
       width: 100%;
       border: 1px solid var(--line);
@@ -59,12 +53,10 @@
       padding: 8px 9px;
       min-height: 34px;
     }
-
     textarea {
       min-height: 92px;
       resize: vertical;
     }
-
     .shell {
       min-height: 100vh;
       display: grid;
@@ -72,7 +64,6 @@
       background:
         linear-gradient(90deg, #f4f6f5 0, #f4f6f5 320px, #fff 320px);
     }
-
     .rail {
       border-right: 1px solid var(--line);
       padding: 18px;
@@ -80,7 +71,6 @@
       flex-direction: column;
       gap: 16px;
     }
-
     .main {
       padding: 18px;
       display: grid;
@@ -88,13 +78,11 @@
       gap: 16px;
       min-width: 0;
     }
-
     .brand {
       display: flex;
       align-items: center;
       gap: 10px;
     }
-
     .mark {
       width: 34px;
       height: 34px;
@@ -106,30 +94,24 @@
       font-weight: 800;
       border: 1px solid #c7ddd6;
     }
-
     h1, h2, h3, p { margin: 0; }
     h1 { font-size: 18px; font-weight: 700; }
     h2 { font-size: 13px; font-weight: 700; text-transform: uppercase; color: var(--muted); }
     h3 { font-size: 14px; font-weight: 700; }
-
     .subtle { color: var(--muted); }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; }
-
     .stack { display: flex; flex-direction: column; gap: 10px; }
     .row { display: flex; align-items: center; gap: 8px; }
     .row.spread { justify-content: space-between; }
-
     .section {
       border-top: 1px solid var(--line);
       padding-top: 13px;
     }
-
     .stat-grid {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 8px;
     }
-
     .stat {
       border: 1px solid var(--line);
       border-radius: 7px;
@@ -138,14 +120,12 @@
       box-shadow: var(--shadow);
       min-height: 70px;
     }
-
     .stat .value {
       font-size: 24px;
       line-height: 1.1;
       font-weight: 750;
       margin-top: 3px;
     }
-
     .pill {
       display: inline-flex;
       align-items: center;
@@ -160,11 +140,9 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
-
     .pill.ok { color: var(--green); border-color: #bddad1; background: #eef8f4; }
     .pill.warn { color: var(--amber); border-color: #ead2a9; background: #fff7e8; }
     .pill.bad { color: var(--red); border-color: #e7bcbc; background: #fff0f0; }
-
     .tabs {
       display: inline-grid;
       grid-auto-flow: column;
@@ -175,33 +153,28 @@
       background: var(--panel);
       width: fit-content;
     }
-
     .tab {
       border: 0;
       background: transparent;
       min-height: 30px;
       padding: 5px 10px;
     }
-
     .tab.active {
       background: #fff;
       box-shadow: var(--shadow);
     }
-
     .toolbar {
       display: grid;
       grid-template-columns: 1fr 160px auto;
       gap: 8px;
       align-items: center;
     }
-
     .content-grid {
       display: grid;
       grid-template-columns: minmax(300px, 0.8fr) minmax(360px, 1.2fr);
       gap: 14px;
       min-height: 0;
     }
-
     .panel {
       border: 1px solid var(--line);
       border-radius: 8px;
@@ -210,7 +183,6 @@
       overflow: hidden;
       box-shadow: var(--shadow);
     }
-
     .panel-head {
       min-height: 44px;
       padding: 11px 12px;
@@ -221,12 +193,10 @@
       justify-content: space-between;
       gap: 8px;
     }
-
     .panel-body {
       padding: 12px;
       overflow: auto;
     }
-
     .results {
       padding: 0;
       margin: 0;
@@ -234,24 +204,20 @@
       display: flex;
       flex-direction: column;
     }
-
     .result {
       border-bottom: 1px solid var(--line);
       padding: 11px 12px;
       cursor: pointer;
       background: #fff;
     }
-
     .result:hover { background: #f7faf8; }
     .result.active { border-left: 3px solid var(--green); padding-left: 9px; background: #f1f7f4; }
-
     .result-title {
       display: flex;
       justify-content: space-between;
       gap: 8px;
       font-weight: 700;
     }
-
     .preview {
       color: var(--muted);
       margin-top: 4px;
@@ -260,7 +226,6 @@
       -webkit-box-orient: vertical;
       overflow: hidden;
     }
-
     .detail-text {
       white-space: pre-wrap;
       overflow-wrap: anywhere;
@@ -268,15 +233,12 @@
       padding-top: 10px;
       margin-top: 10px;
     }
-
     .form-grid {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 10px;
     }
-
     .form-grid .wide { grid-column: 1 / -1; }
-
     .message {
       border: 1px solid var(--line);
       border-radius: 7px;
@@ -284,13 +246,11 @@
       background: var(--panel);
       color: var(--muted);
     }
-
     .message.error {
       border-color: #e7bcbc;
       background: #fff0f0;
       color: var(--red);
     }
-
     pre {
       white-space: pre-wrap;
       overflow-wrap: anywhere;
@@ -302,9 +262,7 @@
       max-height: 280px;
       overflow: auto;
     }
-
     .hidden { display: none !important; }
-
     @media (max-width: 860px) {
       .shell { grid-template-columns: 1fr; background: #fff; }
       .rail { border-right: 0; border-bottom: 1px solid var(--line); }
@@ -324,7 +282,6 @@
           <p class="subtle">Project memory control surface</p>
         </div>
       </div>
-
       <section class="section stack">
         <div class="row spread">
           <h2>Runtime</h2>
@@ -332,7 +289,6 @@
         </div>
         <div id="runtime-status" class="stack"></div>
       </section>
-
       <section class="section stack">
         <h2>Memory Store</h2>
         <div class="stat-grid">
@@ -342,23 +298,21 @@
           <div class="stat"><p class="subtle">Queue</p><div class="value" id="count-queue">0</div></div>
         </div>
       </section>
-
       <section class="section stack">
         <h2>Activation</h2>
         <div id="activation-summary" class="stack"></div>
       </section>
     </aside>
-
     <main class="main">
       <div class="row spread">
         <div class="tabs" role="tablist">
           <button class="tab active" data-view="search">Search</button>
           <button class="tab" data-view="save">Save</button>
+          <button class="tab" data-view="governance">Governance</button>
           <button class="tab" data-view="activation">Activation</button>
         </div>
         <span class="pill" id="health-pill">Loading</span>
       </div>
-
       <section id="search-view" class="stack">
         <div class="toolbar">
           <input id="search-query" placeholder="Search project memory">
@@ -389,7 +343,6 @@
           </section>
         </div>
       </section>
-
       <section id="save-view" class="panel hidden">
         <div class="panel-head"><h3>Save Explicit Memory</h3></div>
         <div class="panel-body stack">
@@ -429,7 +382,44 @@
           <div id="save-result" class="message hidden"></div>
         </div>
       </section>
-
+      <section id="governance-view" class="panel hidden">
+        <div class="panel-head"><h3>Governance Preview</h3></div>
+        <div class="panel-body stack">
+          <div class="message">Dry-run only. This preview never mutates memory rows.</div>
+          <div class="form-grid">
+            <label>Action
+              <select id="govern-action">
+                <option value="stale">Stale</option>
+                <option value="reject">Reject</option>
+                <option value="delete">Delete</option>
+              </select>
+            </label>
+            <label>Limit
+              <input id="govern-limit" type="number" min="1" max="200" value="50">
+            </label>
+            <label class="wide">Memory IDs
+              <input id="govern-ids" placeholder="7, 12, 42">
+            </label>
+            <label class="wide">Project
+              <input id="govern-project" placeholder="/path/to/repo">
+            </label>
+            <label class="wide">Query selector
+              <input id="govern-query" placeholder="old migration plan">
+            </label>
+            <label>Type
+              <input id="govern-type" placeholder="decision">
+            </label>
+            <label>Status
+              <input id="govern-status" placeholder="active">
+            </label>
+          </div>
+          <div class="row spread">
+            <span class="subtle">IDs or a selector are required.</span>
+            <button class="primary" id="govern-button">Preview</button>
+          </div>
+          <div id="govern-result" class="message hidden"></div>
+        </div>
+      </section>
       <section id="activation-view" class="panel hidden">
         <div class="panel-head">
           <h3>Activation Plan</h3>
@@ -442,19 +432,15 @@
       </section>
     </main>
   </div>
-
   <script>
     const state = { snapshot: null, results: [], selected: null };
     const $ = (id) => document.getElementById(id);
-
     function cls(value, truthy) {
       value.classList.toggle("hidden", !truthy);
     }
-
     function valueAt(object, path, fallback = 0) {
       return path.split(".").reduce((acc, key) => acc && acc[key], object) ?? fallback;
     }
-
     async function request(route, options = {}) {
       if (canCallHostTool(route)) {
         return requestViaHostTool(route, options);
@@ -466,32 +452,28 @@
       }
       return payload;
     }
-
     function canCallHostTool(route) {
       return typeof window.openai?.callTool === "function" && String(route).startsWith("/api/");
     }
-
     async function requestViaHostTool(route, options = {}) {
       const method = String(options.method || "GET").toUpperCase();
       const url = new URL(route, "http://remem.local");
       const result = await callHostTool(apiToolName(url.pathname, method), apiToolArgs(url, method, options));
       return result?.structuredContent ?? result;
     }
-
     async function callHostTool(name, args) {
       if (!name) throw new Error("No host tool is available for this action");
       return window.openai.callTool(name, args);
     }
-
     function apiToolName(pathname, method) {
       if (method === "GET" && pathname === "/api/status") return "remem_dashboard";
       if (method === "GET" && pathname === "/api/search") return "remem_search";
       if (method === "GET" && pathname === "/api/memory") return "remem_get_memory";
       if (method === "GET" && pathname === "/api/activation-plan") return "remem_activation_plan";
       if (method === "POST" && pathname === "/api/save") return "remem_save_memory";
+      if (method === "POST" && pathname === "/api/governance-preview") return "remem_governance_preview";
       return null;
     }
-
     function apiToolArgs(url, method, options) {
       if (method === "GET" && url.pathname === "/api/search") {
         return {
@@ -510,22 +492,22 @@
       if (method === "POST" && url.pathname === "/api/save") {
         return JSON.parse(options.body || "{}");
       }
+      if (method === "POST" && url.pathname === "/api/governance-preview") {
+        return JSON.parse(options.body || "{}");
+      }
       return {};
     }
-
     function numericParam(params, key, fallback) {
       const value = params.get(key);
       if (value === null || value === "") return fallback;
       const number = Number(value);
       return Number.isFinite(number) ? number : fallback;
     }
-
     function booleanParam(params, key) {
       const value = params.get(key);
       if (value === null || value === "") return undefined;
       return value === "true" || value === "1";
     }
-
     function renderRuntime(snapshot) {
       const runtime = snapshot.runtime || {};
       const selected = runtime.selected || runtime.pathMatch;
@@ -539,7 +521,6 @@
         <div class="mono">${escapeHtml(snapshot.plugin_data || runtime.pluginData || "")}</div>
       `;
     }
-
     function renderCounts(status) {
       $("count-memories").textContent = valueAt(status, "totals.memories");
       $("count-observations").textContent = valueAt(status, "totals.observations");
@@ -549,7 +530,6 @@
         valueAt(status, "jobs.pending");
       $("count-queue").textContent = queue;
     }
-
     function renderActivation(activation) {
       const stateClass = activation?.mentions_hooks ? "warn" : "ok";
       $("activation-summary").innerHTML = `
@@ -558,7 +538,6 @@
       `;
       $("activation-plan").textContent = activation?.plan_text || "";
     }
-
     function renderHealth(snapshot) {
       const doctor = snapshot.doctor || {};
       const failed = Number(doctor.fails || 0);
@@ -567,7 +546,6 @@
       pill.className = `pill ${failed ? "bad" : warned ? "warn" : "ok"}`;
       pill.textContent = failed ? `${failed} failing check(s)` : warned ? `${warned} warning(s)` : "Healthy";
     }
-
     async function refresh() {
       try {
         state.snapshot = await request("/api/status");
@@ -581,7 +559,6 @@
         $("health-pill").textContent = "Error";
       }
     }
-
     async function runSearch() {
       const query = $("search-query").value.trim();
       if (!query) return;
@@ -599,7 +576,6 @@
       $("result-count").textContent = `${state.results.length}`;
       renderResults();
     }
-
     function searchResults(payload) {
       const memories = (payload.data || []).map((item) => ({
         ...item,
@@ -621,7 +597,6 @@
       }));
       return memories.concat(rawHits);
     }
-
     function renderResults() {
       const results = $("results");
       if (!state.results.length) {
@@ -638,7 +613,6 @@
         </li>
       `).join("");
     }
-
     async function selectResult(id) {
       document.querySelectorAll(".result").forEach((node) => {
         node.classList.toggle("active", node.dataset.id === String(id));
@@ -676,7 +650,6 @@
         </div>
       `;
     }
-
     async function saveMemory() {
       const text = $("save-text").value.trim();
       const target = $("save-result");
@@ -708,22 +681,63 @@
         target.className = "message error";
       }
     }
-
     async function refreshPlan() {
       $("activation-plan").textContent = "Generating...";
       const plan = await request("/api/activation-plan");
       renderActivation(plan);
     }
-
+    function governancePayload() {
+      const ids = $("govern-ids").value
+        .split(/[,\s]+/)
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map(Number);
+      if (ids.some((id) => !Number.isInteger(id) || id <= 0)) {
+        throw new Error("Memory IDs must be positive integers.");
+      }
+      return {
+        action: $("govern-action").value,
+        ids,
+        project: $("govern-project").value.trim() || undefined,
+        query: $("govern-query").value.trim() || undefined,
+        memory_type: $("govern-type").value.trim() || undefined,
+        status: $("govern-status").value.trim() || undefined,
+        limit: Number($("govern-limit").value || 50),
+        actor: "codex-remem-app"
+      };
+    }
+    async function previewGovernance() {
+      const target = $("govern-result");
+      target.textContent = "Previewing...";
+      target.className = "message";
+      try {
+        const preview = await request("/api/governance-preview", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(governancePayload())
+        });
+        const affected = preview.affected || [];
+        target.className = "message";
+        target.innerHTML = `
+          <div><strong>${affected.length}</strong> affected memory result(s); dry_run=${escapeHtml(preview.dry_run)}</div>
+          ${affected.map((item) => `
+            <div class="detail-text mono">#${escapeHtml(item.id)} ${escapeHtml(item.previous_status)} -> ${escapeHtml(item.new_status)} ${escapeHtml(item.title || "")}</div>
+          `).join("")}
+        `;
+      } catch (error) {
+        target.textContent = error.message;
+        target.className = "message error";
+      }
+    }
     function switchView(name) {
       document.querySelectorAll(".tab").forEach((tab) => {
         tab.classList.toggle("active", tab.dataset.view === name);
       });
       cls($("search-view"), name === "search");
       cls($("save-view"), name === "save");
+      cls($("governance-view"), name === "governance");
       cls($("activation-view"), name === "activation");
     }
-
     function escapeHtml(value) {
       return String(value ?? "")
         .replaceAll("&", "&amp;")
@@ -732,7 +746,6 @@
         .replaceAll('"', "&quot;")
         .replaceAll("'", "&#039;");
     }
-
     function receiveHostResult(event) {
       const message = event.data;
       if (!message || message.method !== "ui/notifications/tool-result") return;
@@ -744,7 +757,6 @@
       renderActivation(data.activation || {});
       renderHealth(data);
     }
-
     window.addEventListener("message", receiveHostResult);
     $("refresh").addEventListener("click", refresh);
     $("search-button").addEventListener("click", () => runSearch().catch((error) => {
@@ -758,13 +770,13 @@
       if (item?.dataset.id) selectResult(item.dataset.id);
     });
     $("save-button").addEventListener("click", saveMemory);
+    $("govern-button").addEventListener("click", previewGovernance);
     $("plan-button").addEventListener("click", () => refreshPlan().catch((error) => {
       $("activation-plan").textContent = error.message;
     }));
     document.querySelectorAll(".tab").forEach((tab) => {
       tab.addEventListener("click", () => switchView(tab.dataset.view));
     });
-
     refresh();
   </script>
 </body>

--- a/plugins/remem/apps/remem/server.js
+++ b/plugins/remem/apps/remem/server.js
@@ -15,8 +15,9 @@ const {
   pluginDataDir,
   pluginRoot
 } = require("../../scripts/remem-runtime");
+const { governancePreviewArgs } = require("./governance");
+const { toolDescriptors, UI_RESOURCE } = require("./tools");
 
-const UI_RESOURCE = "ui://remem/dashboard.html";
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 5577;
 const JSON_LIMIT_BYTES = 1_000_000;
@@ -370,6 +371,17 @@ function createBackend(options = {}) {
       );
       return activationSummary(result.stdout || result.stderr || "");
     },
+    async governancePreview(input) {
+      const { args, requested } = governancePreviewArgs(input);
+      const result = await runRememJson(args, {
+        allowDownload: false,
+        timeoutMs: 20000
+      });
+      return {
+        ...result,
+        requested
+      };
+    },
     stop() {
       api.stop?.();
     }
@@ -452,113 +464,6 @@ function setupActivation(name, error) {
   };
 }
 
-function toolDescriptors() {
-  return [
-    {
-      name: "remem_dashboard",
-      title: "Remem Dashboard",
-      description: "Render Remem runtime, memory health, search, save, and activation state.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          project: { type: "string" }
-        },
-        additionalProperties: false
-      },
-      outputSchema: {
-        type: "object",
-        properties: {
-          expected_version: { type: "string" },
-          plugin_data: { type: "string" }
-        },
-        additionalProperties: true
-      },
-      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
-      _meta: {
-        ui: { resourceUri: UI_RESOURCE, visibility: ["model", "app"] },
-        "openai/outputTemplate": UI_RESOURCE,
-        "openai/widgetAccessible": true,
-        "openai/toolInvocation/invoking": "Loading Remem",
-        "openai/toolInvocation/invoked": "Remem ready"
-      }
-    },
-    {
-      name: "remem_search",
-      title: "Search Remem",
-      description: "Search curated Remem memories and raw archive fallback rows.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          query: { type: "string" },
-          project: { type: "string" },
-          type: { type: "string" },
-          limit: { type: "number" },
-          offset: { type: "number" },
-          include_stale: { type: "boolean" },
-          multi_hop: { type: "boolean" }
-        },
-        required: ["query"],
-        additionalProperties: false
-      },
-      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
-      _meta: {
-        ui: { visibility: ["model", "app"] },
-        "openai/widgetAccessible": true
-      }
-    },
-    {
-      name: "remem_get_memory",
-      title: "Get Remem Memory",
-      description: "Fetch full details for a selected Remem memory by ID.",
-      inputSchema: {
-        type: "object",
-        properties: { id: { type: "number" } },
-        required: ["id"],
-        additionalProperties: false
-      },
-      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
-      _meta: {
-        ui: { visibility: ["model", "app"] },
-        "openai/widgetAccessible": true
-      }
-    },
-    {
-      name: "remem_save_memory",
-      title: "Save Remem Memory",
-      description: "Explicitly save one durable Remem memory.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          text: { type: "string" },
-          title: { type: "string" },
-          project: { type: "string" },
-          memory_type: { type: "string" },
-          topic_key: { type: "string" },
-          scope: { type: "string" }
-        },
-        required: ["text"],
-        additionalProperties: false
-      },
-      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
-      _meta: {
-        ui: { visibility: ["model", "app"] },
-        "openai/widgetAccessible": true
-      }
-    },
-    {
-      name: "remem_activation_plan",
-      title: "Remem Activation Plan",
-      description: "Preview Codex hook activation without writing config.",
-      inputSchema: { type: "object", properties: {}, additionalProperties: false },
-      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
-      _meta: {
-        ui: { visibility: ["model", "app"] },
-        "openai/widgetAccessible": true
-      }
-    }
-  ];
-}
-
 async function callTool(backend, name, args = {}) {
   if (name === "remem_dashboard") {
     const snapshot = await buildSnapshot(backend);
@@ -588,6 +493,13 @@ async function callTool(backend, name, args = {}) {
     const result = await backend.activationPlan();
     return toolResult("Activation plan generated without writing config.", result);
   }
+  if (name === "remem_governance_preview") {
+    const result = await backend.governancePreview(args);
+    return toolResult(
+      `Governance dry-run found ${result.affected?.length ?? 0} affected memory result(s).`,
+      result
+    );
+  }
   throw Object.assign(new Error(`Unknown tool: ${name}`), { code: -32602 });
 }
 
@@ -609,7 +521,7 @@ async function handleJsonRpc(backend, message) {
       protocolVersion: message.params?.protocolVersion || "2025-06-18",
       capabilities: { tools: {}, resources: {} },
       serverInfo: { name: "remem-app", version: expectedVersion() },
-      instructions: "Use Remem to inspect project memory, search details, save explicit durable memories, and preview hook activation."
+      instructions: "Use Remem to inspect project memory, search details, save explicit durable memories, preview governance, and preview hook activation."
     };
   }
   if (method === "tools/list") return { tools: toolDescriptors() };
@@ -686,6 +598,10 @@ function createServer(options = {}) {
       if (req.method === "POST" && url.pathname === "/api/save") {
         assertLocalPostAllowed(req);
         return jsonResponse(res, 201, await backend.save(await readJsonBody(req)));
+      }
+      if (req.method === "POST" && url.pathname === "/api/governance-preview") {
+        assertLocalPostAllowed(req);
+        return jsonResponse(res, 200, await backend.governancePreview(await readJsonBody(req)));
       }
       if (req.method === "POST" && url.pathname === "/mcp") {
         assertLocalPostAllowed(req);

--- a/plugins/remem/apps/remem/server.test.js
+++ b/plugins/remem/apps/remem/server.test.js
@@ -14,6 +14,7 @@ const {
   toolDescriptors,
   UI_RESOURCE
 } = require("./server");
+const { governancePreviewArgs } = require("./governance");
 const pluginManifest = require("../../.codex-plugin/plugin.json");
 
 function fakeBackend() {
@@ -103,6 +104,22 @@ function fakeBackend() {
     async activationPlan() {
       return activationSummary("Would write Codex hooks\nWould update MCP config\n");
     },
+    async governancePreview(input) {
+      return {
+        dry_run: true,
+        action: input.action || "stale",
+        reason: input.reason || null,
+        requested: input,
+        affected: [
+          {
+            id: Number(input.ids?.[0] || 7),
+            title: "Old decision",
+            previous_status: "active",
+            new_status: "stale"
+          }
+        ]
+      };
+    },
     stop() {}
   };
 }
@@ -137,7 +154,8 @@ test("widget-callable tools are exposed to the app surface", () => {
     "remem_search",
     "remem_get_memory",
     "remem_save_memory",
-    "remem_activation_plan"
+    "remem_activation_plan",
+    "remem_governance_preview"
   ]) {
     const descriptor = toolDescriptors().find((tool) => tool.name === name);
     assert.deepEqual(descriptor._meta.ui.visibility, ["model", "app"]);
@@ -152,6 +170,7 @@ test("JSON-RPC tools/list and dashboard call return structured content", async (
     params: {}
   });
   assert.ok(tools.tools.some((tool) => tool.name === "remem_save_memory"));
+  assert.ok(tools.tools.some((tool) => tool.name === "remem_governance_preview"));
 
   const result = await handleJsonRpc(fakeBackend(), {
     id: 2,
@@ -186,6 +205,14 @@ test("HTTP API serves widget, status, search, memory detail, and save", async ()
       body: JSON.stringify({ text: "Remember this.", memory_type: "decision" })
     }).then((response) => response.json());
     assert.equal(save.id, 9);
+
+    const preview = await fetch(`${base}/api/governance-preview`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: base },
+      body: JSON.stringify({ action: "stale", ids: [7], project: "/tmp/remem" })
+    }).then((response) => response.json());
+    assert.equal(preview.dry_run, true);
+    assert.equal(preview.affected[0].id, 7);
   });
 });
 
@@ -195,6 +222,11 @@ test("HTTP write routes reject cross-site browser requests", async () => {
   backend.save = async () => {
     saves += 1;
     return { id: 9 };
+  };
+  let previews = 0;
+  backend.governancePreview = async () => {
+    previews += 1;
+    return { dry_run: true, affected: [] };
   };
 
   await withServer(async (base) => {
@@ -222,9 +254,17 @@ test("HTTP write routes reject cross-site browser requests", async () => {
       })
     });
     assert.equal(mcpSave.status, 403);
+
+    const apiGovernance = await fetch(`${base}/api/governance-preview`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "https://attacker.example" },
+      body: JSON.stringify({ action: "delete", ids: [7] })
+    });
+    assert.equal(apiGovernance.status, 403);
   }, backend);
 
   assert.equal(saves, 0);
+  assert.equal(previews, 0);
 });
 
 test("widget renders raw archive fallback results", async () => {
@@ -247,7 +287,54 @@ test("widget routes embedded app actions through host tool calls", async () => {
     assert.match(widget, /remem_get_memory/);
     assert.match(widget, /remem_save_memory/);
     assert.match(widget, /remem_activation_plan/);
+    assert.match(widget, /remem_governance_preview/);
+    assert.match(widget, /\/api\/governance-preview/);
   });
+});
+
+test("governance preview args are always dry-run JSON CLI calls", () => {
+  const { args, requested } = governancePreviewArgs({
+    action: "delete",
+    ids: [7, "8"],
+    project: "/tmp/remem",
+    query: "old plan",
+    memory_type: "decision",
+    status: "active",
+    limit: 12,
+    actor: "codex-remem-app"
+  });
+
+  assert.deepEqual(args, [
+    "govern",
+    "--action",
+    "delete",
+    "--dry-run",
+    "--json",
+    "--project",
+    "/tmp/remem",
+    "--actor",
+    "codex-remem-app",
+    "--query",
+    "old plan",
+    "--memory-type",
+    "decision",
+    "--status",
+    "active",
+    "--limit",
+    "12",
+    "--offset",
+    "0",
+    "7",
+    "8"
+  ]);
+  assert.equal(requested.action, "delete");
+  assert.deepEqual(requested.ids, [7, 8]);
+});
+
+test("governance preview rejects unsafe or empty requests before CLI execution", () => {
+  assert.throws(() => governancePreviewArgs({ action: "archive", ids: [7] }), /delete, reject, or stale/);
+  assert.throws(() => governancePreviewArgs({ action: "stale" }), /requires memory IDs or a selector/);
+  assert.throws(() => governancePreviewArgs({ action: "stale", ids: [null] }), /Expected integer/);
 });
 
 test("API proxy clears failed readiness so later requests can retry", async () => {

--- a/plugins/remem/apps/remem/tools.js
+++ b/plugins/remem/apps/remem/tools.js
@@ -1,0 +1,142 @@
+"use strict";
+
+const UI_RESOURCE = "ui://remem/dashboard.html";
+
+function toolDescriptors() {
+  return [
+    {
+      name: "remem_dashboard",
+      title: "Remem Dashboard",
+      description: "Render Remem runtime, memory health, search, save, governance, and activation state.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string" }
+        },
+        additionalProperties: false
+      },
+      outputSchema: {
+        type: "object",
+        properties: {
+          expected_version: { type: "string" },
+          plugin_data: { type: "string" }
+        },
+        additionalProperties: true
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { resourceUri: UI_RESOURCE, visibility: ["model", "app"] },
+        "openai/outputTemplate": UI_RESOURCE,
+        "openai/widgetAccessible": true,
+        "openai/toolInvocation/invoking": "Loading Remem",
+        "openai/toolInvocation/invoked": "Remem ready"
+      }
+    },
+    {
+      name: "remem_search",
+      title: "Search Remem",
+      description: "Search curated Remem memories and raw archive fallback rows.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          project: { type: "string" },
+          type: { type: "string" },
+          limit: { type: "number" },
+          offset: { type: "number" },
+          include_stale: { type: "boolean" },
+          multi_hop: { type: "boolean" }
+        },
+        required: ["query"],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    },
+    {
+      name: "remem_get_memory",
+      title: "Get Remem Memory",
+      description: "Fetch full details for a selected Remem memory by ID.",
+      inputSchema: {
+        type: "object",
+        properties: { id: { type: "number" } },
+        required: ["id"],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    },
+    {
+      name: "remem_save_memory",
+      title: "Save Remem Memory",
+      description: "Explicitly save one durable Remem memory.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          title: { type: "string" },
+          project: { type: "string" },
+          memory_type: { type: "string" },
+          topic_key: { type: "string" },
+          scope: { type: "string" }
+        },
+        required: ["text"],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    },
+    {
+      name: "remem_activation_plan",
+      title: "Remem Activation Plan",
+      description: "Preview Codex hook activation without writing config.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    },
+    {
+      name: "remem_governance_preview",
+      title: "Preview Remem Governance",
+      description: "Dry-run stale, reject, or delete governance for selected Remem memories.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          action: { type: "string", enum: ["stale", "reject", "delete"] },
+          ids: { type: "array", items: { type: "number" } },
+          project: { type: "string" },
+          query: { type: "string" },
+          memory_type: { type: "string" },
+          status: { type: "string" },
+          limit: { type: "number" },
+          offset: { type: "number" },
+          reason: { type: "string" },
+          actor: { type: "string" }
+        },
+        required: ["action"],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    }
+  ];
+}
+
+module.exports = {
+  toolDescriptors,
+  UI_RESOURCE
+};


### PR DESCRIPTION
## Summary

Refs #390.

This adds the next local Remem app slice: governance dry-run preview. It does not add destructive mutation controls and does not add `.app.json` because the real app/connector id remains unavailable.

Changes:
- adds `remem_governance_preview` as a read-only app tool
- adds `POST /api/governance-preview` guarded by the existing local POST checks
- bridges to `remem govern --dry-run --json` with array args, not shell parsing
- adds a Governance tab to the widget for IDs or selector-based previews
- splits app tool descriptors and governance arg normalization out of `server.js`

## Validation

- `node --test plugins/remem/apps/remem/server.test.js`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- HTTP smoke on `http://127.0.0.1:5577/`: widget served, invalid governance action returned 400, non-JSON governance POST returned 415

Browser note: the in-app Browser connector was unavailable in this session, and local Playwright was not installed, so the UI verification used HTTP smoke plus Node app tests rather than a visual browser screenshot.