### PR TITLE
[codex] Fix SessionStart strict gate latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.22"
+version = "0.5.23"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.22"
+version = "0.5.23"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.22": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.22",
+    "0.5.23": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.23",
       "assets": {}
     }
   }

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -7,6 +7,9 @@ use super::host::HostKind;
 use super::invocation::ContextInvocation;
 
 mod delta;
+mod pre_render;
+
+pub(super) use pre_render::pre_render_context_gate;
 
 const DEFAULT_GATE_HOSTS: &str = "codex-cli,claude-code";
 const DEFAULT_SUPPRESSED_SOURCES: &str = "compact";

--- a/src/context/injection_gate/pre_render.rs
+++ b/src/context/injection_gate/pre_render.rs
@@ -1,0 +1,132 @@
+use super::*;
+
+pub(in crate::context) fn pre_render_context_gate(
+    invocation: &ContextInvocation,
+) -> Option<ContextGateDecision> {
+    if !host_is_gated(invocation.host) {
+        return None;
+    }
+    if resolve_gate_mode(invocation.gate_mode.as_deref()) != ContextGateMode::Strict {
+        return None;
+    }
+    if invocation.force || source_requires_fresh_emission(invocation.source.as_deref()) {
+        return None;
+    }
+    if !has_trusted_gate_identity(invocation) {
+        return None;
+    }
+
+    let key = injection_key(invocation);
+    let conn = match crate::db::open_db_read_only() {
+        Ok(conn) => conn,
+        Err(error) => {
+            crate::log::warn(
+                "context-gate",
+                &format!("pre_render_skip reason=open_db_read_only error={}", error),
+            );
+            return None;
+        }
+    };
+    let row = match load_gate_row(&conn, invocation.host.as_env_value(), &key) {
+        Ok(row) => row,
+        Err(error) => {
+            crate::log::warn(
+                "context-gate",
+                &format!("pre_render_skip reason=gate_read error={}", error),
+            );
+            return None;
+        }
+    };
+
+    let row = row?;
+    crate::log::info(
+        "context-gate",
+        &format!(
+            "pre_render_suppress host={} key={} reason=strict hash={} project={}",
+            invocation.host.as_env_value(),
+            key,
+            row.context_hash,
+            invocation.project
+        ),
+    );
+    Some(gate_decision(
+        String::new(),
+        ContextGateAction::Suppressed,
+        "strict_pre_render",
+        &key,
+        &row.context_hash,
+        "suppressed",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gate_invocation(session_id: Option<&str>) -> ContextInvocation {
+        ContextInvocation {
+            cwd: "/tmp/remem".to_string(),
+            project: "/tmp/remem".to_string(),
+            session_id: session_id.map(str::to_string),
+            transcript_path: Some("/tmp/remem.jsonl".to_string()),
+            source: None,
+            host: HostKind::CodexCli,
+            use_colors: false,
+            debug: false,
+            force: false,
+            gate_mode: None,
+        }
+    }
+
+    #[test]
+    fn strict_pre_render_suppresses_existing_session_without_render_output() {
+        let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render");
+        let mut invocation = gate_invocation(Some("sess-pre-render"));
+        invocation.gate_mode = Some("strict".to_string());
+
+        let first = apply_context_gate(
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        );
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let decision = pre_render_context_gate(&invocation)
+            .expect("existing strict gate row should suppress before render");
+        assert_eq!(decision.action, ContextGateAction::Suppressed);
+        assert_eq!(decision.reason, "strict_pre_render");
+        assert!(decision.output.is_empty());
+        assert_eq!(decision.output_mode, Some("suppressed"));
+        assert_eq!(decision.context_hash, first.context_hash);
+    }
+
+    #[test]
+    fn strict_pre_render_does_not_suppress_first_session_context() {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-first");
+        let mut invocation = gate_invocation(Some("sess-pre-render-first"));
+        invocation.gate_mode = Some("strict".to_string());
+
+        assert!(pre_render_context_gate(&invocation).is_none());
+    }
+
+    #[test]
+    fn strict_pre_render_does_not_suppress_force_or_clear() {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-clear");
+        let mut invocation = gate_invocation(Some("sess-pre-render-clear"));
+        invocation.gate_mode = Some("strict".to_string());
+
+        let first = apply_context_gate(
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        );
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        invocation.force = true;
+        assert!(pre_render_context_gate(&invocation).is_none());
+
+        invocation.force = false;
+        invocation.source = Some("clear".to_string());
+        assert!(pre_render_context_gate(&invocation).is_none());
+    }
+}

--- a/src/context/injection_gate/pre_render.rs
+++ b/src/context/injection_gate/pre_render.rs
@@ -37,6 +37,16 @@ pub(in crate::context) fn pre_render_context_gate(
     };
 
     let row = row?;
+    if !fallback_cooldown_allows_suppression(invocation, &row, now) {
+        return None;
+    }
+    if let Err(error) = record_suppression(conn, invocation, &key, now) {
+        crate::log::warn(
+            "context-gate",
+            &format!("pre_render_skip reason=gate_write error={}", error),
+        );
+        return None;
+    }
     crate::log::info(
         "context-gate",
         &format!(
@@ -215,6 +225,82 @@ mod tests {
         )?;
 
         assert!(pre_render_context_gate(&conn, &invocation).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn strict_pre_render_respects_fallback_cooldown_expiry() -> anyhow::Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-fallback");
+        let _cooldown = ScopedEnvVar::set("REMEM_CONTEXT_GATE_FALLBACK_COOLDOWN_SECS", "900");
+        let mut invocation = gate_invocation(None);
+        invocation.gate_mode = Some("strict".to_string());
+        let conn = crate::db::test_support::runtime_connection()?;
+
+        let first = apply_context_gate(
+            &conn,
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        );
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let old_last_emitted = chrono::Utc::now().timestamp().saturating_sub(901);
+        conn.execute(
+            "UPDATE context_injections
+             SET last_emitted_epoch = ?1
+             WHERE host = ?2 AND injection_key = ?3",
+            params![
+                old_last_emitted,
+                invocation.host.as_env_value(),
+                injection_key(&invocation)
+            ],
+        )?;
+
+        assert!(pre_render_context_gate(&conn, &invocation).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn strict_pre_render_records_suppression_refresh() -> anyhow::Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-refresh");
+        let mut invocation = gate_invocation(Some("sess-pre-render-refresh"));
+        invocation.gate_mode = Some("strict".to_string());
+        let conn = crate::db::test_support::runtime_connection()?;
+
+        let first = apply_context_gate(
+            &conn,
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        );
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let old_epoch = chrono::Utc::now().timestamp().saturating_sub(60);
+        conn.execute(
+            "UPDATE context_injections
+             SET updated_at_epoch = ?1, suppress_count = 0
+             WHERE host = ?2 AND injection_key = ?3",
+            params![
+                old_epoch,
+                invocation.host.as_env_value(),
+                injection_key(&invocation)
+            ],
+        )?;
+
+        let Some(decision) = pre_render_context_gate(&conn, &invocation) else {
+            anyhow::bail!("existing strict gate row should suppress before render");
+        };
+        assert_eq!(decision.action, ContextGateAction::Suppressed);
+
+        let (updated_at_epoch, suppress_count): (i64, i64) = conn.query_row(
+            "SELECT updated_at_epoch, suppress_count
+             FROM context_injections
+             WHERE host = ?1 AND injection_key = ?2",
+            params![invocation.host.as_env_value(), injection_key(&invocation)],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert!(updated_at_epoch > old_epoch);
+        assert_eq!(suppress_count, 1);
         Ok(())
     }
 }

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -6,7 +6,9 @@ use crate::db;
 
 use super::format::{char_len, truncate_chars_with_ellipsis};
 use super::host::resolve_profile;
-use super::injection_gate::{apply_context_gate, ContextGateAction, ContextGateDecision};
+use super::injection_gate::{
+    apply_context_gate, pre_render_context_gate, ContextGateAction, ContextGateDecision,
+};
 use super::invocation::{
     direct_context_invocation, resolve_context_invocation, ContextCliOptions, ContextInvocation,
 };
@@ -221,18 +223,27 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         host: invocation.host,
         use_colors: invocation.use_colors,
     };
-    let rendered = render_context_output(&request, debug_enabled)?;
-    let mut decision = if use_gate {
-        apply_context_gate(&invocation, rendered.output)
-    } else {
-        ContextGateDecision {
-            output: rendered.output,
-            action: ContextGateAction::Bypassed,
-            reason: "legacy_direct",
-            key: None,
-            context_hash: None,
-            output_mode: None,
+    let (mut decision, stats) = if use_gate {
+        if let Some(decision) = pre_render_context_gate(&invocation) {
+            (decision, ContextRenderStats::default())
+        } else {
+            let rendered = render_context_output(&request, debug_enabled)?;
+            let decision = apply_context_gate(&invocation, rendered.output);
+            (decision, rendered.stats)
         }
+    } else {
+        let rendered = render_context_output(&request, debug_enabled)?;
+        (
+            ContextGateDecision {
+                output: rendered.output,
+                action: ContextGateAction::Bypassed,
+                reason: "legacy_direct",
+                key: None,
+                context_hash: None,
+                output_mode: None,
+            },
+            rendered.stats,
+        )
     };
     if debug_enabled {
         let decision_for_debug = decision.clone();
@@ -255,13 +266,13 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         capabilities.has_user_prompt_submit_hook,
         capabilities.observes_native_file_edits,
         capabilities.observes_bash,
-        rendered.stats.memories_loaded,
-        rendered.stats.core.count,
-        rendered.stats.lessons.count,
-        rendered.stats.index.count,
-        rendered.stats.preferences.count,
-        rendered.stats.sessions.count,
-        rendered.stats.workstreams.count,
+        stats.memories_loaded,
+        stats.core.count,
+        stats.lessons.count,
+        stats.index.count,
+        stats.preferences.count,
+        stats.sessions.count,
+        stats.workstreams.count,
     ));
     Ok(())
 }
@@ -311,7 +322,7 @@ fn render_context_output_with_policy(
     policy: ContextPolicy,
 ) -> Result<RenderedContext> {
     let profile = resolve_profile(request.host);
-    let conn = match db::open_db() {
+    let conn = match open_context_db() {
         Ok(connection) => connection,
         Err(error) => {
             crate::log::error(
@@ -507,6 +518,22 @@ fn render_context_output_with_policy(
         &stats_footer,
     );
     Ok(RenderedContext { output, stats })
+}
+
+fn open_context_db() -> Result<rusqlite::Connection> {
+    match db::open_db_read_only() {
+        Ok(connection) => Ok(connection),
+        Err(read_error) => {
+            crate::log::warn(
+                "context",
+                &format!(
+                    "open_db_read_only failed, falling back to read-write open: {}",
+                    read_error
+                ),
+            );
+            db::open_db()
+        }
+    }
 }
 
 fn context_error_output(request: &ContextRequest, errors: &[ContextLoadError]) -> String {


### PR DESCRIPTION
Fixes #402.

## Root Cause

`remem context` rendered the full context before checking the strict duplicate SessionStart gate. A duplicate SessionStart hook could still load and render context, then suppress the already-built output. That made hook startup latency worse under worker/MCP load.

## Changes

- Add a pre-render strict gate check for trusted Codex context invocations so repeated SessionStart calls can suppress before full context rendering.
- Reconcile with #410: the pre-render gate reuses the single context DB connection and keeps the hook path on `open_db_no_migrate()` / schema-current validation instead of running migrations.
- Honor `REMEM_CONTEXT_GATE_RETENTION_DAYS` in the pre-render path by requiring retained gate rows before suppression.
- Preserve fallback-identity cooldown behavior before fast suppression.
- Refresh suppression metadata when pre-render suppresses, matching the normal gate path.
- Keep first-session, `--force`, and `clear` behavior unchanged.
- Bump remem from `0.5.23` to `0.5.24` and sync Codex plugin runtime metadata.

## Verification

- `cargo fmt --check`
- `cargo check --message-format=short`
- `cargo clippy -- -D warnings`
- `cargo test context::injection_gate::pre_render --lib -- --nocapture`
- `cargo test strict_context_pipeline_opens_one_database_connection -- --nocapture`
- `cargo test`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
