### PR TITLE
Reuse one DB connection for context hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.22"
+version = "0.5.23"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.22"
+version = "0.5.23"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.22": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.22",
+    "0.5.23": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.23",
       "assets": {}
     }
   }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -73,7 +73,8 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         Commands::SyncMemory { cwd } => {
             let cwd = resolve_cwd_arg(cwd);
             let project = db::project_from_cwd(&cwd);
-            context::claude_memory::sync_to_claude_memory(&cwd, &project)?;
+            let conn = db::open_db()?;
+            context::claude_memory::sync_to_claude_memory(&conn, &cwd, &project)?;
         }
         Commands::Preferences { action } => run_preferences(action)?,
         Commands::Memory { action } => match action {

--- a/src/context/claude_memory/runtime.rs
+++ b/src/context/claude_memory/runtime.rs
@@ -14,7 +14,7 @@ const DEFAULT_NATIVE_MEMORY_MAX_BYTES: usize = 16 * 1024;
 const TRUNCATION_NOTE: &str =
     "\n\n---\n*Truncated by remem native memory guard; use `remem search` for full memory.*\n";
 
-pub fn sync_to_claude_memory(cwd: &str, project: &str) -> Result<()> {
+pub fn sync_to_claude_memory(conn: &rusqlite::Connection, cwd: &str, project: &str) -> Result<()> {
     if native_memory_sync_disabled() {
         crate::log::info(
             "claude-mem",
@@ -26,7 +26,6 @@ pub fn sync_to_claude_memory(cwd: &str, project: &str) -> Result<()> {
         return Ok(());
     }
 
-    let conn = crate::db::open_db()?;
     let memory_dir = claude_memory_dir(cwd);
 
     if !memory_dir.exists() {
@@ -37,7 +36,7 @@ pub fn sync_to_claude_memory(cwd: &str, project: &str) -> Result<()> {
         return Ok(());
     }
 
-    let sessions = load_recent_sessions(&conn, project)?;
+    let sessions = load_recent_sessions(conn, project)?;
     let Some(content) = render_memory_content(&sessions) else {
         return Ok(());
     };

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -47,6 +47,7 @@ struct GateRow {
 }
 
 pub(super) fn apply_context_gate(
+    conn: &rusqlite::Connection,
     invocation: &ContextInvocation,
     output: String,
 ) -> ContextGateDecision {
@@ -81,19 +82,9 @@ pub(super) fn apply_context_gate(
     let hash = context_fingerprint(&output);
     let key = injection_key(invocation);
     let now = chrono::Utc::now().timestamp();
-    let conn = match crate::db::open_db() {
-        Ok(conn) => conn,
-        Err(error) => {
-            crate::log::error(
-                "context-gate",
-                &format!("fail_open reason=open_db error={}", error),
-            );
-            return decision(output, ContextGateAction::FailOpen, "open_db");
-        }
-    };
 
-    cleanup_old_rows(&conn, now);
-    let row = match load_gate_row(&conn, invocation.host.as_env_value(), &key) {
+    cleanup_old_rows(conn, now);
+    let row = match load_gate_row(conn, invocation.host.as_env_value(), &key) {
         Ok(row) => row,
         Err(error) => {
             crate::log::warn(
@@ -106,7 +97,7 @@ pub(super) fn apply_context_gate(
 
     let Some(row) = row else {
         return match upsert_emit_row(
-            &conn,
+            conn,
             invocation,
             &key,
             &hash,
@@ -131,7 +122,7 @@ pub(super) fn apply_context_gate(
 
     if invocation.force {
         return match upsert_emit_row(
-            &conn,
+            conn,
             invocation,
             &key,
             &hash,
@@ -155,7 +146,7 @@ pub(super) fn apply_context_gate(
     }
     if source_requires_fresh_emission(invocation.source.as_deref()) {
         return match upsert_emit_row(
-            &conn,
+            conn,
             invocation,
             &key,
             &hash,
@@ -185,7 +176,7 @@ pub(super) fn apply_context_gate(
             } else {
                 "same_hash"
             };
-            return match record_suppression(&conn, invocation, &key, now) {
+            return match record_suppression(conn, invocation, &key, now) {
                 Ok(()) => {
                     log_gate("suppress", invocation, &key, reason, &hash);
                     gate_decision(
@@ -201,7 +192,7 @@ pub(super) fn apply_context_gate(
             };
         }
         return match upsert_emit_row(
-            &conn,
+            conn,
             invocation,
             &key,
             &hash,
@@ -225,7 +216,7 @@ pub(super) fn apply_context_gate(
     }
 
     if mode == ContextGateMode::Strict {
-        return match record_suppression(&conn, invocation, &key, now) {
+        return match record_suppression(conn, invocation, &key, now) {
             Ok(()) => {
                 log_gate("suppress", invocation, &key, "strict", &hash);
                 gate_decision(
@@ -253,7 +244,7 @@ pub(super) fn apply_context_gate(
         };
 
     match upsert_emit_row(
-        &conn,
+        conn,
         invocation,
         &key,
         &hash,

--- a/src/context/injection_gate/delta.rs
+++ b/src/context/injection_gate/delta.rs
@@ -150,12 +150,23 @@ mod tests {
         }
     }
 
+    fn apply_test_context_gate(
+        invocation: &ContextInvocation,
+        output: String,
+    ) -> ContextGateDecision {
+        let conn = match crate::db::test_support::runtime_connection() {
+            Ok(conn) => conn,
+            Err(error) => panic!("test database should open: {error:#}"),
+        };
+        apply_context_gate(&conn, invocation, output)
+    }
+
     #[test]
     fn delta_mode_emits_compact_changed_hash() -> Result<()> {
         let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-delta");
         let mut invocation = invocation(Some("sess-delta"));
         invocation.gate_mode = Some("delta".to_string());
-        let first = apply_context_gate(
+        let first = apply_test_context_gate(
             &invocation,
             "# [/tmp/remem] context now\nBody A\n".to_string(),
         );
@@ -165,7 +176,7 @@ mod tests {
             "# [/tmp/remem] context later\n{}\n\n1 context memories loaded. 1 core (10 chars). 0 lessons (0 chars). 0 indexed (0 chars). 0 preferences (project:0 global:0, 0 chars). 0 sessions (0 chars). host=codex-cli branch=main total=3000 chars/~750 tokens limit=12000 truncated=no\n",
             "Body B ".repeat(400)
         );
-        let second = apply_context_gate(&invocation, changed_output.clone());
+        let second = apply_test_context_gate(&invocation, changed_output.clone());
         assert_eq!(second.action, ContextGateAction::EmittedDelta);
         assert_eq!(second.reason, "changed_hash");
         assert_ne!(second.output, changed_output);
@@ -173,7 +184,7 @@ mod tests {
         assert!(second.output.chars().count() <= 1200);
 
         let key = injection_key(&invocation);
-        let mode: String = crate::db::open_db()?.query_row(
+        let mode: String = crate::db::test_support::runtime_connection()?.query_row(
             "SELECT output_mode FROM context_injections WHERE host = ?1 AND injection_key = ?2",
             params![invocation.host.as_env_value(), key],
             |row| row.get(0),
@@ -186,13 +197,13 @@ mod tests {
     fn auto_mode_emits_delta_on_changed_hash() {
         let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-auto-delta");
         let invocation = invocation(Some("sess-auto-delta"));
-        let first = apply_context_gate(
+        let first = apply_test_context_gate(
             &invocation,
             "# [/tmp/remem] context now\nBody A\n".to_string(),
         );
         assert_eq!(first.action, ContextGateAction::EmittedFull);
 
-        let second = apply_context_gate(
+        let second = apply_test_context_gate(
             &invocation,
             "# [/tmp/remem] context now\nBody B\n".to_string(),
         );
@@ -206,18 +217,18 @@ mod tests {
             crate::db::test_support::ScopedTestDataDir::new("context-gate-fallback-expired");
         let invocation = invocation(None);
         let output = "# [/tmp/remem] context now\nBody\n".to_string();
-        let first = apply_context_gate(&invocation, output.clone());
+        let first = apply_test_context_gate(&invocation, output.clone());
         assert_eq!(first.action, ContextGateAction::EmittedFull);
 
         let key = injection_key(&invocation);
-        crate::db::open_db()?.execute(
+        crate::db::test_support::runtime_connection()?.execute(
             "UPDATE context_injections
              SET last_emitted_epoch = 0
              WHERE host = ?1 AND injection_key = ?2",
             params![invocation.host.as_env_value(), key],
         )?;
 
-        let second = apply_context_gate(&invocation, output.clone());
+        let second = apply_test_context_gate(&invocation, output.clone());
         assert_eq!(second.action, ContextGateAction::EmittedFull);
         assert_eq!(second.reason, "fallback_cooldown_expired");
         assert_eq!(second.output, output);

--- a/src/context/injection_gate/tests.rs
+++ b/src/context/injection_gate/tests.rs
@@ -31,6 +31,14 @@ fn claude_gate_invocation(session_id: Option<&str>) -> ContextInvocation {
     invocation
 }
 
+fn apply_test_context_gate(invocation: &ContextInvocation, output: String) -> ContextGateDecision {
+    let conn = match crate::db::test_support::runtime_connection() {
+        Ok(conn) => conn,
+        Err(error) => panic!("test database should open: {error:#}"),
+    };
+    apply_context_gate(&conn, invocation, output)
+}
+
 #[test]
 fn fingerprint_ignores_header_timestamp() {
     let a = "# [/tmp/remem] context 2026-05-25 1:00pm\nBody\n";
@@ -151,12 +159,12 @@ fn cwd_only_fallback_identity_fails_open_without_suppressing() {
     invocation.transcript_path = None;
     let output = "# [/tmp/remem] context now\nBody\n".to_string();
 
-    let first = apply_context_gate(&invocation, output.clone());
+    let first = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(first.action, ContextGateAction::FailOpen);
     assert_eq!(first.reason, "missing_session_identity");
     assert_eq!(first.output, output);
 
-    let second = apply_context_gate(&invocation, output.clone());
+    let second = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(second.action, ContextGateAction::FailOpen);
     assert_eq!(second.reason, "missing_session_identity");
     assert_eq!(second.output, output);
@@ -209,7 +217,7 @@ fn compact_source_emits_first_context() {
     invocation.source = Some("compact".to_string());
     let output = "# [/tmp/remem] context now\nBody\n".to_string();
 
-    let decision = apply_context_gate(&invocation, output.clone());
+    let decision = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(decision.action, ContextGateAction::EmittedFull);
     assert_eq!(decision.reason, "first_or_forced");
     assert_eq!(decision.output, output);
@@ -228,11 +236,11 @@ fn compact_source_suppresses_same_hash_after_first_context() {
     let mut invocation = gate_invocation(Some("sess-compact-same-hash"));
     let output = "# [/tmp/remem] context now\nBody\n".to_string();
 
-    let first = apply_context_gate(&invocation, output.clone());
+    let first = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(first.action, ContextGateAction::EmittedFull);
 
     invocation.source = Some("compact".to_string());
-    let second = apply_context_gate(&invocation, output);
+    let second = apply_test_context_gate(&invocation, output);
     assert_eq!(second.action, ContextGateAction::Suppressed);
     assert_eq!(second.reason, "suppressed_source");
     assert!(second.output.is_empty());
@@ -244,12 +252,12 @@ fn compact_source_force_bypasses_suppression() {
     let mut invocation = gate_invocation(Some("sess-compact-force"));
     let output = "# [/tmp/remem] context now\nBody\n".to_string();
 
-    let first = apply_context_gate(&invocation, output.clone());
+    let first = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(first.action, ContextGateAction::EmittedFull);
 
     invocation.source = Some("compact".to_string());
     invocation.force = true;
-    let forced = apply_context_gate(&invocation, output.clone());
+    let forced = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(forced.action, ContextGateAction::EmittedFull);
     assert_eq!(forced.reason, "first_or_forced");
     assert_eq!(forced.output, output);
@@ -261,7 +269,7 @@ fn claude_code_resume_suppresses_same_session_same_hash_by_default() {
     let invocation = claude_gate_invocation(Some("claude-session-1"));
     let output = "# [/tmp/remem] context now\nBody\n".to_string();
 
-    let first = apply_context_gate(&invocation, output.clone());
+    let first = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(first.action, ContextGateAction::EmittedFull);
     assert_eq!(first.reason, "first_or_forced");
     assert_eq!(first.output, output);
@@ -270,7 +278,7 @@ fn claude_code_resume_suppresses_same_session_same_hash_by_default() {
         .as_deref()
         .is_some_and(|key| key.contains("claude-session-1")));
 
-    let second = apply_context_gate(&invocation, output);
+    let second = apply_test_context_gate(&invocation, output);
     assert_eq!(second.action, ContextGateAction::Suppressed);
     assert_eq!(second.reason, "same_hash");
     assert!(second.output.is_empty());
@@ -282,11 +290,11 @@ fn claude_code_compact_session_start_suppresses_same_hash_by_default() {
     let mut invocation = claude_gate_invocation(Some("claude-session-compact"));
     let output = "# [/tmp/remem] context now\nBody\n".to_string();
 
-    let first = apply_context_gate(&invocation, output.clone());
+    let first = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(first.action, ContextGateAction::EmittedFull);
 
     invocation.source = Some("compact".to_string());
-    let second = apply_context_gate(&invocation, output);
+    let second = apply_test_context_gate(&invocation, output);
     assert_eq!(second.action, ContextGateAction::Suppressed);
     assert_eq!(second.reason, "suppressed_source");
     assert!(second.output.is_empty());
@@ -298,14 +306,14 @@ fn claude_code_compact_changed_hash_emits_delta_by_default() {
         crate::db::test_support::ScopedTestDataDir::new("context-gate-claude-compact-changed");
     let mut invocation = claude_gate_invocation(Some("claude-session-compact-changed"));
 
-    let first = apply_context_gate(
+    let first = apply_test_context_gate(
         &invocation,
         "# [/tmp/remem] context now\nBody A\n".to_string(),
     );
     assert_eq!(first.action, ContextGateAction::EmittedFull);
 
     invocation.source = Some("compact".to_string());
-    let second = apply_context_gate(
+    let second = apply_test_context_gate(
         &invocation,
         "# [/tmp/remem] context now\nBody B\n".to_string(),
     );
@@ -321,12 +329,12 @@ fn unknown_host_remains_ungated_by_default() {
     invocation.host = HostKind::Unknown;
     let output = "# [/tmp/remem] context now\nBody\n".to_string();
 
-    let first = apply_context_gate(&invocation, output.clone());
+    let first = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(first.action, ContextGateAction::Bypassed);
     assert_eq!(first.reason, "host_not_gated");
     assert_eq!(first.output, output);
 
-    let second = apply_context_gate(&invocation, output.clone());
+    let second = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(second.action, ContextGateAction::Bypassed);
     assert_eq!(second.reason, "host_not_gated");
     assert_eq!(second.output, output);
@@ -340,7 +348,7 @@ fn compact_source_missing_identity_fails_open() {
     invocation.source = Some("compact".to_string());
     let output = "# [/tmp/remem] context now\nBody\n".to_string();
 
-    let decision = apply_context_gate(&invocation, output.clone());
+    let decision = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(decision.action, ContextGateAction::FailOpen);
     assert_eq!(decision.reason, "missing_session_identity");
     assert_eq!(decision.output, output);
@@ -351,14 +359,14 @@ fn compact_source_changed_hash_emits_delta() {
     let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-compact-changed");
     let mut invocation = gate_invocation(Some("sess-compact-changed"));
 
-    let first = apply_context_gate(
+    let first = apply_test_context_gate(
         &invocation,
         "# [/tmp/remem] context now\nBody A\n".to_string(),
     );
     assert_eq!(first.action, ContextGateAction::EmittedFull);
 
     invocation.source = Some("compact".to_string());
-    let second = apply_context_gate(
+    let second = apply_test_context_gate(
         &invocation,
         "# [/tmp/remem] context now\nBody B\n".to_string(),
     );
@@ -373,13 +381,13 @@ fn strict_mode_suppresses_changed_hash_after_first_context() {
     let mut invocation = gate_invocation(Some("sess-strict-changed"));
     invocation.gate_mode = Some("strict".to_string());
 
-    let first = apply_context_gate(
+    let first = apply_test_context_gate(
         &invocation,
         "# [/tmp/remem] context now\nBody A\n".to_string(),
     );
     assert_eq!(first.action, ContextGateAction::EmittedFull);
 
-    let second = apply_context_gate(
+    let second = apply_test_context_gate(
         &invocation,
         "# [/tmp/remem] context now\nBody B\n".to_string(),
     );
@@ -394,14 +402,14 @@ fn restart_source_reemits_same_hash_context() {
     let mut invocation = gate_invocation(Some("sess-restart"));
     let output = "# [/tmp/remem] context now\nBody\n".to_string();
 
-    let first = apply_context_gate(&invocation, output.clone());
+    let first = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(first.action, ContextGateAction::EmittedFull);
 
-    let second = apply_context_gate(&invocation, output.clone());
+    let second = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(second.action, ContextGateAction::Suppressed);
 
     invocation.source = Some("clear".to_string());
-    let restart = apply_context_gate(&invocation, output.clone());
+    let restart = apply_test_context_gate(&invocation, output.clone());
     assert_eq!(restart.action, ContextGateAction::EmittedFull);
     assert_eq!(restart.reason, "restart_source");
     assert_eq!(restart.output, output);

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -114,7 +114,10 @@ pub(crate) fn session_start_eval_snapshot(
         use_colors: false,
     };
     let policy = ContextPolicy::from_limits(ContextLimits::default());
-    let rendered = render_context_output_with_policy(&request, false, policy)?;
+    let rendered = match open_context_connection_or_error(&request, &policy) {
+        Ok(conn) => render_context_output_with_policy(&conn, &request, false, policy)?,
+        Err(rendered) => *rendered,
+    };
     Ok(SessionStartEvalSnapshot {
         rendered_output: rendered.output,
         output_chars: rendered.stats.output_chars,
@@ -221,9 +224,46 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         host: invocation.host,
         use_colors: invocation.use_colors,
     };
-    let rendered = render_context_output(&request, debug_enabled)?;
+    let policy = resolve_profile(request.host).default_policy();
+    let conn = match open_context_connection_or_error(&request, &policy) {
+        Ok(conn) => conn,
+        Err(rendered) => {
+            let rendered = *rendered;
+            let mut decision = if use_gate {
+                ContextGateDecision {
+                    output: rendered.output,
+                    action: ContextGateAction::FailOpen,
+                    reason: "db_open",
+                    key: None,
+                    context_hash: None,
+                    output_mode: None,
+                }
+            } else {
+                ContextGateDecision {
+                    output: rendered.output,
+                    action: ContextGateAction::Bypassed,
+                    reason: "legacy_direct",
+                    key: None,
+                    context_hash: None,
+                    output_mode: None,
+                }
+            };
+            if debug_enabled {
+                let decision_for_debug = decision.clone();
+                append_context_gate_debug_trace(
+                    &mut decision.output,
+                    &request,
+                    &decision_for_debug,
+                );
+            }
+            print!("{}", decision.output);
+            log_context_timer(timer, &request, &decision, &rendered.stats);
+            return Ok(());
+        }
+    };
+    let rendered = render_context_output_with_policy(&conn, &request, debug_enabled, policy)?;
     let mut decision = if use_gate {
-        apply_context_gate(&invocation, rendered.output)
+        apply_context_gate(&conn, &invocation, rendered.output)
     } else {
         ContextGateDecision {
             output: rendered.output,
@@ -239,7 +279,24 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         append_context_gate_debug_trace(&mut decision.output, &request, &decision_for_debug);
     }
     print!("{}", decision.output);
+    log_context_timer(timer, &request, &decision, &rendered.stats);
+    Ok(())
+}
 
+#[cfg(test)]
+pub(in crate::context) fn generate_context_for_test(
+    invocation: ContextInvocation,
+    use_gate: bool,
+) -> Result<()> {
+    generate_context_for_invocation(invocation, use_gate)
+}
+
+fn log_context_timer(
+    timer: crate::log::Timer,
+    request: &ContextRequest,
+    decision: &ContextGateDecision,
+    stats: &ContextRenderStats,
+) {
     let capabilities = resolve_profile(request.host).capabilities();
     timer.done(&format!(
         "project={} cwd={} session={} host={} colors={} gate={:?}:{} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] context_memories={} core={} lessons={} index={} preferences={} sessions={} workstreams={}",
@@ -255,15 +312,14 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         capabilities.has_user_prompt_submit_hook,
         capabilities.observes_native_file_edits,
         capabilities.observes_bash,
-        rendered.stats.memories_loaded,
-        rendered.stats.core.count,
-        rendered.stats.lessons.count,
-        rendered.stats.index.count,
-        rendered.stats.preferences.count,
-        rendered.stats.sessions.count,
-        rendered.stats.workstreams.count,
+        stats.memories_loaded,
+        stats.core.count,
+        stats.lessons.count,
+        stats.index.count,
+        stats.preferences.count,
+        stats.sessions.count,
+        stats.workstreams.count,
     ));
-    Ok(())
 }
 
 pub(in crate::context) fn append_context_gate_debug_trace(
@@ -297,55 +353,36 @@ pub(in crate::context) fn append_context_gate_debug_trace(
     ));
 }
 
+#[cfg(test)]
 pub(in crate::context) fn render_context_output(
     request: &ContextRequest,
     debug: bool,
 ) -> Result<RenderedContext> {
     let profile = resolve_profile(request.host);
-    render_context_output_with_policy(request, debug, profile.default_policy())
+    let policy = profile.default_policy();
+    let conn = match open_context_connection_or_error(request, &policy) {
+        Ok(conn) => conn,
+        Err(rendered) => return Ok(*rendered),
+    };
+    render_context_output_with_policy(&conn, request, debug, policy)
 }
 
 fn render_context_output_with_policy(
+    conn: &rusqlite::Connection,
     request: &ContextRequest,
     debug: bool,
     policy: ContextPolicy,
 ) -> Result<RenderedContext> {
     let profile = resolve_profile(request.host);
-    let conn = match db::open_db() {
-        Ok(connection) => connection,
-        Err(error) => {
-            crate::log::error(
-                "context",
-                &format!("open_db failed for project={}: {}", request.project, error),
-            );
-            let mut output = context_error_output(
-                request,
-                &[ContextLoadError::new(
-                    "database",
-                    format!("failed to open remem database: {error}"),
-                )],
-            );
-            let mut stats = empty_stats(request);
-            stats.total_char_limit = policy.limits.total_char_limit;
-            stats.output_chars = char_len(&output);
-            enforce_total_char_limit_preserving_footer(
-                &mut output,
-                policy.limits.total_char_limit,
-                "",
-            );
-            return Ok(RenderedContext { output, stats });
-        }
-    };
-
     let mut loaded = load_context_data_with_policy(
-        &conn,
+        conn,
         &request.project,
         request.current_branch.as_deref(),
         &policy,
         debug,
     );
     let (preference_output, preference_details) =
-        match render_preferences_to_buffer(&conn, &request.project, &request.cwd, &policy) {
+        match render_preferences_to_buffer(conn, &request.project, &request.cwd, &policy) {
             Ok(rendered) => rendered,
             Err(error) => {
                 let message = format!(
@@ -484,7 +521,7 @@ fn render_context_output_with_policy(
 
     if debug {
         super::diagnostics::apply_preference_diagnostics(
-            &conn,
+            conn,
             &request.project,
             preference_details.rendered_ids,
             &mut loaded.diagnostics,
@@ -507,6 +544,41 @@ fn render_context_output_with_policy(
         &stats_footer,
     );
     Ok(RenderedContext { output, stats })
+}
+
+fn open_context_connection_or_error(
+    request: &ContextRequest,
+    policy: &ContextPolicy,
+) -> std::result::Result<rusqlite::Connection, Box<RenderedContext>> {
+    match db::open_db_no_migrate() {
+        Ok(conn) => Ok(conn),
+        Err(error) => {
+            crate::log::error(
+                "context",
+                &format!("db open failed for project={}: {}", request.project, error),
+            );
+            Err(Box::new(render_context_open_error(request, policy, error)))
+        }
+    }
+}
+
+fn render_context_open_error(
+    request: &ContextRequest,
+    policy: &ContextPolicy,
+    error: anyhow::Error,
+) -> RenderedContext {
+    let mut output = context_error_output(
+        request,
+        &[ContextLoadError::new(
+            "database",
+            format!("failed to open remem database: {error}"),
+        )],
+    );
+    let mut stats = empty_stats(request);
+    stats.total_char_limit = policy.limits.total_char_limit;
+    stats.output_chars = char_len(&output);
+    enforce_total_char_limit_preserving_footer(&mut output, policy.limits.total_char_limit, "");
+    RenderedContext { output, stats }
 }
 
 fn context_error_output(request: &ContextRequest, errors: &[ContextLoadError]) -> String {

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -3,10 +3,12 @@ use crate::workstream::{WorkStream, WorkStreamStatus};
 
 use super::super::host::HostKind;
 use super::super::injection_gate::{ContextGateAction, ContextGateDecision};
+use super::super::invocation::ContextInvocation;
 use super::super::policy::ContextLimits;
 use super::super::render::{
     append_context_gate_debug_trace, build_context_header, build_context_stats_footer,
-    empty_context_output, render_context_output, ContextRenderStats, SectionRenderStats,
+    empty_context_output, generate_context_for_test, render_context_output, ContextRenderStats,
+    SectionRenderStats,
 };
 use super::super::sections::{
     render_core_memory, render_core_memory_with_limits, render_lessons_with_limit,
@@ -541,7 +543,7 @@ fn codex_colored_header_aligns_rows_under_hook_context_value() {
 #[test]
 fn render_context_output_exposes_lesson_query_failures() {
     let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-lesson-error");
-    let conn = crate::db::open_db().unwrap();
+    let conn = crate::db::test_support::runtime_connection().unwrap();
     conn.execute("DROP TABLE memory_lessons", []).unwrap();
     drop(conn);
 
@@ -564,6 +566,34 @@ fn render_context_output_exposes_lesson_query_failures() {
         .output
         .contains("- lessons: failed to load lessons for /tmp/remem"));
     assert!(!rendered.output.contains("No previous sessions found."));
+}
+
+#[test]
+fn strict_context_pipeline_opens_one_database_connection() -> anyhow::Result<()> {
+    let data_dir = crate::db::test_support::ScopedTestDataDir::new("context-single-db-open");
+    let setup = crate::db::test_support::runtime_connection()?;
+    drop(setup);
+
+    crate::db::test_support::reset_runtime_connection_open_count();
+    let cwd = data_dir.path.to_string_lossy().to_string();
+    let transcript_path = data_dir.path.join("transcript.jsonl");
+    let invocation = ContextInvocation {
+        cwd: cwd.clone(),
+        project: crate::db::project_from_cwd(&cwd),
+        session_id: Some("sess-single-db-open".to_string()),
+        transcript_path: Some(transcript_path.to_string_lossy().to_string()),
+        source: Some("session_start".to_string()),
+        host: HostKind::CodexCli,
+        use_colors: false,
+        debug: false,
+        force: false,
+        gate_mode: Some("strict".to_string()),
+    };
+
+    generate_context_for_test(invocation, true)?;
+
+    assert_eq!(crate::db::test_support::runtime_connection_open_count(), 1);
+    Ok(())
 }
 
 fn sample_lesson(id: i64, title: &str, confidence: f64, reinforcement_count: i64) -> LessonMemory {

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -1,11 +1,31 @@
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags};
 
 thread_local! {
     static DATA_DIR_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+static CONFIGURED_CONNECTION_OPENS: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(crate) fn reset_configured_connection_open_count() {
+    CONFIGURED_CONNECTION_OPENS.store(0, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn configured_connection_open_count() -> usize {
+    CONFIGURED_CONNECTION_OPENS.load(Ordering::SeqCst)
+}
+
+#[cfg(test)]
+fn record_configured_connection_open() {
+    CONFIGURED_CONNECTION_OPENS.fetch_add(1, Ordering::SeqCst);
 }
 
 pub(crate) fn with_data_dir<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
@@ -86,6 +106,19 @@ pub fn open_db() -> Result<Connection> {
     Ok(conn)
 }
 
+pub fn open_db_no_migrate() -> Result<Connection> {
+    let path = db_path();
+    let key = super::crypto::require_cipher_key_or_plaintext_override()?;
+    if !path.exists() {
+        anyhow::bail!("database not found: {}", path.display());
+    }
+
+    let conn = open_configured_existing_read_write_connection(&path, key.as_deref())?;
+    crate::retrieval::vector::load_vec_extension(&conn)?;
+    crate::migrate::ensure_schema_current(&conn)?;
+    Ok(conn)
+}
+
 pub fn open_db_read_only() -> Result<Connection> {
     let path = db_path();
     let key = super::crypto::require_cipher_key_or_plaintext_override()?;
@@ -99,6 +132,31 @@ pub fn open_db_read_only() -> Result<Connection> {
 pub(crate) fn open_configured_connection(path: &Path, key: Option<&str>) -> Result<Connection> {
     let conn = Connection::open(path)
         .with_context(|| format!("Failed to open database: {}", path.display()))?;
+    #[cfg(test)]
+    record_configured_connection_open();
+
+    super::crypto::configure_cipher(&conn, key)?;
+
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
+    )?;
+    Ok(conn)
+}
+
+pub(crate) fn open_configured_existing_read_write_connection(
+    path: &Path,
+    key: Option<&str>,
+) -> Result<Connection> {
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE).with_context(
+        || {
+            format!(
+                "Failed to open existing database read-write: {}",
+                path.display()
+            )
+        },
+    )?;
+    #[cfg(test)]
+    record_configured_connection_open();
 
     super::crypto::configure_cipher(&conn, key)?;
 
@@ -114,6 +172,8 @@ pub(crate) fn open_configured_read_only_connection(
 ) -> Result<Connection> {
     let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| format!("Failed to open database read-only: {}", path.display()))?;
+    #[cfg(test)]
+    record_configured_connection_open();
 
     super::crypto::configure_cipher(&conn, key)?;
     conn.execute_batch("PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;")?;
@@ -250,6 +310,173 @@ mod tests {
 
         assert_eq!(marker_exists, 1);
         assert_eq!(migrations_exists, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn open_db_no_migrate_does_not_create_missing_database() {
+        let test_dir = ScopedTestDataDir::new("no-migrate-missing");
+        test_dir.remove_db_files();
+
+        let err = open_db_no_migrate().expect_err("missing database should fail");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("database not found"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !test_dir.path.exists(),
+            "no-migrate open must not create data dir"
+        );
+        assert!(
+            !test_dir.db_path().exists(),
+            "no-migrate open must not create database file"
+        );
+    }
+
+    #[test]
+    fn open_db_no_migrate_refuses_plaintext_without_explicit_override() -> Result<()> {
+        let test_dir = ScopedTestDataDir::new("no-migrate-cipher-fail-closed");
+        let conn = crate::db::open_db()?;
+        drop(conn);
+        std::env::remove_var(ALLOW_PLAINTEXT_ENV);
+
+        let err = crate::db::open_db_no_migrate()
+            .expect_err("no-migrate open must enforce the plaintext guard");
+
+        let message = err.to_string();
+        assert!(message.contains("SQLCipher key"), "got: {message}");
+        assert!(
+            test_dir.db_path().exists(),
+            "no-migrate guard must not remove the existing database"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn open_db_no_migrate_opens_current_schema_read_write() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("no-migrate-current-rw");
+        let setup = crate::db::open_db()?;
+        drop(setup);
+
+        let conn = crate::db::open_db_no_migrate()?;
+        conn.execute(
+            "CREATE TABLE no_migrate_rw_probe(id INTEGER PRIMARY KEY)",
+            [],
+        )?;
+        conn.execute("INSERT INTO no_migrate_rw_probe(id) VALUES (1)", [])?;
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM no_migrate_rw_probe", [], |row| {
+            row.get(0)
+        })?;
+
+        assert_eq!(count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn open_db_no_migrate_does_not_run_migrations() -> Result<()> {
+        let test_dir = ScopedTestDataDir::new("no-migrate-no-migration");
+        std::fs::create_dir_all(&test_dir.path)?;
+        let setup = Connection::open(test_dir.db_path())?;
+        setup.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)", [])?;
+        drop(setup);
+
+        let err = crate::db::open_db_no_migrate().expect_err("stale schema should fail");
+
+        assert!(
+            err.to_string().contains("schema is not initialized"),
+            "unexpected error: {err:#}"
+        );
+        let check = Connection::open(test_dir.db_path())?;
+        let migrations_exists: i64 = check.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '_schema_migrations'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(migrations_exists, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn open_db_no_migrate_rejects_older_schema_without_migrating() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("no-migrate-older-schema");
+        let setup = crate::db::open_db()?;
+        let latest = crate::migrate::latest_schema_version();
+        setup.execute(
+            "DELETE FROM _schema_migrations WHERE version = ?1",
+            [latest],
+        )?;
+        drop(setup);
+
+        let err = crate::db::open_db_no_migrate()
+            .expect_err("older schema should require foreground migration");
+
+        assert!(
+            err.to_string().contains("requires schema"),
+            "unexpected error: {err:#}"
+        );
+        let check = Connection::open(crate::db::db_path())?;
+        let latest_rows: i64 = check.query_row(
+            "SELECT COUNT(*) FROM _schema_migrations WHERE version = ?1",
+            [latest],
+            |row| row.get(0),
+        )?;
+        assert_eq!(latest_rows, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn open_db_no_migrate_rejects_incomplete_schema_without_migrating() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("no-migrate-incomplete-schema");
+        let setup = crate::db::open_db()?;
+        let latest = crate::migrate::latest_schema_version();
+        let missing = latest - 1;
+        setup.execute(
+            "DELETE FROM _schema_migrations WHERE version = ?1",
+            [missing],
+        )?;
+        drop(setup);
+
+        let err = crate::db::open_db_no_migrate()
+            .expect_err("incomplete schema should require foreground migration");
+
+        assert!(
+            err.to_string().contains("missing migration"),
+            "unexpected error: {err:#}"
+        );
+        let check = Connection::open(crate::db::db_path())?;
+        let (missing_rows, latest_rows): (i64, i64) = check.query_row(
+            "SELECT
+                SUM(CASE WHEN version = ?1 THEN 1 ELSE 0 END),
+                SUM(CASE WHEN version = ?2 THEN 1 ELSE 0 END)
+             FROM _schema_migrations",
+            (missing, latest),
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(missing_rows, 0);
+        assert_eq!(latest_rows, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn open_db_no_migrate_rejects_newer_schema_without_migrating() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("no-migrate-newer-schema");
+        let setup = crate::db::open_db()?;
+        let latest = crate::migrate::latest_schema_version();
+        setup.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, 'future-test', 0)",
+            [latest + 1],
+        )?;
+        drop(setup);
+
+        let err = crate::db::open_db_no_migrate().expect_err("newer schema should fail closed");
+
+        assert!(
+            err.to_string().contains("only knows up to"),
+            "unexpected error: {err:#}"
+        );
         Ok(())
     }
 

--- a/src/db/test_support.rs
+++ b/src/db/test_support.rs
@@ -97,3 +97,15 @@ pub fn cleanup_temp_db_files(path: &std::path::Path) {
     let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
     let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
 }
+
+pub fn runtime_connection() -> anyhow::Result<rusqlite::Connection> {
+    crate::db::open_db()
+}
+
+pub fn reset_runtime_connection_open_count() {
+    crate::db::core::reset_configured_connection_open_count();
+}
+
+pub fn runtime_connection_open_count() -> usize {
+    crate::db::core::configured_connection_open_count()
+}

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -16,6 +16,7 @@ mod transition;
 mod types;
 
 pub(crate) use dry_run::dry_run_pending;
+pub(crate) use run::ensure_schema_current;
 pub use run::run_migrations;
 pub(crate) use schema_drift::validate_schema_invariants;
 #[cfg(test)]

--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use rusqlite::Connection;
 
 use super::schema_drift::{install_v031_state_delete_trigger, repair_known_schema_drift};
-use super::state::{applied_versions, ensure_migration_table, mark_applied};
+use super::state::{applied_versions, ensure_migration_table, has_migration_table, mark_applied};
 use super::transition::transition_from_old_system;
 use super::types::{MIGRATIONS, OLD_BASELINE_VERSION};
 
@@ -37,6 +37,40 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
             Err(error)
         }
     }
+}
+
+pub(crate) fn ensure_schema_current(conn: &Connection) -> Result<()> {
+    if !has_migration_table(conn) {
+        return Err(anyhow!(
+            "database schema is not initialized; run a foreground remem command before hook context"
+        ));
+    }
+    let applied = applied_versions(conn)?;
+    let binary_latest = super::latest_schema_version();
+    let db_latest = applied.iter().copied().max().unwrap_or(0);
+    if db_latest > binary_latest {
+        return Err(anyhow!(
+            "database is at schema v{db_latest} but this binary ({}) only knows up to v{binary_latest}; please upgrade remem and verify `remem --version` reports schema v{db_latest} or newer",
+            crate::build_info::version_label()
+        ));
+    }
+    if db_latest < binary_latest {
+        return Err(anyhow!(
+            "database is at schema v{db_latest} but this binary ({}) requires schema v{binary_latest}; run a foreground remem command to migrate before hook context",
+            crate::build_info::version_label()
+        ));
+    }
+    if let Some(missing) = MIGRATIONS
+        .iter()
+        .find(|migration| !applied.contains(&migration.version))
+    {
+        return Err(anyhow!(
+            "database schema is missing migration v{:03}_{}; run a foreground remem command to migrate before hook context",
+            missing.version,
+            missing.name
+        ));
+    }
+    Ok(())
 }
 
 fn run_migrations_locked(conn: &Connection) -> Result<()> {

--- a/src/summarize/summary_job/persist.rs
+++ b/src/summarize/summary_job/persist.rs
@@ -137,8 +137,8 @@ pub(super) fn finalize_summary(
     Ok(())
 }
 
-pub(super) fn sync_native_memory(cwd: &str, project: &str) {
-    if let Err(err) = crate::context::claude_memory::sync_to_claude_memory(cwd, project) {
+pub(super) fn sync_native_memory(conn: &rusqlite::Connection, cwd: &str, project: &str) {
+    if let Err(err) = crate::context::claude_memory::sync_to_claude_memory(conn, cwd, project) {
         crate::log::warn(
             "summary-job",
             &format!("claude memory sync failed: {}", err),

--- a/src/summarize/summary_job/process.rs
+++ b/src/summarize/summary_job/process.rs
@@ -95,7 +95,7 @@ pub async fn process_summary_job_input(
         &msg_hash,
         summary,
     )?;
-    sync_native_memory(cwd, &project);
+    sync_native_memory(&conn, cwd, &project);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- open one hook-path DB connection in the context pipeline and pass it through render and gate instead of reopening
- add `open_db_no_migrate()` for hook context paths so hooks fail closed on missing/stale/incomplete/newer schemas instead of running migrations
- thread the existing connection into Claude native-memory sync and add test-only connection counting for strict context runs
- bump runtime/plugin version metadata to 0.5.23

Closes #403

## Verification
- `cargo fmt --check`
- `cargo check --message-format=short`
- `cargo clippy -- -D warnings`
- `cargo test`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `rg -n "open_db" src/context -S` -> only `src/context/render.rs` uses `db::open_db_no_migrate()`

## Notes
- `context::tests::render::strict_context_pipeline_opens_one_database_connection` asserts a strict gated context run opens exactly one counted DB connection after foreground schema setup.
- Hooks now report an explicit context load error when the schema needs foreground migration.