### PR TITLE
Add context data-version precheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.24"
+version = "0.5.25"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.24"
+version = "0.5.25"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.24": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.24",
+    "0.5.25": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.25",
       "assets": {}
     }
   }

--- a/src/cli/actions/context_gate.rs
+++ b/src/cli/actions/context_gate.rs
@@ -48,15 +48,22 @@ fn load_recent_context_gate_rows(
         return Ok(Vec::new());
     }
 
-    let mut stmt = conn.prepare(
+    let data_version_select = if context_injections_column_exists(conn, "data_version")? {
+        "data_version"
+    } else {
+        "NULL"
+    };
+    let sql = format!(
         "SELECT host, project, injection_key, session_id, hook_source, output_mode,
-                output_chars, updated_at_epoch, last_emitted_epoch, emit_count, suppress_count
+                output_chars, updated_at_epoch, last_emitted_epoch, emit_count, suppress_count,
+                {data_version_select}
          FROM context_injections
          WHERE (?1 IS NULL OR project = ?1)
            AND (?2 IS NULL OR session_id = ?2)
          ORDER BY updated_at_epoch DESC
          LIMIT ?3",
-    )?;
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
         .query_map(params![project, session, limit], |row| {
             let mut status = ContextGateStatusRow {
@@ -73,6 +80,7 @@ fn load_recent_context_gate_rows(
                 last_emitted_at: String::new(),
                 emit_count: row.get(9)?,
                 suppress_count: row.get(10)?,
+                data_version: row.get(11)?,
                 inferred_reason: String::new(),
             };
             status.updated_at = format_context_gate_timestamp(status.updated_at_epoch);
@@ -85,11 +93,25 @@ fn load_recent_context_gate_rows(
 }
 
 fn context_injections_table_exists(conn: &Connection) -> Result<bool> {
+    context_injections_column_exists(conn, "*")
+}
+
+fn context_injections_column_exists(conn: &Connection, column_name: &str) -> Result<bool> {
+    if column_name == "*" {
+        let exists = conn.query_row(
+            "SELECT EXISTS (
+                 SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'context_injections'
+             )",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        return Ok(exists != 0);
+    }
     let exists = conn.query_row(
         "SELECT EXISTS (
-             SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'context_injections'
+             SELECT 1 FROM pragma_table_info('context_injections') WHERE name = ?1
          )",
-        [],
+        [column_name],
         |row| row.get::<_, i64>(0),
     )?;
     Ok(exists != 0)
@@ -124,6 +146,7 @@ fn infer_context_gate_reason(row: &ContextGateStatusRow) -> &'static str {
         "suppressed" if source_is_default_suppressed(row.hook_source.as_deref()) => {
             "suppressed_source"
         }
+        "suppressed" if row.data_version.is_some() => "suppressed_data_version",
         "suppressed" => "same_hash_or_strict",
         "full" if source_requires_restart(row.hook_source.as_deref()) => "restart_source",
         "full" if row.emit_count <= 1 => "first_or_forced",
@@ -181,6 +204,7 @@ struct ContextGateStatusRow {
     last_emitted_at: String,
     emit_count: i64,
     suppress_count: i64,
+    data_version: Option<String>,
     inferred_reason: String,
 }
 
@@ -251,6 +275,7 @@ mod tests {
             last_emitted_at: String::new(),
             emit_count: 1,
             suppress_count: 0,
+            data_version: None,
             inferred_reason: String::new(),
         };
 
@@ -280,6 +305,7 @@ mod tests {
                 last_emitted_at: "1970-01-01 00:01:40 UTC".to_string(),
                 emit_count: 1,
                 suppress_count: 2,
+                data_version: None,
                 inferred_reason: "suppressed_source".to_string(),
             }],
         };
@@ -298,6 +324,44 @@ mod tests {
         let rows = load_recent_context_gate_rows(&conn, None, None, 20)?;
 
         assert!(rows.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn context_gate_status_infers_data_version_suppression() -> Result<()> {
+        let conn = setup_context_gate_conn();
+        conn.execute(
+            "ALTER TABLE context_injections ADD COLUMN data_version TEXT",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO context_injections
+             (host, project, injection_key, session_id, transcript_path, hook_source,
+              context_hash, data_version, output_mode, output_chars, created_at_epoch,
+              updated_at_epoch, last_emitted_epoch, emit_count, suppress_count)
+             VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+            params![
+                "codex-cli",
+                "/tmp/remem",
+                "session:/tmp/remem:sess-1",
+                "sess-1",
+                "SessionStart",
+                "hash-a",
+                "version-a",
+                "suppressed",
+                0,
+                100,
+                110,
+                100,
+                1,
+                2,
+            ],
+        )?;
+
+        let rows = load_recent_context_gate_rows(&conn, Some("/tmp/remem"), Some("sess-1"), 20)?;
+
+        assert_eq!(rows[0].data_version.as_deref(), Some("version-a"));
+        assert_eq!(rows[0].inferred_reason, "suppressed_data_version");
         Ok(())
     }
 

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -1,15 +1,19 @@
 use anyhow::Result;
-use rusqlite::{params, OptionalExtension};
 use sha2::{Digest, Sha256};
 use std::path::{Component, Path, PathBuf};
 
 use super::host::HostKind;
 use super::invocation::ContextInvocation;
+use super::policy::ContextPolicy;
+use super::types::ContextRequest;
 
+mod data_version;
 mod delta;
 mod pre_render;
+mod store;
 
 pub(super) use pre_render::pre_render_context_gate;
+use store::{load_gate_row, record_suppression, upsert_emit_row, GateRow};
 
 const DEFAULT_GATE_HOSTS: &str = "codex-cli,claude-code";
 const DEFAULT_SUPPRESSED_SOURCES: &str = "compact";
@@ -43,16 +47,37 @@ pub(super) struct ContextGateDecision {
     pub output_mode: Option<&'static str>,
 }
 
-#[derive(Debug)]
-struct GateRow {
-    context_hash: String,
-    last_emitted_epoch: i64,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ContextGatePrecheck {
+    Off,
+    Hit,
+    Miss,
 }
 
+impl ContextGatePrecheck {
+    pub(super) fn as_log_value(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Hit => "hit",
+            Self::Miss => "miss",
+        }
+    }
+}
+
+#[cfg(test)]
 pub(super) fn apply_context_gate(
     conn: &rusqlite::Connection,
     invocation: &ContextInvocation,
     output: String,
+) -> ContextGateDecision {
+    apply_context_gate_with_data_version(conn, invocation, output, None)
+}
+
+pub(super) fn apply_context_gate_with_data_version(
+    conn: &rusqlite::Connection,
+    invocation: &ContextInvocation,
+    output: String,
+    data_version: Option<&str>,
 ) -> ContextGateDecision {
     if output.is_empty() {
         return decision(output, ContextGateAction::Bypassed, "empty_output");
@@ -104,6 +129,7 @@ pub(super) fn apply_context_gate(
             invocation,
             &key,
             &hash,
+            data_version,
             "full",
             output.chars().count(),
             now,
@@ -129,6 +155,7 @@ pub(super) fn apply_context_gate(
             invocation,
             &key,
             &hash,
+            data_version,
             "full",
             output.chars().count(),
             now,
@@ -153,6 +180,7 @@ pub(super) fn apply_context_gate(
             invocation,
             &key,
             &hash,
+            data_version,
             "full",
             output.chars().count(),
             now,
@@ -179,7 +207,7 @@ pub(super) fn apply_context_gate(
             } else {
                 "same_hash"
             };
-            return match record_suppression(conn, invocation, &key, now) {
+            return match record_suppression(conn, invocation, &key, data_version, now) {
                 Ok(()) => {
                     log_gate("suppress", invocation, &key, reason, &hash);
                     gate_decision(
@@ -199,6 +227,7 @@ pub(super) fn apply_context_gate(
             invocation,
             &key,
             &hash,
+            data_version,
             "full",
             output.chars().count(),
             now,
@@ -219,7 +248,7 @@ pub(super) fn apply_context_gate(
     }
 
     if mode == ContextGateMode::Strict {
-        return match record_suppression(conn, invocation, &key, now) {
+        return match record_suppression(conn, invocation, &key, data_version, now) {
             Ok(()) => {
                 log_gate("suppress", invocation, &key, "strict", &hash);
                 gate_decision(
@@ -251,6 +280,7 @@ pub(super) fn apply_context_gate(
         invocation,
         &key,
         &hash,
+        data_version,
         output_mode,
         output.chars().count(),
         now,
@@ -393,83 +423,6 @@ fn cleanup_old_rows(conn: &rusqlite::Connection, now: i64) {
 fn retention_cutoff_epoch(now: i64) -> i64 {
     let retention_days = read_i64_env("REMEM_CONTEXT_GATE_RETENTION_DAYS", DEFAULT_RETENTION_DAYS);
     now.saturating_sub(retention_days.saturating_mul(86_400))
-}
-
-fn load_gate_row(conn: &rusqlite::Connection, host: &str, key: &str) -> Result<Option<GateRow>> {
-    conn.query_row(
-        "SELECT context_hash, last_emitted_epoch
-         FROM context_injections
-         WHERE host = ?1 AND injection_key = ?2",
-        params![host, key],
-        |row| {
-            Ok(GateRow {
-                context_hash: row.get(0)?,
-                last_emitted_epoch: row.get(1)?,
-            })
-        },
-    )
-    .optional()
-    .map_err(Into::into)
-}
-
-fn upsert_emit_row(
-    conn: &rusqlite::Connection,
-    invocation: &ContextInvocation,
-    key: &str,
-    hash: &str,
-    output_mode: &str,
-    output_chars: usize,
-    now: i64,
-) -> Result<()> {
-    conn.execute(
-        "INSERT INTO context_injections
-         (host, project, injection_key, session_id, transcript_path, hook_source, context_hash, output_mode,
-          output_chars, created_at_epoch, updated_at_epoch, last_emitted_epoch, emit_count,
-          suppress_count)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10, ?10, 1, 0)
-         ON CONFLICT(host, injection_key) DO UPDATE SET
-          project = excluded.project,
-          session_id = excluded.session_id,
-          transcript_path = excluded.transcript_path,
-          hook_source = excluded.hook_source,
-          context_hash = excluded.context_hash,
-          output_mode = excluded.output_mode,
-          output_chars = excluded.output_chars,
-          updated_at_epoch = excluded.updated_at_epoch,
-          last_emitted_epoch = excluded.last_emitted_epoch,
-          emit_count = context_injections.emit_count + 1",
-        params![
-            invocation.host.as_env_value(),
-            invocation.project,
-            key,
-            invocation.session_id,
-            invocation.transcript_path,
-            invocation.source,
-            hash,
-            output_mode,
-            output_chars as i64,
-            now,
-        ],
-    )?;
-    Ok(())
-}
-
-fn record_suppression(
-    conn: &rusqlite::Connection,
-    invocation: &ContextInvocation,
-    key: &str,
-    now: i64,
-) -> Result<()> {
-    conn.execute(
-        "UPDATE context_injections
-         SET output_mode = 'suppressed',
-             hook_source = ?3,
-             updated_at_epoch = ?4,
-             suppress_count = suppress_count + 1
-         WHERE host = ?1 AND injection_key = ?2",
-        params![invocation.host.as_env_value(), key, invocation.source, now,],
-    )?;
-    Ok(())
 }
 
 fn injection_key(invocation: &ContextInvocation) -> String {
@@ -747,8 +700,12 @@ fn is_context_stats_footer(text: &str) -> bool {
 }
 
 fn sha256_hex(value: &str) -> String {
+    sha256_hex_bytes(value.as_bytes())
+}
+
+fn sha256_hex_bytes(value: &[u8]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(value.as_bytes());
+    hasher.update(value);
     let digest = hasher.finalize();
     let mut out = String::with_capacity(digest.len() * 2);
     for byte in digest {

--- a/src/context/injection_gate/data_version.rs
+++ b/src/context/injection_gate/data_version.rs
@@ -1,0 +1,309 @@
+use anyhow::Result;
+use rusqlite::OptionalExtension;
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+use super::super::invocation::ContextInvocation;
+use super::super::policy::ContextPolicy;
+use super::super::types::ContextRequest;
+
+const SUMMARY_VERSION_SCAN_LIMIT: i64 = 200;
+
+pub(super) fn context_injections_has_data_version(conn: &rusqlite::Connection) -> Result<bool> {
+    conn.query_row(
+        "SELECT 1
+         FROM pragma_table_info('context_injections')
+         WHERE name = 'data_version'
+         LIMIT 1",
+        [],
+        |row| row.get::<_, i64>(0),
+    )
+    .optional()
+    .map(|value| value.is_some())
+    .map_err(Into::into)
+}
+
+pub(super) fn compute_data_version(
+    conn: &rusqlite::Connection,
+    request: &ContextRequest,
+    invocation: &ContextInvocation,
+    policy: &ContextPolicy,
+) -> Result<String> {
+    let mut version = DataVersionBuilder::new();
+    version.push("version", "2");
+    version.push("project", &request.project);
+    version.push("cwd", &request.cwd);
+    version.push("branch", request.current_branch.as_deref().unwrap_or(""));
+    version.push("session", request.session_id.as_deref().unwrap_or(""));
+    version.push("source", request.hook_source.as_deref().unwrap_or(""));
+    version.push("host", request.host.as_env_value());
+    version.push("colors", if request.use_colors { "1" } else { "0" });
+    version.push("gate_mode", invocation.gate_mode.as_deref().unwrap_or(""));
+    version.push("package", env!("CARGO_PKG_VERSION"));
+    version.push(
+        "schema",
+        &crate::migrate::latest_schema_version().to_string(),
+    );
+    version.push("policy", &format!("{:?}", policy));
+    version.push("claude_md", &claude_md_fingerprint(&request.cwd)?);
+
+    let now = chrono::Utc::now().timestamp();
+    version.push("day_bucket", &(now / 86_400).to_string());
+    push_memory_signal(conn, request, now, &mut version)?;
+    push_memory_state_key_signal(conn, &request.project, &mut version)?;
+    push_lesson_signal(conn, request, policy, now, &mut version)?;
+    push_session_signal(conn, &request.project, &mut version)?;
+    push_workstream_signal(conn, &request.project, &mut version)?;
+
+    Ok(version.finish())
+}
+
+fn claude_md_fingerprint(cwd: &str) -> Result<String> {
+    let path = Path::new(cwd).join("CLAUDE.md");
+    match std::fs::read(&path) {
+        Ok(bytes) => Ok(super::sha256_hex_bytes(&bytes)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok("missing".to_string()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn push_memory_signal(
+    conn: &rusqlite::Connection,
+    request: &ContextRequest,
+    now: i64,
+    version: &mut DataVersionBuilder,
+) -> Result<()> {
+    let signal: AggregateSignal = conn.query_row(
+        "SELECT COUNT(*),
+                COALESCE(MAX(m.updated_at_epoch), 0),
+                COALESCE(SUM(m.id), 0)
+         FROM memories m
+         WHERE m.status = 'active'
+           AND (m.expires_at_epoch IS NULL OR m.expires_at_epoch > ?2)
+           AND (m.state_key_id IS NULL OR NOT EXISTS (
+                SELECT 1 FROM memory_state_keys sk
+                WHERE sk.id = m.state_key_id
+                  AND sk.current_memory_id IS NOT NULL
+                  AND sk.current_memory_id <> m.id
+           ))
+           AND (?3 IS NULL OR m.branch = ?3 OR m.branch IS NULL)
+           AND ((m.owner_scope = 'repo' AND m.owner_key = ?1)
+                OR (m.owner_scope = 'repo' AND m.target_project = ?1)
+                OR (m.owner_scope = 'user' AND m.owner_key = 'user:default')
+                OR (m.owner_scope IS NULL AND (
+                    (m.project = ?1 AND COALESCE(m.scope, 'project') != 'global')
+                    OR m.scope = 'global'
+                )))",
+        rusqlite::params![request.project, now, request.current_branch.as_deref()],
+        map_aggregate_signal,
+    )?;
+    signal.push("memories", version);
+    Ok(())
+}
+
+fn push_memory_state_key_signal(
+    conn: &rusqlite::Connection,
+    project: &str,
+    version: &mut DataVersionBuilder,
+) -> Result<()> {
+    let signal: AggregateSignal = conn.query_row(
+        "SELECT COUNT(*),
+                COALESCE(MAX(updated_at_epoch), 0),
+                COALESCE(SUM(COALESCE(current_memory_id, 0)), 0)
+         FROM memory_state_keys
+         WHERE (owner_scope = 'repo' AND owner_key = ?1)
+            OR (owner_scope = 'user' AND owner_key = 'user:default')",
+        [project],
+        map_aggregate_signal,
+    )?;
+    signal.push("memory_state_keys", version);
+    Ok(())
+}
+
+fn push_lesson_signal(
+    conn: &rusqlite::Connection,
+    request: &ContextRequest,
+    policy: &ContextPolicy,
+    now: i64,
+    version: &mut DataVersionBuilder,
+) -> Result<()> {
+    let signal: LessonSignal = conn.query_row(
+        "SELECT COUNT(*),
+                COALESCE(MAX(m.updated_at_epoch), 0),
+                COALESCE(SUM(m.id), 0),
+                COALESCE(MAX(l.last_reinforced_at_epoch), 0),
+                COALESCE(SUM(l.reinforcement_count), 0),
+                COALESCE(SUM(CAST(l.confidence * 1000000 AS INTEGER)), 0),
+                COALESCE(MAX(COALESCE(l.stale_after_epoch, 0)), 0)
+         FROM memories m
+         JOIN memory_lessons l ON l.memory_id = m.id
+         WHERE m.memory_type = 'lesson'
+           AND m.status = 'active'
+           AND (m.expires_at_epoch IS NULL OR m.expires_at_epoch > ?2)
+           AND (m.state_key_id IS NULL OR NOT EXISTS (
+                SELECT 1 FROM memory_state_keys sk
+                WHERE sk.id = m.state_key_id
+                  AND sk.current_memory_id IS NOT NULL
+                  AND sk.current_memory_id <> m.id
+           ))
+           AND ((m.owner_scope = 'repo' AND m.owner_key = ?1)
+                OR (m.owner_scope = 'repo' AND m.target_project = ?1)
+                OR (m.owner_scope = 'user' AND m.owner_key = 'user:default')
+                OR (m.owner_scope IS NULL AND (m.project = ?1 OR m.scope = 'global')))
+           AND l.confidence >= 0.5
+           AND (l.stale_after_epoch IS NULL OR l.stale_after_epoch > ?2)
+           AND (?3 IS NULL OR m.branch = ?3 OR m.branch IS NULL)",
+        rusqlite::params![request.project, now, request.current_branch.as_deref()],
+        |row| {
+            Ok(LessonSignal {
+                count: row.get(0)?,
+                max_memory_updated: row.get(1)?,
+                id_sum: row.get(2)?,
+                max_reinforced: row.get(3)?,
+                reinforcement_sum: row.get(4)?,
+                confidence_sum: row.get(5)?,
+                max_stale_after: row.get(6)?,
+            })
+        },
+    )?;
+    signal.push(version);
+    version.push("lesson_limit", &policy.limits.lesson_limit.to_string());
+    Ok(())
+}
+
+fn push_session_signal(
+    conn: &rusqlite::Connection,
+    project: &str,
+    version: &mut DataVersionBuilder,
+) -> Result<()> {
+    let mut stmt = conn.prepare(
+        "SELECT id, created_at_epoch, request, completed
+         FROM session_summaries
+         WHERE request IS NOT NULL AND request != ''
+           AND session_row_id IS NULL
+           AND ((owner_scope = 'repo' AND owner_key = ?1)
+                OR (owner_scope = 'repo' AND target_project = ?1)
+                OR (owner_scope IS NULL AND project = ?1))
+         ORDER BY created_at_epoch DESC
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(
+        rusqlite::params![project, SUMMARY_VERSION_SCAN_LIMIT],
+        |row| {
+            Ok((
+                row.get::<_, Option<i64>>(0)?.unwrap_or_default(),
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?.unwrap_or_default(),
+            ))
+        },
+    )?;
+
+    let mut count = 0_i64;
+    for row in rows {
+        let (id, created_at_epoch, request, completed) = row?;
+        count += 1;
+        version.push(
+            "session",
+            &format!("{id}|{created_at_epoch}|{request}|{completed}"),
+        );
+    }
+    version.push("sessions_count", &count.to_string());
+    Ok(())
+}
+
+fn push_workstream_signal(
+    conn: &rusqlite::Connection,
+    project: &str,
+    version: &mut DataVersionBuilder,
+) -> Result<()> {
+    let signal: AggregateSignal = conn.query_row(
+        "SELECT COUNT(*),
+                COALESCE(MAX(updated_at_epoch), 0),
+                COALESCE(SUM(id), 0)
+         FROM workstreams
+         WHERE status = 'active'
+           AND ((owner_scope = 'repo' AND owner_key = ?1)
+                OR (owner_scope = 'repo' AND target_project = ?1)
+                OR (owner_scope = 'workstream' AND target_project = ?1)
+                OR (owner_scope IS NULL AND project = ?1))",
+        [project],
+        map_aggregate_signal,
+    )?;
+    signal.push("workstreams", version);
+    Ok(())
+}
+
+fn map_aggregate_signal(row: &rusqlite::Row<'_>) -> rusqlite::Result<AggregateSignal> {
+    Ok(AggregateSignal {
+        count: row.get(0)?,
+        max_epoch: row.get(1)?,
+        id_sum: row.get(2)?,
+    })
+}
+
+struct AggregateSignal {
+    count: i64,
+    max_epoch: i64,
+    id_sum: i64,
+}
+
+impl AggregateSignal {
+    fn push(&self, label: &'static str, version: &mut DataVersionBuilder) {
+        version.push(
+            label,
+            &format!("{}|{}|{}", self.count, self.max_epoch, self.id_sum),
+        );
+    }
+}
+
+struct LessonSignal {
+    count: i64,
+    max_memory_updated: i64,
+    id_sum: i64,
+    max_reinforced: i64,
+    reinforcement_sum: i64,
+    confidence_sum: i64,
+    max_stale_after: i64,
+}
+
+impl LessonSignal {
+    fn push(&self, version: &mut DataVersionBuilder) {
+        version.push(
+            "lessons",
+            &format!(
+                "{}|{}|{}|{}|{}|{}|{}",
+                self.count,
+                self.max_memory_updated,
+                self.id_sum,
+                self.max_reinforced,
+                self.reinforcement_sum,
+                self.confidence_sum,
+                self.max_stale_after
+            ),
+        );
+    }
+}
+
+struct DataVersionBuilder {
+    hasher: Sha256,
+}
+
+impl DataVersionBuilder {
+    fn new() -> Self {
+        Self {
+            hasher: Sha256::new(),
+        }
+    }
+
+    fn push(&mut self, key: &str, value: &str) {
+        self.hasher.update(key.as_bytes());
+        self.hasher.update([0]);
+        self.hasher.update(value.as_bytes());
+        self.hasher.update([0xff]);
+    }
+
+    fn finish(self) -> String {
+        format!("{:x}", self.hasher.finalize())
+    }
+}

--- a/src/context/injection_gate/data_version.rs
+++ b/src/context/injection_gate/data_version.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rusqlite::OptionalExtension;
+use rusqlite::{types::ToSql, OptionalExtension};
 use sha2::{Digest, Sha256};
 use std::path::Path;
 
@@ -9,8 +9,6 @@ use super::super::types::ContextRequest;
 
 const SUMMARY_VERSION_SCAN_LIMIT: i64 = 200;
 const BASENAME_SEARCH_LIMIT: i64 = 20;
-const INDEXED_MEMORY_TYPES_SQL: &str = "'decision', 'discovery', 'bugfix', 'architecture', \
-                                        'procedure', 'session_activity'";
 
 pub(super) fn context_injections_has_data_version(conn: &rusqlite::Connection) -> Result<bool> {
     conn.query_row(
@@ -57,7 +55,7 @@ pub(super) fn compute_data_version(
     push_lesson_signal(conn, request, policy, now, &mut version)?;
     push_preference_signal(conn, &request.project, policy, &mut version)?;
     push_session_signal(conn, &request.project, &mut version)?;
-    push_workstream_signal(conn, &request.project, &mut version)?;
+    push_workstream_signal(conn, &request.project, policy, &mut version)?;
 
     Ok(version.finish())
 }
@@ -82,22 +80,20 @@ fn push_memory_signal(
         .section(SectionKind::MemoryIndex)
         .map(|section| section.exclude_types.as_slice())
         .unwrap_or(&[]);
-    let type_filter = if excluded_types.is_empty() {
-        String::new()
-    } else {
-        format!(" AND m.memory_type IN ({})", INDEXED_MEMORY_TYPES_SQL)
-    };
-    let recent_sql = memory_window_sql(&type_filter, None);
+    let recent_type_filter = memory_type_filter(excluded_types, 4);
+    let recent_sql = memory_window_sql(&recent_type_filter, None, 4 + excluded_types.len());
+    let recent_params = memory_window_params(
+        request,
+        now,
+        None,
+        excluded_types,
+        policy.limits.candidate_fetch_limit as i64,
+    );
     push_memory_window(
         conn,
         "memories_recent",
         &recent_sql,
-        rusqlite::params![
-            request.project,
-            now,
-            request.current_branch.as_deref(),
-            policy.limits.candidate_fetch_limit as i64
-        ],
+        &recent_params,
         version,
     )?;
 
@@ -108,21 +104,24 @@ fn push_memory_signal(
         .filter(|value| !value.trim().is_empty())
         .unwrap_or(&request.project);
     let like_pattern = format!("%{basename}%");
+    let search_type_filter = memory_type_filter(excluded_types, 5);
     let search_sql = memory_window_sql(
-        &type_filter,
+        &search_type_filter,
         Some(" AND (m.title LIKE ?4 OR m.content LIKE ?4)"),
+        5 + excluded_types.len(),
+    );
+    let search_params = memory_window_params(
+        request,
+        now,
+        Some(like_pattern),
+        excluded_types,
+        BASENAME_SEARCH_LIMIT,
     );
     push_memory_window(
         conn,
         "memories_basename",
         &search_sql,
-        rusqlite::params![
-            request.project,
-            now,
-            request.current_branch.as_deref(),
-            like_pattern,
-            BASENAME_SEARCH_LIMIT
-        ],
+        &search_params,
         version,
     )
 }
@@ -274,35 +273,93 @@ fn push_session_signal(
 fn push_workstream_signal(
     conn: &rusqlite::Connection,
     project: &str,
+    policy: &ContextPolicy,
     version: &mut DataVersionBuilder,
 ) -> Result<()> {
-    let workstreams = crate::workstream::query_active_workstreams(conn, project)?;
-    for workstream in &workstreams {
-        version.push_row(
-            "workstream",
-            &[
-                workstream.id.to_string(),
-                workstream.project.clone(),
-                workstream.title.clone(),
-                workstream.description.clone().unwrap_or_default(),
-                workstream.status.as_str().to_string(),
-                workstream.progress.clone().unwrap_or_default(),
-                workstream.next_action.clone().unwrap_or_default(),
-                workstream.blockers.clone().unwrap_or_default(),
-                workstream.created_at_epoch.to_string(),
-                workstream.updated_at_epoch.to_string(),
-                workstream
-                    .completed_at_epoch
-                    .unwrap_or_default()
-                    .to_string(),
-            ],
-        );
+    let limit = policy.section_item_limit(SectionKind::Workstreams, 5);
+    if limit == 0 {
+        version.push("workstreams_count", "0");
+        return Ok(());
     }
-    version.push("workstreams_count", &workstreams.len().to_string());
+
+    let mut stmt = conn.prepare(
+        "SELECT id, project, title, description, status, progress, next_action,
+                blockers, created_at_epoch, updated_at_epoch, completed_at_epoch
+         FROM workstreams
+         WHERE status = 'active'
+           AND ((owner_scope = 'repo' AND owner_key = ?1)
+                OR (owner_scope = 'repo' AND target_project = ?1)
+                OR (owner_scope = 'workstream' AND target_project = ?1)
+                OR (owner_scope IS NULL AND project = ?1))
+         ORDER BY updated_at_epoch DESC
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![project, limit as i64], |row| {
+        Ok(vec![
+            row.get::<_, i64>(0)?.to_string(),
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, Option<String>>(3)?.unwrap_or_default(),
+            row.get::<_, String>(4)?,
+            row.get::<_, Option<String>>(5)?.unwrap_or_default(),
+            row.get::<_, Option<String>>(6)?.unwrap_or_default(),
+            row.get::<_, Option<String>>(7)?.unwrap_or_default(),
+            row.get::<_, i64>(8)?.to_string(),
+            row.get::<_, i64>(9)?.to_string(),
+            row.get::<_, Option<i64>>(10)?
+                .unwrap_or_default()
+                .to_string(),
+        ])
+    })?;
+
+    let mut count = 0usize;
+    for row in rows {
+        version.push_row("workstream", &row?);
+        count += 1;
+    }
+    version.push("workstreams_count", &count.to_string());
     Ok(())
 }
 
-fn memory_window_sql(type_filter: &str, search_filter: Option<&str>) -> String {
+fn memory_type_filter(excluded_types: &[&str], first_param_index: usize) -> String {
+    if excluded_types.is_empty() {
+        return String::new();
+    }
+
+    let placeholders = (first_param_index..first_param_index + excluded_types.len())
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(" AND m.memory_type NOT IN ({placeholders})")
+}
+
+fn memory_window_params(
+    request: &ContextRequest,
+    now: i64,
+    search_pattern: Option<String>,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Vec<Box<dyn ToSql>> {
+    let mut params: Vec<Box<dyn ToSql>> = vec![
+        Box::new(request.project.clone()),
+        Box::new(now),
+        Box::new(request.current_branch.clone()),
+    ];
+    if let Some(pattern) = search_pattern {
+        params.push(Box::new(pattern));
+    }
+    for excluded_type in excluded_types {
+        params.push(Box::new((*excluded_type).to_string()));
+    }
+    params.push(Box::new(limit));
+    params
+}
+
+fn memory_window_sql(
+    type_filter: &str,
+    search_filter: Option<&str>,
+    limit_param_index: usize,
+) -> String {
     format!(
         "SELECT m.id, m.session_id, m.project, m.topic_key, m.title, m.content,
                 m.memory_type, m.files, m.created_at_epoch, m.updated_at_epoch,
@@ -328,22 +385,22 @@ fn memory_window_sql(type_filter: &str, search_filter: Option<&str>) -> String {
          ORDER BY m.updated_at_epoch DESC, m.id DESC
          LIMIT ?{}",
         search_filter.unwrap_or(""),
-        if search_filter.is_some() { 5 } else { 4 }
+        limit_param_index
     )
 }
 
-fn push_memory_window<P>(
+fn push_memory_window(
     conn: &rusqlite::Connection,
     label: &'static str,
     sql: &str,
-    params: P,
+    params: &[Box<dyn ToSql>],
     version: &mut DataVersionBuilder,
-) -> Result<()>
-where
-    P: rusqlite::Params,
-{
+) -> Result<()> {
     let mut stmt = conn.prepare(sql)?;
-    let rows = stmt.query_map(params, map_memory_version_row)?;
+    let rows = stmt.query_map(
+        rusqlite::params_from_iter(crate::db::to_sql_refs(params)),
+        map_memory_version_row,
+    )?;
     let mut count = 0usize;
     for row in rows {
         push_memory_fields(version, label, &row?);

--- a/src/context/injection_gate/data_version.rs
+++ b/src/context/injection_gate/data_version.rs
@@ -4,10 +4,13 @@ use sha2::{Digest, Sha256};
 use std::path::Path;
 
 use super::super::invocation::ContextInvocation;
-use super::super::policy::ContextPolicy;
+use super::super::policy::{ContextPolicy, SectionKind};
 use super::super::types::ContextRequest;
 
 const SUMMARY_VERSION_SCAN_LIMIT: i64 = 200;
+const BASENAME_SEARCH_LIMIT: i64 = 20;
+const INDEXED_MEMORY_TYPES_SQL: &str = "'decision', 'discovery', 'bugfix', 'architecture', \
+                                        'procedure', 'session_activity'";
 
 pub(super) fn context_injections_has_data_version(conn: &rusqlite::Connection) -> Result<bool> {
     conn.query_row(
@@ -49,9 +52,10 @@ pub(super) fn compute_data_version(
 
     let now = chrono::Utc::now().timestamp();
     version.push("day_bucket", &(now / 86_400).to_string());
-    push_memory_signal(conn, request, now, &mut version)?;
+    push_memory_signal(conn, request, now, policy, &mut version)?;
     push_memory_state_key_signal(conn, &request.project, &mut version)?;
     push_lesson_signal(conn, request, policy, now, &mut version)?;
+    push_preference_signal(conn, &request.project, policy, &mut version)?;
     push_session_signal(conn, &request.project, &mut version)?;
     push_workstream_signal(conn, &request.project, &mut version)?;
 
@@ -71,34 +75,56 @@ fn push_memory_signal(
     conn: &rusqlite::Connection,
     request: &ContextRequest,
     now: i64,
+    policy: &ContextPolicy,
     version: &mut DataVersionBuilder,
 ) -> Result<()> {
-    let signal: AggregateSignal = conn.query_row(
-        "SELECT COUNT(*),
-                COALESCE(MAX(m.updated_at_epoch), 0),
-                COALESCE(SUM(m.id), 0)
-         FROM memories m
-         WHERE m.status = 'active'
-           AND (m.expires_at_epoch IS NULL OR m.expires_at_epoch > ?2)
-           AND (m.state_key_id IS NULL OR NOT EXISTS (
-                SELECT 1 FROM memory_state_keys sk
-                WHERE sk.id = m.state_key_id
-                  AND sk.current_memory_id IS NOT NULL
-                  AND sk.current_memory_id <> m.id
-           ))
-           AND (?3 IS NULL OR m.branch = ?3 OR m.branch IS NULL)
-           AND ((m.owner_scope = 'repo' AND m.owner_key = ?1)
-                OR (m.owner_scope = 'repo' AND m.target_project = ?1)
-                OR (m.owner_scope = 'user' AND m.owner_key = 'user:default')
-                OR (m.owner_scope IS NULL AND (
-                    (m.project = ?1 AND COALESCE(m.scope, 'project') != 'global')
-                    OR m.scope = 'global'
-                )))",
-        rusqlite::params![request.project, now, request.current_branch.as_deref()],
-        map_aggregate_signal,
+    let excluded_types = policy
+        .section(SectionKind::MemoryIndex)
+        .map(|section| section.exclude_types.as_slice())
+        .unwrap_or(&[]);
+    let type_filter = if excluded_types.is_empty() {
+        String::new()
+    } else {
+        format!(" AND m.memory_type IN ({})", INDEXED_MEMORY_TYPES_SQL)
+    };
+    let recent_sql = memory_window_sql(&type_filter, None);
+    push_memory_window(
+        conn,
+        "memories_recent",
+        &recent_sql,
+        rusqlite::params![
+            request.project,
+            now,
+            request.current_branch.as_deref(),
+            policy.limits.candidate_fetch_limit as i64
+        ],
+        version,
     )?;
-    signal.push("memories", version);
-    Ok(())
+
+    let basename = request
+        .project
+        .rsplit('/')
+        .next()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(&request.project);
+    let like_pattern = format!("%{basename}%");
+    let search_sql = memory_window_sql(
+        &type_filter,
+        Some(" AND (m.title LIKE ?4 OR m.content LIKE ?4)"),
+    );
+    push_memory_window(
+        conn,
+        "memories_basename",
+        &search_sql,
+        rusqlite::params![
+            request.project,
+            now,
+            request.current_branch.as_deref(),
+            like_pattern,
+            BASENAME_SEARCH_LIMIT
+        ],
+        version,
+    )
 }
 
 fn push_memory_state_key_signal(
@@ -106,17 +132,31 @@ fn push_memory_state_key_signal(
     project: &str,
     version: &mut DataVersionBuilder,
 ) -> Result<()> {
-    let signal: AggregateSignal = conn.query_row(
-        "SELECT COUNT(*),
-                COALESCE(MAX(updated_at_epoch), 0),
-                COALESCE(SUM(COALESCE(current_memory_id, 0)), 0)
+    let mut stmt = conn.prepare(
+        "SELECT id, owner_scope, owner_key, memory_type, state_key, state_label,
+                state_status, current_memory_id, created_at_epoch, updated_at_epoch
          FROM memory_state_keys
          WHERE (owner_scope = 'repo' AND owner_key = ?1)
-            OR (owner_scope = 'user' AND owner_key = 'user:default')",
-        [project],
-        map_aggregate_signal,
+            OR (owner_scope = 'user' AND owner_key = 'user:default')
+         ORDER BY owner_scope, owner_key, memory_type, state_key, id",
     )?;
-    signal.push("memory_state_keys", version);
+    let rows = stmt.query_map([project], |row| {
+        Ok(vec![
+            row.get::<_, i64>(0)?.to_string(),
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, Option<String>>(5)?.unwrap_or_default(),
+            row.get::<_, String>(6)?,
+            row.get::<_, Option<i64>>(7)?
+                .unwrap_or_default()
+                .to_string(),
+            row.get::<_, i64>(8)?.to_string(),
+            row.get::<_, i64>(9)?.to_string(),
+        ])
+    })?;
+    push_rows("memory_state_keys", rows, version)?;
     Ok(())
 }
 
@@ -127,47 +167,66 @@ fn push_lesson_signal(
     now: i64,
     version: &mut DataVersionBuilder,
 ) -> Result<()> {
-    let signal: LessonSignal = conn.query_row(
-        "SELECT COUNT(*),
-                COALESCE(MAX(m.updated_at_epoch), 0),
-                COALESCE(SUM(m.id), 0),
-                COALESCE(MAX(l.last_reinforced_at_epoch), 0),
-                COALESCE(SUM(l.reinforcement_count), 0),
-                COALESCE(SUM(CAST(l.confidence * 1000000 AS INTEGER)), 0),
-                COALESCE(MAX(COALESCE(l.stale_after_epoch, 0)), 0)
-         FROM memories m
-         JOIN memory_lessons l ON l.memory_id = m.id
-         WHERE m.memory_type = 'lesson'
-           AND m.status = 'active'
-           AND (m.expires_at_epoch IS NULL OR m.expires_at_epoch > ?2)
-           AND (m.state_key_id IS NULL OR NOT EXISTS (
-                SELECT 1 FROM memory_state_keys sk
-                WHERE sk.id = m.state_key_id
-                  AND sk.current_memory_id IS NOT NULL
-                  AND sk.current_memory_id <> m.id
-           ))
-           AND ((m.owner_scope = 'repo' AND m.owner_key = ?1)
-                OR (m.owner_scope = 'repo' AND m.target_project = ?1)
-                OR (m.owner_scope = 'user' AND m.owner_key = 'user:default')
-                OR (m.owner_scope IS NULL AND (m.project = ?1 OR m.scope = 'global')))
-           AND l.confidence >= 0.5
-           AND (l.stale_after_epoch IS NULL OR l.stale_after_epoch > ?2)
-           AND (?3 IS NULL OR m.branch = ?3 OR m.branch IS NULL)",
-        rusqlite::params![request.project, now, request.current_branch.as_deref()],
-        |row| {
-            Ok(LessonSignal {
-                count: row.get(0)?,
-                max_memory_updated: row.get(1)?,
-                id_sum: row.get(2)?,
-                max_reinforced: row.get(3)?,
-                reinforcement_sum: row.get(4)?,
-                confidence_sum: row.get(5)?,
-                max_stale_after: row.get(6)?,
-            })
-        },
+    let lessons = crate::memory::lesson::list_lessons_for_context(
+        conn,
+        &request.project,
+        request.current_branch.as_deref(),
+        policy.section_item_limit(SectionKind::Lessons, policy.limits.lesson_limit) as i64,
     )?;
-    signal.push(version);
+    for lesson in &lessons {
+        push_memory(version, "lesson", &lesson.memory);
+        version.push_row(
+            "lesson_meta",
+            &[
+                lesson.metadata.memory_id.to_string(),
+                format!("{:.6}", lesson.metadata.confidence),
+                lesson.metadata.reinforcement_count.to_string(),
+                lesson.metadata.source_evidence.clone().unwrap_or_default(),
+                lesson.metadata.last_reinforced_at_epoch.to_string(),
+                lesson
+                    .metadata
+                    .stale_after_epoch
+                    .unwrap_or_default()
+                    .to_string(),
+            ],
+        );
+    }
+    version.push("lessons_count", &lessons.len().to_string());
+    version.push("lesson_now_bucket", &(now / 86_400).to_string());
     version.push("lesson_limit", &policy.limits.lesson_limit.to_string());
+    Ok(())
+}
+
+fn push_preference_signal(
+    conn: &rusqlite::Connection,
+    project: &str,
+    policy: &ContextPolicy,
+    version: &mut DataVersionBuilder,
+) -> Result<()> {
+    let project_preferences = crate::memory::preference::query_project_preferences(
+        conn,
+        project,
+        policy.limits.preference_project_limit,
+    )?;
+    for memory in &project_preferences {
+        push_memory(version, "preference_project", memory);
+    }
+    version.push(
+        "preferences_project_count",
+        &project_preferences.len().to_string(),
+    );
+
+    let global_preferences = crate::memory::preference::query_global_preferences(
+        conn,
+        policy.limits.preference_global_limit,
+    )?;
+    for memory in &global_preferences {
+        push_memory(version, "preference_global", memory);
+    }
+    version.push(
+        "preferences_global_count",
+        &global_preferences.len().to_string(),
+    );
     Ok(())
 }
 
@@ -217,72 +276,159 @@ fn push_workstream_signal(
     project: &str,
     version: &mut DataVersionBuilder,
 ) -> Result<()> {
-    let signal: AggregateSignal = conn.query_row(
-        "SELECT COUNT(*),
-                COALESCE(MAX(updated_at_epoch), 0),
-                COALESCE(SUM(id), 0)
-         FROM workstreams
-         WHERE status = 'active'
-           AND ((owner_scope = 'repo' AND owner_key = ?1)
-                OR (owner_scope = 'repo' AND target_project = ?1)
-                OR (owner_scope = 'workstream' AND target_project = ?1)
-                OR (owner_scope IS NULL AND project = ?1))",
-        [project],
-        map_aggregate_signal,
-    )?;
-    signal.push("workstreams", version);
+    let workstreams = crate::workstream::query_active_workstreams(conn, project)?;
+    for workstream in &workstreams {
+        version.push_row(
+            "workstream",
+            &[
+                workstream.id.to_string(),
+                workstream.project.clone(),
+                workstream.title.clone(),
+                workstream.description.clone().unwrap_or_default(),
+                workstream.status.as_str().to_string(),
+                workstream.progress.clone().unwrap_or_default(),
+                workstream.next_action.clone().unwrap_or_default(),
+                workstream.blockers.clone().unwrap_or_default(),
+                workstream.created_at_epoch.to_string(),
+                workstream.updated_at_epoch.to_string(),
+                workstream
+                    .completed_at_epoch
+                    .unwrap_or_default()
+                    .to_string(),
+            ],
+        );
+    }
+    version.push("workstreams_count", &workstreams.len().to_string());
     Ok(())
 }
 
-fn map_aggregate_signal(row: &rusqlite::Row<'_>) -> rusqlite::Result<AggregateSignal> {
-    Ok(AggregateSignal {
-        count: row.get(0)?,
-        max_epoch: row.get(1)?,
-        id_sum: row.get(2)?,
-    })
+fn memory_window_sql(type_filter: &str, search_filter: Option<&str>) -> String {
+    format!(
+        "SELECT m.id, m.session_id, m.project, m.topic_key, m.title, m.content,
+                m.memory_type, m.files, m.created_at_epoch, m.updated_at_epoch,
+                m.status, m.branch, m.scope, m.source_project, m.target_project,
+                m.owner_scope, m.owner_key, m.context_class, m.expires_at_epoch,
+                m.valid_from_epoch, m.valid_to_epoch, m.state_key_id, m.search_context
+         FROM memories m
+         WHERE m.status = 'active'
+           AND (m.expires_at_epoch IS NULL OR m.expires_at_epoch > ?2)
+           AND (m.state_key_id IS NULL OR NOT EXISTS (
+                SELECT 1 FROM memory_state_keys sk
+                WHERE sk.id = m.state_key_id
+                  AND sk.current_memory_id IS NOT NULL
+                  AND sk.current_memory_id <> m.id
+           ))
+           AND (?3 IS NULL OR m.branch = ?3 OR m.branch IS NULL)
+           AND ((m.owner_scope = 'repo' AND m.owner_key = ?1)
+                OR (m.owner_scope = 'repo' AND m.target_project = ?1)
+                OR (m.owner_scope IS NULL AND m.project = ?1
+                    AND COALESCE(m.scope, 'project') != 'global'))
+           {type_filter}
+           {}
+         ORDER BY m.updated_at_epoch DESC, m.id DESC
+         LIMIT ?{}",
+        search_filter.unwrap_or(""),
+        if search_filter.is_some() { 5 } else { 4 }
+    )
 }
 
-struct AggregateSignal {
-    count: i64,
-    max_epoch: i64,
-    id_sum: i64,
-}
-
-impl AggregateSignal {
-    fn push(&self, label: &'static str, version: &mut DataVersionBuilder) {
-        version.push(
-            label,
-            &format!("{}|{}|{}", self.count, self.max_epoch, self.id_sum),
-        );
+fn push_memory_window<P>(
+    conn: &rusqlite::Connection,
+    label: &'static str,
+    sql: &str,
+    params: P,
+    version: &mut DataVersionBuilder,
+) -> Result<()>
+where
+    P: rusqlite::Params,
+{
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt.query_map(params, map_memory_version_row)?;
+    let mut count = 0usize;
+    for row in rows {
+        push_memory_fields(version, label, &row?);
+        count += 1;
     }
+    version.push(&format!("{label}_count"), &count.to_string());
+    Ok(())
 }
 
-struct LessonSignal {
-    count: i64,
-    max_memory_updated: i64,
-    id_sum: i64,
-    max_reinforced: i64,
-    reinforcement_sum: i64,
-    confidence_sum: i64,
-    max_stale_after: i64,
+fn map_memory_version_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Vec<String>> {
+    Ok(vec![
+        row.get::<_, i64>(0)?.to_string(),
+        row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+        row.get::<_, String>(2)?,
+        row.get::<_, Option<String>>(3)?.unwrap_or_default(),
+        row.get::<_, String>(4)?,
+        row.get::<_, String>(5)?,
+        row.get::<_, String>(6)?,
+        row.get::<_, Option<String>>(7)?.unwrap_or_default(),
+        row.get::<_, i64>(8)?.to_string(),
+        row.get::<_, i64>(9)?.to_string(),
+        row.get::<_, String>(10)?,
+        row.get::<_, Option<String>>(11)?.unwrap_or_default(),
+        row.get::<_, String>(12)?,
+        row.get::<_, Option<String>>(13)?.unwrap_or_default(),
+        row.get::<_, Option<String>>(14)?.unwrap_or_default(),
+        row.get::<_, Option<String>>(15)?.unwrap_or_default(),
+        row.get::<_, Option<String>>(16)?.unwrap_or_default(),
+        row.get::<_, Option<String>>(17)?.unwrap_or_default(),
+        row.get::<_, Option<i64>>(18)?
+            .unwrap_or_default()
+            .to_string(),
+        row.get::<_, Option<i64>>(19)?
+            .unwrap_or_default()
+            .to_string(),
+        row.get::<_, Option<i64>>(20)?
+            .unwrap_or_default()
+            .to_string(),
+        row.get::<_, Option<i64>>(21)?
+            .unwrap_or_default()
+            .to_string(),
+        row.get::<_, Option<String>>(22)?.unwrap_or_default(),
+    ])
 }
 
-impl LessonSignal {
-    fn push(&self, version: &mut DataVersionBuilder) {
-        version.push(
-            "lessons",
-            &format!(
-                "{}|{}|{}|{}|{}|{}|{}",
-                self.count,
-                self.max_memory_updated,
-                self.id_sum,
-                self.max_reinforced,
-                self.reinforcement_sum,
-                self.confidence_sum,
-                self.max_stale_after
-            ),
-        );
+fn push_memory(
+    version: &mut DataVersionBuilder,
+    label: &'static str,
+    memory: &crate::memory::Memory,
+) {
+    version.push_row(
+        label,
+        &[
+            memory.id.to_string(),
+            memory.session_id.clone().unwrap_or_default(),
+            memory.project.clone(),
+            memory.topic_key.clone().unwrap_or_default(),
+            memory.title.clone(),
+            memory.text.clone(),
+            memory.memory_type.clone(),
+            memory.files.clone().unwrap_or_default(),
+            memory.created_at_epoch.to_string(),
+            memory.updated_at_epoch.to_string(),
+            memory.status.clone(),
+            memory.branch.clone().unwrap_or_default(),
+            memory.scope.clone(),
+        ],
+    );
+}
+
+fn push_memory_fields(version: &mut DataVersionBuilder, label: &'static str, fields: &[String]) {
+    version.push_row(label, fields);
+}
+
+fn push_rows<I>(label: &'static str, rows: I, version: &mut DataVersionBuilder) -> Result<()>
+where
+    I: Iterator<Item = rusqlite::Result<Vec<String>>>,
+{
+    let mut count = 0usize;
+    for row in rows {
+        version.push_row(label, &row?);
+        count += 1;
     }
+    version.push(&format!("{label}_count"), &count.to_string());
+    Ok(())
 }
 
 struct DataVersionBuilder {
@@ -301,6 +447,14 @@ impl DataVersionBuilder {
         self.hasher.update([0]);
         self.hasher.update(value.as_bytes());
         self.hasher.update([0xff]);
+    }
+
+    fn push_row(&mut self, label: &str, fields: &[String]) {
+        self.push(label, &fields.len().to_string());
+        for field in fields {
+            self.push("field", field);
+        }
+        self.push("row_end", label);
     }
 
     fn finish(self) -> String {

--- a/src/context/injection_gate/pre_render.rs
+++ b/src/context/injection_gate/pre_render.rs
@@ -481,6 +481,48 @@ mod tests {
     }
 
     #[test]
+    fn strict_pre_render_misses_after_unknown_memory_type_content_change() -> anyhow::Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-custom-row");
+        let mut invocation = gate_invocation(Some("sess-pre-render-custom-row"));
+        invocation.gate_mode = Some("strict".to_string());
+        let conn = crate::db::test_support::runtime_connection()?;
+        let memory_id = crate::memory::insert_memory_full(
+            &conn,
+            Some("sess-pre-render-custom-row"),
+            &invocation.project,
+            Some("custom/context-gate-row"),
+            "Custom context row",
+            "Original custom row text.",
+            "custom_context",
+            None,
+            None,
+            "project",
+            None,
+        )?;
+
+        let first = apply_gate_with_current_data_version(
+            &conn,
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        )?;
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        conn.execute(
+            "UPDATE memories
+             SET content = 'Changed custom row text.'
+             WHERE id = ?1",
+            params![memory_id],
+        )?;
+
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Miss);
+        assert!(result.data_version.is_some());
+        Ok(())
+    }
+
+    #[test]
     fn strict_pre_render_misses_after_preference_content_change() -> anyhow::Result<()> {
         let _data_dir =
             crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-pref-row");
@@ -557,6 +599,51 @@ mod tests {
         assert!(result.decision.is_none());
         assert_eq!(result.precheck, ContextGatePrecheck::Miss);
         assert!(result.data_version.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn strict_pre_render_ignores_workstream_past_render_limit() -> anyhow::Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-work-limit");
+        let mut invocation = gate_invocation(Some("sess-pre-render-work-limit"));
+        invocation.gate_mode = Some("strict".to_string());
+        let conn = crate::db::test_support::runtime_connection()?;
+        for idx in 0..6 {
+            conn.execute(
+                "INSERT INTO workstreams
+                 (project, title, status, next_action, created_at_epoch, updated_at_epoch,
+                  source_project, target_project, owner_scope, owner_key, context_class)
+                 VALUES (?1, ?2, 'active', ?3, ?4, ?4, ?1, ?1, 'repo', ?1, 'startup_core')",
+                params![
+                    invocation.project,
+                    format!("Context gate workstream {idx}"),
+                    format!("Next action {idx}"),
+                    2_000_i64 - idx,
+                ],
+            )?;
+        }
+
+        let first = apply_gate_with_current_data_version(
+            &conn,
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        )?;
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        conn.execute(
+            "UPDATE workstreams
+             SET next_action = 'Changed offscreen next action'
+             WHERE title = 'Context gate workstream 5'",
+            [],
+        )?;
+
+        let result = pre_render_for_test(&conn, &invocation);
+        let Some(decision) = result.decision else {
+            anyhow::bail!("off-limit workstream should not invalidate rendered context");
+        };
+        assert_eq!(result.precheck, ContextGatePrecheck::Hit);
+        assert_eq!(decision.reason, "suppressed_data_version");
         Ok(())
     }
 

--- a/src/context/injection_gate/pre_render.rs
+++ b/src/context/injection_gate/pre_render.rs
@@ -439,6 +439,128 @@ mod tests {
     }
 
     #[test]
+    fn strict_pre_render_misses_after_same_second_memory_content_change() -> anyhow::Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-memory-row");
+        let mut invocation = gate_invocation(Some("sess-pre-render-memory-row"));
+        invocation.gate_mode = Some("strict".to_string());
+        let conn = crate::db::test_support::runtime_connection()?;
+        let memory_id = crate::memory::insert_memory_full(
+            &conn,
+            Some("sess-pre-render-memory-row"),
+            &invocation.project,
+            Some("context-gate-memory-row"),
+            "Context gate row hash",
+            "Original render-relevant memory text.",
+            "decision",
+            None,
+            None,
+            "project",
+            None,
+        )?;
+
+        let first = apply_gate_with_current_data_version(
+            &conn,
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        )?;
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        conn.execute(
+            "UPDATE memories
+             SET content = 'Changed render-relevant memory text.'
+             WHERE id = ?1",
+            params![memory_id],
+        )?;
+
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Miss);
+        assert!(result.data_version.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn strict_pre_render_misses_after_preference_content_change() -> anyhow::Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-pref-row");
+        let mut invocation = gate_invocation(Some("sess-pre-render-pref-row"));
+        invocation.gate_mode = Some("strict".to_string());
+        let conn = crate::db::test_support::runtime_connection()?;
+        let memory_id = crate::memory::insert_memory_full(
+            &conn,
+            Some("sess-pre-render-pref-row"),
+            &invocation.project,
+            Some("preference/context-gate-row"),
+            "Preference: context gate",
+            "Original preference text.",
+            "preference",
+            None,
+            None,
+            "project",
+            None,
+        )?;
+
+        let first = apply_gate_with_current_data_version(
+            &conn,
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        )?;
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        conn.execute(
+            "UPDATE memories
+             SET content = 'Changed preference text.'
+             WHERE id = ?1",
+            params![memory_id],
+        )?;
+
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Miss);
+        assert!(result.data_version.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn strict_pre_render_misses_after_workstream_next_action_change() -> anyhow::Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-workstream");
+        let mut invocation = gate_invocation(Some("sess-pre-render-workstream"));
+        invocation.gate_mode = Some("strict".to_string());
+        let conn = crate::db::test_support::runtime_connection()?;
+        conn.execute(
+            "INSERT INTO workstreams
+             (project, title, status, next_action, created_at_epoch, updated_at_epoch,
+              source_project, target_project, owner_scope, owner_key, context_class)
+             VALUES (?1, 'Context gate workstream', 'active', 'Original next action',
+                     ?2, ?2, ?1, ?1, 'repo', ?1, 'startup_core')",
+            params![invocation.project, chrono::Utc::now().timestamp()],
+        )?;
+        let workstream_id = conn.last_insert_rowid();
+
+        let first = apply_gate_with_current_data_version(
+            &conn,
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        )?;
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        conn.execute(
+            "UPDATE workstreams
+             SET next_action = 'Changed next action'
+             WHERE id = ?1",
+            params![workstream_id],
+        )?;
+
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Miss);
+        assert!(result.data_version.is_some());
+        Ok(())
+    }
+
+    #[test]
     fn strict_pre_render_falls_open_when_data_version_query_fails() -> anyhow::Result<()> {
         let _data_dir =
             crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-fail-open");

--- a/src/context/injection_gate/pre_render.rs
+++ b/src/context/injection_gate/pre_render.rs
@@ -4,19 +4,52 @@ use rusqlite::OptionalExtension;
 pub(in crate::context) fn pre_render_context_gate(
     conn: &rusqlite::Connection,
     invocation: &ContextInvocation,
-) -> Option<ContextGateDecision> {
+    request: &ContextRequest,
+    policy: &ContextPolicy,
+    debug_enabled: bool,
+) -> ContextGatePrecheckResult {
     if !host_is_gated(invocation.host) {
-        return None;
+        return ContextGatePrecheckResult::off();
     }
     if resolve_gate_mode(invocation.gate_mode.as_deref()) != ContextGateMode::Strict {
-        return None;
+        return ContextGatePrecheckResult::off();
     }
     if invocation.force || source_requires_fresh_emission(invocation.source.as_deref()) {
-        return None;
+        return ContextGatePrecheckResult::off();
     }
     if !has_trusted_gate_identity(invocation) {
-        return None;
+        return ContextGatePrecheckResult::off();
     }
+    if debug_enabled {
+        return ContextGatePrecheckResult::off();
+    }
+    let has_data_version = match data_version::context_injections_has_data_version(conn) {
+        Ok(value) => value,
+        Err(error) => {
+            crate::log::warn(
+                "context-gate",
+                &format!("pre_render_skip reason=schema_check error={}", error),
+            );
+            return ContextGatePrecheckResult::miss(None);
+        }
+    };
+    if !has_data_version {
+        return ContextGatePrecheckResult::miss(None);
+    }
+    let current_data_version =
+        match data_version::compute_data_version(conn, request, invocation, policy) {
+            Ok(value) => value,
+            Err(error) => {
+                crate::log::warn(
+                    "context-gate",
+                    &format!("pre_render_skip reason=data_version error={}", error),
+                );
+                return ContextGatePrecheckResult::miss(None);
+            }
+        };
+
+    let data_version = Some(current_data_version);
+    let data_version_ref = data_version.as_deref();
 
     let key = injection_key(invocation);
     let now = chrono::Utc::now().timestamp();
@@ -32,39 +65,93 @@ pub(in crate::context) fn pre_render_context_gate(
                 "context-gate",
                 &format!("pre_render_skip reason=gate_read error={}", error),
             );
-            return None;
+            return ContextGatePrecheckResult::miss(data_version);
         }
     };
 
-    let row = row?;
-    if !fallback_cooldown_allows_suppression(invocation, &row, now) {
-        return None;
+    let Some(row) = row else {
+        return ContextGatePrecheckResult::miss(data_version);
+    };
+    if row.data_version.as_deref() != data_version_ref {
+        return ContextGatePrecheckResult::miss(data_version);
     }
-    if let Err(error) = record_suppression(conn, invocation, &key, now) {
+    suppress_matching_row(conn, invocation, row, data_version)
+}
+
+pub(in crate::context) struct ContextGatePrecheckResult {
+    pub(in crate::context) decision: Option<ContextGateDecision>,
+    pub(in crate::context) precheck: ContextGatePrecheck,
+    pub(in crate::context) data_version: Option<String>,
+}
+
+impl ContextGatePrecheckResult {
+    fn off() -> Self {
+        Self {
+            decision: None,
+            precheck: ContextGatePrecheck::Off,
+            data_version: None,
+        }
+    }
+
+    fn miss(data_version: Option<String>) -> Self {
+        Self {
+            decision: None,
+            precheck: ContextGatePrecheck::Miss,
+            data_version,
+        }
+    }
+
+    fn hit(decision: ContextGateDecision, data_version: String) -> Self {
+        Self {
+            decision: Some(decision),
+            precheck: ContextGatePrecheck::Hit,
+            data_version: Some(data_version),
+        }
+    }
+}
+
+fn suppress_matching_row(
+    conn: &rusqlite::Connection,
+    invocation: &ContextInvocation,
+    row: GateRow,
+    data_version: Option<String>,
+) -> ContextGatePrecheckResult {
+    let Some(data_version) = data_version else {
+        return ContextGatePrecheckResult::miss(None);
+    };
+    let key = injection_key(invocation);
+    let now = chrono::Utc::now().timestamp();
+    if !fallback_cooldown_allows_suppression(invocation, &row, now) {
+        return ContextGatePrecheckResult::miss(Some(data_version));
+    }
+    if let Err(error) = record_suppression(conn, invocation, &key, Some(&data_version), now) {
         crate::log::warn(
             "context-gate",
             &format!("pre_render_skip reason=gate_write error={}", error),
         );
-        return None;
+        return ContextGatePrecheckResult::miss(Some(data_version));
     }
     crate::log::info(
         "context-gate",
         &format!(
-            "pre_render_suppress host={} key={} reason=strict hash={} project={}",
+            "pre_render_suppress host={} key={} reason=data_version hash={} project={}",
             invocation.host.as_env_value(),
             key,
             row.context_hash,
             invocation.project
         ),
     );
-    Some(gate_decision(
-        String::new(),
-        ContextGateAction::Suppressed,
-        "strict_pre_render",
-        &key,
-        &row.context_hash,
-        "suppressed",
-    ))
+    ContextGatePrecheckResult::hit(
+        gate_decision(
+            String::new(),
+            ContextGateAction::Suppressed,
+            "suppressed_data_version",
+            &key,
+            &row.context_hash,
+            "suppressed",
+        ),
+        data_version,
+    )
 }
 
 fn load_retained_gate_row(
@@ -74,7 +161,7 @@ fn load_retained_gate_row(
     cutoff_epoch: i64,
 ) -> Result<Option<GateRow>> {
     conn.query_row(
-        "SELECT context_hash, last_emitted_epoch
+        "SELECT context_hash, last_emitted_epoch, data_version
          FROM context_injections
          WHERE host = ?1
            AND injection_key = ?2
@@ -84,6 +171,7 @@ fn load_retained_gate_row(
             Ok(GateRow {
                 context_hash: row.get(0)?,
                 last_emitted_epoch: row.get(1)?,
+                data_version: row.get(2)?,
             })
         },
     )
@@ -94,6 +182,7 @@ fn load_retained_gate_row(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::policy::ContextLimits;
     use rusqlite::params;
     use std::ffi::OsString;
 
@@ -135,6 +224,47 @@ mod tests {
         }
     }
 
+    fn test_request(invocation: &ContextInvocation) -> ContextRequest {
+        ContextRequest {
+            cwd: invocation.cwd.clone(),
+            project: invocation.project.clone(),
+            session_id: invocation.session_id.clone(),
+            hook_source: invocation.source.clone(),
+            current_branch: None,
+            host: invocation.host,
+            use_colors: invocation.use_colors,
+        }
+    }
+
+    fn test_policy() -> ContextPolicy {
+        ContextPolicy::from_limits(ContextLimits::default())
+    }
+
+    fn apply_gate_with_current_data_version(
+        conn: &rusqlite::Connection,
+        invocation: &ContextInvocation,
+        output: String,
+    ) -> anyhow::Result<ContextGateDecision> {
+        let request = test_request(invocation);
+        let policy = test_policy();
+        let data_version = data_version::compute_data_version(conn, &request, invocation, &policy)?;
+        Ok(apply_context_gate_with_data_version(
+            conn,
+            invocation,
+            output,
+            Some(&data_version),
+        ))
+    }
+
+    fn pre_render_for_test(
+        conn: &rusqlite::Connection,
+        invocation: &ContextInvocation,
+    ) -> ContextGatePrecheckResult {
+        let request = test_request(invocation);
+        let policy = test_policy();
+        pre_render_context_gate(conn, invocation, &request, &policy, false)
+    }
+
     #[test]
     fn strict_pre_render_suppresses_existing_session_without_render_output() -> anyhow::Result<()> {
         let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render");
@@ -142,18 +272,20 @@ mod tests {
         invocation.gate_mode = Some("strict".to_string());
         let conn = crate::db::test_support::runtime_connection()?;
 
-        let first = apply_context_gate(
+        let first = apply_gate_with_current_data_version(
             &conn,
             &invocation,
             "# [/tmp/remem] context now\nBody A\n".to_string(),
-        );
+        )?;
         assert_eq!(first.action, ContextGateAction::EmittedFull);
 
-        let Some(decision) = pre_render_context_gate(&conn, &invocation) else {
+        let result = pre_render_for_test(&conn, &invocation);
+        let Some(decision) = result.decision else {
             anyhow::bail!("existing strict gate row should suppress before render");
         };
+        assert_eq!(result.precheck, ContextGatePrecheck::Hit);
         assert_eq!(decision.action, ContextGateAction::Suppressed);
-        assert_eq!(decision.reason, "strict_pre_render");
+        assert_eq!(decision.reason, "suppressed_data_version");
         assert!(decision.output.is_empty());
         assert_eq!(decision.output_mode, Some("suppressed"));
         assert_eq!(decision.context_hash, first.context_hash);
@@ -168,7 +300,9 @@ mod tests {
         invocation.gate_mode = Some("strict".to_string());
         let conn = crate::db::test_support::runtime_connection()?;
 
-        assert!(pre_render_context_gate(&conn, &invocation).is_none());
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Miss);
         Ok(())
     }
 
@@ -180,19 +314,23 @@ mod tests {
         invocation.gate_mode = Some("strict".to_string());
         let conn = crate::db::test_support::runtime_connection()?;
 
-        let first = apply_context_gate(
+        let first = apply_gate_with_current_data_version(
             &conn,
             &invocation,
             "# [/tmp/remem] context now\nBody A\n".to_string(),
-        );
+        )?;
         assert_eq!(first.action, ContextGateAction::EmittedFull);
 
         invocation.force = true;
-        assert!(pre_render_context_gate(&conn, &invocation).is_none());
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Off);
 
         invocation.force = false;
         invocation.source = Some("clear".to_string());
-        assert!(pre_render_context_gate(&conn, &invocation).is_none());
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Off);
         Ok(())
     }
 
@@ -205,11 +343,11 @@ mod tests {
         invocation.gate_mode = Some("strict".to_string());
         let conn = crate::db::test_support::runtime_connection()?;
 
-        let first = apply_context_gate(
+        let first = apply_gate_with_current_data_version(
             &conn,
             &invocation,
             "# [/tmp/remem] context now\nBody A\n".to_string(),
-        );
+        )?;
         assert_eq!(first.action, ContextGateAction::EmittedFull);
 
         let old_epoch = chrono::Utc::now().timestamp().saturating_sub(31 * 86_400);
@@ -224,7 +362,9 @@ mod tests {
             ],
         )?;
 
-        assert!(pre_render_context_gate(&conn, &invocation).is_none());
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Miss);
         Ok(())
     }
 
@@ -237,11 +377,11 @@ mod tests {
         invocation.gate_mode = Some("strict".to_string());
         let conn = crate::db::test_support::runtime_connection()?;
 
-        let first = apply_context_gate(
+        let first = apply_gate_with_current_data_version(
             &conn,
             &invocation,
             "# [/tmp/remem] context now\nBody A\n".to_string(),
-        );
+        )?;
         assert_eq!(first.action, ContextGateAction::EmittedFull);
 
         let old_last_emitted = chrono::Utc::now().timestamp().saturating_sub(901);
@@ -256,7 +396,68 @@ mod tests {
             ],
         )?;
 
-        assert!(pre_render_context_gate(&conn, &invocation).is_none());
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Miss);
+        Ok(())
+    }
+
+    #[test]
+    fn strict_pre_render_misses_after_project_memory_write() -> anyhow::Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-data-change");
+        let mut invocation = gate_invocation(Some("sess-pre-render-data-change"));
+        invocation.gate_mode = Some("strict".to_string());
+        let conn = crate::db::test_support::runtime_connection()?;
+
+        let first = apply_gate_with_current_data_version(
+            &conn,
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        )?;
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        crate::memory::insert_memory_full(
+            &conn,
+            Some("sess-pre-render-data-change"),
+            &invocation.project,
+            Some("context-gate-data-change"),
+            "New context memory",
+            "A relevant project memory changed.",
+            "decision",
+            None,
+            None,
+            "project",
+            None,
+        )?;
+
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Miss);
+        assert!(result.data_version.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn strict_pre_render_falls_open_when_data_version_query_fails() -> anyhow::Result<()> {
+        let _data_dir =
+            crate::db::test_support::ScopedTestDataDir::new("context-gate-pre-render-fail-open");
+        let mut invocation = gate_invocation(Some("sess-pre-render-fail-open"));
+        invocation.gate_mode = Some("strict".to_string());
+        let conn = crate::db::test_support::runtime_connection()?;
+
+        let first = apply_gate_with_current_data_version(
+            &conn,
+            &invocation,
+            "# [/tmp/remem] context now\nBody A\n".to_string(),
+        )?;
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+        conn.execute("DROP TABLE memories", [])?;
+
+        let result = pre_render_for_test(&conn, &invocation);
+        assert!(result.decision.is_none());
+        assert_eq!(result.precheck, ContextGatePrecheck::Miss);
+        assert!(result.data_version.is_none());
         Ok(())
     }
 
@@ -268,11 +469,11 @@ mod tests {
         invocation.gate_mode = Some("strict".to_string());
         let conn = crate::db::test_support::runtime_connection()?;
 
-        let first = apply_context_gate(
+        let first = apply_gate_with_current_data_version(
             &conn,
             &invocation,
             "# [/tmp/remem] context now\nBody A\n".to_string(),
-        );
+        )?;
         assert_eq!(first.action, ContextGateAction::EmittedFull);
 
         let old_epoch = chrono::Utc::now().timestamp().saturating_sub(60);
@@ -287,9 +488,11 @@ mod tests {
             ],
         )?;
 
-        let Some(decision) = pre_render_context_gate(&conn, &invocation) else {
+        let result = pre_render_for_test(&conn, &invocation);
+        let Some(decision) = result.decision else {
             anyhow::bail!("existing strict gate row should suppress before render");
         };
+        assert_eq!(result.precheck, ContextGatePrecheck::Hit);
         assert_eq!(decision.action, ContextGateAction::Suppressed);
 
         let (updated_at_epoch, suppress_count): (i64, i64) = conn.query_row(

--- a/src/context/injection_gate/store.rs
+++ b/src/context/injection_gate/store.rs
@@ -1,0 +1,169 @@
+use anyhow::Result;
+use rusqlite::{params, OptionalExtension};
+
+use super::data_version;
+use super::ContextInvocation;
+
+#[derive(Debug)]
+pub(super) struct GateRow {
+    pub(super) context_hash: String,
+    pub(super) last_emitted_epoch: i64,
+    pub(super) data_version: Option<String>,
+}
+
+pub(super) fn load_gate_row(
+    conn: &rusqlite::Connection,
+    host: &str,
+    key: &str,
+) -> Result<Option<GateRow>> {
+    if data_version::context_injections_has_data_version(conn)? {
+        return conn
+            .query_row(
+                "SELECT context_hash, last_emitted_epoch, data_version
+                 FROM context_injections
+                 WHERE host = ?1 AND injection_key = ?2",
+                params![host, key],
+                |row| {
+                    Ok(GateRow {
+                        context_hash: row.get(0)?,
+                        last_emitted_epoch: row.get(1)?,
+                        data_version: row.get(2)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into);
+    }
+
+    conn.query_row(
+        "SELECT context_hash, last_emitted_epoch
+         FROM context_injections
+         WHERE host = ?1 AND injection_key = ?2",
+        params![host, key],
+        |row| {
+            Ok(GateRow {
+                context_hash: row.get(0)?,
+                last_emitted_epoch: row.get(1)?,
+                data_version: None,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub(super) fn upsert_emit_row(
+    conn: &rusqlite::Connection,
+    invocation: &ContextInvocation,
+    key: &str,
+    hash: &str,
+    data_version: Option<&str>,
+    output_mode: &str,
+    output_chars: usize,
+    now: i64,
+) -> Result<()> {
+    if data_version.is_some() && data_version::context_injections_has_data_version(conn)? {
+        conn.execute(
+            "INSERT INTO context_injections
+             (host, project, injection_key, session_id, transcript_path, hook_source, context_hash,
+              data_version, output_mode, output_chars, created_at_epoch, updated_at_epoch,
+              last_emitted_epoch, emit_count, suppress_count)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?11, ?11, 1, 0)
+             ON CONFLICT(host, injection_key) DO UPDATE SET
+              project = excluded.project,
+              session_id = excluded.session_id,
+              transcript_path = excluded.transcript_path,
+              hook_source = excluded.hook_source,
+              context_hash = excluded.context_hash,
+              data_version = excluded.data_version,
+              output_mode = excluded.output_mode,
+              output_chars = excluded.output_chars,
+              updated_at_epoch = excluded.updated_at_epoch,
+              last_emitted_epoch = excluded.last_emitted_epoch,
+              emit_count = context_injections.emit_count + 1",
+            params![
+                invocation.host.as_env_value(),
+                invocation.project,
+                key,
+                invocation.session_id,
+                invocation.transcript_path,
+                invocation.source,
+                hash,
+                data_version,
+                output_mode,
+                output_chars as i64,
+                now,
+            ],
+        )?;
+    } else {
+        conn.execute(
+            "INSERT INTO context_injections
+             (host, project, injection_key, session_id, transcript_path, hook_source, context_hash,
+              output_mode, output_chars, created_at_epoch, updated_at_epoch, last_emitted_epoch,
+              emit_count, suppress_count)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10, ?10, 1, 0)
+             ON CONFLICT(host, injection_key) DO UPDATE SET
+              project = excluded.project,
+              session_id = excluded.session_id,
+              transcript_path = excluded.transcript_path,
+              hook_source = excluded.hook_source,
+              context_hash = excluded.context_hash,
+              output_mode = excluded.output_mode,
+              output_chars = excluded.output_chars,
+              updated_at_epoch = excluded.updated_at_epoch,
+              last_emitted_epoch = excluded.last_emitted_epoch,
+              emit_count = context_injections.emit_count + 1",
+            params![
+                invocation.host.as_env_value(),
+                invocation.project,
+                key,
+                invocation.session_id,
+                invocation.transcript_path,
+                invocation.source,
+                hash,
+                output_mode,
+                output_chars as i64,
+                now,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+pub(super) fn record_suppression(
+    conn: &rusqlite::Connection,
+    invocation: &ContextInvocation,
+    key: &str,
+    data_version: Option<&str>,
+    now: i64,
+) -> Result<()> {
+    if data_version.is_some() && data_version::context_injections_has_data_version(conn)? {
+        conn.execute(
+            "UPDATE context_injections
+             SET output_mode = 'suppressed',
+                 hook_source = ?3,
+                 data_version = ?4,
+                 updated_at_epoch = ?5,
+                 suppress_count = suppress_count + 1
+             WHERE host = ?1 AND injection_key = ?2",
+            params![
+                invocation.host.as_env_value(),
+                key,
+                invocation.source,
+                data_version,
+                now,
+            ],
+        )?;
+    } else {
+        conn.execute(
+            "UPDATE context_injections
+             SET output_mode = 'suppressed',
+                 hook_source = ?3,
+                 updated_at_epoch = ?4,
+                 suppress_count = suppress_count + 1
+             WHERE host = ?1 AND injection_key = ?2",
+            params![invocation.host.as_env_value(), key, invocation.source, now],
+        )?;
+    }
+    Ok(())
+}

--- a/src/context/injection_gate/tests.rs
+++ b/src/context/injection_gate/tests.rs
@@ -10,6 +10,15 @@ fn setup_gate_conn() -> rusqlite::Connection {
     conn
 }
 
+fn setup_gate_conn_with_data_version() -> Result<rusqlite::Connection> {
+    let conn = setup_gate_conn();
+    conn.execute(
+        "ALTER TABLE context_injections ADD COLUMN data_version TEXT",
+        [],
+    )?;
+    Ok(conn)
+}
+
 fn gate_invocation(session_id: Option<&str>) -> ContextInvocation {
     ContextInvocation {
         cwd: "/tmp/remem".to_string(),
@@ -109,12 +118,12 @@ fn first_same_session_context_emits_and_second_suppresses() -> Result<()> {
     let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
 
     assert!(load_gate_row(&conn, invocation.host.as_env_value(), &key)?.is_none());
-    upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
+    upsert_emit_row(&conn, &invocation, &key, &hash, None, "full", 32, 100)?;
     let row = load_gate_row(&conn, invocation.host.as_env_value(), &key)?
         .ok_or_else(|| anyhow::anyhow!("missing context injection gate row"))?;
     assert_eq!(row.context_hash, hash);
 
-    record_suppression(&conn, &invocation, &key, 101)?;
+    record_suppression(&conn, &invocation, &key, None, 101)?;
     let suppress_count: i64 = conn.query_row(
         "SELECT suppress_count FROM context_injections WHERE host = ?1 AND injection_key = ?2",
         params![invocation.host.as_env_value(), key],
@@ -177,8 +186,8 @@ fn suppression_does_not_extend_fallback_cooldown() -> Result<()> {
     let key = injection_key(&invocation);
     let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
 
-    upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
-    record_suppression(&conn, &invocation, &key, 150)?;
+    upsert_emit_row(&conn, &invocation, &key, &hash, None, "full", 32, 100)?;
+    record_suppression(&conn, &invocation, &key, None, 150)?;
 
     let (updated_at_epoch, last_emitted_epoch, suppress_count): (i64, i64, i64) = conn.query_row(
         "SELECT updated_at_epoch, last_emitted_epoch, suppress_count
@@ -416,6 +425,47 @@ fn restart_source_reemits_same_hash_context() {
 }
 
 #[test]
+fn strict_suppression_after_render_refreshes_data_version_only() -> Result<()> {
+    let conn = setup_gate_conn_with_data_version()?;
+    let mut invocation = gate_invocation(Some("sess-strict-data-version"));
+    invocation.gate_mode = Some("strict".to_string());
+    let key = injection_key(&invocation);
+    let emitted_hash = context_fingerprint("# [/tmp/remem] context now\nBody A\n");
+    let now = chrono::Utc::now().timestamp();
+
+    upsert_emit_row(
+        &conn,
+        &invocation,
+        &key,
+        &emitted_hash,
+        Some("version-a"),
+        "full",
+        32,
+        now,
+    )?;
+
+    let decision = apply_context_gate_with_data_version(
+        &conn,
+        &invocation,
+        "# [/tmp/remem] context now\nBody B\n".to_string(),
+        Some("version-b"),
+    );
+
+    assert_eq!(decision.action, ContextGateAction::Suppressed);
+    assert_eq!(decision.reason, "strict");
+    let (stored_hash, stored_version): (String, Option<String>) = conn.query_row(
+        "SELECT context_hash, data_version
+         FROM context_injections
+         WHERE host = ?1 AND injection_key = ?2",
+        params![invocation.host.as_env_value(), key],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    assert_eq!(stored_hash, emitted_hash);
+    assert_eq!(stored_version.as_deref(), Some("version-b"));
+    Ok(())
+}
+
+#[test]
 fn emit_and_suppress_persist_hook_source() -> Result<()> {
     let conn = setup_gate_conn();
     let mut invocation = gate_invocation(Some("sess-source"));
@@ -423,9 +473,9 @@ fn emit_and_suppress_persist_hook_source() -> Result<()> {
     let key = injection_key(&invocation);
     let hash = context_fingerprint("# [/tmp/remem] context now\nBody\n");
 
-    upsert_emit_row(&conn, &invocation, &key, &hash, "full", 32, 100)?;
+    upsert_emit_row(&conn, &invocation, &key, &hash, None, "full", 32, 100)?;
     invocation.source = Some("resume".to_string());
-    record_suppression(&conn, &invocation, &key, 101)?;
+    record_suppression(&conn, &invocation, &key, None, 101)?;
 
     let hook_source: Option<String> = conn.query_row(
         "SELECT hook_source FROM context_injections WHERE host = ?1 AND injection_key = ?2",

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -7,7 +7,8 @@ use crate::db;
 use super::format::{char_len, truncate_chars_with_ellipsis};
 use super::host::resolve_profile;
 use super::injection_gate::{
-    apply_context_gate, pre_render_context_gate, ContextGateAction, ContextGateDecision,
+    apply_context_gate_with_data_version, pre_render_context_gate, ContextGateAction,
+    ContextGateDecision, ContextGatePrecheck,
 };
 use super::invocation::{
     direct_context_invocation, resolve_context_invocation, ContextCliOptions, ContextInvocation,
@@ -21,6 +22,8 @@ use super::sections::{
     render_workstreams_with_limits,
 };
 use super::types::{ContextLoadError, ContextRequest};
+mod timer;
+use timer::log_context_timer;
 
 pub(in crate::context) use super::debug::build_context_debug_trace;
 
@@ -259,18 +262,31 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
                 );
             }
             print!("{}", decision.output);
-            log_context_timer(timer, &request, &decision, &rendered.stats);
+            log_context_timer(
+                timer,
+                &request,
+                &decision,
+                &rendered.stats,
+                ContextGatePrecheck::Off,
+            );
             return Ok(());
         }
     };
-    let (mut decision, stats) = if use_gate {
-        if let Some(decision) = pre_render_context_gate(&conn, &invocation) {
-            (decision, ContextRenderStats::default())
+    let (mut decision, stats, precheck) = if use_gate {
+        let precheck =
+            pre_render_context_gate(&conn, &invocation, &request, &policy, debug_enabled);
+        if let Some(decision) = precheck.decision {
+            (decision, ContextRenderStats::default(), precheck.precheck)
         } else {
             let rendered =
                 render_context_output_with_policy(&conn, &request, debug_enabled, policy)?;
-            let decision = apply_context_gate(&conn, &invocation, rendered.output);
-            (decision, rendered.stats)
+            let decision = apply_context_gate_with_data_version(
+                &conn,
+                &invocation,
+                rendered.output,
+                precheck.data_version.as_deref(),
+            );
+            (decision, rendered.stats, precheck.precheck)
         }
     } else {
         let rendered = render_context_output_with_policy(&conn, &request, debug_enabled, policy)?;
@@ -284,6 +300,7 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
                 output_mode: None,
             },
             rendered.stats,
+            ContextGatePrecheck::Off,
         )
     };
     if debug_enabled {
@@ -291,7 +308,7 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
         append_context_gate_debug_trace(&mut decision.output, &request, &decision_for_debug);
     }
     print!("{}", decision.output);
-    log_context_timer(timer, &request, &decision, &stats);
+    log_context_timer(timer, &request, &decision, &stats, precheck);
     Ok(())
 }
 
@@ -301,37 +318,6 @@ pub(in crate::context) fn generate_context_for_test(
     use_gate: bool,
 ) -> Result<()> {
     generate_context_for_invocation(invocation, use_gate)
-}
-
-fn log_context_timer(
-    timer: crate::log::Timer,
-    request: &ContextRequest,
-    decision: &ContextGateDecision,
-    stats: &ContextRenderStats,
-) {
-    let capabilities = resolve_profile(request.host).capabilities();
-    timer.done(&format!(
-        "project={} cwd={} session={} host={} colors={} gate={:?}:{} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] context_memories={} core={} lessons={} index={} preferences={} sessions={} workstreams={}",
-        request.project,
-        request.cwd,
-        request.session_id.as_deref().unwrap_or("-"),
-        request.host.as_env_value(),
-        request.use_colors,
-        decision.action,
-        decision.reason,
-        capabilities.has_mcp_tools,
-        capabilities.has_session_start_hook,
-        capabilities.has_user_prompt_submit_hook,
-        capabilities.observes_native_file_edits,
-        capabilities.observes_bash,
-        stats.memories_loaded,
-        stats.core.count,
-        stats.lessons.count,
-        stats.index.count,
-        stats.preferences.count,
-        stats.sessions.count,
-        stats.workstreams.count,
-    ));
 }
 
 pub(in crate::context) fn append_context_gate_debug_trace(

--- a/src/context/render/timer.rs
+++ b/src/context/render/timer.rs
@@ -1,0 +1,37 @@
+use super::ContextRenderStats;
+use crate::context::host::resolve_profile;
+use crate::context::injection_gate::{ContextGateDecision, ContextGatePrecheck};
+use crate::context::types::ContextRequest;
+
+pub(super) fn log_context_timer(
+    timer: crate::log::Timer,
+    request: &ContextRequest,
+    decision: &ContextGateDecision,
+    stats: &ContextRenderStats,
+    precheck: ContextGatePrecheck,
+) {
+    let capabilities = resolve_profile(request.host).capabilities();
+    timer.done(&format!(
+        "project={} cwd={} session={} host={} colors={} gate={:?}:{} precheck={} caps=[mcp:{} session_start:{} prompt_submit:{} native_edits:{} bash:{}] context_memories={} core={} lessons={} index={} preferences={} sessions={} workstreams={}",
+        request.project,
+        request.cwd,
+        request.session_id.as_deref().unwrap_or("-"),
+        request.host.as_env_value(),
+        request.use_colors,
+        decision.action,
+        decision.reason,
+        precheck.as_log_value(),
+        capabilities.has_mcp_tools,
+        capabilities.has_session_start_hook,
+        capabilities.has_user_prompt_submit_hook,
+        capabilities.observes_native_file_edits,
+        capabilities.observes_bash,
+        stats.memories_loaded,
+        stats.core.count,
+        stats.lessons.count,
+        stats.index.count,
+        stats.preferences.count,
+        stats.sessions.count,
+        stats.workstreams.count,
+    ));
+}

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -175,6 +175,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "graph_edge_file_nodes",
         sql: include_str!("../migrations/v034_graph_edge_file_nodes.sql"),
     },
+    Migration {
+        version: 35,
+        name: "context_injection_data_version",
+        sql: include_str!("../migrations/v035_context_injection_data_version.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v035_context_injection_data_version.sql
+++ b/src/migrations/v035_context_injection_data_version.sql
@@ -1,0 +1,11 @@
+-- v035_context_injection_data_version: persist a conservative context data
+-- fingerprint so strict SessionStart can suppress duplicate context before
+-- paying full render cost.
+
+ALTER TABLE context_injections ADD COLUMN data_version TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_workstreams_target_status
+    ON workstreams(target_project, status, updated_at_epoch DESC);
+
+CREATE INDEX IF NOT EXISTS idx_session_summaries_target_created
+    ON session_summaries(target_project, created_at_epoch DESC);


### PR DESCRIPTION
Fixes #406. Part of #402.

## Summary
- adds v035 `context_injections.data_version` plus target-project indexes for strict context precheck inputs
- computes a conservative context data-version before render and suppresses unchanged strict SessionStart runs without rendering
- preserves existing post-render hash gate behavior, including strict suppression while refreshing `data_version` without overwriting the last emitted `context_hash`
- adds `precheck=off|hit|miss` timer logging and `suppressed_data_version` status inference
- bumps binary/plugin version to `0.5.25`

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo check --message-format=short`
- `cargo test`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `python3 scripts/ci/check_plugin_version_sync.py`

## Query Plan Check
- workstreams precheck aggregate uses `MULTI-INDEX OR`; target branches use `idx_workstreams_target_status`
- session summaries precheck query uses `idx_session_summaries_session_range` and a temp B-tree only for ordering
