### PR TITLE
Add singleton worker lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1227,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "fs2",
  "getrandom 0.3.4",
  "libc",
  "reqwest",
@@ -1956,6 +1967,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.25"
+version = "0.5.26"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.25"
+version = "0.5.26"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 anyhow = "1"
+fs2 = "0.4"
 tokio = { version = "1", features = ["full"] }
 rmcp = { version = "0.15", features = ["server", "transport-io", "macros"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.25",
+  "version": "0.5.26",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.25": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.25",
+    "0.5.26": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.26",
       "assets": {}
     }
   }

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -80,6 +80,16 @@ pub fn data_dir() -> PathBuf {
         })
 }
 
+pub fn absolute_data_dir() -> Result<PathBuf> {
+    let path = data_dir();
+    if path.is_absolute() {
+        return Ok(path);
+    }
+    Ok(std::env::current_dir()
+        .context("read current directory for relative REMEM_DATA_DIR")?
+        .join(path))
+}
+
 pub fn db_path() -> PathBuf {
     data_dir().join("remem.db")
 }

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -75,7 +75,7 @@ pub struct CandidatePromotionStat {
 pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
     let now = chrono::Utc::now().timestamp();
     let raw_ingest = query_raw_ingest_failure_stats(conn)?;
-    let worker_heartbeat = crate::db::worker::latest_worker_heartbeat(conn)?;
+    let worker_heartbeat = crate::db::worker::latest_daemon_worker_heartbeat(conn)?;
     let healthy_worker_heartbeat = crate::db::worker::healthy_daemon_worker_heartbeat(
         conn,
         crate::db::worker::WORKER_HEARTBEAT_HEALTH_SECS,

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -76,7 +76,7 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
     let now = chrono::Utc::now().timestamp();
     let raw_ingest = query_raw_ingest_failure_stats(conn)?;
     let worker_heartbeat = crate::db::worker::latest_worker_heartbeat(conn)?;
-    let healthy_worker_heartbeat = crate::db::worker::healthy_worker_heartbeat(
+    let healthy_worker_heartbeat = crate::db::worker::healthy_daemon_worker_heartbeat(
         conn,
         crate::db::worker::WORKER_HEARTBEAT_HEALTH_SECS,
     )?;

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -294,6 +294,36 @@ fn query_system_stats_and_related_views_share_one_definition() {
 }
 
 #[test]
+fn query_system_stats_reports_daemon_heartbeat_not_once() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_stats_schema(&conn);
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "INSERT INTO worker_heartbeats (owner, pid, started_at_epoch, updated_at_epoch)
+         VALUES ('worker-daemon-stats', ?1, ?2, ?2)",
+        (i64::from(std::process::id()), now - 10),
+    )?;
+    conn.execute(
+        "INSERT INTO worker_heartbeats (owner, pid, started_at_epoch, updated_at_epoch)
+         VALUES ('worker-once-stats', ?1, ?2, ?2)",
+        (i64::from(std::process::id()), now),
+    )?;
+
+    let system = query_system_stats(&conn)?;
+
+    assert!(system.worker_daemon_healthy);
+    assert_eq!(
+        system.worker_heartbeat_owner.as_deref(),
+        Some("worker-daemon-stats")
+    );
+    assert!(
+        system.worker_heartbeat_age_secs.unwrap_or_default() >= 10,
+        "reported age should come from daemon heartbeat"
+    );
+    Ok(())
+}
+
+#[test]
 fn query_system_stats_defaults_raw_ingest_failures_when_table_is_absent() -> anyhow::Result<()> {
     let conn = Connection::open_in_memory()?;
     setup_stats_schema(&conn);

--- a/src/db/worker.rs
+++ b/src/db/worker.rs
@@ -53,14 +53,35 @@ pub fn healthy_worker_heartbeat(
     conn: &Connection,
     max_age_secs: i64,
 ) -> Result<Option<WorkerHeartbeat>> {
+    query_healthy_worker_heartbeat(conn, max_age_secs, false)
+}
+
+pub fn healthy_daemon_worker_heartbeat(
+    conn: &Connection,
+    max_age_secs: i64,
+) -> Result<Option<WorkerHeartbeat>> {
+    query_healthy_worker_heartbeat(conn, max_age_secs, true)
+}
+
+fn query_healthy_worker_heartbeat(
+    conn: &Connection,
+    max_age_secs: i64,
+    daemon_only: bool,
+) -> Result<Option<WorkerHeartbeat>> {
     let now = chrono::Utc::now().timestamp();
-    let mut stmt = conn.prepare(
+    let daemon_filter = if daemon_only {
+        " AND owner NOT LIKE 'worker-once-%'"
+    } else {
+        ""
+    };
+    let mut stmt = conn.prepare(&format!(
         "SELECT owner, pid, started_at_epoch, updated_at_epoch
          FROM worker_heartbeats
          WHERE updated_at_epoch >= ?1
+         {daemon_filter}
          ORDER BY updated_at_epoch DESC, owner ASC
-         LIMIT 10",
-    )?;
+         LIMIT 10"
+    ))?;
     let rows = stmt.query_map(params![now.saturating_sub(max_age_secs)], |row| {
         Ok(WorkerHeartbeat {
             owner: row.get(0)?,
@@ -112,8 +133,8 @@ mod tests {
     use rusqlite::Connection;
 
     use super::{
-        healthy_worker_heartbeat, latest_worker_heartbeat, test_heartbeat_process_alive,
-        upsert_worker_heartbeat, WORKER_HEARTBEAT_HEALTH_SECS,
+        healthy_daemon_worker_heartbeat, healthy_worker_heartbeat, latest_worker_heartbeat,
+        test_heartbeat_process_alive, upsert_worker_heartbeat, WORKER_HEARTBEAT_HEALTH_SECS,
     };
 
     fn setup(conn: &Connection) {
@@ -171,6 +192,52 @@ mod tests {
         let healthy = healthy_worker_heartbeat(&conn, WORKER_HEARTBEAT_HEALTH_SECS)
             .expect("healthy heartbeat query should run");
         assert!(healthy.is_none());
+    }
+
+    #[test]
+    fn once_heartbeat_is_not_daemon_healthy() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup(&conn);
+        let now = chrono::Utc::now().timestamp();
+
+        upsert_worker_heartbeat(
+            &conn,
+            "worker-once-test",
+            i64::from(std::process::id()),
+            now,
+            now,
+        )?;
+
+        let healthy = healthy_worker_heartbeat(&conn, WORKER_HEARTBEAT_HEALTH_SECS)?;
+        assert_eq!(
+            healthy.as_ref().map(|heartbeat| heartbeat.owner.as_str()),
+            Some("worker-once-test")
+        );
+        let healthy_daemon = healthy_daemon_worker_heartbeat(&conn, WORKER_HEARTBEAT_HEALTH_SECS)?;
+        assert!(healthy_daemon.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_worker_heartbeat_counts_as_daemon_healthy() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup(&conn);
+        let now = chrono::Utc::now().timestamp();
+
+        upsert_worker_heartbeat(
+            &conn,
+            "worker-legacy",
+            i64::from(std::process::id()),
+            now,
+            now,
+        )?;
+
+        let healthy_daemon = healthy_daemon_worker_heartbeat(&conn, WORKER_HEARTBEAT_HEALTH_SECS)?;
+        let Some(healthy_daemon) = healthy_daemon else {
+            anyhow::bail!("legacy daemon heartbeat should be healthy");
+        };
+        assert_eq!(healthy_daemon.owner, "worker-legacy");
+        Ok(())
     }
 
     #[test]

--- a/src/db/worker.rs
+++ b/src/db/worker.rs
@@ -30,11 +30,30 @@ pub fn upsert_worker_heartbeat(
 }
 
 pub fn latest_worker_heartbeat(conn: &Connection) -> Result<Option<WorkerHeartbeat>> {
+    query_latest_worker_heartbeat(conn, false)
+}
+
+pub fn latest_daemon_worker_heartbeat(conn: &Connection) -> Result<Option<WorkerHeartbeat>> {
+    query_latest_worker_heartbeat(conn, true)
+}
+
+fn query_latest_worker_heartbeat(
+    conn: &Connection,
+    daemon_only: bool,
+) -> Result<Option<WorkerHeartbeat>> {
+    let daemon_filter = if daemon_only {
+        "WHERE owner NOT LIKE 'worker-once-%'"
+    } else {
+        ""
+    };
     conn.query_row(
-        "SELECT owner, pid, started_at_epoch, updated_at_epoch
+        &format!(
+            "SELECT owner, pid, started_at_epoch, updated_at_epoch
          FROM worker_heartbeats
+         {daemon_filter}
          ORDER BY updated_at_epoch DESC, owner ASC
-         LIMIT 1",
+         LIMIT 1"
+        ),
         [],
         |row| {
             Ok(WorkerHeartbeat {
@@ -133,8 +152,9 @@ mod tests {
     use rusqlite::Connection;
 
     use super::{
-        healthy_daemon_worker_heartbeat, healthy_worker_heartbeat, latest_worker_heartbeat,
-        test_heartbeat_process_alive, upsert_worker_heartbeat, WORKER_HEARTBEAT_HEALTH_SECS,
+        healthy_daemon_worker_heartbeat, healthy_worker_heartbeat, latest_daemon_worker_heartbeat,
+        latest_worker_heartbeat, test_heartbeat_process_alive, upsert_worker_heartbeat,
+        WORKER_HEARTBEAT_HEALTH_SECS,
     };
 
     fn setup(conn: &Connection) {
@@ -237,6 +257,43 @@ mod tests {
             anyhow::bail!("legacy daemon heartbeat should be healthy");
         };
         assert_eq!(healthy_daemon.owner, "worker-legacy");
+        Ok(())
+    }
+
+    #[test]
+    fn latest_daemon_heartbeat_ignores_once_heartbeat() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        setup(&conn);
+        let now = chrono::Utc::now().timestamp();
+
+        upsert_worker_heartbeat(
+            &conn,
+            "worker-daemon-test",
+            i64::from(std::process::id()),
+            now - 10,
+            now - 10,
+        )?;
+        upsert_worker_heartbeat(
+            &conn,
+            "worker-once-test",
+            i64::from(std::process::id()),
+            now,
+            now,
+        )?;
+
+        let latest = latest_worker_heartbeat(&conn)?;
+        assert_eq!(
+            latest.as_ref().map(|heartbeat| heartbeat.owner.as_str()),
+            Some("worker-once-test")
+        );
+
+        let latest_daemon = latest_daemon_worker_heartbeat(&conn)?;
+        assert_eq!(
+            latest_daemon
+                .as_ref()
+                .map(|heartbeat| heartbeat.owner.as_str()),
+            Some("worker-daemon-test")
+        );
         Ok(())
     }
 

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -229,6 +229,7 @@ fn spawn_worker_once() -> Result<()> {
         .arg("worker")
         .arg("--once")
         .current_dir(&worker_dir)
+        .env("REMEM_DATA_DIR", &worker_dir)
         .env("REMEM_STDERR_TO_LOG", "1")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
@@ -238,7 +239,19 @@ fn spawn_worker_once() -> Result<()> {
 }
 
 fn stable_worker_dir() -> std::path::PathBuf {
-    let data_dir = crate::db::data_dir();
+    let data_dir = match crate::db::absolute_data_dir() {
+        Ok(path) => path,
+        Err(err) => {
+            crate::log::warn(
+                "summarize",
+                &format!(
+                    "failed to resolve worker dir from REMEM_DATA_DIR: {}; falling back to temp dir",
+                    err
+                ),
+            );
+            return std::env::temp_dir();
+        }
+    };
     if let Err(err) = std::fs::create_dir_all(&data_dir) {
         crate::log::warn(
             "summarize",
@@ -535,6 +548,25 @@ mod tests {
 
         assert_eq!(got, data_dir.path);
         assert!(got.is_dir());
+    }
+
+    #[test]
+    fn stable_worker_dir_absolutizes_relative_data_dir() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-worker-relative-dir");
+        let relative = std::path::PathBuf::from(format!(
+            ".remem-summary-worker-relative-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::env::set_var("REMEM_DATA_DIR", &relative);
+
+        let got = stable_worker_dir();
+
+        assert_eq!(got, std::env::current_dir()?.join(&relative));
+        assert!(got.is_absolute());
+        assert!(got.is_dir());
+        std::fs::remove_dir_all(relative)?;
+        Ok(())
     }
 
     #[test]

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -213,7 +213,7 @@ fn legacy_hook_host_from_env() -> Option<String> {
 }
 
 fn should_spawn_worker_once(conn: &rusqlite::Connection) -> Result<bool> {
-    Ok(db::healthy_worker_heartbeat(conn, db::WORKER_HEARTBEAT_HEALTH_SECS)?.is_none())
+    Ok(db::healthy_daemon_worker_heartbeat(conn, db::WORKER_HEARTBEAT_HEALTH_SECS)?.is_none())
 }
 
 fn spawn_worker_once() -> Result<()> {
@@ -491,6 +491,26 @@ mod tests {
             !should_spawn_worker_once(&conn).expect("daemon check should run"),
             "healthy heartbeat should skip worker --once fallback"
         );
+    }
+
+    #[test]
+    fn healthy_once_worker_does_not_skip_stop_spawn() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-healthy-once-worker");
+        let conn = db::open_db()?;
+        let now = chrono::Utc::now().timestamp();
+        db::upsert_worker_heartbeat(
+            &conn,
+            "worker-once-test",
+            i64::from(std::process::id()),
+            now - 5,
+            now - 5,
+        )?;
+
+        assert!(
+            should_spawn_worker_once(&conn)?,
+            "healthy worker --once heartbeat should not suppress Stop fallback"
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3,6 +3,8 @@ use tokio::time::{sleep, Duration};
 
 use crate::{db, summarize};
 
+mod lock;
+
 // The lease is the maximum time another worker will wait before requeuing a
 // job whose owner died, so `JOB_LEASE_SECS` must always exceed
 // `JOB_TIMEOUT_SECS`. Otherwise a job that legitimately runs near the
@@ -87,12 +89,25 @@ fn job_profile(payload_json: &str) -> Option<String> {
 
 pub async fn run(once: bool, idle_sleep_ms: u64) -> Result<()> {
     let started_at_epoch = chrono::Utc::now().timestamp();
+    let mode = if once { "once" } else { "daemon" };
     let lease_owner = format!(
-        "worker-{}-{}",
+        "worker-{}-{}-{}",
+        mode,
         std::process::id(),
         chrono::Utc::now().timestamp_millis()
     );
-    crate::log::info("worker", &format!("start owner={}", lease_owner));
+    let Some(_singleton) = lock::acquire_worker_singleton()? else {
+        crate::log::info("worker", "worker already running, exiting");
+        return Ok(());
+    };
+    crate::log::info(
+        "worker",
+        &format!("start owner={} mode={}", lease_owner, mode),
+    );
+    {
+        let conn = db::open_db()?;
+        record_worker_heartbeat(&conn, &lease_owner, started_at_epoch)?;
+    }
 
     loop {
         let mut conn = db::open_db()?;
@@ -193,7 +208,7 @@ mod tests {
 
     use crate::db::{self, test_support::ScopedTestDataDir};
 
-    use super::run;
+    use super::{lock, run};
     use test_support::install_stub_codex;
 
     mod test_support;
@@ -318,6 +333,88 @@ mod tests {
                 .as_deref()
                 .is_some_and(|err| err.contains("not implemented")),
             "expected explicit unimplemented error"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn worker_once_records_startup_heartbeat_without_work() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-once-startup-heartbeat");
+
+        run(true, 10).await?;
+
+        let conn = db::open_db()?;
+        let Some(heartbeat) = db::latest_worker_heartbeat(&conn)? else {
+            anyhow::bail!("worker --once should record startup heartbeat");
+        };
+        anyhow::ensure!(
+            heartbeat.owner.starts_with("worker-once-"),
+            "unexpected heartbeat owner {}",
+            heartbeat.owner
+        );
+        anyhow::ensure!(
+            heartbeat.started_at_epoch <= heartbeat.updated_at_epoch,
+            "heartbeat should be valid immediately after singleton acquisition"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn worker_once_exits_without_work_when_singleton_lock_is_held() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-once-lock-held");
+        let Some(_guard) = lock::acquire_worker_singleton()? else {
+            anyhow::bail!("test worker lock should acquire");
+        };
+        let conn = db::open_db()?;
+        let job_id = db::enqueue_job(
+            &conn,
+            "codex-cli",
+            db::JobType::Observation,
+            "/tmp/remem",
+            Some("sess-lock-held"),
+            r#"{"host":"codex-cli","session_id":"sess-lock-held","project":"/tmp/remem"}"#,
+            50,
+        )?;
+
+        run(true, 10).await?;
+
+        let conn = db::open_db()?;
+        let state: String = conn.query_row(
+            "SELECT state FROM jobs WHERE id = ?1",
+            params![job_id],
+            |row| row.get(0),
+        )?;
+        anyhow::ensure!(
+            state == "pending",
+            "locked-out worker should not process job"
+        );
+        anyhow::ensure!(
+            db::latest_worker_heartbeat(&conn)?.is_none(),
+            "locked-out worker should exit before recording heartbeat"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn daemon_and_once_are_mutually_exclusive() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-daemon-once-mutual-exclusion");
+        let Some(_daemon_lock) = lock::acquire_worker_singleton()? else {
+            anyhow::bail!("test daemon lock should acquire");
+        };
+        let conn = db::open_db()?;
+        let now = chrono::Utc::now().timestamp();
+        let daemon_owner = "worker-daemon-test";
+        db::upsert_worker_heartbeat(&conn, daemon_owner, i64::from(std::process::id()), now, now)?;
+
+        run(true, 10).await?;
+
+        let conn = db::open_db()?;
+        let Some(heartbeat) = db::latest_worker_heartbeat(&conn)? else {
+            anyhow::bail!("daemon heartbeat should remain present");
+        };
+        anyhow::ensure!(
+            heartbeat.owner == daemon_owner,
+            "worker --once should not replace daemon heartbeat while daemon holds singleton"
         );
         Ok(())
     }

--- a/src/worker/lock.rs
+++ b/src/worker/lock.rs
@@ -2,39 +2,27 @@ use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use fs2::FileExt;
 
 pub(super) struct WorkerLockGuard {
     file: File,
-    #[cfg(not(unix))]
-    path: PathBuf,
 }
 
 pub(super) fn acquire_worker_singleton() -> Result<Option<WorkerLockGuard>> {
-    let path = worker_lock_path();
+    let path = worker_lock_path()?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create worker lock directory {}", parent.display()))?;
     }
 
-    #[cfg(unix)]
-    {
-        acquire_unix_lock(path)
-    }
-
-    #[cfg(not(unix))]
-    {
-        acquire_fallback_lock(path)
-    }
+    acquire_file_lock(path)
 }
 
-pub(super) fn worker_lock_path() -> PathBuf {
-    crate::db::data_dir().join("worker.lock")
+pub(super) fn worker_lock_path() -> Result<PathBuf> {
+    Ok(crate::db::absolute_data_dir()?.join("worker.lock"))
 }
 
-#[cfg(unix)]
-fn acquire_unix_lock(path: PathBuf) -> Result<Option<WorkerLockGuard>> {
-    use std::os::fd::AsRawFd;
-
+fn acquire_file_lock(path: PathBuf) -> Result<Option<WorkerLockGuard>> {
     let file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -42,57 +30,30 @@ fn acquire_unix_lock(path: PathBuf) -> Result<Option<WorkerLockGuard>> {
         .truncate(false)
         .open(&path)
         .with_context(|| format!("open worker lock {}", path.display()))?;
-    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-    if result == 0 {
-        return Ok(Some(WorkerLockGuard { file }));
-    }
 
-    let error = std::io::Error::last_os_error();
-    match error.raw_os_error() {
-        Some(code) if code == libc::EWOULDBLOCK || code == libc::EAGAIN => Ok(None),
-        _ => Err(error).with_context(|| format!("lock worker singleton {}", path.display())),
-    }
-}
-
-#[cfg(not(unix))]
-fn acquire_fallback_lock(path: PathBuf) -> Result<Option<WorkerLockGuard>> {
-    match OpenOptions::new().write(true).create_new(true).open(&path) {
-        Ok(file) => Ok(Some(WorkerLockGuard { file, path })),
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(None),
-        Err(error) => Err(error).with_context(|| format!("create worker lock {}", path.display())),
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(Some(WorkerLockGuard { file })),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => {
+            Err(error).with_context(|| format!("lock worker singleton {}", path.display()))
+        }
     }
 }
 
 impl Drop for WorkerLockGuard {
     fn drop(&mut self) {
-        #[cfg(unix)]
-        {
-            use std::os::fd::AsRawFd;
-
-            let result = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
-            if result != 0 {
-                let error = std::io::Error::last_os_error();
-                crate::log::warn(
-                    "worker",
-                    &format!("unlock worker singleton failed: {}", error),
-                );
-            }
-        }
-
-        #[cfg(not(unix))]
-        {
-            if let Err(error) = std::fs::remove_file(&self.path) {
-                crate::log::warn(
-                    "worker",
-                    &format!("remove worker singleton lock failed: {}", error),
-                );
-            }
+        if let Err(error) = self.file.unlock() {
+            crate::log::warn(
+                "worker",
+                &format!("unlock worker singleton failed: {}", error),
+            );
         }
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Barrier,
@@ -111,10 +72,31 @@ mod tests {
         };
 
         assert!(acquire_worker_singleton()?.is_none());
-        assert_eq!(worker_lock_path(), data_dir.path.join("worker.lock"));
+        assert_eq!(worker_lock_path()?, data_dir.path.join("worker.lock"));
 
         drop(first);
         assert!(acquire_worker_singleton()?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn worker_lock_path_absolutizes_relative_data_dir() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-lock-relative-data-dir");
+        let relative = PathBuf::from(format!(
+            ".remem-worker-lock-relative-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        if relative.exists() {
+            std::fs::remove_dir_all(&relative)?;
+        }
+        std::env::set_var("REMEM_DATA_DIR", &relative);
+        let expected = std::env::current_dir()?.join(&relative).join("worker.lock");
+
+        assert_eq!(worker_lock_path()?, expected);
+        if relative.exists() {
+            std::fs::remove_dir_all(relative)?;
+        }
         Ok(())
     }
 

--- a/src/worker/lock.rs
+++ b/src/worker/lock.rs
@@ -1,0 +1,160 @@
+use std::fs::{File, OpenOptions};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+pub(super) struct WorkerLockGuard {
+    file: File,
+    #[cfg(not(unix))]
+    path: PathBuf,
+}
+
+pub(super) fn acquire_worker_singleton() -> Result<Option<WorkerLockGuard>> {
+    let path = worker_lock_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create worker lock directory {}", parent.display()))?;
+    }
+
+    #[cfg(unix)]
+    {
+        acquire_unix_lock(path)
+    }
+
+    #[cfg(not(unix))]
+    {
+        acquire_fallback_lock(path)
+    }
+}
+
+pub(super) fn worker_lock_path() -> PathBuf {
+    crate::db::data_dir().join("worker.lock")
+}
+
+#[cfg(unix)]
+fn acquire_unix_lock(path: PathBuf) -> Result<Option<WorkerLockGuard>> {
+    use std::os::fd::AsRawFd;
+
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .with_context(|| format!("open worker lock {}", path.display()))?;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if result == 0 {
+        return Ok(Some(WorkerLockGuard { file }));
+    }
+
+    let error = std::io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(code) if code == libc::EWOULDBLOCK || code == libc::EAGAIN => Ok(None),
+        _ => Err(error).with_context(|| format!("lock worker singleton {}", path.display())),
+    }
+}
+
+#[cfg(not(unix))]
+fn acquire_fallback_lock(path: PathBuf) -> Result<Option<WorkerLockGuard>> {
+    match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(file) => Ok(Some(WorkerLockGuard { file, path })),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("create worker lock {}", path.display())),
+    }
+}
+
+impl Drop for WorkerLockGuard {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            let result = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+            if result != 0 {
+                let error = std::io::Error::last_os_error();
+                crate::log::warn(
+                    "worker",
+                    &format!("unlock worker singleton failed: {}", error),
+                );
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            if let Err(error) = std::fs::remove_file(&self.path) {
+                crate::log::warn(
+                    "worker",
+                    &format!("remove worker singleton lock failed: {}", error),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Barrier,
+    };
+    use std::time::Duration;
+
+    use crate::db::test_support::ScopedTestDataDir;
+
+    use super::{acquire_worker_singleton, worker_lock_path};
+
+    #[test]
+    fn singleton_returns_none_when_lock_is_held() -> anyhow::Result<()> {
+        let data_dir = ScopedTestDataDir::new("worker-lock-held");
+        let Some(first) = acquire_worker_singleton()? else {
+            anyhow::bail!("first worker lock should acquire");
+        };
+
+        assert!(acquire_worker_singleton()?.is_none());
+        assert_eq!(worker_lock_path(), data_dir.path.join("worker.lock"));
+
+        drop(first);
+        assert!(acquire_worker_singleton()?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn singleton_excludes_concurrent_acquire() -> anyhow::Result<()> {
+        let _data_dir = ScopedTestDataDir::new("worker-lock-concurrent");
+        let barrier = Arc::new(Barrier::new(2));
+        let acquired = Arc::new(AtomicUsize::new(0));
+        let blocked = Arc::new(AtomicUsize::new(0));
+
+        std::thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for _ in 0..2 {
+                let barrier = Arc::clone(&barrier);
+                let acquired = Arc::clone(&acquired);
+                let blocked = Arc::clone(&blocked);
+                handles.push(scope.spawn(move || -> anyhow::Result<()> {
+                    barrier.wait();
+                    match acquire_worker_singleton()? {
+                        Some(_guard) => {
+                            acquired.fetch_add(1, Ordering::SeqCst);
+                            std::thread::sleep(Duration::from_millis(50));
+                        }
+                        None => {
+                            blocked.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                    Ok(())
+                }));
+            }
+            for handle in handles {
+                handle
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("lock thread panicked"))??;
+            }
+            Ok::<(), anyhow::Error>(())
+        })?;
+
+        assert_eq!(acquired.load(Ordering::SeqCst), 1);
+        assert_eq!(blocked.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add a non-blocking worker singleton lock at REMEM_DATA_DIR/worker.lock for daemon and --once runs
- record worker heartbeat immediately after lock acquisition, before job recovery or claims
- keep Stop-hook heartbeat as a cheap prefilter but only treat daemon-compatible heartbeats as suppressing fallback spawn
- cover --once lock exclusion, early heartbeat, daemon/once mutual exclusion, and daemon-only heartbeat semantics

Fixes #407.
Part of #402.

## Verification
- cargo fmt --check
- git diff --check
- cargo check --message-format=short
- cargo clippy -- -D warnings
- cargo test worker --lib -- --nocapture
- cargo test summarize::summary_job::hook --lib -- --nocapture
- cargo test db::worker --lib -- --nocapture
- cargo test db::query::stats --lib -- --nocapture
- cargo test doctor::tests::check_worker_daemon --lib -- --nocapture
- cargo test cli::actions::query::status --lib -- --nocapture
- cargo test
- node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- python3 scripts/ci/check_plugin_version_sync.py