### PR TITLE
Stream doctor checks with shared DB connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.27"
+version = "0.5.28"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.27"
+version = "0.5.28"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.27": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.27",
+    "0.5.28": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.28",
       "assets": {}
     }
   }

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -3,66 +3,65 @@ use crate::db;
 use crate::doctor::health_action::{
     queue_actions, render_inline_hints, worker_once_fallback_detail,
 };
+use rusqlite::Connection;
 
-pub(super) fn check_database() -> Check {
+pub(super) fn check_database(conn: Option<&Connection>, open_error: Option<&str>) -> Check {
     let db_path = db::db_path();
     if !db_path.exists() {
-        return Check {
-            name: "Database",
-            status: Status::Fail,
-            detail: format!("{} (not found)", db_path.display()),
-        };
+        return Check::new(
+            "Database",
+            Status::Fail,
+            format!("{} (not found)", db_path.display()),
+        );
     }
 
     let size = std::fs::metadata(&db_path)
         .map(|meta| meta.len())
         .unwrap_or(0);
-    match db::open_db_read_only() {
-        Ok(conn) => match db::query_system_stats(&conn) {
-            Ok(stats) => Check {
-                name: "Database",
-                status: Status::Ok,
-                detail: format!(
-                    "{} ({:.1} MB, {} memories)",
-                    db_path.display(),
-                    size as f64 / 1_048_576.0,
-                    stats.active_memories
-                ),
-            },
-            Err(err) => Check {
-                name: "Database",
-                status: Status::Fail,
-                detail: format!("{} (stats error: {})", db_path.display(), err),
-            },
-        },
-        Err(err) => Check {
-            name: "Database",
-            status: Status::Fail,
-            detail: format!("{} (open error: {})", db_path.display(), err),
-        },
+    let Some(conn) = conn else {
+        return Check::new(
+            "Database",
+            Status::Fail,
+            format!(
+                "{} (open error: {})",
+                db_path.display(),
+                open_error.unwrap_or("database connection unavailable")
+            ),
+        );
+    };
+
+    match db::query_system_stats(conn) {
+        Ok(stats) => Check::new(
+            "Database",
+            Status::Ok,
+            format!(
+                "{} ({:.1} MB, {} memories)",
+                db_path.display(),
+                size as f64 / 1_048_576.0,
+                stats.active_memories
+            ),
+        ),
+        Err(err) => Check::new(
+            "Database",
+            Status::Fail,
+            format!("{} (stats error: {})", db_path.display(), err),
+        ),
     }
 }
 
-pub(super) fn check_pending_queue() -> Check {
-    let conn = match db::open_db_read_only() {
-        Ok(conn) => conn,
-        Err(_) => {
-            return Check {
-                name: "Pending queue",
-                status: Status::Warn,
-                detail: "cannot open database".to_string(),
-            };
-        }
+pub(super) fn check_pending_queue(conn: Option<&Connection>) -> Check {
+    let Some(conn) = conn else {
+        return Check::new("Pending queue", Status::Warn, "cannot open database");
     };
 
-    let stats = match db::query_system_stats(&conn) {
+    let stats = match db::query_system_stats(conn) {
         Ok(stats) => stats,
         Err(err) => {
-            return Check {
-                name: "Pending queue",
-                status: Status::Warn,
-                detail: format!("cannot load queue stats: {}", err),
-            };
+            return Check::new(
+                "Pending queue",
+                Status::Warn,
+                format!("cannot load queue stats: {}", err),
+            );
         }
     };
     let detail = format!(
@@ -89,61 +88,50 @@ pub(super) fn check_pending_queue() -> Check {
         .unwrap_or_default();
 
     if stats.expired_processing_pending_observations > 0 || stats.stuck_jobs > 0 {
-        Check {
-            name: "Pending queue",
-            status: Status::Warn,
-            detail: format!("{detail} (will auto-recover{action_suffix})"),
-        }
+        Check::new(
+            "Pending queue",
+            Status::Warn,
+            format!("{detail} (will auto-recover{action_suffix})"),
+        )
     } else if stats.failed_pending_observations > 0 || stats.failed_jobs > 0 {
-        Check {
-            name: "Pending queue",
-            status: Status::Warn,
-            detail: format!("{detail} (inspect failures{action_suffix})"),
-        }
+        Check::new(
+            "Pending queue",
+            Status::Warn,
+            format!("{detail} (inspect failures{action_suffix})"),
+        )
     } else if stats.ready_pending_observations > 100 {
-        Check {
-            name: "Pending queue",
-            status: Status::Warn,
-            detail: format!("{detail} (backlog building up; action: `remem worker --once`)"),
-        }
+        Check::new(
+            "Pending queue",
+            Status::Warn,
+            format!("{detail} (backlog building up; action: `remem worker --once`)"),
+        )
     } else {
-        Check {
-            name: "Pending queue",
-            status: Status::Ok,
-            detail,
-        }
+        Check::new("Pending queue", Status::Ok, detail)
     }
 }
 
-pub(super) fn check_raw_archive_ingest() -> Check {
-    let conn = match db::open_db_read_only() {
-        Ok(conn) => conn,
-        Err(_) => {
-            return Check {
-                name: "Raw archive ingest",
-                status: Status::Warn,
-                detail: "cannot open database".to_string(),
-            };
-        }
+pub(super) fn check_raw_archive_ingest(conn: Option<&Connection>) -> Check {
+    let Some(conn) = conn else {
+        return Check::new("Raw archive ingest", Status::Warn, "cannot open database");
     };
 
-    let stats = match db::query_system_stats(&conn) {
+    let stats = match db::query_system_stats(conn) {
         Ok(stats) => stats,
         Err(err) => {
-            return Check {
-                name: "Raw archive ingest",
-                status: Status::Warn,
-                detail: format!("cannot load raw ingest stats: {}", err),
-            };
+            return Check::new(
+                "Raw archive ingest",
+                Status::Warn,
+                format!("cannot load raw ingest stats: {}", err),
+            );
         }
     };
 
     if stats.raw_ingest_failures == 0 {
-        return Check {
-            name: "Raw archive ingest",
-            status: Status::Ok,
-            detail: format!("{} raw messages, no ingest failures", stats.raw_messages),
-        };
+        return Check::new(
+            "Raw archive ingest",
+            Status::Ok,
+            format!("{} raw messages, no ingest failures", stats.raw_messages),
+        );
     }
 
     let mut detail = format!(
@@ -160,96 +148,75 @@ pub(super) fn check_raw_archive_ingest() -> Check {
         detail.push_str(&format!(" ({})", crate::db::truncate_str(&message, 160)));
     }
 
-    Check {
-        name: "Raw archive ingest",
-        status: Status::Warn,
-        detail,
-    }
+    Check::new("Raw archive ingest", Status::Warn, detail)
 }
 
-pub(super) fn check_temporal_facts() -> Check {
-    let conn = match db::open_db_read_only() {
-        Ok(conn) => conn,
-        Err(_) => {
-            return Check {
-                name: "Temporal facts",
-                status: Status::Warn,
-                detail: "cannot open database".to_string(),
-            };
-        }
+pub(super) fn check_temporal_facts(conn: Option<&Connection>) -> Check {
+    let Some(conn) = conn else {
+        return Check::new("Temporal facts", Status::Warn, "cannot open database");
     };
 
-    let stats = match db::query_memory_facts_stats(&conn) {
+    let stats = match db::query_memory_facts_stats(conn) {
         Ok(stats) => stats,
         Err(err) => {
-            return Check {
-                name: "Temporal facts",
-                status: Status::Warn,
-                detail: format!("cannot load fact stats: {}", err),
-            };
+            return Check::new(
+                "Temporal facts",
+                Status::Warn,
+                format!("cannot load fact stats: {}", err),
+            );
         }
     };
 
     if !stats.table_exists {
-        return Check {
-            name: "Temporal facts",
-            status: Status::Ok,
-            detail: "memory_facts table not present; temporal retrieval uses created_at fallback"
-                .to_string(),
-        };
+        return Check::new(
+            "Temporal facts",
+            Status::Ok,
+            "memory_facts table not present; temporal retrieval uses created_at fallback",
+        );
     }
 
     if stats.retrieval_eligible == 0 && stats.active_memories == 0 && stats.captured_events == 0 {
-        return Check {
-            name: "Temporal facts",
-            status: Status::Ok,
-            detail:
-                "memory_facts table is empty because this store has no memories or captured events yet"
-                    .to_string(),
-        };
+        return Check::new(
+            "Temporal facts",
+            Status::Ok,
+            "memory_facts table is empty because this store has no memories or captured events yet",
+        );
     }
 
     if stats.retrieval_eligible == 0 {
-        return Check {
-            name: "Temporal facts",
-            status: Status::Warn,
-            detail: format!(
+        return Check::new(
+            "Temporal facts",
+            Status::Warn,
+            format!(
                 "temporal retrieval can read memory_facts, but 0 of {} fact row(s) are linked active event-time facts; production fact extraction is not populating retrievable facts yet",
                 stats.total
             ),
-        };
+        );
     }
 
-    Check {
-        name: "Temporal facts",
-        status: Status::Ok,
-        detail: format!(
+    Check::new(
+        "Temporal facts",
+        Status::Ok,
+        format!(
             "{} linked active memory fact(s) available for event-time retrieval",
             stats.retrieval_eligible
         ),
-    }
+    )
 }
 
-pub(super) fn check_worker_daemon() -> Check {
-    let conn = match db::open_db_read_only() {
-        Ok(conn) => conn,
-        Err(_) => {
-            return Check {
-                name: "Worker daemon",
-                status: Status::Warn,
-                detail: "cannot open database".to_string(),
-            };
-        }
+pub(super) fn check_worker_daemon(conn: Option<&Connection>) -> Check {
+    let Some(conn) = conn else {
+        return Check::new("Worker daemon", Status::Warn, "cannot open database");
     };
 
-    let stats = match db::query_system_stats(&conn) {
+    let stats = match db::query_system_stats(conn) {
         Ok(stats) => stats,
         Err(err) => {
-            return Check {
-                name: "Worker daemon",
-                status: Status::Warn,
-                detail: format!("cannot load heartbeat stats: {}", err),
-            };
+            return Check::new(
+                "Worker daemon",
+                Status::Warn,
+                format!("cannot load heartbeat stats: {}", err),
+            );
         }
     };
 
@@ -258,26 +225,26 @@ pub(super) fn check_worker_daemon() -> Check {
         stats.worker_heartbeat_owner,
         stats.worker_heartbeat_age_secs,
     ) {
-        (true, Some(owner), Some(age_secs)) => Check {
-            name: "Worker daemon",
-            status: Status::Ok,
-            detail: format!("healthy, last heartbeat {}s ago ({})", age_secs, owner),
-        },
-        (false, Some(owner), Some(age_secs)) => Check {
-            name: "Worker daemon",
-            status: Status::Warn,
-            detail: format!(
+        (true, Some(owner), Some(age_secs)) => Check::new(
+            "Worker daemon",
+            Status::Ok,
+            format!("healthy, last heartbeat {}s ago ({})", age_secs, owner),
+        ),
+        (false, Some(owner), Some(age_secs)) => Check::new(
+            "Worker daemon",
+            Status::Warn,
+            format!(
                 "stale, last heartbeat {}s ago ({}); {}",
                 age_secs,
                 owner,
                 worker_once_fallback_detail()
             ),
-        },
-        _ => Check {
-            name: "Worker daemon",
-            status: Status::Ok,
-            detail: format!("not running; {}", worker_once_fallback_detail()),
-        },
+        ),
+        _ => Check::new(
+            "Worker daemon",
+            Status::Ok,
+            format!("not running; {}", worker_once_fallback_detail()),
+        ),
     }
 }
 
@@ -294,26 +261,26 @@ pub(super) fn check_disk_space() -> Check {
     let total_mb = (db_size + log_size) as f64 / 1_048_576.0;
 
     if total_mb > 500.0 {
-        Check {
-            name: "Disk usage",
-            status: Status::Warn,
-            detail: format!(
+        Check::new(
+            "Disk usage",
+            Status::Warn,
+            format!(
                 "{:.1} MB total (DB: {:.1} MB, logs: {:.1} MB) — consider `remem cleanup`",
                 total_mb,
                 db_size as f64 / 1_048_576.0,
                 log_size as f64 / 1_048_576.0
             ),
-        }
+        )
     } else {
-        Check {
-            name: "Disk usage",
-            status: Status::Ok,
-            detail: format!(
+        Check::new(
+            "Disk usage",
+            Status::Ok,
+            format!(
                 "{:.1} MB total (DB: {:.1} MB, logs: {:.1} MB)",
                 total_mb,
                 db_size as f64 / 1_048_576.0,
                 log_size as f64 / 1_048_576.0
             ),
-        }
+        )
     }
 }

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -8,11 +8,7 @@ pub(super) fn check_binary() -> Check {
     let exe = std::env::current_exe()
         .map(|path| path.display().to_string())
         .unwrap_or_else(|_| "unknown".to_string());
-    Check {
-        name: "Binary",
-        status: Status::Ok,
-        detail: exe,
-    }
+    Check::new("Binary", Status::Ok, exe)
 }
 
 pub(super) fn check_install_paths() -> Check {
@@ -26,15 +22,15 @@ pub(super) fn check_install_paths() -> Check {
     }
     let report =
         crate::install::duplicates::inspect_install_paths_with_configured_paths(&configured);
-    Check {
-        name: "Install paths",
-        status: if report.has_warning() {
+    Check::new(
+        "Install paths",
+        if report.has_warning() {
             Status::Warn
         } else {
             Status::Ok
         },
-        detail: crate::install::duplicates::format_doctor_detail(&report),
-    }
+        crate::install::duplicates::format_doctor_detail(&report),
+    )
 }
 
 fn configured_remem_paths_for(hosts: Vec<HostProbe>) -> Vec<PathBuf> {
@@ -100,11 +96,11 @@ fn check_hooks_for(hosts: Vec<HostProbe>) -> Vec<Check> {
         checks.push(probe_hooks(probe));
     }
     if checks.is_empty() {
-        checks.push(Check {
-            name: "Hooks",
-            status: Status::Fail,
-            detail: "no supported host detected (install Claude Code or Codex)".to_string(),
-        });
+        checks.push(Check::new(
+            "Hooks",
+            Status::Fail,
+            "no supported host detected (install Claude Code or Codex)",
+        ));
     }
     checks
 }
@@ -119,11 +115,11 @@ fn check_mcp_for(hosts: Vec<HostProbe>) -> Vec<Check> {
         checks.push(probe_mcp(probe));
     }
     if checks.is_empty() {
-        checks.push(Check {
-            name: "MCP server",
-            status: Status::Fail,
-            detail: "no supported host detected".to_string(),
-        });
+        checks.push(Check::new(
+            "MCP server",
+            Status::Fail,
+            "no supported host detected",
+        ));
     }
     checks
 }
@@ -132,35 +128,35 @@ fn probe_hooks(probe: HostProbe) -> Check {
     let name = hooks_check_name(probe.name);
 
     if !probe.hooks_path.exists() {
-        return Check {
+        return Check::new(
             name,
-            status: Status::Fail,
-            detail: format!(
+            Status::Fail,
+            format!(
                 "{} not found (run `remem install`)",
                 probe.hooks_path.display()
             ),
-        };
+        );
     }
 
     let content = match std::fs::read_to_string(&probe.hooks_path) {
         Ok(content) => content,
         Err(err) => {
-            return Check {
+            return Check::new(
                 name,
-                status: Status::Fail,
-                detail: format!("cannot read {}: {}", probe.hooks_path.display(), err),
-            };
+                Status::Fail,
+                format!("cannot read {}: {}", probe.hooks_path.display(), err),
+            );
         }
     };
 
     let doc: Value = match serde_json::from_str(&content) {
         Ok(doc) => doc,
         Err(err) => {
-            return Check {
+            return Check::new(
                 name,
-                status: Status::Fail,
-                detail: format!("cannot parse {}: {}", probe.hooks_path.display(), err),
-            };
+                Status::Fail,
+                format!("cannot parse {}: {}", probe.hooks_path.display(), err),
+            );
         }
     };
 
@@ -175,57 +171,57 @@ fn probe_hooks(probe: HostProbe) -> Check {
 
     if found == events.len() {
         if legacy_policy {
-            return Check {
+            return Check::new(
                 name,
-                status: Status::Warn,
-                detail: format!(
+                Status::Warn,
+                format!(
                     "{}/{} registered in {}; legacy memory-AI hook policy remains (run `remem install --target {}`)",
                     found, events.len(), probe.hooks_path.display(), probe.name
                 ),
-            };
+            );
         }
         if deprecated_codex_observe {
-            return Check {
+            return Check::new(
                 name,
-                status: Status::Warn,
-                detail: format!(
+                Status::Warn,
+                format!(
                     "{}/{} registered in {}; remove Codex PostToolUse observe to avoid unbounded Bash backlog",
                     found,
                     events.len(),
                     probe.hooks_path.display()
                 ),
-            };
+            );
         }
-        Check {
+        Check::new(
             name,
-            status: Status::Ok,
-            detail: format!(
+            Status::Ok,
+            format!(
                 "{}/{} registered in {}",
                 found,
                 events.len(),
                 probe.hooks_path.display()
             ),
-        }
+        )
     } else if found > 0 {
-        Check {
+        Check::new(
             name,
-            status: Status::Warn,
-            detail: format!(
+            Status::Warn,
+            format!(
                 "{}/{} registered (run `remem install --target {}` to fix)",
                 found,
                 events.len(),
                 probe.name
             ),
-        }
+        )
     } else {
-        Check {
+        Check::new(
             name,
-            status: Status::Fail,
-            detail: format!(
+            Status::Fail,
+            format!(
                 "no remem hooks (run `remem install --target {}`)",
                 probe.name
             ),
-        }
+        )
     }
 }
 
@@ -239,23 +235,23 @@ fn probe_mcp(probe: HostProbe) -> Check {
         .find_map(|path| probe_mcp_path(probe.name, path))
     {
         return match result {
-            Ok(path) => Check {
+            Ok(path) => Check::new(
                 name,
-                status: Status::Ok,
-                detail: format!("registered in {}", path.display()),
-            },
-            Err((path, err)) => Check {
+                Status::Ok,
+                format!("registered in {}", path.display()),
+            ),
+            Err((path, err)) => Check::new(
                 name,
-                status: Status::Fail,
-                detail: format!("cannot parse {}: {}", path.display(), err),
-            },
+                Status::Fail,
+                format!("cannot parse {}: {}", path.display(), err),
+            ),
         };
     }
 
-    Check {
+    Check::new(
         name,
-        status: Status::Fail,
-        detail: if has_existing_path {
+        Status::Fail,
+        if has_existing_path {
             format!(
                 "not registered (run `remem install --target {}`)",
                 probe.name
@@ -267,7 +263,7 @@ fn probe_mcp(probe: HostProbe) -> Check {
                 probe.name
             )
         },
-    }
+    )
 }
 
 fn hooks_check_name(host: &str) -> &'static str {

--- a/src/doctor/native_memory.rs
+++ b/src/doctor/native_memory.rs
@@ -18,19 +18,19 @@ fn check_native_memory_sync_for(projects_dir: &Path, max_bytes: usize, disabled:
     let mut files = match collect_remem_native_memory_files(projects_dir) {
         Ok(files) => files,
         Err(err) => {
-            return Check {
-                name: "Claude native memory",
-                status: Status::Warn,
-                detail: format!("cannot inspect {}: {}", projects_dir.display(), err),
-            };
+            return Check::new(
+                "Claude native memory",
+                Status::Warn,
+                format!("cannot inspect {}: {}", projects_dir.display(), err),
+            );
         }
     };
 
     if files.is_empty() {
-        return Check {
-            name: "Claude native memory",
-            status: Status::Ok,
-            detail: if disabled {
+        return Check::new(
+            "Claude native memory",
+            Status::Ok,
+            if disabled {
                 format!(
                     "disabled by {}; no remem_sessions.md files found",
                     crate::context::claude_memory::DISABLE_NATIVE_MEMORY_SYNC_ENV
@@ -38,7 +38,7 @@ fn check_native_memory_sync_for(projects_dir: &Path, max_bytes: usize, disabled:
             } else {
                 "no remem_sessions.md files found".to_string()
             },
-        };
+        );
     }
 
     files.sort_by(|a, b| b.bytes.cmp(&a.bytes).then_with(|| a.path.cmp(&b.path)));
@@ -57,10 +57,10 @@ fn check_native_memory_sync_for(projects_dir: &Path, max_bytes: usize, disabled:
     };
 
     if oversized.is_empty() {
-        return Check {
-            name: "Claude native memory",
-            status: Status::Ok,
-            detail: format!(
+        return Check::new(
+            "Claude native memory",
+            Status::Ok,
+            format!(
                 "{} remem_sessions.md file(s), largest {} bytes, limit {}={} bytes{}",
                 files.len(),
                 largest,
@@ -68,7 +68,7 @@ fn check_native_memory_sync_for(projects_dir: &Path, max_bytes: usize, disabled:
                 max_bytes,
                 disabled_note
             ),
-        };
+        );
     }
 
     let examples = oversized
@@ -77,10 +77,10 @@ fn check_native_memory_sync_for(projects_dir: &Path, max_bytes: usize, disabled:
         .map(|file| format!("{} ({} bytes)", file.path.display(), file.bytes))
         .collect::<Vec<_>>()
         .join("; ");
-    Check {
-        name: "Claude native memory",
-        status: Status::Warn,
-        detail: format!(
+    Check::new(
+        "Claude native memory",
+        Status::Warn,
+        format!(
             "{} of {} remem_sessions.md file(s) exceed {} bytes{}; host-side Claude Code loads are not included in remem usage: {}",
             oversized.len(),
             files.len(),
@@ -88,7 +88,7 @@ fn check_native_memory_sync_for(projects_dir: &Path, max_bytes: usize, disabled:
             disabled_note,
             examples
         ),
-    }
+    )
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -1,6 +1,10 @@
-use std::io::{self, Write};
+use std::{
+    io::{self, Write},
+    time::{Duration, Instant},
+};
 
 use anyhow::Result;
+use rusqlite::Connection;
 
 use super::database::{
     check_database, check_disk_space, check_pending_queue, check_raw_archive_ingest,
@@ -11,6 +15,8 @@ use super::native_memory::check_native_memory_sync;
 use super::runtime_config_check::check_runtime_config;
 use super::schema::{check_key_format, check_schema_migration};
 use super::types::{Check, CheckJson, DoctorOutcome, ReportJson, Status, REPORT_SCHEMA_VERSION};
+
+const SLOW_CHECK_WARN_MS: u64 = 10_000;
 
 /// Caller-supplied options for `remem doctor`. Defaulting all fields keeps
 /// the unit tests and any future callers small while letting `cli::dispatch`
@@ -36,36 +42,140 @@ pub(crate) fn run_doctor_with_writer<W: Write>(
     opts: DoctorOptions,
     out: &mut W,
 ) -> Result<DoctorOutcome> {
-    let checks = collect_checks();
+    let started = Instant::now();
+    if !opts.json && !opts.quiet {
+        write_human_header(out)?;
+    }
+
+    let checks = run_checks(|check| {
+        if !opts.json && !opts.quiet {
+            write_human_check(out, check)?;
+            out.flush()?;
+        }
+        Ok(())
+    })?;
     let outcome = tally(&checks);
+    let elapsed_ms = duration_ms(started.elapsed());
 
     if opts.json {
-        write_json(out, &checks, outcome)?;
+        write_json(out, &checks, outcome, elapsed_ms)?;
     } else if !opts.quiet {
-        write_human(out, &checks, outcome)?;
+        write_human_summary(out, outcome)?;
     }
 
     Ok(outcome)
 }
 
-fn collect_checks() -> Vec<Check> {
-    let mut checks = vec![
-        check_binary(),
-        check_schema_migration(),
-        check_key_format(),
-        check_database(),
-    ];
-    checks.push(check_install_paths());
-    checks.push(check_runtime_config());
-    checks.extend(check_hooks());
-    checks.extend(check_mcp());
-    checks.push(check_raw_archive_ingest());
-    checks.push(check_temporal_facts());
-    checks.push(check_worker_daemon());
-    checks.push(check_pending_queue());
-    checks.push(check_native_memory_sync());
-    checks.push(check_disk_space());
-    checks
+fn run_checks(mut on_check: impl FnMut(&Check) -> Result<()>) -> Result<Vec<Check>> {
+    let mut checks = Vec::new();
+
+    push_check(&mut checks, &mut on_check, check_binary)?;
+    let shared_db = SharedDoctorDb::open();
+    push_check(&mut checks, &mut on_check, || {
+        check_schema_migration(shared_db.conn(), shared_db.open_error())
+    })?;
+    push_check(&mut checks, &mut on_check, check_key_format)?;
+    push_check(&mut checks, &mut on_check, || {
+        check_database(shared_db.conn(), shared_db.open_error())
+    })?;
+    push_check(&mut checks, &mut on_check, check_install_paths)?;
+    push_check(&mut checks, &mut on_check, check_runtime_config)?;
+    push_checks(&mut checks, &mut on_check, check_hooks)?;
+    push_checks(&mut checks, &mut on_check, check_mcp)?;
+    push_check(&mut checks, &mut on_check, || {
+        check_raw_archive_ingest(shared_db.conn())
+    })?;
+    push_check(&mut checks, &mut on_check, || {
+        check_temporal_facts(shared_db.conn())
+    })?;
+    push_check(&mut checks, &mut on_check, || {
+        check_worker_daemon(shared_db.conn())
+    })?;
+    push_check(&mut checks, &mut on_check, || {
+        check_pending_queue(shared_db.conn())
+    })?;
+    push_check(&mut checks, &mut on_check, check_native_memory_sync)?;
+    push_check(&mut checks, &mut on_check, check_disk_space)?;
+    Ok(checks)
+}
+
+fn push_check(
+    checks: &mut Vec<Check>,
+    on_check: &mut impl FnMut(&Check) -> Result<()>,
+    build: impl FnOnce() -> Check,
+) -> Result<()> {
+    let started = Instant::now();
+    let check = build().with_duration_ms(duration_ms(started.elapsed()));
+    push_ready_check(checks, on_check, check)
+}
+
+fn push_checks(
+    checks: &mut Vec<Check>,
+    on_check: &mut impl FnMut(&Check) -> Result<()>,
+    build: impl FnOnce() -> Vec<Check>,
+) -> Result<()> {
+    let started = Instant::now();
+    let built = build();
+    let duration = duration_ms(started.elapsed());
+    for check in built {
+        push_ready_check(checks, on_check, check.with_duration_ms(duration))?;
+    }
+    Ok(())
+}
+
+fn push_ready_check(
+    checks: &mut Vec<Check>,
+    on_check: &mut impl FnMut(&Check) -> Result<()>,
+    check: Check,
+) -> Result<()> {
+    if check.duration_ms > SLOW_CHECK_WARN_MS {
+        crate::log::warn(
+            "doctor",
+            &format!("slow check '{}' took {}ms", check.name, check.duration_ms),
+        );
+    }
+    on_check(&check)?;
+    checks.push(check);
+    Ok(())
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+struct SharedDoctorDb {
+    conn: Option<Connection>,
+    open_error: Option<String>,
+}
+
+impl SharedDoctorDb {
+    fn open() -> Self {
+        if !crate::db::db_path().exists() {
+            return Self {
+                conn: None,
+                open_error: None,
+            };
+        }
+
+        match crate::db::open_db_read_only() {
+            Ok(conn) => Self {
+                conn: Some(conn),
+                open_error: None,
+            },
+            Err(error) => Self {
+                conn: None,
+                open_error: Some(error.to_string()),
+            },
+        }
+    }
+
+    fn conn(&self) -> Option<&Connection> {
+        self.conn.as_ref()
+    }
+
+    fn open_error(&self) -> Option<&str> {
+        self.open_error.as_deref()
+    }
 }
 
 fn tally(checks: &[Check]) -> DoctorOutcome {
@@ -80,18 +190,38 @@ fn tally(checks: &[Check]) -> DoctorOutcome {
     outcome
 }
 
+#[cfg(test)]
 fn write_human<W: Write>(out: &mut W, checks: &[Check], outcome: DoctorOutcome) -> Result<()> {
+    write_human_header(out)?;
+    for check in checks {
+        write_human_check(out, check)?;
+    }
+    write_human_summary(out, outcome)
+}
+
+fn write_human_header<W: Write>(out: &mut W) -> Result<()> {
     writeln!(
         out,
         "remem v{} — system check",
         crate::build_info::version_label()
     )?;
     writeln!(out)?;
+    Ok(())
+}
 
-    for check in checks {
-        writeln!(out, "  [{}] {}: {}", check.icon(), check.name, check.detail)?;
-    }
+fn write_human_check<W: Write>(out: &mut W, check: &Check) -> Result<()> {
+    writeln!(
+        out,
+        "  [{}] {}: {} ({}ms)",
+        check.icon(),
+        check.name,
+        check.detail,
+        check.duration_ms
+    )?;
+    Ok(())
+}
 
+fn write_human_summary<W: Write>(out: &mut W, outcome: DoctorOutcome) -> Result<()> {
     writeln!(out)?;
     if outcome.fails > 0 {
         writeln!(
@@ -108,7 +238,12 @@ fn write_human<W: Write>(out: &mut W, checks: &[Check], outcome: DoctorOutcome) 
     Ok(())
 }
 
-fn write_json<W: Write>(out: &mut W, checks: &[Check], outcome: DoctorOutcome) -> Result<()> {
+fn write_json<W: Write>(
+    out: &mut W,
+    checks: &[Check],
+    outcome: DoctorOutcome,
+    elapsed_ms: u64,
+) -> Result<()> {
     let overall = if outcome.fails > 0 {
         Status::Fail
     } else if outcome.warns > 0 {
@@ -124,12 +259,14 @@ fn write_json<W: Write>(out: &mut W, checks: &[Check], outcome: DoctorOutcome) -
         status: overall.as_json_tag(),
         fails: outcome.fails,
         warns: outcome.warns,
+        elapsed_ms,
         checks: checks
             .iter()
             .map(|c| CheckJson {
                 name: c.name,
                 status: c.status.as_json_tag(),
                 detail: c.detail.as_str(),
+                duration_ms: c.duration_ms,
             })
             .collect(),
     };
@@ -144,11 +281,7 @@ mod tests {
     use super::*;
 
     fn make(name: &'static str, status: Status, detail: &str) -> Check {
-        Check {
-            name,
-            status,
-            detail: detail.into(),
-        }
+        Check::new(name, status, detail)
     }
 
     #[test]
@@ -205,10 +338,10 @@ mod tests {
         ];
         let outcome = tally(&checks);
         let mut buf = Vec::new();
-        write_json(&mut buf, &checks, outcome).unwrap();
+        write_json(&mut buf, &checks, outcome, 123).unwrap();
         let text = String::from_utf8(buf).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
-        assert_eq!(parsed["schema_version"], 1);
+        assert_eq!(parsed["schema_version"], 2);
         assert_eq!(
             parsed["binary_schema_version"],
             crate::migrate::latest_schema_version()
@@ -216,10 +349,12 @@ mod tests {
         assert_eq!(parsed["status"], "fail");
         assert_eq!(parsed["fails"], 1);
         assert_eq!(parsed["warns"], 0);
+        assert_eq!(parsed["elapsed_ms"], 123);
         let checks_json = parsed["checks"].as_array().unwrap();
         assert_eq!(checks_json.len(), 2);
         assert_eq!(checks_json[0]["name"], "Database");
         assert_eq!(checks_json[0]["status"], "ok");
+        assert_eq!(checks_json[0]["duration_ms"], 0);
         assert_eq!(checks_json[1]["status"], "fail");
     }
 
@@ -231,12 +366,75 @@ mod tests {
         ];
         let outcome = tally(&checks);
         let mut buf = Vec::new();
-        write_json(&mut buf, &checks, outcome).unwrap();
+        write_json(&mut buf, &checks, outcome, 0).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_str(String::from_utf8(buf).unwrap().trim()).unwrap();
         assert_eq!(parsed["status"], "ok");
         assert_eq!(parsed["fails"], 0);
         assert_eq!(parsed["warns"], 0);
+    }
+
+    #[test]
+    fn push_check_invokes_callback_before_next_check_runs() -> anyhow::Result<()> {
+        let events = std::cell::RefCell::new(Vec::new());
+        let mut checks = Vec::new();
+
+        push_check(
+            &mut checks,
+            &mut |check| {
+                events.borrow_mut().push(format!("write {}", check.name));
+                Ok(())
+            },
+            || {
+                events.borrow_mut().push("build first".to_string());
+                Check::new("first", Status::Ok, "ok")
+            },
+        )?;
+
+        push_check(
+            &mut checks,
+            &mut |check| {
+                events.borrow_mut().push(format!("write {}", check.name));
+                Ok(())
+            },
+            || {
+                assert_eq!(
+                    *events.borrow(),
+                    vec!["build first".to_string(), "write first".to_string()]
+                );
+                Check::new("second", Status::Ok, "ok")
+            },
+        )?;
+
+        assert_eq!(checks.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn push_checks_assigns_measured_duration_to_each_check() -> anyhow::Result<()> {
+        let mut checks = Vec::new();
+        let mut observed = Vec::new();
+
+        push_checks(
+            &mut checks,
+            &mut |check| {
+                observed.push((check.name, check.duration_ms));
+                Ok(())
+            },
+            || {
+                std::thread::sleep(Duration::from_millis(5));
+                vec![
+                    make("first", Status::Ok, "ok"),
+                    make("second", Status::Ok, "ok"),
+                ]
+            },
+        )?;
+
+        assert_eq!(observed.len(), 2);
+        assert_eq!(checks.len(), 2);
+        assert!(observed.iter().all(|(_, duration)| *duration > 0));
+        assert!(checks.iter().all(|check| check.duration_ms > 0));
+        Ok(())
     }
 
     #[test]
@@ -253,7 +451,7 @@ mod tests {
         let outcome = tally(&checks);
         let mut buf = Vec::new();
         if opts.json {
-            write_json(&mut buf, &checks, outcome).unwrap();
+            write_json(&mut buf, &checks, outcome, 0).unwrap();
         } else if !opts.quiet {
             write_human(&mut buf, &checks, outcome).unwrap();
         }
@@ -275,7 +473,7 @@ mod tests {
         let outcome = tally(&checks);
         let mut buf = Vec::new();
         if opts.json {
-            write_json(&mut buf, &checks, outcome).unwrap();
+            write_json(&mut buf, &checks, outcome, 0).unwrap();
         } else if !opts.quiet {
             write_human(&mut buf, &checks, outcome).unwrap();
         }

--- a/src/doctor/runtime_config_check.rs
+++ b/src/doctor/runtime_config_check.rs
@@ -3,31 +3,31 @@ use super::types::{Check, Status};
 pub(super) fn check_runtime_config() -> Check {
     let path = crate::runtime_config::config_path();
     if !path.exists() {
-        return Check {
-            name: "Runtime config",
-            status: Status::Warn,
-            detail: format!("{} not found (run `remem config init`)", path.display()),
-        };
+        return Check::new(
+            "Runtime config",
+            Status::Warn,
+            format!("{} not found (run `remem config init`)", path.display()),
+        );
     }
 
     match crate::runtime_config::resolve_memory_ai_profile(
         crate::runtime_config::MemoryAiSelection::default(),
     ) {
-        Ok(profile) => Check {
-            name: "Runtime config",
-            status: Status::Ok,
-            detail: format!(
+        Ok(profile) => Check::new(
+            "Runtime config",
+            Status::Ok,
+            format!(
                 "{} default profile={} executor={:?} model={}",
                 path.display(),
                 profile.profile_name,
                 profile.executor,
                 profile.model.as_deref().unwrap_or("auto")
             ),
-        },
-        Err(error) => Check {
-            name: "Runtime config",
-            status: Status::Fail,
-            detail: format!("{} invalid: {}", path.display(), error),
-        },
+        ),
+        Err(error) => Check::new(
+            "Runtime config",
+            Status::Fail,
+            format!("{} invalid: {}", path.display(), error),
+        ),
     }
 }

--- a/src/doctor/schema.rs
+++ b/src/doctor/schema.rs
@@ -1,44 +1,34 @@
 use super::types::{Check, Status};
 use crate::db;
+use rusqlite::Connection;
 
-pub(super) fn check_schema_migration() -> Check {
+pub(super) fn check_schema_migration(conn: Option<&Connection>, open_error: Option<&str>) -> Check {
     let db_path = db::db_path();
     if !db_path.exists() {
-        return Check {
-            name: "Schema",
-            status: Status::Ok,
-            detail: "no database yet (will create on first use)".into(),
-        };
+        return Check::new(
+            "Schema",
+            Status::Ok,
+            "no database yet (will create on first use)",
+        );
     }
 
-    let key = match db::require_cipher_key_or_plaintext_override() {
-        Ok(key) => key,
-        Err(err) => {
-            return Check {
-                name: "Schema",
-                status: Status::Fail,
-                detail: format!("cannot open DB: {}", err),
-            };
-        }
+    let Some(conn) = conn else {
+        return Check::new(
+            "Schema",
+            Status::Fail,
+            format!(
+                "cannot open DB: {}",
+                open_error.unwrap_or("database connection unavailable")
+            ),
+        );
     };
-
-    let real_conn = match db::open_configured_connection(&db_path, key.as_ref()) {
-        Ok(conn) => conn,
-        Err(err) => {
-            return Check {
-                name: "Schema",
-                status: Status::Fail,
-                detail: format!("cannot open DB: {}", err),
-            };
-        }
-    };
-    match crate::migrate::dry_run_pending(&real_conn) {
+    match crate::migrate::dry_run_pending(conn) {
         Ok(result) => {
             if let Some(err) = result.error {
-                Check {
-                    name: "Schema",
-                    status: Status::Fail,
-                    detail: if result.pending_count == 0 {
+                Check::new(
+                    "Schema",
+                    Status::Fail,
+                    if result.pending_count == 0 {
                         format!("schema check failed: {}", err)
                     } else {
                         format!(
@@ -46,29 +36,25 @@ pub(super) fn check_schema_migration() -> Check {
                             result.pending_count, err
                         )
                     },
-                }
+                )
             } else if result.pending_count == 0 {
-                Check {
-                    name: "Schema",
-                    status: Status::Ok,
-                    detail: format!("v{} (up to date)", result.current_version),
-                }
+                Check::new(
+                    "Schema",
+                    Status::Ok,
+                    format!("v{} (up to date)", result.current_version),
+                )
             } else {
-                Check {
-                    name: "Schema",
-                    status: Status::Ok,
-                    detail: format!(
+                Check::new(
+                    "Schema",
+                    Status::Ok,
+                    format!(
                         "v{} ({} pending migration(s), dry-run passed)",
                         result.current_version, result.pending_count
                     ),
-                }
+                )
             }
         }
-        Err(err) => Check {
-            name: "Schema",
-            status: Status::Fail,
-            detail: format!("dry-run error: {}", err),
-        },
+        Err(err) => Check::new("Schema", Status::Fail, format!("dry-run error: {}", err)),
     }
 }
 
@@ -81,21 +67,17 @@ pub(super) fn check_key_format() -> Check {
 
     let key_path = db::data_dir().join(".key");
     if !key_path.exists() {
-        return Check {
-            name: "Key format",
-            status: Status::Ok,
-            detail: "no SQLCipher key file yet".into(),
-        };
+        return Check::new("Key format", Status::Ok, "no SQLCipher key file yet");
     }
 
     let key_text = match std::fs::read_to_string(&key_path) {
         Ok(key_text) => key_text,
         Err(error) => {
-            return Check {
-                name: "Key format",
-                status: Status::Fail,
-                detail: format!("cannot read {}: {}", key_path.display(), error),
-            };
+            return Check::new(
+                "Key format",
+                Status::Fail,
+                format!("cannot read {}: {}", key_path.display(), error),
+            );
         }
     };
     let source = key_path.display().to_string();
@@ -104,35 +86,35 @@ pub(super) fn check_key_format() -> Check {
 
 fn check_key_format_value(source: &str, key_text: &str, is_file: bool) -> Check {
     match db::parse_cipher_key(key_text) {
-        Ok(Some(db::CipherKey::Raw(_))) => Check {
-            name: "Key format",
-            status: Status::Ok,
-            detail: format!("raw-key format (v2) from {source}"),
-        },
-        Ok(Some(db::CipherKey::Passphrase(_))) => Check {
-            name: "Key format",
-            status: Status::Warn,
-            detail: if is_file {
+        Ok(Some(db::CipherKey::Raw(_))) => Check::new(
+            "Key format",
+            Status::Ok,
+            format!("raw-key format (v2) from {source}"),
+        ),
+        Ok(Some(db::CipherKey::Passphrase(_))) => Check::new(
+            "Key format",
+            Status::Warn,
+            if is_file {
                 format!("legacy passphrase key format in {source}; run `remem encrypt --rekey-raw`")
             } else {
                 format!(
                     "legacy passphrase key format in {source}; use v2:<64hex> or unset {source} and run `remem encrypt --rekey-raw`"
                 )
             },
-        },
-        Ok(None) => Check {
-            name: "Key format",
-            status: Status::Fail,
-            detail: if is_file {
+        ),
+        Ok(None) => Check::new(
+            "Key format",
+            Status::Fail,
+            if is_file {
                 format!("empty SQLCipher key file at {source}")
             } else {
                 format!("empty SQLCipher key in {source}")
             },
-        },
-        Err(error) => Check {
-            name: "Key format",
-            status: Status::Fail,
-            detail: format!("invalid SQLCipher key in {source}: {error}"),
-        },
+        ),
+        Err(error) => Check::new(
+            "Key format",
+            Status::Fail,
+            format!("invalid SQLCipher key in {source}: {error}"),
+        ),
     }
 }

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -1,6 +1,8 @@
 use rusqlite::params;
 
-use crate::db::test_support::ScopedTestDataDir;
+use crate::db::test_support::{
+    reset_runtime_connection_open_count, runtime_connection_open_count, ScopedTestDataDir,
+};
 use crate::{db, memory};
 
 use super::database::{
@@ -72,9 +74,7 @@ fn check_database_reports_shared_active_memory_count() {
     .expect("archive update should succeed");
 
     let stats = db::query_system_stats(&conn).expect("system stats should load");
-    drop(conn);
-
-    let check = check_database();
+    let check = check_database(Some(&conn), None);
     assert_eq!(check.icon(), "ok");
     assert!(check
         .detail
@@ -213,9 +213,7 @@ fn check_pending_queue_reports_shared_counts() -> anyhow::Result<()> {
     )?;
 
     let stats = db::query_system_stats(&conn).expect("system stats should load");
-    drop(conn);
-
-    let check = check_pending_queue();
+    let check = check_pending_queue(Some(&conn));
     assert_eq!(check.icon(), "WARN");
     let expected_counts = format!(
         "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} jobs pending, {} processing, {} failed, {} stuck",
@@ -276,9 +274,7 @@ fn check_raw_archive_ingest_warns_on_recorded_failures() -> anyhow::Result<()> {
                  'read_error', 'read failed', 0, 0, 0, 0, ?1)",
         params![chrono::Utc::now().timestamp()],
     )?;
-    drop(conn);
-
-    let check = check_raw_archive_ingest();
+    let check = check_raw_archive_ingest(Some(&conn));
     assert_eq!(check.icon(), "WARN");
     assert!(check.detail.contains("1 failure"), "{}", check.detail);
     assert!(check.detail.contains("read_error"), "{}", check.detail);
@@ -301,13 +297,11 @@ fn check_temporal_facts_warns_when_fact_table_is_empty() -> anyhow::Result<()> {
         None,
     )?;
     let stats = db::query_memory_facts_stats(&conn)?;
-    drop(conn);
-
     assert!(stats.table_exists);
     assert_eq!(stats.total, 0);
     assert_eq!(stats.retrieval_eligible, 0);
 
-    let check = check_temporal_facts();
+    let check = check_temporal_facts(Some(&conn));
     assert_eq!(check.icon(), "WARN");
     assert!(
         check
@@ -331,15 +325,13 @@ fn check_temporal_facts_is_ok_when_store_has_no_source_data() -> anyhow::Result<
     let _test_dir = ScopedTestDataDir::new("doctor-temporal-facts-empty-store");
     let conn = db::open_db()?;
     let stats = db::query_memory_facts_stats(&conn)?;
-    drop(conn);
-
     assert!(stats.table_exists);
     assert_eq!(stats.total, 0);
     assert_eq!(stats.retrieval_eligible, 0);
     assert_eq!(stats.active_memories, 0);
     assert_eq!(stats.captured_events, 0);
 
-    let check = check_temporal_facts();
+    let check = check_temporal_facts(Some(&conn));
     assert_eq!(check.icon(), "ok");
     assert!(
         check.detail.contains("no memories or captured events yet"),
@@ -374,12 +366,10 @@ fn check_temporal_facts_warns_when_rows_are_not_retrievable() -> anyhow::Result<
         params![now],
     )?;
     let stats = db::query_memory_facts_stats(&conn)?;
-    drop(conn);
-
     assert_eq!(stats.total, 1);
     assert_eq!(stats.retrieval_eligible, 0);
 
-    let check = check_temporal_facts();
+    let check = check_temporal_facts(Some(&conn));
     assert_eq!(check.icon(), "WARN");
     assert!(
         check.detail.contains("0 of 1 fact row(s)"),
@@ -418,12 +408,10 @@ fn check_temporal_facts_warns_when_source_memory_is_expired() -> anyhow::Result<
         params![now, memory_id],
     )?;
     let stats = db::query_memory_facts_stats(&conn)?;
-    drop(conn);
-
     assert_eq!(stats.total, 1);
     assert_eq!(stats.retrieval_eligible, 0);
 
-    let check = check_temporal_facts();
+    let check = check_temporal_facts(Some(&conn));
     assert_eq!(check.icon(), "WARN");
     assert!(
         check.detail.contains("0 of 1 fact row(s)"),
@@ -458,12 +446,10 @@ fn check_temporal_facts_is_ok_when_fact_table_has_rows() -> anyhow::Result<()> {
         params![now, memory_id],
     )?;
     let stats = db::query_memory_facts_stats(&conn)?;
-    drop(conn);
-
     assert_eq!(stats.total, 1);
     assert_eq!(stats.retrieval_eligible, 1);
 
-    let check = check_temporal_facts();
+    let check = check_temporal_facts(Some(&conn));
     assert_eq!(check.icon(), "ok");
     assert!(
         check
@@ -481,9 +467,8 @@ fn check_schema_migration_reads_encrypted_database() -> anyhow::Result<()> {
     std::fs::create_dir_all(&test_dir.path)?;
     std::fs::write(test_dir.path.join(".key"), "doctor-schema-key")?;
     let conn = db::open_db()?;
-    drop(conn);
 
-    let check = check_schema_migration();
+    let check = check_schema_migration(Some(&conn), None);
     assert_eq!(check.icon(), "ok");
     assert!(check.detail.contains("up to date"), "got: {}", check.detail);
     Ok(())
@@ -498,9 +483,7 @@ fn check_schema_migration_reports_v022_schema_drift() -> anyhow::Result<()> {
          DROP TABLE memory_state_keys;
          PRAGMA foreign_keys=ON;",
     )?;
-    drop(conn);
-
-    let check = check_schema_migration();
+    let check = check_schema_migration(Some(&conn), None);
     assert_eq!(check.icon(), "FAIL");
     assert!(
         check.detail.contains("schema drift"),
@@ -535,12 +518,34 @@ fn run_doctor_with_writer_returns_outcome_and_emits_human_lines() {
     let text = String::from_utf8(buf).expect("output should be utf-8");
     assert!(text.contains("system check"));
     assert!(text.contains("Database"));
+    assert!(text.contains("ms)"), "{text}");
     // Exit code is a function of fails/warns; the absolute counts depend on
     // host config (claude/codex hooks may or may not exist on the test
     // machine), but the contract — fails maps to exit 2 — must hold.
     if outcome.fails > 0 {
         assert_eq!(outcome.exit_code(), 2);
     }
+}
+
+#[test]
+fn run_doctor_with_writer_opens_one_shared_database_connection() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-run-one-connection");
+    let conn = db::open_db()?;
+    drop(conn);
+
+    reset_runtime_connection_open_count();
+    let mut buf = Vec::new();
+    let outcome = run_doctor_with_writer(
+        DoctorOptions {
+            json: false,
+            quiet: true,
+        },
+        &mut buf,
+    )?;
+
+    assert!(outcome.exit_code() <= 2);
+    assert_eq!(runtime_connection_open_count(), 1);
+    Ok(())
 }
 
 #[test]
@@ -561,10 +566,15 @@ fn run_doctor_with_writer_emits_parseable_json() {
     let text = String::from_utf8(buf).expect("output should be utf-8");
     let parsed: serde_json::Value =
         serde_json::from_str(text.trim()).expect("output must be a single JSON object");
+    assert_eq!(parsed["schema_version"], 2);
     assert!(parsed["version"].is_string());
     assert!(parsed["status"].is_string());
+    assert!(parsed["elapsed_ms"].is_u64());
     let checks = parsed["checks"].as_array().expect("checks must be array");
     assert!(!checks.is_empty(), "doctor should always emit some checks");
+    for check in checks {
+        assert!(check["duration_ms"].is_u64(), "{check}");
+    }
     assert_eq!(
         parsed["fails"].as_u64().unwrap_or(0) as usize,
         outcome.fails
@@ -573,6 +583,33 @@ fn run_doctor_with_writer_emits_parseable_json() {
         parsed["warns"].as_u64().unwrap_or(0) as usize,
         outcome.warns
     );
+}
+
+#[test]
+fn run_doctor_with_writer_json_wins_over_quiet() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-run-json-quiet");
+    let conn = db::open_db()?;
+    drop(conn);
+
+    let mut buf: Vec<u8> = Vec::new();
+    let outcome = run_doctor_with_writer(
+        DoctorOptions {
+            json: true,
+            quiet: true,
+        },
+        &mut buf,
+    )?;
+
+    let text = String::from_utf8(buf).expect("output should be utf-8");
+    let parsed: serde_json::Value =
+        serde_json::from_str(text.trim()).expect("output must be a single JSON object");
+    assert_eq!(
+        parsed["fails"].as_u64().unwrap_or_default() as usize,
+        outcome.fails
+    );
+    assert!(parsed["checks"].is_array());
+    assert!(parsed["elapsed_ms"].is_u64());
+    Ok(())
 }
 
 #[test]
@@ -606,9 +643,7 @@ fn check_worker_daemon_reports_healthy_heartbeat() {
         now - 5,
     )
     .expect("heartbeat should insert");
-    drop(conn);
-
-    let check = check_worker_daemon();
+    let check = check_worker_daemon(Some(&conn));
     assert_eq!(check.icon(), "ok");
     assert!(check.detail.contains("healthy"));
     assert!(check.detail.contains("worker-daemon"));
@@ -618,9 +653,7 @@ fn check_worker_daemon_reports_healthy_heartbeat() {
 fn check_worker_daemon_reports_missing_as_fallback_ok() -> anyhow::Result<()> {
     let _test_dir = ScopedTestDataDir::new("doctor-worker-missing");
     let conn = db::open_db()?;
-    drop(conn);
-
-    let check = check_worker_daemon();
+    let check = check_worker_daemon(Some(&conn));
     assert_eq!(check.icon(), "ok");
     assert_eq!(
         check.detail,

--- a/src/doctor/types.rs
+++ b/src/doctor/types.rs
@@ -6,6 +6,7 @@ pub(crate) struct Check {
     pub name: &'static str,
     pub status: Status,
     pub detail: String,
+    pub duration_ms: u64,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -38,6 +39,20 @@ impl Status {
 }
 
 impl Check {
+    pub(crate) fn new(name: &'static str, status: Status, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            status,
+            detail: detail.into(),
+            duration_ms: 0,
+        }
+    }
+
+    pub(crate) fn with_duration_ms(mut self, duration_ms: u64) -> Self {
+        self.duration_ms = duration_ms;
+        self
+    }
+
     pub(crate) fn icon(&self) -> &'static str {
         self.status.icon()
     }
@@ -71,9 +86,9 @@ impl DoctorOutcome {
     }
 }
 
-/// Current JSON contract version. Bump when removing or renaming a field;
-/// adding new optional fields does NOT require a bump.
-pub(crate) const REPORT_SCHEMA_VERSION: u32 = 1;
+/// Current JSON contract version. Bump when removing or renaming a field, or
+/// when adding mandatory observability fields to every check/root report.
+pub(crate) const REPORT_SCHEMA_VERSION: u32 = 2;
 
 /// JSON-stable shape for `remem doctor --json`. Field names and the
 /// `status` tag are part of the CLI's machine-readable contract; do not
@@ -83,6 +98,7 @@ pub(crate) struct CheckJson<'a> {
     pub name: &'a str,
     pub status: &'a str,
     pub detail: &'a str,
+    pub duration_ms: u64,
 }
 
 #[derive(Serialize)]
@@ -93,5 +109,6 @@ pub(crate) struct ReportJson<'a> {
     pub status: &'a str,
     pub fails: usize,
     pub warns: usize,
+    pub elapsed_ms: u64,
     pub checks: Vec<CheckJson<'a>>,
 }


### PR DESCRIPTION
## Summary
- stream human `remem doctor` checks as they finish and flush each line
- reuse one shared read-only DB connection for DB-backed doctor checks
- add per-check `duration_ms` plus root `elapsed_ms` in JSON schema v2
- warn on slow checks without changing check status, and keep `--json` as one final document
- bump release metadata to `0.5.28`

Fixes #408. Part of #402.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo check --message-format=short`
- `cargo clippy -- -D warnings`
- `cargo test doctor --lib -- --nocapture` (44 passed)
- `cargo test` (1071 lib tests + integration/doc tests passed)
- `cargo build`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js` (24 passed)
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `python3 scripts/ci/check_plugin_version_sync.py`

Runtime checks:
- first human check line observed in `1813.1ms`: `  [ok] Binary: /private/tmp/remem-issue408/target/debug/remem (0ms)`
- `remem doctor --json` parsed as one JSON object with `schema_version=2`, integer root `elapsed_ms`, 16 checks, and integer `duration_ms` on every check

## Review notes
- Independent read-only review initially found a Hooks/MCP timing gap.
- Fixed by timing Vec-backed check batches in the runner before pushing each check.
- Follow-up read-only review reported no findings and no new blocker.
