### PR TITLE
Add Remem app current-state and trace tools

### DIFF
--- a/plugins/remem/apps/remem/README.md
+++ b/plugins/remem/apps/remem/README.md
@@ -9,7 +9,27 @@ This app surface provides:
 - search: compact results with detail drill-down
 - save memory: explicit decision, bugfix, architecture, discovery, or preference save
 - governance: stale, reject, or delete dry-run preview with affected IDs and status transitions
+- current-state resolution: stable state keys with current/conflict/history metadata
+- traceability: commit lookup and session-to-commit links
 - activation: hooks-only dry-run plan without writing Codex config
+
+## Surface map
+
+| Surface | App tool | HTTP route | Remem backend |
+| --- | --- | --- | --- |
+| Dashboard | `remem_dashboard` | `GET /api/status` | `remem status --json`, `remem doctor --json`, runtime inspection |
+| Search | `remem_search` | `GET /api/search` | local Remem API `GET /api/v1/search` |
+| Detail | `remem_get_memory` | `GET /api/memory` | local Remem API `GET /api/v1/memory` |
+| Save | `remem_save_memory` | `POST /api/save` | local Remem API `POST /api/v1/memories` |
+| Governance preview | `remem_governance_preview` | `POST /api/governance-preview` | `remem govern --dry-run --json` |
+| Current state | `remem_current_state` | `GET /api/current-state` | `remem current --json` |
+| Commit lookup | `remem_commit_lookup` | `GET /api/commit` | `remem commit show --json` |
+| Session commits | `remem_session_commits` | `GET /api/session-commits` | `remem commit session --json` |
+| Activation plan | `remem_activation_plan` | `GET /api/activation-plan` | `remem install --target codex --hooks-only --dry-run` |
+
+Workstream mutation and chronological timeline browsing remain MCP-native Rust
+tools today. Add them to this app after a small HTTP/MCP bridge exists; do not
+parse human CLI output for those surfaces.
 
 Run locally:
 

--- a/plugins/remem/apps/remem/server.js
+++ b/plugins/remem/apps/remem/server.js
@@ -149,6 +149,18 @@ function runProcess(command, args, options = {}) {
   });
 }
 
+function requiredText(value, name) {
+  const text = String(value || "").trim();
+  if (!text) throw Object.assign(new Error(`${name} is required`), { statusCode: 400 });
+  return text;
+}
+
+function pushOptional(args, flag, value) {
+  if (value !== undefined && value !== null && String(value).trim() !== "") {
+    args.push(flag, String(value));
+  }
+}
+
 async function runRemem(args, options = {}) {
   const binary = options.binary || (await ensureRuntime({
     allowDownload: options.allowDownload === true,
@@ -382,6 +394,35 @@ function createBackend(options = {}) {
         requested
       };
     },
+    async currentState(input) {
+      const args = ["current", requiredText(input.state_key, "state_key"), "--json"];
+      pushOptional(args, "--project", input.project);
+      pushOptional(args, "--type", input.memory_type);
+      pushOptional(args, "--owner-scope", input.owner_scope);
+      pushOptional(args, "--owner-key", input.owner_key);
+      pushOptional(args, "--as-of-epoch", input.as_of_epoch);
+      return runRememJson(args, {
+        allowDownload: false,
+        timeoutMs: 15000
+      });
+    },
+    async commitLookup(input) {
+      const args = ["commit", "show", requiredText(input.sha, "sha"), "--json"];
+      pushOptional(args, "--project", input.project);
+      return runRememJson(args, {
+        allowDownload: false,
+        timeoutMs: 15000
+      });
+    },
+    async sessionCommits(input) {
+      const args = ["commit", "session", requiredText(input.session_id, "session_id"), "--json"];
+      pushOptional(args, "--project", input.project);
+      pushOptional(args, "--limit", input.limit || 20);
+      return runRememJson(args, {
+        allowDownload: false,
+        timeoutMs: 15000
+      });
+    },
     stop() {
       api.stop?.();
     }
@@ -500,6 +541,22 @@ async function callTool(backend, name, args = {}) {
       result
     );
   }
+  if (name === "remem_current_state") {
+    const result = await backend.currentState(args);
+    return toolResult(`Current state ${result.status || "resolved"}.`, result);
+  }
+  if (name === "remem_commit_lookup") {
+    const result = await backend.commitLookup(args);
+    return toolResult(`Found ${Array.isArray(result) ? result.length : 0} commit match(es).`, {
+      results: result
+    });
+  }
+  if (name === "remem_session_commits") {
+    const result = await backend.sessionCommits(args);
+    return toolResult(`Found ${Array.isArray(result) ? result.length : 0} linked commit(s).`, {
+      results: result
+    });
+  }
   throw Object.assign(new Error(`Unknown tool: ${name}`), { code: -32602 });
 }
 
@@ -594,6 +651,15 @@ function createServer(options = {}) {
       }
       if (req.method === "GET" && url.pathname === "/api/activation-plan") {
         return jsonResponse(res, 200, await backend.activationPlan());
+      }
+      if (req.method === "GET" && url.pathname === "/api/current-state") {
+        return jsonResponse(res, 200, await backend.currentState(Object.fromEntries(url.searchParams)));
+      }
+      if (req.method === "GET" && url.pathname === "/api/commit") {
+        return jsonResponse(res, 200, await backend.commitLookup(Object.fromEntries(url.searchParams)));
+      }
+      if (req.method === "GET" && url.pathname === "/api/session-commits") {
+        return jsonResponse(res, 200, await backend.sessionCommits(Object.fromEntries(url.searchParams)));
       }
       if (req.method === "POST" && url.pathname === "/api/save") {
         assertLocalPostAllowed(req);

--- a/plugins/remem/apps/remem/server.test.js
+++ b/plugins/remem/apps/remem/server.test.js
@@ -120,6 +120,43 @@ function fakeBackend() {
         ]
       };
     },
+    async currentState(input) {
+      return {
+        state_key: input.state_key,
+        status: "current",
+        current: {
+          id: 11,
+          title: "Current deployment target"
+        },
+        history: []
+      };
+    },
+    async commitLookup(input) {
+      return [
+        {
+          git: {
+            sha: input.sha,
+            short_sha: String(input.sha).slice(0, 7),
+            message: "Wire Remem app trace tools"
+          },
+          sessions: []
+        }
+      ];
+    },
+    async sessionCommits(input) {
+      return [
+        {
+          link: {
+            session_id: input.session_id,
+            source: "test"
+          },
+          git: {
+            sha: "abcdef123456",
+            short_sha: "abcdef1"
+          }
+        }
+      ];
+    },
     stop() {}
   };
 }
@@ -155,7 +192,10 @@ test("widget-callable tools are exposed to the app surface", () => {
     "remem_get_memory",
     "remem_save_memory",
     "remem_activation_plan",
-    "remem_governance_preview"
+    "remem_governance_preview",
+    "remem_current_state",
+    "remem_commit_lookup",
+    "remem_session_commits"
   ]) {
     const descriptor = toolDescriptors().find((tool) => tool.name === name);
     assert.deepEqual(descriptor._meta.ui.visibility, ["model", "app"]);
@@ -171,6 +211,8 @@ test("JSON-RPC tools/list and dashboard call return structured content", async (
   });
   assert.ok(tools.tools.some((tool) => tool.name === "remem_save_memory"));
   assert.ok(tools.tools.some((tool) => tool.name === "remem_governance_preview"));
+  assert.ok(tools.tools.some((tool) => tool.name === "remem_current_state"));
+  assert.ok(tools.tools.some((tool) => tool.name === "remem_commit_lookup"));
 
   const result = await handleJsonRpc(fakeBackend(), {
     id: 2,
@@ -213,6 +255,21 @@ test("HTTP API serves widget, status, search, memory detail, and save", async ()
     }).then((response) => response.json());
     assert.equal(preview.dry_run, true);
     assert.equal(preview.affected[0].id, 7);
+
+    const current = await fetch(`${base}/api/current-state?state_key=deploy-target`).then((response) =>
+      response.json()
+    );
+    assert.equal(current.current.id, 11);
+
+    const commit = await fetch(`${base}/api/commit?sha=abcdef123456`).then((response) =>
+      response.json()
+    );
+    assert.equal(commit[0].git.short_sha, "abcdef1");
+
+    const sessionCommits = await fetch(`${base}/api/session-commits?session_id=session-1`).then(
+      (response) => response.json()
+    );
+    assert.equal(sessionCommits[0].link.session_id, "session-1");
   });
 });
 
@@ -290,6 +347,29 @@ test("widget routes embedded app actions through host tool calls", async () => {
     assert.match(widget, /remem_governance_preview/);
     assert.match(widget, /\/api\/governance-preview/);
   });
+});
+
+test("JSON-RPC trace tools return structured content", async () => {
+  const current = await handleJsonRpc(fakeBackend(), {
+    id: 1,
+    method: "tools/call",
+    params: { name: "remem_current_state", arguments: { state_key: "deploy-target" } }
+  });
+  assert.equal(current.structuredContent.current.id, 11);
+
+  const commit = await handleJsonRpc(fakeBackend(), {
+    id: 2,
+    method: "tools/call",
+    params: { name: "remem_commit_lookup", arguments: { sha: "abcdef123456" } }
+  });
+  assert.equal(commit.structuredContent.results[0].git.short_sha, "abcdef1");
+
+  const sessionCommits = await handleJsonRpc(fakeBackend(), {
+    id: 3,
+    method: "tools/call",
+    params: { name: "remem_session_commits", arguments: { session_id: "session-1" } }
+  });
+  assert.equal(sessionCommits.structuredContent.results[0].link.session_id, "session-1");
 });
 
 test("governance preview args are always dry-run JSON CLI calls", () => {

--- a/plugins/remem/apps/remem/tools.js
+++ b/plugins/remem/apps/remem/tools.js
@@ -132,6 +132,68 @@ function toolDescriptors() {
         ui: { visibility: ["model", "app"] },
         "openai/widgetAccessible": true
       }
+    },
+    {
+      name: "remem_current_state",
+      title: "Resolve Current State",
+      description: "Resolve the current Remem memory for a stable state key, including conflict and history metadata.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          state_key: { type: "string" },
+          project: { type: "string" },
+          memory_type: { type: "string" },
+          owner_scope: { type: "string" },
+          owner_key: { type: "string" },
+          as_of_epoch: { type: "number" }
+        },
+        required: ["state_key"],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    },
+    {
+      name: "remem_commit_lookup",
+      title: "Lookup Commit Memory",
+      description: "Look up git commit metadata and linked Remem memory sessions by full or short SHA.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          sha: { type: "string" },
+          project: { type: "string" }
+        },
+        required: ["sha"],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    },
+    {
+      name: "remem_session_commits",
+      title: "Session Commits",
+      description: "List git commits linked to a content session ID or Remem memory session ID.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          session_id: { type: "string" },
+          project: { type: "string" },
+          limit: { type: "number" }
+        },
+        required: ["session_id"],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
     }
   ];
 }


### PR DESCRIPTION
## Summary
- add read-only Remem Apps SDK tools and HTTP routes for current-state lookup, commit lookup, and session commit traceability
- document the exact GUI surface-to-backend operation map, including current state and trace flows
- keep `.app.json` out until a real Apps SDK app/connector id exists, and document remaining MCP-native workstream/timeline bridge work

## Verification
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `python3 /Users/lifcc/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/remem`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `git diff --check origin/main...HEAD`
- `cargo check --message-format=short`
- `cargo test`

Refs #390
