### PR TITLE
Publish checked plugin runtime manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
         run: |
           cd artifacts
           find . -name '*.tar.gz' -type f -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+      - name: Generate plugin runtime manifest
+        run: python3 scripts/ci/generate_plugin_release_manifest.py "${GITHUB_REF_NAME#v}" artifacts artifacts/remem-releases.json
       - name: Create Release
         uses: softprops/action-gh-release@v3.0.0
         with:
@@ -67,6 +69,7 @@ jobs:
           files: |
             artifacts/**/*.tar.gz
             artifacts/SHA256SUMS
+            artifacts/remem-releases.json
 
   publish-crate:
     needs: release

--- a/plugins/remem/README.md
+++ b/plugins/remem/README.md
@@ -46,10 +46,13 @@ node plugins/remem/scripts/remem-runtime.js install
 node plugins/remem/scripts/remem-runtime.js status
 ```
 
-Release download support is intentionally checksum-gated. Until a matching
-release manifest exists for the plugin version, fresh installs outside a local
-checkout must provide `REMEM_BINARY` or use a published plugin build that
-includes checked runtime assets.
+Release download support is intentionally checksum-gated. The release workflow
+uploads platform tarballs, `SHA256SUMS`, and a release-hosted
+`remem-releases.json` manifest with exact asset checksums. The checked-in
+manifest only needs the version and `base_url`; when its asset map is empty, the
+runtime manager fetches the release-hosted manifest before downloading a binary.
+Fresh installs outside a local checkout must provide `REMEM_BINARY` until a
+matching GitHub release has those checked assets.
 
 CI enforces that `Cargo.toml`, `Cargo.lock`,
 `.codex-plugin/plugin.json`, and `runtimes/remem-releases.json` carry the same

--- a/plugins/remem/scripts/remem-runtime.js
+++ b/plugins/remem/scripts/remem-runtime.js
@@ -9,6 +9,7 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 const VERSION_RE = /remem\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s]+)?)\s+\(schema v([0-9]+)\)/;
+const REMOTE_MANIFEST_BYTES = 1_000_000;
 
 function binaryName() {
   return process.platform === "win32" ? "remem.exe" : "remem";
@@ -245,6 +246,10 @@ function readReleaseManifest(options = {}) {
   return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
 }
 
+function defaultReleaseBaseUrl(expected) {
+  return `https://github.com/majiayu000/remem/releases/download/v${expected}`;
+}
+
 function platformKey() {
   const platform = os.platform();
   const arch = os.arch();
@@ -255,19 +260,90 @@ function platformKey() {
   throw new Error(`Unsupported platform: ${platform}/${arch}`);
 }
 
-function releaseAssetForCurrentPlatform(options = {}) {
-  const manifest = readReleaseManifest(options);
-  if (!manifest) return null;
-  const expected = expectedVersion(options);
-  const release = manifest.versions && manifest.versions[expected];
+function readJsonFromHttps(url, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if (
+        response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        response.headers.location
+      ) {
+        response.resume();
+        if (redirects >= 5) {
+          reject(new Error(`Too many redirects while downloading ${url}`));
+          return;
+        }
+        const next = new URL(response.headers.location, url).toString();
+        resolve(readJsonFromHttps(next, redirects + 1));
+        return;
+      }
+
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`Download failed with HTTP ${response.statusCode}: ${url}`));
+        return;
+      }
+
+      let size = 0;
+      const chunks = [];
+      response.on("data", (chunk) => {
+        size += chunk.length;
+        if (size > REMOTE_MANIFEST_BYTES) {
+          request.destroy(new Error(`Remote manifest exceeds ${REMOTE_MANIFEST_BYTES} bytes`));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.on("end", () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+        } catch (error) {
+          reject(new Error(`Invalid remote manifest JSON: ${error.message}`));
+        }
+      });
+    });
+    request.on("error", reject);
+  });
+}
+
+async function fetchReleaseManifest(url, options = {}) {
+  if (options.fetchJson) return options.fetchJson(url);
+  return readJsonFromHttps(url);
+}
+
+function releaseEntry(manifest, expected) {
+  const versions = manifest && manifest.versions;
+  if (!versions || typeof versions !== "object") return null;
+  const release = versions[expected];
+  if (!release || typeof release !== "object") return null;
+  return release;
+}
+
+function releaseAssetFromManifest(manifest, expected, key, fallbackBaseUrl) {
+  const release = releaseEntry(manifest, expected);
   if (!release) return null;
-  const asset = release.assets && release.assets[platformKey()];
+  const asset = release.assets && release.assets[key];
   if (!asset) return null;
-  const baseUrl = release.base_url || `https://github.com/majiayu000/remem/releases/download/v${expected}`;
+  const baseUrl = release.base_url || fallbackBaseUrl || defaultReleaseBaseUrl(expected);
   return {
     ...asset,
-    url: asset.url || `${baseUrl}/${asset.file}`
+    url: asset.url || `${baseUrl.replace(/\/$/, "")}/${asset.file}`
   };
+}
+
+async function releaseAssetForCurrentPlatform(options = {}) {
+  const expected = expectedVersion(options);
+  const key = platformKey();
+  const manifest = readReleaseManifest(options);
+  const localRelease = releaseEntry(manifest, expected);
+  const localBaseUrl = localRelease?.base_url || defaultReleaseBaseUrl(expected);
+  const localAsset = releaseAssetFromManifest(manifest, expected, key, localBaseUrl);
+  if (localAsset || options.remoteManifest === false) return localAsset;
+  if (!localRelease?.base_url) return null;
+
+  const remoteManifestUrl = `${localRelease.base_url.replace(/\/$/, "")}/remem-releases.json`;
+  const remoteManifest = await fetchReleaseManifest(remoteManifestUrl, options);
+  return releaseAssetFromManifest(remoteManifest, expected, key, localRelease.base_url);
 }
 
 function download(url, dest, redirects = 0) {
@@ -310,7 +386,7 @@ function sha256(file) {
 }
 
 async function downloadRuntime(options = {}) {
-  const asset = releaseAssetForCurrentPlatform(options);
+  const asset = await releaseAssetForCurrentPlatform(options);
   if (!asset) {
     throw new Error(
       `No checked release asset is available for remem ${expectedVersion(options)} on ${platformKey()}`
@@ -550,6 +626,7 @@ module.exports = {
   pathCandidates,
   pluginDataDir,
   pluginRoot,
+  releaseAssetForCurrentPlatform,
   repoCandidates,
   repoRoot,
   runRemem,

--- a/plugins/remem/scripts/remem-runtime.test.js
+++ b/plugins/remem/scripts/remem-runtime.test.js
@@ -16,6 +16,7 @@ const {
   inspectRuntime,
   managedBinaryPath,
   pluginDataDir,
+  releaseAssetForCurrentPlatform,
   runRememAsync,
   runtimeMetadataPath,
   shouldCodesignRuntime
@@ -126,6 +127,75 @@ test("installRuntime honors no-download fallback", async () => {
       assert.doesNotMatch(error.message, /No checked release asset/);
       return true;
     }
+  );
+});
+
+test("release asset resolver uses release-hosted manifest when local assets are empty", async () => {
+  const fx = fixture();
+  writeJson(path.join(fx.pluginRoot, "runtimes", "remem-releases.json"), {
+    versions: {
+      "0.5.17": {
+        base_url: "https://example.test/remem/releases/download/v0.5.17",
+        assets: {}
+      }
+    }
+  });
+  const sha = "a".repeat(64);
+
+  const asset = await releaseAssetForCurrentPlatform({
+    ...fx,
+    fetchJson: async (url) => {
+      assert.equal(url, "https://example.test/remem/releases/download/v0.5.17/remem-releases.json");
+      return {
+        versions: {
+          "0.5.17": {
+            assets: {
+              "darwin-arm64": { file: "remem-darwin-arm64.tar.gz", sha256: sha },
+              "darwin-x64": { file: "remem-darwin-x64.tar.gz", sha256: sha },
+              "linux-arm64": { file: "remem-linux-arm64.tar.gz", sha256: sha },
+              "linux-x64": { file: "remem-linux-x64.tar.gz", sha256: sha }
+            }
+          }
+        }
+      };
+    }
+  });
+
+  assert.match(asset.file, /^remem-(darwin|linux)-/);
+  assert.equal(asset.sha256, sha);
+  assert.match(asset.url, /^https:\/\/example\.test\/remem\/releases\/download\/v0\.5\.17\/remem-/);
+});
+
+test("release download rejects remote manifest assets without valid checksums", async () => {
+  const fx = fixture();
+  writeJson(path.join(fx.pluginRoot, "runtimes", "remem-releases.json"), {
+    versions: {
+      "0.5.17": {
+        base_url: "https://example.test/remem/releases/download/v0.5.17",
+        assets: {}
+      }
+    }
+  });
+
+  await assert.rejects(
+    () =>
+      ensureRuntime({
+        ...fx,
+        allowDownload: true,
+        fetchJson: async () => ({
+          versions: {
+            "0.5.17": {
+              assets: {
+                "linux-x64": { file: "remem-linux-x64.tar.gz", sha256: "not-a-sha" },
+                "linux-arm64": { file: "remem-linux-arm64.tar.gz", sha256: "not-a-sha" },
+                "darwin-x64": { file: "remem-darwin-x64.tar.gz", sha256: "not-a-sha" },
+                "darwin-arm64": { file: "remem-darwin-arm64.tar.gz", sha256: "not-a-sha" }
+              }
+            }
+          }
+        })
+      }),
+    /missing a valid sha256/
   );
 });
 

--- a/scripts/ci/generate_plugin_release_manifest.py
+++ b/scripts/ci/generate_plugin_release_manifest.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate the Codex plugin runtime release manifest from SHA256SUMS."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+EXPECTED_ASSETS = {
+    "remem-darwin-arm64.tar.gz": "darwin-arm64",
+    "remem-darwin-x64.tar.gz": "darwin-x64",
+    "remem-linux-arm64.tar.gz": "linux-arm64",
+    "remem-linux-x64.tar.gz": "linux-x64",
+}
+SHA256_RE = re.compile(r"^([0-9a-fA-F]{64})\s+\*?(.+)$")
+
+
+def parse_checksums(path: Path) -> dict[str, dict[str, str]]:
+    assets: dict[str, dict[str, str]] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        match = SHA256_RE.match(line.strip())
+        if not match:
+            raise ValueError(f"invalid SHA256SUMS line: {line!r}")
+        checksum, artifact = match.groups()
+        filename = Path(artifact).name
+        if filename not in EXPECTED_ASSETS:
+            raise ValueError(f"unexpected runtime artifact in SHA256SUMS: {filename}")
+        platform = EXPECTED_ASSETS[filename]
+        assets[platform] = {
+            "file": filename,
+            "sha256": checksum.lower(),
+        }
+    missing = sorted(set(EXPECTED_ASSETS.values()) - set(assets.keys()))
+    if missing:
+        raise ValueError(f"missing runtime artifact checksums for: {', '.join(missing)}")
+    return assets
+
+
+def write_manifest(version: str, artifacts_dir: Path, output: Path, base_url: str | None) -> None:
+    if not version or version.startswith("v"):
+        raise ValueError("version must be the bare package version, for example 0.5.28")
+    checksums = artifacts_dir / "SHA256SUMS"
+    if not checksums.exists():
+        raise ValueError(f"missing checksum file: {checksums}")
+    manifest = {
+        "versions": {
+            version: {
+                "base_url": base_url
+                or f"https://github.com/majiayu000/remem/releases/download/v{version}",
+                "assets": parse_checksums(checksums),
+            }
+        }
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(f"{json.dumps(manifest, indent=2, sort_keys=True)}\n", encoding="utf-8")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) not in (3, 4):
+        print(
+            "usage: generate_plugin_release_manifest.py VERSION ARTIFACTS_DIR OUTPUT [BASE_URL]",
+            file=sys.stderr,
+        )
+        return 2
+    version = argv[0]
+    artifacts_dir = Path(argv[1])
+    output = Path(argv[2])
+    base_url = argv[3] if len(argv) == 4 else None
+    write_manifest(version, artifacts_dir, output, base_url)
+    print(f"wrote plugin release manifest: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- generate a release-hosted `remem-releases.json` manifest from `SHA256SUMS` during release publishing
- let the plugin runtime fetch that release manifest when the checked-in manifest has an empty asset map
- keep runtime downloads checksum-gated, including a negative test for invalid remote manifest checksums

## Verification
- `node --check plugins/remem/scripts/remem-runtime.js`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `python3 -m py_compile scripts/ci/generate_plugin_release_manifest.py scripts/ci/check_plugin_version_sync.py scripts/ci/check_version_bump.py`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- manifest generator smoke test with fake `SHA256SUMS`
- `git diff --check origin/main`
- `cargo check --message-format=short`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`

Refs #390
