### PR TITLE
Add CLI JSON bridges for timeline and workstreams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.28"
+version = "0.5.29"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.28"
+version = "0.5.29"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.28",
+  "version": "0.5.29",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/apps/remem/README.md
+++ b/plugins/remem/apps/remem/README.md
@@ -27,9 +27,11 @@ This app surface provides:
 | Session commits | `remem_session_commits` | `GET /api/session-commits` | `remem commit session --json` |
 | Activation plan | `remem_activation_plan` | `GET /api/activation-plan` | `remem install --target codex --hooks-only --dry-run` |
 
-Workstream mutation and chronological timeline browsing remain MCP-native Rust
-tools today. Add them to this app after a small HTTP/MCP bridge exists; do not
-parse human CLI output for those surfaces.
+Workstream mutation and chronological timeline browsing now have machine-readable
+Rust CLI bridges (`remem workstreams ... --json`, `remem timeline ... --json`)
+plus MCP-native tools. Add them to this app through those JSON bridges; do not
+parse human CLI output for those surfaces. Workstream updates must pass an
+explicit project and `--confirm`.
 
 Run locally:
 

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.28": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.28",
+    "0.5.29": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.29",
       "assets": {}
     }
   }

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -24,7 +24,7 @@ pub(super) use pending::run_pending;
 pub(super) use preferences::run_preferences;
 pub(super) use query::{
     run_backfill_entities, run_commit, run_current_state, run_raw, run_search, run_show,
-    run_status, run_why,
+    run_status, run_timeline, run_why, run_workstreams,
 };
 pub(super) use review::{run_graph_review, run_review};
 pub(super) use scope_cleanup::{

--- a/src/cli/actions/query.rs
+++ b/src/cli/actions/query.rs
@@ -7,7 +7,9 @@ mod show;
 mod status;
 #[cfg(test)]
 mod tests;
+mod timeline;
 mod why;
+mod workstreams;
 
 pub(in crate::cli) use backfill::run_backfill_entities;
 pub(in crate::cli) use commit::run_commit;
@@ -16,4 +18,6 @@ pub(in crate::cli) use raw::run_raw;
 pub(in crate::cli) use search::run_search;
 pub(in crate::cli) use show::run_show;
 pub(in crate::cli) use status::run_status;
+pub(in crate::cli) use timeline::run_timeline;
 pub(in crate::cli) use why::run_why;
+pub(in crate::cli) use workstreams::run_workstreams;

--- a/src/cli/actions/query/timeline.rs
+++ b/src/cli/actions/query/timeline.rs
@@ -1,0 +1,200 @@
+use anyhow::{bail, Result};
+use serde::Serialize;
+
+use crate::cli::types::TimelineAction;
+use crate::{db, retrieval::search::search_observations};
+
+use super::show::format_memory_timestamp;
+
+pub(in crate::cli) fn run_timeline(action: TimelineAction) -> Result<()> {
+    match action {
+        TimelineAction::Around {
+            anchor,
+            query,
+            project,
+            depth_before,
+            depth_after,
+            json,
+        } => run_timeline_around(
+            anchor,
+            query.as_deref(),
+            project.as_deref(),
+            depth_before,
+            depth_after,
+            json,
+        ),
+        TimelineAction::Report {
+            project,
+            full,
+            json,
+        } => run_timeline_report(&project, full, json),
+    }
+}
+
+fn run_timeline_around(
+    anchor: Option<i64>,
+    query: Option<&str>,
+    project: Option<&str>,
+    depth_before: i64,
+    depth_after: i64,
+    json: bool,
+) -> Result<()> {
+    let conn = db::open_db()?;
+    let anchor_id = resolve_anchor(&conn, anchor, query, project)?;
+    let before = depth_before.max(0);
+    let after = depth_after.max(0);
+    let results = db::get_timeline_around(&conn, anchor_id, before, after, project)?;
+    if json {
+        let output = TimelineAroundJson {
+            anchor_id,
+            query: query.map(str::to_string),
+            project: project.map(str::to_string),
+            depth_before: before,
+            depth_after: after,
+            count: results.len(),
+            results,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+    print!("{}", render_timeline_around(anchor_id, &results));
+    Ok(())
+}
+
+fn resolve_anchor(
+    conn: &rusqlite::Connection,
+    anchor: Option<i64>,
+    query: Option<&str>,
+    project: Option<&str>,
+) -> Result<i64> {
+    if let Some(anchor) = anchor {
+        let found = db::get_observations_by_ids(conn, &[anchor], project)?;
+        if found.is_empty() {
+            bail!("No observation found for anchor id {anchor}");
+        }
+        return Ok(anchor);
+    }
+    let Some(query) = query else {
+        bail!("timeline around requires --anchor or --query");
+    };
+    let results = search_observations(conn, Some(query), project, None, 1, 0, true)?;
+    let Some(result) = results.first() else {
+        bail!("No results for query '{query}'");
+    };
+    Ok(result.id)
+}
+
+fn run_timeline_report(project: &str, full: bool, json: bool) -> Result<()> {
+    let conn = db::open_db()?;
+    if json {
+        let output = TimelineReportJson {
+            project: project.to_string(),
+            full,
+            report: crate::timeline::generate_timeline_report_data(&conn, project, full)?,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+    let report = crate::timeline::generate_timeline_report(&conn, project, full)?;
+    print!("{report}");
+    Ok(())
+}
+
+fn render_timeline_around(anchor_id: i64, results: &[db::Observation]) -> String {
+    let mut output = format!("Timeline around observation #{anchor_id}:\n\n");
+    for observation in results {
+        let marker = if observation.id == anchor_id {
+            "*"
+        } else {
+            " "
+        };
+        let title = observation.title.as_deref().unwrap_or("(untitled)");
+        output.push_str(&format!(
+            "{} #{} [{}] {} {}\n",
+            marker,
+            observation.id,
+            observation.r#type,
+            format_memory_timestamp(observation.created_at_epoch),
+            title
+        ));
+    }
+    output
+}
+
+#[derive(Debug, Serialize)]
+struct TimelineAroundJson {
+    anchor_id: i64,
+    query: Option<String>,
+    project: Option<String>,
+    depth_before: i64,
+    depth_after: i64,
+    count: usize,
+    results: Vec<db::Observation>,
+}
+
+#[derive(Debug, Serialize)]
+struct TimelineReportJson {
+    project: String,
+    full: bool,
+    report: crate::timeline::TimelineReportData,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    #[test]
+    fn query_anchor_resolves_observation_id_not_memory_id() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+
+        let memory_id = crate::memory::insert_memory(
+            &conn,
+            Some("m1"),
+            "/repo",
+            None,
+            "Release manifest memory",
+            "release manifest from memory",
+            "decision",
+            None,
+        )?;
+        let unrelated_observation_id = crate::db::insert_observation(
+            &conn,
+            "s0",
+            "/repo",
+            "decision",
+            Some("Unrelated observation"),
+            None,
+            Some("unrelated operational note"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            0,
+        )?;
+        let matching_observation_id = crate::db::insert_observation(
+            &conn,
+            "s1",
+            "/repo",
+            "decision",
+            Some("Release manifest observation"),
+            None,
+            Some("release manifest observation anchor"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            0,
+        )?;
+
+        assert_eq!(memory_id, unrelated_observation_id);
+        assert_ne!(memory_id, matching_observation_id);
+
+        let resolved = resolve_anchor(&conn, None, Some("release manifest"), Some("/repo"))?;
+        assert_eq!(resolved, matching_observation_id);
+        Ok(())
+    }
+}

--- a/src/cli/actions/query/workstreams.rs
+++ b/src/cli/actions/query/workstreams.rs
@@ -1,0 +1,175 @@
+use anyhow::{bail, Result};
+use serde::Serialize;
+
+use crate::cli::types::{WorkstreamAction, WorkstreamStatusArg};
+use crate::{db, workstream};
+
+pub(in crate::cli) fn run_workstreams(action: WorkstreamAction) -> Result<()> {
+    match action {
+        WorkstreamAction::List {
+            project,
+            status,
+            json,
+        } => run_workstream_list(&project, status, json),
+        WorkstreamAction::Update {
+            id,
+            project,
+            status,
+            next_action,
+            blockers,
+            confirm,
+            json,
+        } => run_workstream_update(
+            id,
+            &project,
+            status,
+            next_action.as_deref(),
+            blockers.as_deref(),
+            confirm,
+            json,
+        ),
+    }
+}
+
+fn run_workstream_list(
+    project: &str,
+    status: Option<WorkstreamStatusArg>,
+    json: bool,
+) -> Result<()> {
+    let conn = db::open_db()?;
+    let status_str = status.map(WorkstreamStatusArg::as_str);
+    let results = workstream::query_workstreams(&conn, project, status_str)?;
+    if json {
+        let output = WorkstreamListJson {
+            project: project.to_string(),
+            status: status_str.map(str::to_string),
+            count: results.len(),
+            workstreams: results,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+    print!("{}", render_workstream_list(&results));
+    Ok(())
+}
+
+fn run_workstream_update(
+    id: i64,
+    project: &str,
+    status: Option<WorkstreamStatusArg>,
+    next_action: Option<&str>,
+    blockers: Option<&str>,
+    confirm: bool,
+    json: bool,
+) -> Result<()> {
+    validate_workstream_update_request(status, next_action, blockers, confirm)?;
+    let conn = db::open_db()?;
+    let belongs_to_project = workstream::query_workstreams(&conn, project, None)?
+        .iter()
+        .any(|item| item.id == id);
+    if !belongs_to_project {
+        bail!("No workstream found for id {id} in project {project}");
+    }
+    let updated = workstream::update_workstream_manual(
+        &conn,
+        id,
+        status.map(WorkstreamStatusArg::as_str),
+        next_action,
+        blockers,
+    )?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&WorkstreamUpdateJson {
+                id,
+                project,
+                updated
+            })?
+        );
+        return Ok(());
+    }
+    if updated {
+        println!("Updated workstream #{id}.");
+    } else {
+        println!("No workstream found for id {id}.");
+    }
+    Ok(())
+}
+
+fn validate_workstream_update_request(
+    status: Option<WorkstreamStatusArg>,
+    next_action: Option<&str>,
+    blockers: Option<&str>,
+    confirm: bool,
+) -> Result<()> {
+    if status.is_none() && next_action.is_none() && blockers.is_none() {
+        bail!("workstreams update requires --status, --next-action, or --blockers");
+    }
+    if !confirm {
+        bail!("workstreams update requires --confirm");
+    }
+    Ok(())
+}
+
+fn render_workstream_list(workstreams: &[workstream::WorkStream]) -> String {
+    let mut output = String::new();
+    if workstreams.is_empty() {
+        output.push_str("No workstreams found.\n");
+        return output;
+    }
+    output.push_str("Workstreams:\n\n");
+    for item in workstreams {
+        output.push_str(&format!(
+            "#{} [{}] {}\n",
+            item.id,
+            item.status.as_str(),
+            item.title
+        ));
+        if let Some(next_action) = &item.next_action {
+            output.push_str(&format!("  next: {next_action}\n"));
+        }
+        if let Some(blockers) = &item.blockers {
+            output.push_str(&format!("  blockers: {blockers}\n"));
+        }
+        output.push('\n');
+    }
+    output
+}
+
+#[derive(Debug, Serialize)]
+struct WorkstreamListJson {
+    project: String,
+    status: Option<String>,
+    count: usize,
+    workstreams: Vec<workstream::WorkStream>,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkstreamUpdateJson<'a> {
+    id: i64,
+    project: &'a str,
+    updated: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workstream_update_rejects_empty_mutation() {
+        let error = validate_workstream_update_request(None, None, None, true).unwrap_err();
+        assert!(error.to_string().contains("--status"));
+    }
+
+    #[test]
+    fn workstream_update_requires_confirmation() {
+        let error = validate_workstream_update_request(
+            Some(WorkstreamStatusArg::Paused),
+            None,
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--confirm"));
+    }
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -7,8 +7,8 @@ use super::actions::{
     run_config, run_current_state, run_dream, run_encrypt, run_eval, run_eval_e2e,
     run_eval_governance, run_eval_local, run_governance, run_graph_review, run_import,
     run_memory_cleanup, run_merge_preferences, run_model, run_pending, run_preferences, run_raw,
-    run_reroute, run_review, run_search, run_show, run_status, run_usage, run_why,
-    GovernanceCliRequest, RerouteCliRequest,
+    run_reroute, run_review, run_search, run_show, run_status, run_timeline, run_usage, run_why,
+    run_workstreams, GovernanceCliRequest, RerouteCliRequest,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands, ContextGateAction, MemoryAction};
@@ -236,6 +236,8 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             json,
         )?,
         Commands::Raw { action } => run_raw(action)?,
+        Commands::Timeline { action } => run_timeline(action)?,
+        Commands::Workstreams { action } => run_workstreams(action)?,
         Commands::Commit { action } => run_commit(action)?,
         Commands::Show { id, json } => run_show(id, json)?,
         Commands::Why {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ mod actions;
 mod config_types;
 mod cwd;
 mod dispatch;
+mod query_types;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]
@@ -10,6 +11,8 @@ mod tests_config;
 mod tests_eval;
 #[cfg(test)]
 mod tests_maintenance;
+#[cfg(test)]
+mod tests_trace;
 mod types;
 
 use anyhow::Result;

--- a/src/cli/query_types.rs
+++ b/src/cli/query_types.rs
@@ -1,0 +1,159 @@
+use clap::{Subcommand, ValueEnum};
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum TimelineAction {
+    /// Get chronological observations around an anchor observation or search query.
+    Around {
+        /// Anchor observation ID.
+        #[arg(long)]
+        anchor: Option<i64>,
+        /// Search query used to resolve the anchor.
+        #[arg(long)]
+        query: Option<String>,
+        /// Restrict timeline rows to one project path.
+        #[arg(long, short)]
+        project: Option<String>,
+        /// Observations before the anchor.
+        #[arg(long, default_value = "5")]
+        depth_before: i64,
+        /// Observations after the anchor.
+        #[arg(long, default_value = "5")]
+        depth_after: i64,
+        /// Emit a single JSON object with stable fields for scripts.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Generate a project timeline report.
+    Report {
+        /// Project path to report.
+        project: String,
+        /// Include recent timeline and monthly breakdown.
+        #[arg(long)]
+        full: bool,
+        /// Emit a single JSON object with stable fields for scripts.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum WorkstreamAction {
+    /// List project workstreams.
+    List {
+        /// Project path to list workstreams for.
+        #[arg(long, short)]
+        project: String,
+        /// Status filter: active, paused, completed, abandoned.
+        #[arg(long, value_enum)]
+        status: Option<WorkstreamStatusArg>,
+        /// Emit a single JSON object with stable fields for scripts.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Update a workstream's manual status, next action, or blockers.
+    Update {
+        /// Workstream ID to update.
+        id: i64,
+        /// Project path that owns the workstream.
+        #[arg(long, short)]
+        project: String,
+        /// New status: active, paused, completed, abandoned.
+        #[arg(long, value_enum)]
+        status: Option<WorkstreamStatusArg>,
+        /// Next action to take.
+        #[arg(long)]
+        next_action: Option<String>,
+        /// Current blockers.
+        #[arg(long)]
+        blockers: Option<String>,
+        /// Confirm the mutation after reviewing id, project, and fields.
+        #[arg(long)]
+        confirm: bool,
+        /// Emit a single JSON object with stable fields for scripts.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(in crate::cli) enum WorkstreamStatusArg {
+    Active,
+    Paused,
+    Completed,
+    Abandoned,
+}
+
+impl WorkstreamStatusArg {
+    pub(in crate::cli) fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Paused => "paused",
+            Self::Completed => "completed",
+            Self::Abandoned => "abandoned",
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum CommitAction {
+    /// Look up git metadata and linked memory sessions for a full or short SHA.
+    Show {
+        sha: String,
+        #[arg(long, short)]
+        project: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// List commits linked to a content session ID or memory session ID.
+    Session {
+        session_id: String,
+        #[arg(long, short)]
+        project: Option<String>,
+        #[arg(long, short = 'n', default_value = "20")]
+        limit: i64,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub(in crate::cli) enum RawAction {
+    /// Search raw captured user/assistant chat turns, not curated memories.
+    Search {
+        /// Literal phrase or terms to search in raw archive rows.
+        query: String,
+        /// Restrict search to one project path.
+        #[arg(long, short)]
+        project: Option<String>,
+        /// Include rows from this branch plus branchless older rows.
+        #[arg(long)]
+        branch: Option<String>,
+        /// Restrict search to one message role.
+        #[arg(long, value_enum)]
+        role: Option<RawRole>,
+        /// Maximum raw rows to show.
+        #[arg(long, short = 'n', default_value = "20")]
+        limit: i64,
+        /// Result offset for pagination.
+        #[arg(long, default_value = "0")]
+        offset: i64,
+        /// Emit a single JSON object with stable fields for scripts.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(in crate::cli) enum RawRole {
+    User,
+    Assistant,
+}
+
+impl RawRole {
+    pub(in crate::cli) fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+        }
+    }
+}

--- a/src/cli/tests_trace.rs
+++ b/src/cli/tests_trace.rs
@@ -1,0 +1,104 @@
+use super::types::{Cli, Commands, TimelineAction, WorkstreamAction, WorkstreamStatusArg};
+use clap::Parser;
+
+#[test]
+fn cli_parses_timeline_around_json_filters() {
+    let cli = Cli::parse_from([
+        "remem",
+        "timeline",
+        "around",
+        "--query",
+        "release manifest",
+        "--project",
+        "/repo",
+        "--depth-before",
+        "3",
+        "--depth-after",
+        "4",
+        "--json",
+    ]);
+
+    match cli.command {
+        Commands::Timeline {
+            action:
+                TimelineAction::Around {
+                    anchor,
+                    query,
+                    project,
+                    depth_before,
+                    depth_after,
+                    json,
+                },
+        } => {
+            assert_eq!(anchor, None);
+            assert_eq!(query.as_deref(), Some("release manifest"));
+            assert_eq!(project.as_deref(), Some("/repo"));
+            assert_eq!(depth_before, 3);
+            assert_eq!(depth_after, 4);
+            assert!(json);
+        }
+        _ => panic!("expected timeline around command"),
+    }
+}
+
+#[test]
+fn cli_parses_workstream_update_json_filters() {
+    let cli = Cli::parse_from([
+        "remem",
+        "workstreams",
+        "update",
+        "42",
+        "--project",
+        "/repo",
+        "--status",
+        "paused",
+        "--next-action",
+        "wait for connector id",
+        "--blockers",
+        "external registration",
+        "--confirm",
+        "--json",
+    ]);
+
+    match cli.command {
+        Commands::Workstreams {
+            action:
+                WorkstreamAction::Update {
+                    id,
+                    project,
+                    status,
+                    next_action,
+                    blockers,
+                    confirm,
+                    json,
+                },
+        } => {
+            assert_eq!(id, 42);
+            assert_eq!(project, "/repo");
+            assert_eq!(status, Some(WorkstreamStatusArg::Paused));
+            assert_eq!(next_action.as_deref(), Some("wait for connector id"));
+            assert_eq!(blockers.as_deref(), Some("external registration"));
+            assert!(confirm);
+            assert!(json);
+        }
+        _ => panic!("expected workstream update command"),
+    }
+}
+
+#[test]
+fn cli_rejects_invalid_workstream_status() {
+    let parsed = Cli::try_parse_from([
+        "remem",
+        "workstreams",
+        "update",
+        "42",
+        "--project",
+        "/repo",
+        "--status",
+        "waiting",
+        "--confirm",
+        "--json",
+    ]);
+
+    assert!(parsed.is_err());
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -2,6 +2,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 pub(in crate::cli) use super::config_types::ConfigAction;
+pub(in crate::cli) use super::query_types::{
+    CommitAction, RawAction, RawRole, TimelineAction, WorkstreamAction, WorkstreamStatusArg,
+};
 pub(super) use crate::install::InstallTarget;
 
 #[derive(Parser)]
@@ -379,6 +382,16 @@ pub(super) enum Commands {
         #[command(subcommand)]
         action: RawAction,
     },
+    /// Inspect chronological observations and project timeline reports.
+    Timeline {
+        #[command(subcommand)]
+        action: TimelineAction,
+    },
+    /// List or manually update tracked workstreams.
+    Workstreams {
+        #[command(subcommand)]
+        action: WorkstreamAction,
+    },
     /// Look up git commits and linked memory sessions.
     Commit {
         #[command(subcommand)]
@@ -623,70 +636,6 @@ pub(in crate::cli) enum ImportAction {
         #[arg(long)]
         best_effort: bool,
     },
-}
-
-#[derive(Subcommand)]
-pub(in crate::cli) enum CommitAction {
-    /// Look up git metadata and linked memory sessions for a full or short SHA.
-    Show {
-        sha: String,
-        #[arg(long, short)]
-        project: Option<String>,
-        #[arg(long)]
-        json: bool,
-    },
-    /// List commits linked to a content session ID or memory session ID.
-    Session {
-        session_id: String,
-        #[arg(long, short)]
-        project: Option<String>,
-        #[arg(long, short = 'n', default_value = "20")]
-        limit: i64,
-        #[arg(long)]
-        json: bool,
-    },
-}
-
-#[derive(Subcommand)]
-pub(in crate::cli) enum RawAction {
-    /// Search raw captured user/assistant chat turns, not curated memories.
-    Search {
-        /// Literal phrase or terms to search in raw archive rows.
-        query: String,
-        /// Restrict search to one project path.
-        #[arg(long, short)]
-        project: Option<String>,
-        /// Include rows from this branch plus branchless older rows.
-        #[arg(long)]
-        branch: Option<String>,
-        /// Restrict search to one message role.
-        #[arg(long, value_enum)]
-        role: Option<RawRole>,
-        /// Maximum raw rows to show.
-        #[arg(long, short = 'n', default_value = "20")]
-        limit: i64,
-        /// Result offset for pagination.
-        #[arg(long, default_value = "0")]
-        offset: i64,
-        /// Emit a single JSON object with stable fields for scripts.
-        #[arg(long)]
-        json: bool,
-    },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub(in crate::cli) enum RawRole {
-    User,
-    Assistant,
-}
-
-impl RawRole {
-    pub(in crate::cli) fn as_str(self) -> &'static str {
-        match self {
-            Self::User => "user",
-            Self::Assistant => "assistant",
-        }
-    }
 }
 
 #[derive(Subcommand)]

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -6,3 +6,4 @@ mod tests;
 mod types;
 
 pub use report::generate_timeline_report;
+pub(crate) use report::{generate_timeline_report_data, TimelineReportData};

--- a/src/timeline/report.rs
+++ b/src/timeline/report.rs
@@ -2,13 +2,27 @@ use std::fmt::Write;
 
 use anyhow::Result;
 use rusqlite::Connection;
+use serde::Serialize;
 
 use super::detail::{query_monthly, query_recent_observations};
 use super::summary::{query_overview, query_token_economics, query_type_counts};
+use super::types::{MonthRow, Overview, RecentObservation, TokenEcon, TypeCount};
 
-fn render_recent_timeline(out: &mut String, conn: &Connection, project: &str) -> Result<()> {
+#[derive(Debug, Serialize)]
+pub(crate) struct TimelineReportData {
+    project: String,
+    full: bool,
+    overview: Overview,
+    activity_by_type: Vec<TypeCount>,
+    token_economics: TokenEcon,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    recent_timeline: Option<Vec<RecentObservation>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    monthly_breakdown: Option<Vec<MonthRow>>,
+}
+
+fn render_recent_timeline(out: &mut String, recent: &[RecentObservation]) -> Result<()> {
     writeln!(out, "## Timeline (recent first)")?;
-    let recent = query_recent_observations(conn, project, 200)?;
 
     let mut current_date = String::new();
     for observation in recent {
@@ -30,12 +44,11 @@ fn render_recent_timeline(out: &mut String, conn: &Connection, project: &str) ->
     Ok(())
 }
 
-fn render_monthly_breakdown(out: &mut String, conn: &Connection, project: &str) -> Result<()> {
-    let monthly = query_monthly(conn, project)?;
+fn render_monthly_breakdown(out: &mut String, monthly: &[MonthRow]) -> Result<()> {
     writeln!(out, "## Monthly Breakdown")?;
     writeln!(out, "| Month | Observations | Sessions | AI Cost |")?;
     writeln!(out, "|-------|-------------|----------|---------|")?;
-    for month in &monthly {
+    for month in monthly {
         writeln!(
             out,
             "| {} | {} | {} | ${:.2} |",
@@ -45,11 +58,38 @@ fn render_monthly_breakdown(out: &mut String, conn: &Connection, project: &str) 
     Ok(())
 }
 
-pub fn generate_timeline_report(conn: &Connection, project: &str, full: bool) -> Result<String> {
+pub(crate) fn generate_timeline_report_data(
+    conn: &Connection,
+    project: &str,
+    full: bool,
+) -> Result<TimelineReportData> {
     let overview = query_overview(conn, project)?;
-    let type_counts = query_type_counts(conn, project)?;
-    let token_econ = query_token_economics(conn, project)?;
+    let activity_by_type = query_type_counts(conn, project)?;
+    let token_economics = query_token_economics(conn, project)?;
+    let recent_timeline = if full {
+        Some(query_recent_observations(conn, project, 200)?)
+    } else {
+        None
+    };
+    let monthly_breakdown = if full {
+        Some(query_monthly(conn, project)?)
+    } else {
+        None
+    };
 
+    Ok(TimelineReportData {
+        project: project.to_string(),
+        full,
+        overview,
+        activity_by_type,
+        token_economics,
+        recent_timeline,
+        monthly_breakdown,
+    })
+}
+
+pub fn generate_timeline_report(conn: &Connection, project: &str, full: bool) -> Result<String> {
+    let report = generate_timeline_report_data(conn, project, full)?;
     let mut out = String::with_capacity(4096);
     writeln!(out, "# Journey Into {}\n", project)?;
 
@@ -57,15 +97,23 @@ pub fn generate_timeline_report(conn: &Connection, project: &str, full: bool) ->
     writeln!(
         out,
         "- Time span: {} -> {} ({} days)",
-        overview.first_date, overview.last_date, overview.days_span
+        report.overview.first_date, report.overview.last_date, report.overview.days_span
     )?;
-    writeln!(out, "- Total observations: {}", overview.total_observations)?;
-    writeln!(out, "- Total sessions: {}", overview.total_sessions)?;
-    writeln!(out, "- Total memories: {}\n", overview.total_memories)?;
+    writeln!(
+        out,
+        "- Total observations: {}",
+        report.overview.total_observations
+    )?;
+    writeln!(out, "- Total sessions: {}", report.overview.total_sessions)?;
+    writeln!(
+        out,
+        "- Total memories: {}\n",
+        report.overview.total_memories
+    )?;
 
     writeln!(out, "## Activity by Type")?;
-    let total = overview.total_observations.max(1) as f64;
-    for type_count in &type_counts {
+    let total = report.overview.total_observations.max(1) as f64;
+    for type_count in &report.activity_by_type {
         let pct = (type_count.count as f64 / total * 100.0).round() as i64;
         writeln!(
             out,
@@ -76,24 +124,30 @@ pub fn generate_timeline_report(conn: &Connection, project: &str, full: bool) ->
     writeln!(out)?;
 
     writeln!(out, "## Token Economics")?;
-    writeln!(out, "- Total AI cost: ${:.2}", token_econ.total_ai_cost)?;
-    let discovery_m = token_econ.total_discovery_tokens as f64 / 1_000_000.0;
+    writeln!(
+        out,
+        "- Total AI cost: ${:.2}",
+        report.token_economics.total_ai_cost
+    )?;
+    let discovery_m = report.token_economics.total_discovery_tokens as f64 / 1_000_000.0;
     writeln!(out, "- Total discovery tokens: {:.1}M", discovery_m)?;
     writeln!(
         out,
         "- Sessions with context injection: {}",
-        token_econ.sessions_with_context
+        report.token_economics.sessions_with_context
     )?;
-    let recall_savings = token_econ.sessions_with_context * 300;
+    let recall_savings = report.token_economics.sessions_with_context * 300;
     writeln!(
         out,
         "- Estimated passive recall savings: ~{}K tokens\n",
         recall_savings
     )?;
 
-    if full {
-        render_recent_timeline(&mut out, conn, project)?;
-        render_monthly_breakdown(&mut out, conn, project)?;
+    if let Some(recent) = report.recent_timeline.as_deref() {
+        render_recent_timeline(&mut out, recent)?;
+    }
+    if let Some(monthly) = report.monthly_breakdown.as_deref() {
+        render_monthly_breakdown(&mut out, monthly)?;
     }
 
     Ok(out)

--- a/src/timeline/tests.rs
+++ b/src/timeline/tests.rs
@@ -1,6 +1,6 @@
 use rusqlite::{params, Connection};
 
-use super::generate_timeline_report;
+use super::{generate_timeline_report, generate_timeline_report_data};
 
 fn setup_test_db(conn: &Connection) {
     conn.execute_batch(
@@ -95,6 +95,30 @@ fn summary_report_excludes_timeline() {
     assert!(report.contains("Total observations: 1"));
     assert!(!report.contains("## Timeline"));
     assert!(!report.contains("## Monthly Breakdown"));
+}
+
+#[test]
+fn json_report_data_exposes_structured_fields() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_test_db(&conn);
+    let now = chrono::Utc::now().timestamp();
+
+    conn.execute(
+        "INSERT INTO observations (memory_session_id, project, type, title, created_at_epoch, discovery_tokens) \
+         VALUES ('s1', 'tools/remem', 'decision', 'Structured report', ?1, 100)",
+        params![now],
+    )?;
+
+    let report = generate_timeline_report_data(&conn, "tools/remem", true)?;
+    let json = serde_json::to_value(report)?;
+
+    assert_eq!(json["project"], "tools/remem");
+    assert_eq!(json["overview"]["total_observations"], 1);
+    assert_eq!(json["activity_by_type"][0]["obs_type"], "decision");
+    assert_eq!(json["token_economics"]["total_discovery_tokens"], 100);
+    assert!(json["recent_timeline"].is_array());
+    assert!(json["monthly_breakdown"].is_array());
+    Ok(())
 }
 
 #[test]

--- a/src/timeline/types.rs
+++ b/src/timeline/types.rs
@@ -1,3 +1,6 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
 pub(super) struct Overview {
     pub first_date: String,
     pub last_date: String,
@@ -7,11 +10,13 @@ pub(super) struct Overview {
     pub total_memories: i64,
 }
 
+#[derive(Debug, Serialize)]
 pub(super) struct TypeCount {
     pub obs_type: String,
     pub count: i64,
 }
 
+#[derive(Debug, Serialize)]
 pub(super) struct MonthRow {
     pub month: String,
     pub observations: i64,
@@ -19,12 +24,14 @@ pub(super) struct MonthRow {
     pub ai_cost: f64,
 }
 
+#[derive(Debug, Serialize)]
 pub(super) struct TokenEcon {
     pub total_ai_cost: f64,
     pub total_discovery_tokens: i64,
     pub sessions_with_context: i64,
 }
 
+#[derive(Debug, Serialize)]
 pub(super) struct RecentObservation {
     pub id: i64,
     pub obs_type: String,


### PR DESCRIPTION
Refs #390

## Summary
- Add machine-readable `remem timeline ... --json` and `remem workstreams ... --json` CLI bridges for the app surface to consume later without parsing human output.
- Move raw/commit query action types into `src/cli/query_types.rs` to keep `src/cli/types.rs` below the 800-line hard cap while preserving existing imports.
- Make timeline report JSON structured, resolve timeline query anchors through observations, and gate workstream mutations with `--project`, `--confirm`, valid status values, and non-empty update fields.
- Document that the Remem app should use these JSON bridges for future workstream/timeline routes.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main`
- `cargo check --message-format=short`
- `cargo clippy -- -D warnings`
- `cargo test cli::actions::query::timeline::tests --lib -- --nocapture`
- `cargo test cli::actions::query::workstreams::tests --lib -- --nocapture`
- `cargo test cli::tests_trace --lib -- --nocapture`
- `cargo test timeline::tests --lib -- --nocapture`
- `cargo test`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `python3 scripts/ci/check_plugin_version_sync.py && python3 scripts/ci/check_version_bump.py origin/main HEAD`
- CLI smoke with explicit plaintext test DB: `timeline report --json`, `workstreams list --json`, missing `--confirm`, and empty update rejection

## Review
- Independent read-only reviewer found three blockers: timeline query id-domain mismatch, JSON-wrapped timeline Markdown, and ungated/no-op workstream update.
- Fixed all three and reran verification.
- Second independent read-only reviewer found no blockers.
