### PR TITLE
Add app routes for timeline and workstreams

### DIFF
--- a/plugins/remem/apps/remem/README.md
+++ b/plugins/remem/apps/remem/README.md
@@ -25,13 +25,16 @@ This app surface provides:
 | Current state | `remem_current_state` | `GET /api/current-state` | `remem current --json` |
 | Commit lookup | `remem_commit_lookup` | `GET /api/commit` | `remem commit show --json` |
 | Session commits | `remem_session_commits` | `GET /api/session-commits` | `remem commit session --json` |
+| Timeline around | `remem_timeline_around` | `GET /api/timeline-around` | `remem timeline around --json` |
+| Timeline report | `remem_timeline_report` | `GET /api/timeline-report` | `remem timeline report --json` |
+| Workstreams | `remem_workstreams_list` | `GET /api/workstreams` | `remem workstreams list --json` |
+| Workstream update | `remem_workstream_update` | `POST /api/workstream-update` | `remem workstreams update --json --confirm` |
 | Activation plan | `remem_activation_plan` | `GET /api/activation-plan` | `remem install --target codex --hooks-only --dry-run` |
 
-Workstream mutation and chronological timeline browsing now have machine-readable
-Rust CLI bridges (`remem workstreams ... --json`, `remem timeline ... --json`)
-plus MCP-native tools. Add them to this app through those JSON bridges; do not
-parse human CLI output for those surfaces. Workstream updates must pass an
-explicit project and `--confirm`.
+Timeline and workstream backend routes are wired for app and MCP callers through
+machine-readable Rust CLI bridges. The visible widget UI remains unchanged until
+`public/widget.html` is split below the 800-line cap. Workstream updates must
+pass an explicit project and `--confirm`.
 
 Run locally:
 

--- a/plugins/remem/apps/remem/server.js
+++ b/plugins/remem/apps/remem/server.js
@@ -17,6 +17,7 @@ const {
 } = require("../../scripts/remem-runtime");
 const { governancePreviewArgs } = require("./governance");
 const { toolDescriptors, UI_RESOURCE } = require("./tools");
+const { callTraceTool, createTraceBackend } = require("./trace");
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 5577;
@@ -147,18 +148,6 @@ function runProcess(command, args, options = {}) {
       resolve({ status, signal, stdout, stderr });
     });
   });
-}
-
-function requiredText(value, name) {
-  const text = String(value || "").trim();
-  if (!text) throw Object.assign(new Error(`${name} is required`), { statusCode: 400 });
-  return text;
-}
-
-function pushOptional(args, flag, value) {
-  if (value !== undefined && value !== null && String(value).trim() !== "") {
-    args.push(flag, String(value));
-  }
 }
 
 async function runRemem(args, options = {}) {
@@ -394,35 +383,7 @@ function createBackend(options = {}) {
         requested
       };
     },
-    async currentState(input) {
-      const args = ["current", requiredText(input.state_key, "state_key"), "--json"];
-      pushOptional(args, "--project", input.project);
-      pushOptional(args, "--type", input.memory_type);
-      pushOptional(args, "--owner-scope", input.owner_scope);
-      pushOptional(args, "--owner-key", input.owner_key);
-      pushOptional(args, "--as-of-epoch", input.as_of_epoch);
-      return runRememJson(args, {
-        allowDownload: false,
-        timeoutMs: 15000
-      });
-    },
-    async commitLookup(input) {
-      const args = ["commit", "show", requiredText(input.sha, "sha"), "--json"];
-      pushOptional(args, "--project", input.project);
-      return runRememJson(args, {
-        allowDownload: false,
-        timeoutMs: 15000
-      });
-    },
-    async sessionCommits(input) {
-      const args = ["commit", "session", requiredText(input.session_id, "session_id"), "--json"];
-      pushOptional(args, "--project", input.project);
-      pushOptional(args, "--limit", input.limit || 20);
-      return runRememJson(args, {
-        allowDownload: false,
-        timeoutMs: 15000
-      });
-    },
+    ...createTraceBackend(runRememJson),
     stop() {
       api.stop?.();
     }
@@ -541,22 +502,8 @@ async function callTool(backend, name, args = {}) {
       result
     );
   }
-  if (name === "remem_current_state") {
-    const result = await backend.currentState(args);
-    return toolResult(`Current state ${result.status || "resolved"}.`, result);
-  }
-  if (name === "remem_commit_lookup") {
-    const result = await backend.commitLookup(args);
-    return toolResult(`Found ${Array.isArray(result) ? result.length : 0} commit match(es).`, {
-      results: result
-    });
-  }
-  if (name === "remem_session_commits") {
-    const result = await backend.sessionCommits(args);
-    return toolResult(`Found ${Array.isArray(result) ? result.length : 0} linked commit(s).`, {
-      results: result
-    });
-  }
+  const traceResult = await callTraceTool(backend, name, args, toolResult);
+  if (traceResult) return traceResult;
   throw Object.assign(new Error(`Unknown tool: ${name}`), { code: -32602 });
 }
 
@@ -661,6 +608,15 @@ function createServer(options = {}) {
       if (req.method === "GET" && url.pathname === "/api/session-commits") {
         return jsonResponse(res, 200, await backend.sessionCommits(Object.fromEntries(url.searchParams)));
       }
+      if (req.method === "GET" && url.pathname === "/api/timeline-around") {
+        return jsonResponse(res, 200, await backend.timelineAround(Object.fromEntries(url.searchParams)));
+      }
+      if (req.method === "GET" && url.pathname === "/api/timeline-report") {
+        return jsonResponse(res, 200, await backend.timelineReport(Object.fromEntries(url.searchParams)));
+      }
+      if (req.method === "GET" && url.pathname === "/api/workstreams") {
+        return jsonResponse(res, 200, await backend.workstreamsList(Object.fromEntries(url.searchParams)));
+      }
       if (req.method === "POST" && url.pathname === "/api/save") {
         assertLocalPostAllowed(req);
         return jsonResponse(res, 201, await backend.save(await readJsonBody(req)));
@@ -668,6 +624,10 @@ function createServer(options = {}) {
       if (req.method === "POST" && url.pathname === "/api/governance-preview") {
         assertLocalPostAllowed(req);
         return jsonResponse(res, 200, await backend.governancePreview(await readJsonBody(req)));
+      }
+      if (req.method === "POST" && url.pathname === "/api/workstream-update") {
+        assertLocalPostAllowed(req);
+        return jsonResponse(res, 200, await backend.workstreamUpdate(await readJsonBody(req)));
       }
       if (req.method === "POST" && url.pathname === "/mcp") {
         assertLocalPostAllowed(req);

--- a/plugins/remem/apps/remem/server.test.js
+++ b/plugins/remem/apps/remem/server.test.js
@@ -15,6 +15,7 @@ const {
   UI_RESOURCE
 } = require("./server");
 const { governancePreviewArgs } = require("./governance");
+const { createTraceBackend } = require("./trace");
 const pluginManifest = require("../../.codex-plugin/plugin.json");
 
 function fakeBackend() {
@@ -157,6 +158,55 @@ function fakeBackend() {
         }
       ];
     },
+    async timelineAround(input) {
+      return {
+        anchor_id: Number(input.anchor || 15),
+        query: input.query || null,
+        project: input.project || null,
+        count: 1,
+        results: [
+          {
+            id: Number(input.anchor || 15),
+            title: "Release manifest",
+            type: "decision"
+          }
+        ]
+      };
+    },
+    async timelineReport(input) {
+      return {
+        project: input.project,
+        full: input.full === true || input.full === "true",
+        report: {
+          overview: {
+            total_observations: 2
+          },
+          activity_by_type: [],
+          token_economics: {}
+        }
+      };
+    },
+    async workstreamsList(input) {
+      return {
+        project: input.project,
+        status: input.status || null,
+        count: 1,
+        workstreams: [
+          {
+            id: 21,
+            title: "Wire app routes",
+            status: "active"
+          }
+        ]
+      };
+    },
+    async workstreamUpdate(input) {
+      return {
+        id: Number(input.id),
+        project: input.project,
+        updated: input.confirm === true
+      };
+    },
     stop() {}
   };
 }
@@ -195,12 +245,27 @@ test("widget-callable tools are exposed to the app surface", () => {
     "remem_governance_preview",
     "remem_current_state",
     "remem_commit_lookup",
-    "remem_session_commits"
+    "remem_session_commits",
+    "remem_timeline_around",
+    "remem_timeline_report",
+    "remem_workstreams_list",
+    "remem_workstream_update"
   ]) {
     const descriptor = toolDescriptors().find((tool) => tool.name === name);
     assert.deepEqual(descriptor._meta.ui.visibility, ["model", "app"]);
     assert.equal(descriptor._meta["openai/widgetAccessible"], true);
   }
+  const timelineAround = toolDescriptors().find((tool) => tool.name === "remem_timeline_around");
+  assert.deepEqual(timelineAround.inputSchema.anyOf, [
+    { required: ["anchor"] },
+    { required: ["query"] }
+  ]);
+  const workstreamUpdate = toolDescriptors().find((tool) => tool.name === "remem_workstream_update");
+  assert.deepEqual(workstreamUpdate.inputSchema.anyOf, [
+    { required: ["status"] },
+    { required: ["next_action"] },
+    { required: ["blockers"] }
+  ]);
 });
 
 test("JSON-RPC tools/list and dashboard call return structured content", async () => {
@@ -270,6 +335,33 @@ test("HTTP API serves widget, status, search, memory detail, and save", async ()
       (response) => response.json()
     );
     assert.equal(sessionCommits[0].link.session_id, "session-1");
+
+    const timelineAround = await fetch(`${base}/api/timeline-around?anchor=15`).then((response) =>
+      response.json()
+    );
+    assert.equal(timelineAround.anchor_id, 15);
+
+    const timelineReport = await fetch(
+      `${base}/api/timeline-report?project=/tmp/remem&full=true`
+    ).then((response) => response.json());
+    assert.equal(timelineReport.report.overview.total_observations, 2);
+
+    const workstreams = await fetch(`${base}/api/workstreams?project=/tmp/remem&status=active`).then(
+      (response) => response.json()
+    );
+    assert.equal(workstreams.workstreams[0].id, 21);
+
+    const workstreamUpdate = await fetch(`${base}/api/workstream-update`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: base },
+      body: JSON.stringify({
+        id: 21,
+        project: "/tmp/remem",
+        status: "paused",
+        confirm: true
+      })
+    }).then((response) => response.json());
+    assert.equal(workstreamUpdate.updated, true);
   });
 });
 
@@ -284,6 +376,11 @@ test("HTTP write routes reject cross-site browser requests", async () => {
   backend.governancePreview = async () => {
     previews += 1;
     return { dry_run: true, affected: [] };
+  };
+  let workstreamUpdates = 0;
+  backend.workstreamUpdate = async () => {
+    workstreamUpdates += 1;
+    return { id: 21, updated: true };
   };
 
   await withServer(async (base) => {
@@ -318,10 +415,18 @@ test("HTTP write routes reject cross-site browser requests", async () => {
       body: JSON.stringify({ action: "delete", ids: [7] })
     });
     assert.equal(apiGovernance.status, 403);
+
+    const apiWorkstreamUpdate = await fetch(`${base}/api/workstream-update`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "https://attacker.example" },
+      body: JSON.stringify({ id: 21, project: "/tmp/remem", status: "paused", confirm: true })
+    });
+    assert.equal(apiWorkstreamUpdate.status, 403);
   }, backend);
 
   assert.equal(saves, 0);
   assert.equal(previews, 0);
+  assert.equal(workstreamUpdates, 0);
 });
 
 test("widget renders raw archive fallback results", async () => {
@@ -370,6 +475,96 @@ test("JSON-RPC trace tools return structured content", async () => {
     params: { name: "remem_session_commits", arguments: { session_id: "session-1" } }
   });
   assert.equal(sessionCommits.structuredContent.results[0].link.session_id, "session-1");
+
+  const timelineAround = await handleJsonRpc(fakeBackend(), {
+    id: 4,
+    method: "tools/call",
+    params: { name: "remem_timeline_around", arguments: { anchor: 15 } }
+  });
+  assert.equal(timelineAround.structuredContent.anchor_id, 15);
+
+  const timelineReport = await handleJsonRpc(fakeBackend(), {
+    id: 5,
+    method: "tools/call",
+    params: { name: "remem_timeline_report", arguments: { project: "/tmp/remem" } }
+  });
+  assert.equal(timelineReport.structuredContent.report.overview.total_observations, 2);
+
+  const workstreams = await handleJsonRpc(fakeBackend(), {
+    id: 6,
+    method: "tools/call",
+    params: { name: "remem_workstreams_list", arguments: { project: "/tmp/remem" } }
+  });
+  assert.equal(workstreams.structuredContent.workstreams[0].id, 21);
+
+  const update = await handleJsonRpc(fakeBackend(), {
+    id: 7,
+    method: "tools/call",
+    params: {
+      name: "remem_workstream_update",
+      arguments: { id: 21, project: "/tmp/remem", status: "paused", confirm: true }
+    }
+  });
+  assert.equal(update.structuredContent.updated, true);
+});
+
+test("trace backend builds guarded timeline and workstream CLI args", async () => {
+  const calls = [];
+  const backend = createTraceBackend(async (args) => {
+    calls.push(args);
+    return { ok: true };
+  });
+
+  await backend.timelineAround({ query: "release manifest", project: "/tmp/remem", depth_before: 2 });
+  await backend.timelineReport({ project: "/tmp/remem", full: true });
+  await backend.workstreamsList({ project: "/tmp/remem", status: "active" });
+  await backend.workstreamUpdate({
+    id: 21,
+    project: "/tmp/remem",
+    status: "paused",
+    confirm: true
+  });
+
+  assert.deepEqual(calls[0], [
+    "timeline",
+    "around",
+    "--json",
+    "--query",
+    "release manifest",
+    "--project",
+    "/tmp/remem",
+    "--depth-before",
+    "2"
+  ]);
+  assert.deepEqual(calls[1], ["timeline", "report", "/tmp/remem", "--json", "--full"]);
+  assert.deepEqual(calls[2], [
+    "workstreams",
+    "list",
+    "--project",
+    "/tmp/remem",
+    "--json",
+    "--status",
+    "active"
+  ]);
+  assert.deepEqual(calls[3], [
+    "workstreams",
+    "update",
+    "21",
+    "--project",
+    "/tmp/remem",
+    "--json",
+    "--status",
+    "paused",
+    "--confirm"
+  ]);
+  assert.throws(
+    () => backend.workstreamUpdate({ id: 21, project: "/tmp/remem", confirm: true }),
+    /required/
+  );
+  assert.throws(
+    () => backend.workstreamUpdate({ id: 21, project: "/tmp/remem", status: "paused" }),
+    /confirm/
+  );
 });
 
 test("governance preview args are always dry-run JSON CLI calls", () => {

--- a/plugins/remem/apps/remem/tools.js
+++ b/plugins/remem/apps/remem/tools.js
@@ -194,6 +194,90 @@ function toolDescriptors() {
         ui: { visibility: ["model", "app"] },
         "openai/widgetAccessible": true
       }
+    },
+    {
+      name: "remem_timeline_around",
+      title: "Timeline Around Observation",
+      description: "Load chronological Remem observations around an anchor observation ID or query.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          anchor: { type: "integer", minimum: 1 },
+          query: { type: "string", minLength: 1 },
+          project: { type: "string" },
+          depth_before: { type: "integer", minimum: 1 },
+          depth_after: { type: "integer", minimum: 1 }
+        },
+        anyOf: [{ required: ["anchor"] }, { required: ["query"] }],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    },
+    {
+      name: "remem_timeline_report",
+      title: "Timeline Report",
+      description: "Generate a structured project timeline report with optional timeline and monthly breakdown.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string" },
+          full: { type: "boolean" }
+        },
+        required: ["project"],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    },
+    {
+      name: "remem_workstreams_list",
+      title: "List Workstreams",
+      description: "List Remem workstreams for a project, optionally filtered by status.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project: { type: "string" },
+          status: { type: "string", enum: ["active", "paused", "completed", "abandoned"] }
+        },
+        required: ["project"],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
+    },
+    {
+      name: "remem_workstream_update",
+      title: "Update Workstream",
+      description: "Update a Remem workstream status, next action, or blockers after explicit confirmation.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: { type: "integer", minimum: 1 },
+          project: { type: "string" },
+          status: { type: "string", enum: ["active", "paused", "completed", "abandoned"] },
+          next_action: { type: "string", minLength: 1 },
+          blockers: { type: "string", minLength: 1 },
+          confirm: { type: "boolean" }
+        },
+        required: ["id", "project", "confirm"],
+        anyOf: [{ required: ["status"] }, { required: ["next_action"] }, { required: ["blockers"] }],
+        additionalProperties: false
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        ui: { visibility: ["model", "app"] },
+        "openai/widgetAccessible": true
+      }
     }
   ];
 }

--- a/plugins/remem/apps/remem/trace.js
+++ b/plugins/remem/apps/remem/trace.js
@@ -1,0 +1,161 @@
+"use strict";
+
+function badRequest(message) {
+  return Object.assign(new Error(message), { statusCode: 400 });
+}
+
+function requiredText(value, name) {
+  const text = String(value || "").trim();
+  if (!text) throw badRequest(`${name} is required`);
+  return text;
+}
+
+function positiveInteger(value, name) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw badRequest(`${name} must be a positive integer`);
+  }
+  return number;
+}
+
+function optionalPositiveInteger(value, name) {
+  if (value === undefined || value === null || String(value).trim() === "") return null;
+  return positiveInteger(value, name);
+}
+
+function truthy(value) {
+  return value === true || value === "true" || value === "1" || value === 1;
+}
+
+function pushOptional(args, flag, value) {
+  if (value !== undefined && value !== null && String(value).trim() !== "") {
+    args.push(flag, String(value));
+  }
+}
+
+function currentStateArgs(input) {
+  const args = ["current", requiredText(input.state_key, "state_key"), "--json"];
+  pushOptional(args, "--project", input.project);
+  pushOptional(args, "--type", input.memory_type);
+  pushOptional(args, "--owner-scope", input.owner_scope);
+  pushOptional(args, "--owner-key", input.owner_key);
+  pushOptional(args, "--as-of-epoch", input.as_of_epoch);
+  return args;
+}
+
+function commitLookupArgs(input) {
+  const args = ["commit", "show", requiredText(input.sha, "sha"), "--json"];
+  pushOptional(args, "--project", input.project);
+  return args;
+}
+
+function sessionCommitsArgs(input) {
+  const args = ["commit", "session", requiredText(input.session_id, "session_id"), "--json"];
+  pushOptional(args, "--project", input.project);
+  pushOptional(args, "--limit", input.limit || 20);
+  return args;
+}
+
+function timelineAroundArgs(input) {
+  const args = ["timeline", "around", "--json"];
+  const anchor = optionalPositiveInteger(input.anchor, "anchor");
+  const query = String(input.query || "").trim();
+  if (anchor !== null) args.push("--anchor", String(anchor));
+  if (query) args.push("--query", query);
+  if (anchor === null && !query) throw badRequest("anchor or query is required");
+  pushOptional(args, "--project", input.project);
+  pushOptional(args, "--depth-before", input.depth_before);
+  pushOptional(args, "--depth-after", input.depth_after);
+  return args;
+}
+
+function timelineReportArgs(input) {
+  const args = ["timeline", "report", requiredText(input.project, "project"), "--json"];
+  if (truthy(input.full)) args.push("--full");
+  return args;
+}
+
+function workstreamsListArgs(input) {
+  const args = ["workstreams", "list", "--project", requiredText(input.project, "project"), "--json"];
+  pushOptional(args, "--status", input.status);
+  return args;
+}
+
+function workstreamUpdateArgs(input) {
+  const args = [
+    "workstreams",
+    "update",
+    String(positiveInteger(input.id, "id")),
+    "--project",
+    requiredText(input.project, "project"),
+    "--json"
+  ];
+  pushOptional(args, "--status", input.status);
+  pushOptional(args, "--next-action", input.next_action);
+  pushOptional(args, "--blockers", input.blockers);
+  if (!args.includes("--status") && !args.includes("--next-action") && !args.includes("--blockers")) {
+    throw badRequest("status, next_action, or blockers is required");
+  }
+  if (!truthy(input.confirm)) throw badRequest("confirm is required");
+  args.push("--confirm");
+  return args;
+}
+
+function createTraceBackend(runRememJson) {
+  const run = (args, timeoutMs = 15000) => runRememJson(args, {
+    allowDownload: false,
+    timeoutMs
+  });
+  return {
+    currentState: (input) => run(currentStateArgs(input)),
+    commitLookup: (input) => run(commitLookupArgs(input)),
+    sessionCommits: (input) => run(sessionCommitsArgs(input)),
+    timelineAround: (input) => run(timelineAroundArgs(input)),
+    timelineReport: (input) => run(timelineReportArgs(input)),
+    workstreamsList: (input) => run(workstreamsListArgs(input)),
+    workstreamUpdate: (input) => run(workstreamUpdateArgs(input))
+  };
+}
+
+async function callTraceTool(backend, name, args, toolResult) {
+  if (name === "remem_current_state") {
+    const result = await backend.currentState(args);
+    return toolResult(`Current state ${result.status || "resolved"}.`, result);
+  }
+  if (name === "remem_commit_lookup") {
+    const result = await backend.commitLookup(args);
+    return toolResult(`Found ${Array.isArray(result) ? result.length : 0} commit match(es).`, {
+      results: result
+    });
+  }
+  if (name === "remem_session_commits") {
+    const result = await backend.sessionCommits(args);
+    return toolResult(`Found ${Array.isArray(result) ? result.length : 0} linked commit(s).`, {
+      results: result
+    });
+  }
+  if (name === "remem_timeline_around") {
+    const result = await backend.timelineAround(args);
+    return toolResult(`Loaded ${result.count || 0} timeline observation(s).`, result);
+  }
+  if (name === "remem_timeline_report") {
+    const result = await backend.timelineReport(args);
+    return toolResult("Timeline report generated.", result);
+  }
+  if (name === "remem_workstreams_list") {
+    const result = await backend.workstreamsList(args);
+    return toolResult(`Loaded ${result.count || 0} workstream(s).`, result);
+  }
+  if (name === "remem_workstream_update") {
+    const result = await backend.workstreamUpdate(args);
+    return toolResult(`Workstream ${result.id} update ${result.updated ? "applied" : "not applied"}.`, result);
+  }
+  return null;
+}
+
+module.exports = {
+  callTraceTool,
+  createTraceBackend,
+  pushOptional,
+  requiredText
+};


### PR DESCRIPTION
Refs #390

## Summary
- Move trace-related app backend calls into a shared `trace.js` helper.
- Add MCP/app tool descriptors and HTTP routes for timeline around/report plus workstream list/update.
- Keep visible widget UI unchanged because `public/widget.html` is 783 lines and should be split before adding more UI.

## Verification
- `node --test plugins/remem/apps/remem/server.test.js`
- `node --test --test-concurrency=1 plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `cargo fmt --check`
- `cargo check --message-format=short`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `cargo test`
- `git diff --check origin/main`

## Notes
- Workstream update remains guarded by local POST checks, explicit `project`, explicit `confirm`, and at least one mutation field.
- Tool schemas include `anyOf` constraints for `timeline around` and `workstream update` so descriptors match backend validation.