### PR TITLE
Split widget assets and add trace UI tabs

### DIFF
--- a/plugins/remem/apps/remem/README.md
+++ b/plugins/remem/apps/remem/README.md
@@ -11,6 +11,8 @@ This app surface provides:
 - governance: stale, reject, or delete dry-run preview with affected IDs and status transitions
 - current-state resolution: stable state keys with current/conflict/history metadata
 - traceability: commit lookup and session-to-commit links
+- timeline: project report and around-anchor/query browsing
+- workstreams: status filtering plus confirmed status/next-action/blocker updates
 - activation: hooks-only dry-run plan without writing Codex config
 
 ## Surface map
@@ -32,9 +34,9 @@ This app surface provides:
 | Activation plan | `remem_activation_plan` | `GET /api/activation-plan` | `remem install --target codex --hooks-only --dry-run` |
 
 Timeline and workstream backend routes are wired for app and MCP callers through
-machine-readable Rust CLI bridges. The visible widget UI remains unchanged until
-`public/widget.html` is split below the 800-line cap. Workstream updates must
-pass an explicit project and `--confirm`.
+machine-readable Rust CLI bridges. The visible widget is split into HTML, CSS,
+and JS assets so new timeline/workstream tabs can stay below the 800-line cap.
+Workstream updates must pass an explicit project and `--confirm`.
 
 Run locally:
 

--- a/plugins/remem/apps/remem/public/widget.css
+++ b/plugins/remem/apps/remem/public/widget.css
@@ -1,0 +1,269 @@
+:root {
+  color-scheme: light;
+  --ink: #1d2428;
+  --muted: #6f777b;
+  --line: #d9e0de;
+  --panel: #f7f8f6;
+  --paper: #ffffff;
+  --blue: #2364aa;
+  --green: #178260;
+  --amber: #a76518;
+  --red: #b73535;
+  --shadow: 0 1px 2px rgba(22, 30, 33, 0.08);
+  font-family: Avenir Next, ui-sans-serif, system-ui, sans-serif;
+  letter-spacing: 0;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 14px;
+  line-height: 1.45;
+}
+button, input, textarea, select {
+  font: inherit;
+  letter-spacing: 0;
+}
+button {
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--ink);
+  border-radius: 6px;
+  min-height: 34px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+button:hover { border-color: #9fb0ad; }
+button.primary { background: var(--ink); color: #fff; border-color: var(--ink); }
+button.icon { width: 34px; padding: 0; }
+input[type="checkbox"] {
+  width: auto;
+  min-height: auto;
+}
+input, textarea, select {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+  padding: 8px 9px;
+  min-height: 34px;
+}
+textarea {
+  min-height: 92px;
+  resize: vertical;
+}
+.shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  background:
+    linear-gradient(90deg, #f4f6f5 0, #f4f6f5 320px, #fff 320px);
+}
+.rail {
+  border-right: 1px solid var(--line);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.main {
+  padding: 18px;
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 16px;
+  min-width: 0;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.mark {
+  width: 34px;
+  height: 34px;
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+  background: #e6f1ed;
+  color: var(--green);
+  font-weight: 800;
+  border: 1px solid #c7ddd6;
+}
+h1, h2, h3, p { margin: 0; }
+h1 { font-size: 18px; font-weight: 700; }
+h2 { font-size: 13px; font-weight: 700; text-transform: uppercase; color: var(--muted); }
+h3 { font-size: 14px; font-weight: 700; }
+.subtle { color: var(--muted); }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; }
+.stack { display: flex; flex-direction: column; gap: 10px; }
+.row { display: flex; align-items: center; gap: 8px; }
+.row.spread { justify-content: space-between; }
+.section {
+  border-top: 1px solid var(--line);
+  padding-top: 13px;
+}
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.stat {
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--paper);
+  padding: 10px;
+  box-shadow: var(--shadow);
+  min-height: 70px;
+}
+.stat .value {
+  font-size: 24px;
+  line-height: 1.1;
+  font-weight: 750;
+  margin-top: 3px;
+}
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 3px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pill.ok { color: var(--green); border-color: #bddad1; background: #eef8f4; }
+.pill.warn { color: var(--amber); border-color: #ead2a9; background: #fff7e8; }
+.pill.bad { color: var(--red); border-color: #e7bcbc; background: #fff0f0; }
+.tabs {
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: 2px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 2px;
+  background: var(--panel);
+  width: fit-content;
+}
+.tab {
+  border: 0;
+  background: transparent;
+  min-height: 30px;
+  padding: 5px 10px;
+}
+.tab.active {
+  background: #fff;
+  box-shadow: var(--shadow);
+}
+.toolbar {
+  display: grid;
+  grid-template-columns: 1fr 160px auto;
+  gap: 8px;
+  align-items: center;
+}
+.content-grid {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.8fr) minmax(360px, 1.2fr);
+  gap: 14px;
+  min-height: 0;
+}
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--paper);
+  min-width: 0;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+.panel-head {
+  min-height: 44px;
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--line);
+  background: #fbfcfb;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.panel-body {
+  padding: 12px;
+  overflow: auto;
+}
+.results {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+.result {
+  border-bottom: 1px solid var(--line);
+  padding: 11px 12px;
+  cursor: pointer;
+  background: #fff;
+}
+.result:hover { background: #f7faf8; }
+.result.active { border-left: 3px solid var(--green); padding-left: 9px; background: #f1f7f4; }
+.result-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-weight: 700;
+}
+.preview {
+  color: var(--muted);
+  margin-top: 4px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.detail-text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+  margin-top: 10px;
+}
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.form-grid .wide { grid-column: 1 / -1; }
+.message {
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 10px;
+  background: var(--panel);
+  color: var(--muted);
+}
+.message.error {
+  border-color: #e7bcbc;
+  background: #fff0f0;
+  color: var(--red);
+}
+pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 10px;
+  background: #f8f9f8;
+  max-height: 280px;
+  overflow: auto;
+}
+.hidden { display: none !important; }
+@media (max-width: 860px) {
+  .shell { grid-template-columns: 1fr; background: #fff; }
+  .rail { border-right: 0; border-bottom: 1px solid var(--line); }
+  .toolbar { grid-template-columns: 1fr; }
+  .content-grid { grid-template-columns: 1fr; }
+  .form-grid { grid-template-columns: 1fr; }
+}

--- a/plugins/remem/apps/remem/public/widget.html
+++ b/plugins/remem/apps/remem/public/widget.html
@@ -4,273 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Remem Dashboard</title>
-  <style>
-    :root {
-      color-scheme: light;
-      --ink: #1d2428;
-      --muted: #6f777b;
-      --line: #d9e0de;
-      --panel: #f7f8f6;
-      --paper: #ffffff;
-      --blue: #2364aa;
-      --green: #178260;
-      --amber: #a76518;
-      --red: #b73535;
-      --shadow: 0 1px 2px rgba(22, 30, 33, 0.08);
-      font-family: Avenir Next, ui-sans-serif, system-ui, sans-serif;
-      letter-spacing: 0;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      background: var(--paper);
-      color: var(--ink);
-      font-size: 14px;
-      line-height: 1.45;
-    }
-    button, input, textarea, select {
-      font: inherit;
-      letter-spacing: 0;
-    }
-    button {
-      border: 1px solid var(--line);
-      background: #fff;
-      color: var(--ink);
-      border-radius: 6px;
-      min-height: 34px;
-      padding: 6px 10px;
-      cursor: pointer;
-    }
-    button:hover { border-color: #9fb0ad; }
-    button.primary { background: var(--ink); color: #fff; border-color: var(--ink); }
-    button.icon { width: 34px; padding: 0; }
-    input, textarea, select {
-      width: 100%;
-      border: 1px solid var(--line);
-      border-radius: 6px;
-      background: #fff;
-      color: var(--ink);
-      padding: 8px 9px;
-      min-height: 34px;
-    }
-    textarea {
-      min-height: 92px;
-      resize: vertical;
-    }
-    .shell {
-      min-height: 100vh;
-      display: grid;
-      grid-template-columns: minmax(260px, 320px) 1fr;
-      background:
-        linear-gradient(90deg, #f4f6f5 0, #f4f6f5 320px, #fff 320px);
-    }
-    .rail {
-      border-right: 1px solid var(--line);
-      padding: 18px;
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
-    .main {
-      padding: 18px;
-      display: grid;
-      grid-template-rows: auto auto 1fr;
-      gap: 16px;
-      min-width: 0;
-    }
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    .mark {
-      width: 34px;
-      height: 34px;
-      border-radius: 7px;
-      display: grid;
-      place-items: center;
-      background: #e6f1ed;
-      color: var(--green);
-      font-weight: 800;
-      border: 1px solid #c7ddd6;
-    }
-    h1, h2, h3, p { margin: 0; }
-    h1 { font-size: 18px; font-weight: 700; }
-    h2 { font-size: 13px; font-weight: 700; text-transform: uppercase; color: var(--muted); }
-    h3 { font-size: 14px; font-weight: 700; }
-    .subtle { color: var(--muted); }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; }
-    .stack { display: flex; flex-direction: column; gap: 10px; }
-    .row { display: flex; align-items: center; gap: 8px; }
-    .row.spread { justify-content: space-between; }
-    .section {
-      border-top: 1px solid var(--line);
-      padding-top: 13px;
-    }
-    .stat-grid {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 8px;
-    }
-    .stat {
-      border: 1px solid var(--line);
-      border-radius: 7px;
-      background: var(--paper);
-      padding: 10px;
-      box-shadow: var(--shadow);
-      min-height: 70px;
-    }
-    .stat .value {
-      font-size: 24px;
-      line-height: 1.1;
-      font-weight: 750;
-      margin-top: 3px;
-    }
-    .pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      max-width: 100%;
-      padding: 3px 7px;
-      border-radius: 999px;
-      border: 1px solid var(--line);
-      background: #fff;
-      color: var(--muted);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .pill.ok { color: var(--green); border-color: #bddad1; background: #eef8f4; }
-    .pill.warn { color: var(--amber); border-color: #ead2a9; background: #fff7e8; }
-    .pill.bad { color: var(--red); border-color: #e7bcbc; background: #fff0f0; }
-    .tabs {
-      display: inline-grid;
-      grid-auto-flow: column;
-      gap: 2px;
-      border: 1px solid var(--line);
-      border-radius: 7px;
-      padding: 2px;
-      background: var(--panel);
-      width: fit-content;
-    }
-    .tab {
-      border: 0;
-      background: transparent;
-      min-height: 30px;
-      padding: 5px 10px;
-    }
-    .tab.active {
-      background: #fff;
-      box-shadow: var(--shadow);
-    }
-    .toolbar {
-      display: grid;
-      grid-template-columns: 1fr 160px auto;
-      gap: 8px;
-      align-items: center;
-    }
-    .content-grid {
-      display: grid;
-      grid-template-columns: minmax(300px, 0.8fr) minmax(360px, 1.2fr);
-      gap: 14px;
-      min-height: 0;
-    }
-    .panel {
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      background: var(--paper);
-      min-width: 0;
-      overflow: hidden;
-      box-shadow: var(--shadow);
-    }
-    .panel-head {
-      min-height: 44px;
-      padding: 11px 12px;
-      border-bottom: 1px solid var(--line);
-      background: #fbfcfb;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 8px;
-    }
-    .panel-body {
-      padding: 12px;
-      overflow: auto;
-    }
-    .results {
-      padding: 0;
-      margin: 0;
-      list-style: none;
-      display: flex;
-      flex-direction: column;
-    }
-    .result {
-      border-bottom: 1px solid var(--line);
-      padding: 11px 12px;
-      cursor: pointer;
-      background: #fff;
-    }
-    .result:hover { background: #f7faf8; }
-    .result.active { border-left: 3px solid var(--green); padding-left: 9px; background: #f1f7f4; }
-    .result-title {
-      display: flex;
-      justify-content: space-between;
-      gap: 8px;
-      font-weight: 700;
-    }
-    .preview {
-      color: var(--muted);
-      margin-top: 4px;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-    .detail-text {
-      white-space: pre-wrap;
-      overflow-wrap: anywhere;
-      border-top: 1px solid var(--line);
-      padding-top: 10px;
-      margin-top: 10px;
-    }
-    .form-grid {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 10px;
-    }
-    .form-grid .wide { grid-column: 1 / -1; }
-    .message {
-      border: 1px solid var(--line);
-      border-radius: 7px;
-      padding: 10px;
-      background: var(--panel);
-      color: var(--muted);
-    }
-    .message.error {
-      border-color: #e7bcbc;
-      background: #fff0f0;
-      color: var(--red);
-    }
-    pre {
-      white-space: pre-wrap;
-      overflow-wrap: anywhere;
-      margin: 0;
-      border: 1px solid var(--line);
-      border-radius: 7px;
-      padding: 10px;
-      background: #f8f9f8;
-      max-height: 280px;
-      overflow: auto;
-    }
-    .hidden { display: none !important; }
-    @media (max-width: 860px) {
-      .shell { grid-template-columns: 1fr; background: #fff; }
-      .rail { border-right: 0; border-bottom: 1px solid var(--line); }
-      .toolbar { grid-template-columns: 1fr; }
-      .content-grid { grid-template-columns: 1fr; }
-      .form-grid { grid-template-columns: 1fr; }
-    }
-  </style>
+  <link rel="stylesheet" href="/widget.css">
 </head>
 <body>
   <div class="shell">
@@ -309,6 +43,8 @@
           <button class="tab active" data-view="search">Search</button>
           <button class="tab" data-view="save">Save</button>
           <button class="tab" data-view="governance">Governance</button>
+          <button class="tab" data-view="timeline">Timeline</button>
+          <button class="tab" data-view="workstreams">Workstreams</button>
           <button class="tab" data-view="activation">Activation</button>
         </div>
         <span class="pill" id="health-pill">Loading</span>
@@ -420,6 +156,79 @@
           <div id="govern-result" class="message hidden"></div>
         </div>
       </section>
+      <section id="timeline-view" class="panel hidden">
+        <div class="panel-head"><h3>Timeline</h3></div>
+        <div class="panel-body stack">
+          <div class="form-grid">
+            <label class="wide">Project
+              <input id="timeline-project" placeholder="/path/to/repo">
+            </label>
+            <label>Anchor ID
+              <input id="timeline-anchor" type="number" min="1">
+            </label>
+            <label>Query
+              <input id="timeline-query" placeholder="release manifest">
+            </label>
+            <label>Before
+              <input id="timeline-before" type="number" min="1" value="6">
+            </label>
+            <label>After
+              <input id="timeline-after" type="number" min="1" value="6">
+            </label>
+          </div>
+          <div class="row spread">
+            <button id="timeline-around-button">Around</button>
+            <button class="primary" id="timeline-report-button">Report</button>
+          </div>
+          <div id="timeline-result" class="message hidden"></div>
+        </div>
+      </section>
+      <section id="workstreams-view" class="panel hidden">
+        <div class="panel-head"><h3>Workstreams</h3></div>
+        <div class="panel-body stack">
+          <div class="form-grid">
+            <label class="wide">Project
+              <input id="workstream-project" placeholder="/path/to/repo">
+            </label>
+            <label>Status
+              <select id="workstream-status">
+                <option value="">Any</option>
+                <option value="active">Active</option>
+                <option value="paused">Paused</option>
+                <option value="completed">Completed</option>
+                <option value="abandoned">Abandoned</option>
+              </select>
+            </label>
+            <label>Workstream ID
+              <input id="workstream-id" type="number" min="1">
+            </label>
+            <label>New status
+              <select id="workstream-new-status">
+                <option value="">Unchanged</option>
+                <option value="active">Active</option>
+                <option value="paused">Paused</option>
+                <option value="completed">Completed</option>
+                <option value="abandoned">Abandoned</option>
+              </select>
+            </label>
+            <label class="wide">Next action
+              <input id="workstream-next-action">
+            </label>
+            <label class="wide">Blockers
+              <input id="workstream-blockers">
+            </label>
+            <label class="row">
+              <input id="workstream-confirm" type="checkbox">
+              <span>Confirm update</span>
+            </label>
+          </div>
+          <div class="row spread">
+            <button id="workstream-list-button">Load</button>
+            <button class="primary" id="workstream-update-button">Update</button>
+          </div>
+          <div id="workstream-result" class="message hidden"></div>
+        </div>
+      </section>
       <section id="activation-view" class="panel hidden">
         <div class="panel-head">
           <h3>Activation Plan</h3>
@@ -432,352 +241,6 @@
       </section>
     </main>
   </div>
-  <script>
-    const state = { snapshot: null, results: [], selected: null };
-    const $ = (id) => document.getElementById(id);
-    function cls(value, truthy) {
-      value.classList.toggle("hidden", !truthy);
-    }
-    function valueAt(object, path, fallback = 0) {
-      return path.split(".").reduce((acc, key) => acc && acc[key], object) ?? fallback;
-    }
-    async function request(route, options = {}) {
-      if (canCallHostTool(route)) {
-        return requestViaHostTool(route, options);
-      }
-      const response = await fetch(route, options);
-      const payload = await response.json();
-      if (!response.ok) {
-        throw new Error(payload.error?.message || `Request failed with ${response.status}`);
-      }
-      return payload;
-    }
-    function canCallHostTool(route) {
-      return typeof window.openai?.callTool === "function" && String(route).startsWith("/api/");
-    }
-    async function requestViaHostTool(route, options = {}) {
-      const method = String(options.method || "GET").toUpperCase();
-      const url = new URL(route, "http://remem.local");
-      const result = await callHostTool(apiToolName(url.pathname, method), apiToolArgs(url, method, options));
-      return result?.structuredContent ?? result;
-    }
-    async function callHostTool(name, args) {
-      if (!name) throw new Error("No host tool is available for this action");
-      return window.openai.callTool(name, args);
-    }
-    function apiToolName(pathname, method) {
-      if (method === "GET" && pathname === "/api/status") return "remem_dashboard";
-      if (method === "GET" && pathname === "/api/search") return "remem_search";
-      if (method === "GET" && pathname === "/api/memory") return "remem_get_memory";
-      if (method === "GET" && pathname === "/api/activation-plan") return "remem_activation_plan";
-      if (method === "POST" && pathname === "/api/save") return "remem_save_memory";
-      if (method === "POST" && pathname === "/api/governance-preview") return "remem_governance_preview";
-      return null;
-    }
-    function apiToolArgs(url, method, options) {
-      if (method === "GET" && url.pathname === "/api/search") {
-        return {
-          query: url.searchParams.get("query") || "",
-          project: url.searchParams.get("project") || undefined,
-          type: url.searchParams.get("type") || undefined,
-          limit: numericParam(url.searchParams, "limit", 12),
-          offset: numericParam(url.searchParams, "offset", 0),
-          include_stale: booleanParam(url.searchParams, "include_stale"),
-          multi_hop: booleanParam(url.searchParams, "multi_hop")
-        };
-      }
-      if (method === "GET" && url.pathname === "/api/memory") {
-        return { id: Number(url.searchParams.get("id")) };
-      }
-      if (method === "POST" && url.pathname === "/api/save") {
-        return JSON.parse(options.body || "{}");
-      }
-      if (method === "POST" && url.pathname === "/api/governance-preview") {
-        return JSON.parse(options.body || "{}");
-      }
-      return {};
-    }
-    function numericParam(params, key, fallback) {
-      const value = params.get(key);
-      if (value === null || value === "") return fallback;
-      const number = Number(value);
-      return Number.isFinite(number) ? number : fallback;
-    }
-    function booleanParam(params, key) {
-      const value = params.get(key);
-      if (value === null || value === "") return undefined;
-      return value === "true" || value === "1";
-    }
-    function renderRuntime(snapshot) {
-      const runtime = snapshot.runtime || {};
-      const selected = runtime.selected || runtime.pathMatch;
-      const selectedOk = Boolean(runtime.selected);
-      const binarySource = selected?.source || "needs setup";
-      $("runtime-status").innerHTML = `
-        <span class="pill ${selectedOk ? "ok" : "warn"}">${escapeHtml(binarySource)}</span>
-        <div class="mono">${escapeHtml(selected?.path || runtime.managedBinary || "No runtime found")}</div>
-        <div class="subtle">version ${escapeHtml(selected?.version || snapshot.expected_version || "unknown")} · schema ${escapeHtml(String(selected?.schemaVersion || "-"))}</div>
-        <div class="subtle">plugin data</div>
-        <div class="mono">${escapeHtml(snapshot.plugin_data || runtime.pluginData || "")}</div>
-      `;
-    }
-    function renderCounts(status) {
-      $("count-memories").textContent = valueAt(status, "totals.memories");
-      $("count-observations").textContent = valueAt(status, "totals.observations");
-      $("count-raw").textContent = valueAt(status, "totals.raw_messages");
-      const queue = valueAt(status, "capture_pipeline.extract_todo") +
-        valueAt(status, "pending_observations.ready") +
-        valueAt(status, "jobs.pending");
-      $("count-queue").textContent = queue;
-    }
-    function renderActivation(activation) {
-      const stateClass = activation?.mentions_hooks ? "warn" : "ok";
-      $("activation-summary").innerHTML = `
-        <span class="pill ${stateClass}">${activation?.mentions_hooks ? "hooks preview" : "no hook plan"}</span>
-        <div class="subtle">${activation?.line_count || 0} dry-run line(s)</div>
-      `;
-      $("activation-plan").textContent = activation?.plan_text || "";
-    }
-    function renderHealth(snapshot) {
-      const doctor = snapshot.doctor || {};
-      const failed = Number(doctor.fails || 0);
-      const warned = Number(doctor.warns || 0);
-      const pill = $("health-pill");
-      pill.className = `pill ${failed ? "bad" : warned ? "warn" : "ok"}`;
-      pill.textContent = failed ? `${failed} failing check(s)` : warned ? `${warned} warning(s)` : "Healthy";
-    }
-    async function refresh() {
-      try {
-        state.snapshot = await request("/api/status");
-        renderRuntime(state.snapshot);
-        renderCounts(state.snapshot.status || {});
-        renderActivation(state.snapshot.activation || {});
-        renderHealth(state.snapshot);
-      } catch (error) {
-        $("runtime-status").innerHTML = `<div class="message error">${escapeHtml(error.message)}</div>`;
-        $("health-pill").className = "pill bad";
-        $("health-pill").textContent = "Error";
-      }
-    }
-    async function runSearch() {
-      const query = $("search-query").value.trim();
-      if (!query) return;
-      const params = new URLSearchParams({
-        query,
-        limit: "12",
-        include_stale: "true"
-      });
-      const type = $("search-type").value;
-      if (type) params.set("type", type);
-      $("results").innerHTML = `<li class="result"><span class="subtle">Searching...</span></li>`;
-      $("detail").innerHTML = "";
-      const payload = await request(`/api/search?${params.toString()}`);
-      state.results = searchResults(payload);
-      $("result-count").textContent = `${state.results.length}`;
-      renderResults();
-    }
-    function searchResults(payload) {
-      const memories = (payload.data || []).map((item) => ({
-        ...item,
-        result_kind: "memory",
-        result_id: String(item.id)
-      }));
-      const rawHits = (payload.raw_hits || []).map((item) => ({
-        ...item,
-        id: `raw-${item.id}`,
-        raw_id: item.id,
-        result_kind: "raw_archive",
-        result_id: `raw-${item.id}`,
-        title: `${item.role || "raw"} message from raw archive`,
-        content: item.preview || "",
-        memory_type: "raw archive",
-        status: "raw",
-        scope: item.source || "",
-        project: item.project || ""
-      }));
-      return memories.concat(rawHits);
-    }
-    function renderResults() {
-      const results = $("results");
-      if (!state.results.length) {
-        results.innerHTML = `<li class="result"><span class="subtle">No memories found</span></li>`;
-        return;
-      }
-      results.innerHTML = state.results.map((item) => `
-        <li class="result" data-id="${escapeHtml(item.result_id || item.id)}">
-          <div class="result-title">
-            <span>${escapeHtml(item.title || `Memory ${item.id}`)}</span>
-            <span class="pill">${escapeHtml(item.memory_type || item.type || "memory")}</span>
-          </div>
-          <div class="preview">${escapeHtml(item.content || item.preview || "")}</div>
-        </li>
-      `).join("");
-    }
-    async function selectResult(id) {
-      document.querySelectorAll(".result").forEach((node) => {
-        node.classList.toggle("active", node.dataset.id === String(id));
-      });
-      $("detail").innerHTML = `<div class="message">Loading memory ${id}...</div>`;
-      const cached = state.results.find((item) => String(item.result_id || item.id) === String(id));
-      if (cached?.result_kind === "raw_archive") {
-        state.selected = cached;
-        $("detail-type").textContent = "raw archive";
-        $("detail").innerHTML = `
-          <div class="stack">
-            <h3>${escapeHtml(cached.title)}</h3>
-            <div class="row">
-              <span class="pill">${escapeHtml(cached.role || "")}</span>
-              <span class="pill">${escapeHtml(cached.source || "")}</span>
-            </div>
-            <div class="subtle mono">${escapeHtml(cached.project || "")}</div>
-            <div class="detail-text">${escapeHtml(cached.preview || cached.content || "")}</div>
-          </div>
-        `;
-        return;
-      }
-      const item = await request(`/api/memory?id=${encodeURIComponent(id)}`);
-      state.selected = item;
-      $("detail-type").textContent = item.memory_type || "memory";
-      $("detail").innerHTML = `
-        <div class="stack">
-          <h3>${escapeHtml(item.title || `Memory ${item.id}`)}</h3>
-          <div class="row">
-            <span class="pill">${escapeHtml(item.status || "")}</span>
-            <span class="pill">${escapeHtml(item.scope || "")}</span>
-          </div>
-          <div class="subtle mono">${escapeHtml(item.project || "")}</div>
-          <div class="detail-text">${escapeHtml(item.content || "")}</div>
-        </div>
-      `;
-    }
-    async function saveMemory() {
-      const text = $("save-text").value.trim();
-      const target = $("save-result");
-      if (!text) {
-        target.textContent = "Memory text is required.";
-        target.className = "message error";
-        return;
-      }
-      const payload = {
-        text,
-        title: $("save-title").value.trim() || undefined,
-        project: $("save-project").value.trim() || undefined,
-        topic_key: $("save-topic").value.trim() || undefined,
-        memory_type: $("save-type").value,
-        scope: $("save-scope").value
-      };
-      target.textContent = "Saving...";
-      target.className = "message";
-      try {
-        const saved = await request("/api/save", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(payload)
-        });
-        target.textContent = `Saved memory ${saved.id} (${saved.operation}).`;
-        target.className = "message";
-      } catch (error) {
-        target.textContent = error.message;
-        target.className = "message error";
-      }
-    }
-    async function refreshPlan() {
-      $("activation-plan").textContent = "Generating...";
-      const plan = await request("/api/activation-plan");
-      renderActivation(plan);
-    }
-    function governancePayload() {
-      const ids = $("govern-ids").value
-        .split(/[,\s]+/)
-        .map((value) => value.trim())
-        .filter(Boolean)
-        .map(Number);
-      if (ids.some((id) => !Number.isInteger(id) || id <= 0)) {
-        throw new Error("Memory IDs must be positive integers.");
-      }
-      return {
-        action: $("govern-action").value,
-        ids,
-        project: $("govern-project").value.trim() || undefined,
-        query: $("govern-query").value.trim() || undefined,
-        memory_type: $("govern-type").value.trim() || undefined,
-        status: $("govern-status").value.trim() || undefined,
-        limit: Number($("govern-limit").value || 50),
-        actor: "codex-remem-app"
-      };
-    }
-    async function previewGovernance() {
-      const target = $("govern-result");
-      target.textContent = "Previewing...";
-      target.className = "message";
-      try {
-        const preview = await request("/api/governance-preview", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(governancePayload())
-        });
-        const affected = preview.affected || [];
-        target.className = "message";
-        target.innerHTML = `
-          <div><strong>${affected.length}</strong> affected memory result(s); dry_run=${escapeHtml(preview.dry_run)}</div>
-          ${affected.map((item) => `
-            <div class="detail-text mono">#${escapeHtml(item.id)} ${escapeHtml(item.previous_status)} -> ${escapeHtml(item.new_status)} ${escapeHtml(item.title || "")}</div>
-          `).join("")}
-        `;
-      } catch (error) {
-        target.textContent = error.message;
-        target.className = "message error";
-      }
-    }
-    function switchView(name) {
-      document.querySelectorAll(".tab").forEach((tab) => {
-        tab.classList.toggle("active", tab.dataset.view === name);
-      });
-      cls($("search-view"), name === "search");
-      cls($("save-view"), name === "save");
-      cls($("governance-view"), name === "governance");
-      cls($("activation-view"), name === "activation");
-    }
-    function escapeHtml(value) {
-      return String(value ?? "")
-        .replaceAll("&", "&amp;")
-        .replaceAll("<", "&lt;")
-        .replaceAll(">", "&gt;")
-        .replaceAll('"', "&quot;")
-        .replaceAll("'", "&#039;");
-    }
-    function receiveHostResult(event) {
-      const message = event.data;
-      if (!message || message.method !== "ui/notifications/tool-result") return;
-      const data = message.params?.structuredContent;
-      if (!data) return;
-      state.snapshot = data;
-      renderRuntime(data);
-      renderCounts(data.status || {});
-      renderActivation(data.activation || {});
-      renderHealth(data);
-    }
-    window.addEventListener("message", receiveHostResult);
-    $("refresh").addEventListener("click", refresh);
-    $("search-button").addEventListener("click", () => runSearch().catch((error) => {
-      $("results").innerHTML = `<li class="result"><span class="message error">${escapeHtml(error.message)}</span></li>`;
-    }));
-    $("search-query").addEventListener("keydown", (event) => {
-      if (event.key === "Enter") runSearch();
-    });
-    $("results").addEventListener("click", (event) => {
-      const item = event.target.closest(".result");
-      if (item?.dataset.id) selectResult(item.dataset.id);
-    });
-    $("save-button").addEventListener("click", saveMemory);
-    $("govern-button").addEventListener("click", previewGovernance);
-    $("plan-button").addEventListener("click", () => refreshPlan().catch((error) => {
-      $("activation-plan").textContent = error.message;
-    }));
-    document.querySelectorAll(".tab").forEach((tab) => {
-      tab.addEventListener("click", () => switchView(tab.dataset.view));
-    });
-    refresh();
-  </script>
+  <script src="/widget.js"></script>
 </body>
 </html>

--- a/plugins/remem/apps/remem/public/widget.js
+++ b/plugins/remem/apps/remem/public/widget.js
@@ -1,0 +1,519 @@
+const state = { snapshot: null, results: [], selected: null };
+const $ = (id) => document.getElementById(id);
+function cls(value, truthy) {
+  value.classList.toggle("hidden", !truthy);
+}
+function valueAt(object, path, fallback = 0) {
+  return path.split(".").reduce((acc, key) => acc && acc[key], object) ?? fallback;
+}
+async function request(route, options = {}) {
+  if (canCallHostTool(route)) {
+    return requestViaHostTool(route, options);
+  }
+  const response = await fetch(route, options);
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(payload.error?.message || `Request failed with ${response.status}`);
+  }
+  return payload;
+}
+function canCallHostTool(route) {
+  return typeof window.openai?.callTool === "function" && String(route).startsWith("/api/");
+}
+async function requestViaHostTool(route, options = {}) {
+  const method = String(options.method || "GET").toUpperCase();
+  const url = new URL(route, "http://remem.local");
+  const result = await callHostTool(apiToolName(url.pathname, method), apiToolArgs(url, method, options));
+  return result?.structuredContent ?? result;
+}
+async function callHostTool(name, args) {
+  if (!name) throw new Error("No host tool is available for this action");
+  return window.openai.callTool(name, args);
+}
+function apiToolName(pathname, method) {
+  if (method === "GET" && pathname === "/api/status") return "remem_dashboard";
+  if (method === "GET" && pathname === "/api/search") return "remem_search";
+  if (method === "GET" && pathname === "/api/memory") return "remem_get_memory";
+  if (method === "GET" && pathname === "/api/activation-plan") return "remem_activation_plan";
+  if (method === "GET" && pathname === "/api/timeline-around") return "remem_timeline_around";
+  if (method === "GET" && pathname === "/api/timeline-report") return "remem_timeline_report";
+  if (method === "GET" && pathname === "/api/workstreams") return "remem_workstreams_list";
+  if (method === "POST" && pathname === "/api/save") return "remem_save_memory";
+  if (method === "POST" && pathname === "/api/governance-preview") return "remem_governance_preview";
+  if (method === "POST" && pathname === "/api/workstream-update") return "remem_workstream_update";
+  return null;
+}
+function apiToolArgs(url, method, options) {
+  if (method === "GET" && url.pathname === "/api/search") {
+    return {
+      query: url.searchParams.get("query") || "",
+      project: url.searchParams.get("project") || undefined,
+      type: url.searchParams.get("type") || undefined,
+      limit: numericParam(url.searchParams, "limit", 12),
+      offset: numericParam(url.searchParams, "offset", 0),
+      include_stale: booleanParam(url.searchParams, "include_stale"),
+      multi_hop: booleanParam(url.searchParams, "multi_hop")
+    };
+  }
+  if (method === "GET" && url.pathname === "/api/memory") {
+    return { id: Number(url.searchParams.get("id")) };
+  }
+  if (method === "GET" && url.pathname === "/api/timeline-around") {
+    return {
+      anchor: optionalNumericParam(url.searchParams, "anchor"),
+      query: url.searchParams.get("query") || undefined,
+      project: url.searchParams.get("project") || undefined,
+      depth_before: optionalNumericParam(url.searchParams, "depth_before"),
+      depth_after: optionalNumericParam(url.searchParams, "depth_after")
+    };
+  }
+  if (method === "GET" && url.pathname === "/api/timeline-report") {
+    return {
+      project: url.searchParams.get("project") || undefined,
+      full: booleanParam(url.searchParams, "full")
+    };
+  }
+  if (method === "GET" && url.pathname === "/api/workstreams") {
+    return {
+      project: url.searchParams.get("project") || undefined,
+      status: url.searchParams.get("status") || undefined
+    };
+  }
+  if (method === "POST" && url.pathname === "/api/save") {
+    return JSON.parse(options.body || "{}");
+  }
+  if (method === "POST" && url.pathname === "/api/governance-preview") {
+    return JSON.parse(options.body || "{}");
+  }
+  if (method === "POST" && url.pathname === "/api/workstream-update") {
+    return JSON.parse(options.body || "{}");
+  }
+  return {};
+}
+function numericParam(params, key, fallback) {
+  const value = params.get(key);
+  if (value === null || value === "") return fallback;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+function booleanParam(params, key) {
+  const value = params.get(key);
+  if (value === null || value === "") return undefined;
+  return value === "true" || value === "1";
+}
+function optionalNumericParam(params, key) {
+  const value = params.get(key);
+  if (value === null || value === "") return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+function renderRuntime(snapshot) {
+  const runtime = snapshot.runtime || {};
+  const selected = runtime.selected || runtime.pathMatch;
+  const selectedOk = Boolean(runtime.selected);
+  const binarySource = selected?.source || "needs setup";
+  $("runtime-status").innerHTML = `
+    <span class="pill ${selectedOk ? "ok" : "warn"}">${escapeHtml(binarySource)}</span>
+    <div class="mono">${escapeHtml(selected?.path || runtime.managedBinary || "No runtime found")}</div>
+    <div class="subtle">version ${escapeHtml(selected?.version || snapshot.expected_version || "unknown")} · schema ${escapeHtml(String(selected?.schemaVersion || "-"))}</div>
+    <div class="subtle">plugin data</div>
+    <div class="mono">${escapeHtml(snapshot.plugin_data || runtime.pluginData || "")}</div>
+  `;
+}
+function renderCounts(status) {
+  $("count-memories").textContent = valueAt(status, "totals.memories");
+  $("count-observations").textContent = valueAt(status, "totals.observations");
+  $("count-raw").textContent = valueAt(status, "totals.raw_messages");
+  const queue = valueAt(status, "capture_pipeline.extract_todo") +
+    valueAt(status, "pending_observations.ready") +
+    valueAt(status, "jobs.pending");
+  $("count-queue").textContent = queue;
+}
+function renderActivation(activation) {
+  const stateClass = activation?.mentions_hooks ? "warn" : "ok";
+  $("activation-summary").innerHTML = `
+    <span class="pill ${stateClass}">${activation?.mentions_hooks ? "hooks preview" : "no hook plan"}</span>
+    <div class="subtle">${activation?.line_count || 0} dry-run line(s)</div>
+  `;
+  $("activation-plan").textContent = activation?.plan_text || "";
+}
+function renderHealth(snapshot) {
+  const doctor = snapshot.doctor || {};
+  const failed = Number(doctor.fails || 0);
+  const warned = Number(doctor.warns || 0);
+  const pill = $("health-pill");
+  pill.className = `pill ${failed ? "bad" : warned ? "warn" : "ok"}`;
+  pill.textContent = failed ? `${failed} failing check(s)` : warned ? `${warned} warning(s)` : "Healthy";
+}
+async function refresh() {
+  try {
+    state.snapshot = await request("/api/status");
+    renderRuntime(state.snapshot);
+    renderCounts(state.snapshot.status || {});
+    renderActivation(state.snapshot.activation || {});
+    renderHealth(state.snapshot);
+  } catch (error) {
+    $("runtime-status").innerHTML = `<div class="message error">${escapeHtml(error.message)}</div>`;
+    $("health-pill").className = "pill bad";
+    $("health-pill").textContent = "Error";
+  }
+}
+async function runSearch() {
+  const query = $("search-query").value.trim();
+  if (!query) return;
+  const params = new URLSearchParams({
+    query,
+    limit: "12",
+    include_stale: "true"
+  });
+  const type = $("search-type").value;
+  if (type) params.set("type", type);
+  $("results").innerHTML = `<li class="result"><span class="subtle">Searching...</span></li>`;
+  $("detail").innerHTML = "";
+  const payload = await request(`/api/search?${params.toString()}`);
+  state.results = searchResults(payload);
+  $("result-count").textContent = `${state.results.length}`;
+  renderResults();
+}
+function searchResults(payload) {
+  const memories = (payload.data || []).map((item) => ({
+    ...item,
+    result_kind: "memory",
+    result_id: String(item.id)
+  }));
+  const rawHits = (payload.raw_hits || []).map((item) => ({
+    ...item,
+    id: `raw-${item.id}`,
+    raw_id: item.id,
+    result_kind: "raw_archive",
+    result_id: `raw-${item.id}`,
+    title: `${item.role || "raw"} message from raw archive`,
+    content: item.preview || "",
+    memory_type: "raw archive",
+    status: "raw",
+    scope: item.source || "",
+    project: item.project || ""
+  }));
+  return memories.concat(rawHits);
+}
+function renderResults() {
+  const results = $("results");
+  if (!state.results.length) {
+    results.innerHTML = `<li class="result"><span class="subtle">No memories found</span></li>`;
+    return;
+  }
+  results.innerHTML = state.results.map((item) => `
+    <li class="result" data-id="${escapeHtml(item.result_id || item.id)}">
+      <div class="result-title">
+        <span>${escapeHtml(item.title || `Memory ${item.id}`)}</span>
+        <span class="pill">${escapeHtml(item.memory_type || item.type || "memory")}</span>
+      </div>
+      <div class="preview">${escapeHtml(item.content || item.preview || "")}</div>
+    </li>
+  `).join("");
+}
+async function selectResult(id) {
+  document.querySelectorAll(".result").forEach((node) => {
+    node.classList.toggle("active", node.dataset.id === String(id));
+  });
+  $("detail").innerHTML = `<div class="message">Loading memory ${id}...</div>`;
+  const cached = state.results.find((item) => String(item.result_id || item.id) === String(id));
+  if (cached?.result_kind === "raw_archive") {
+    state.selected = cached;
+    $("detail-type").textContent = "raw archive";
+    $("detail").innerHTML = `
+      <div class="stack">
+        <h3>${escapeHtml(cached.title)}</h3>
+        <div class="row">
+          <span class="pill">${escapeHtml(cached.role || "")}</span>
+          <span class="pill">${escapeHtml(cached.source || "")}</span>
+        </div>
+        <div class="subtle mono">${escapeHtml(cached.project || "")}</div>
+        <div class="detail-text">${escapeHtml(cached.preview || cached.content || "")}</div>
+      </div>
+    `;
+    return;
+  }
+  const item = await request(`/api/memory?id=${encodeURIComponent(id)}`);
+  state.selected = item;
+  $("detail-type").textContent = item.memory_type || "memory";
+  $("detail").innerHTML = `
+    <div class="stack">
+      <h3>${escapeHtml(item.title || `Memory ${item.id}`)}</h3>
+      <div class="row">
+        <span class="pill">${escapeHtml(item.status || "")}</span>
+        <span class="pill">${escapeHtml(item.scope || "")}</span>
+      </div>
+      <div class="subtle mono">${escapeHtml(item.project || "")}</div>
+      <div class="detail-text">${escapeHtml(item.content || "")}</div>
+    </div>
+  `;
+}
+async function saveMemory() {
+  const text = $("save-text").value.trim();
+  const target = $("save-result");
+  if (!text) {
+    target.textContent = "Memory text is required.";
+    target.className = "message error";
+    return;
+  }
+  const payload = {
+    text,
+    title: $("save-title").value.trim() || undefined,
+    project: $("save-project").value.trim() || undefined,
+    topic_key: $("save-topic").value.trim() || undefined,
+    memory_type: $("save-type").value,
+    scope: $("save-scope").value
+  };
+  target.textContent = "Saving...";
+  target.className = "message";
+  try {
+    const saved = await request("/api/save", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    target.textContent = `Saved memory ${saved.id} (${saved.operation}).`;
+    target.className = "message";
+  } catch (error) {
+    target.textContent = error.message;
+    target.className = "message error";
+  }
+}
+async function refreshPlan() {
+  $("activation-plan").textContent = "Generating...";
+  const plan = await request("/api/activation-plan");
+  renderActivation(plan);
+}
+function governancePayload() {
+  const ids = $("govern-ids").value
+    .split(/[,\s]+/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map(Number);
+  if (ids.some((id) => !Number.isInteger(id) || id <= 0)) {
+    throw new Error("Memory IDs must be positive integers.");
+  }
+  return {
+    action: $("govern-action").value,
+    ids,
+    project: $("govern-project").value.trim() || undefined,
+    query: $("govern-query").value.trim() || undefined,
+    memory_type: $("govern-type").value.trim() || undefined,
+    status: $("govern-status").value.trim() || undefined,
+    limit: Number($("govern-limit").value || 50),
+    actor: "codex-remem-app"
+  };
+}
+async function previewGovernance() {
+  const target = $("govern-result");
+  target.textContent = "Previewing...";
+  target.className = "message";
+  try {
+    const preview = await request("/api/governance-preview", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(governancePayload())
+    });
+    const affected = preview.affected || [];
+    target.className = "message";
+    target.innerHTML = `
+      <div><strong>${affected.length}</strong> affected memory result(s); dry_run=${escapeHtml(preview.dry_run)}</div>
+      ${affected.map((item) => `
+        <div class="detail-text mono">#${escapeHtml(item.id)} ${escapeHtml(item.previous_status)} -> ${escapeHtml(item.new_status)} ${escapeHtml(item.title || "")}</div>
+      `).join("")}
+    `;
+  } catch (error) {
+    target.textContent = error.message;
+    target.className = "message error";
+  }
+}
+function setOptionalParam(params, key, value) {
+  const text = String(value || "").trim();
+  if (text) params.set(key, text);
+}
+function requireText(id, name) {
+  const text = $(id).value.trim();
+  if (!text) throw new Error(`${name} is required.`);
+  return text;
+}
+async function loadTimelineAround() {
+  const target = $("timeline-result");
+  const params = new URLSearchParams();
+  setOptionalParam(params, "project", $("timeline-project").value);
+  setOptionalParam(params, "anchor", $("timeline-anchor").value);
+  setOptionalParam(params, "query", $("timeline-query").value);
+  setOptionalParam(params, "depth_before", $("timeline-before").value);
+  setOptionalParam(params, "depth_after", $("timeline-after").value);
+  if (!params.has("anchor") && !params.has("query")) {
+    target.textContent = "Anchor ID or query is required.";
+    target.className = "message error";
+    return;
+  }
+  target.textContent = "Loading...";
+  target.className = "message";
+  try {
+    renderTimeline(await request(`/api/timeline-around?${params.toString()}`));
+  } catch (error) {
+    target.textContent = error.message;
+    target.className = "message error";
+  }
+}
+async function loadTimelineReport() {
+  const target = $("timeline-result");
+  const params = new URLSearchParams({ project: requireText("timeline-project", "Project") });
+  target.textContent = "Loading...";
+  target.className = "message";
+  try {
+    renderTimeline(await request(`/api/timeline-report?${params.toString()}`));
+  } catch (error) {
+    target.textContent = error.message;
+    target.className = "message error";
+  }
+}
+function renderTimeline(payload) {
+  const target = $("timeline-result");
+  const rows = payload.results || payload.timeline || payload.observations || [];
+  const overview = payload.report?.overview || payload.overview;
+  target.className = "message";
+  target.innerHTML = `
+    ${overview ? `<div><strong>${escapeHtml(overview.total_observations ?? rows.length)}</strong> observation(s)</div>` : ""}
+    ${rows.map((item) => `
+      <div class="detail-text">
+        <div><strong>${escapeHtml(item.title || item.summary || `Observation ${item.id || ""}`)}</strong></div>
+        <div class="subtle mono">${escapeHtml(item.type || item.memory_type || "")} ${escapeHtml(item.created_at || item.created_at_epoch || "")}</div>
+        <div>${escapeHtml(item.content || item.text || item.preview || "")}</div>
+      </div>
+    `).join("")}
+    <pre>${escapeHtml(JSON.stringify(payload.report || payload, null, 2))}</pre>
+  `;
+}
+async function loadWorkstreams() {
+  const target = $("workstream-result");
+  const params = new URLSearchParams({ project: requireText("workstream-project", "Project") });
+  setOptionalParam(params, "status", $("workstream-status").value);
+  target.textContent = "Loading...";
+  target.className = "message";
+  try {
+    renderWorkstreams(await request(`/api/workstreams?${params.toString()}`));
+  } catch (error) {
+    target.textContent = error.message;
+    target.className = "message error";
+  }
+}
+function workstreamUpdatePayload() {
+  const payload = {
+    id: Number(requireText("workstream-id", "Workstream ID")),
+    project: requireText("workstream-project", "Project"),
+    confirm: $("workstream-confirm").checked
+  };
+  if (!Number.isInteger(payload.id) || payload.id <= 0) throw new Error("Workstream ID must be a positive integer.");
+  const status = $("workstream-new-status").value;
+  const nextAction = $("workstream-next-action").value.trim();
+  const blockers = $("workstream-blockers").value.trim();
+  if (status) payload.status = status;
+  if (nextAction) payload.next_action = nextAction;
+  if (blockers) payload.blockers = blockers;
+  if (!payload.status && !payload.next_action && !payload.blockers) {
+    throw new Error("Status, next action, or blockers is required.");
+  }
+  if (!payload.confirm) throw new Error("Confirm update is required.");
+  return payload;
+}
+async function updateWorkstream() {
+  const target = $("workstream-result");
+  target.textContent = "Updating...";
+  target.className = "message";
+  try {
+    const updated = await request("/api/workstream-update", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(workstreamUpdatePayload())
+    });
+    target.className = "message";
+    target.innerHTML = `<div>Updated workstream ${escapeHtml(updated.id || "")}</div><pre>${escapeHtml(JSON.stringify(updated, null, 2))}</pre>`;
+  } catch (error) {
+    target.textContent = error.message;
+    target.className = "message error";
+  }
+}
+function renderWorkstreams(payload) {
+  const target = $("workstream-result");
+  const rows = payload.workstreams || payload.data || [];
+  target.className = "message";
+  target.innerHTML = `
+    <div><strong>${escapeHtml(payload.count ?? rows.length)}</strong> workstream(s)</div>
+    ${rows.map((item) => `
+      <div class="detail-text">
+        <div><strong>#${escapeHtml(item.id)} ${escapeHtml(item.title || item.summary || "")}</strong></div>
+        <div class="row">
+          <span class="pill">${escapeHtml(item.status || "")}</span>
+          <span class="pill">${escapeHtml(item.updated_at || item.last_activity_epoch || "")}</span>
+        </div>
+        <div>${escapeHtml(item.next_action || "")}</div>
+        <div class="subtle">${escapeHtml(item.blockers || "")}</div>
+      </div>
+    `).join("")}
+  `;
+}
+function switchView(name) {
+  document.querySelectorAll(".tab").forEach((tab) => {
+    tab.classList.toggle("active", tab.dataset.view === name);
+  });
+  cls($("search-view"), name === "search");
+  cls($("save-view"), name === "save");
+  cls($("governance-view"), name === "governance");
+  cls($("timeline-view"), name === "timeline");
+  cls($("workstreams-view"), name === "workstreams");
+  cls($("activation-view"), name === "activation");
+}
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+function receiveHostResult(event) {
+  const message = event.data;
+  if (!message || message.method !== "ui/notifications/tool-result") return;
+  const data = message.params?.structuredContent;
+  if (!data) return;
+  state.snapshot = data;
+  renderRuntime(data);
+  renderCounts(data.status || {});
+  renderActivation(data.activation || {});
+  renderHealth(data);
+}
+window.addEventListener("message", receiveHostResult);
+$("refresh").addEventListener("click", refresh);
+$("search-button").addEventListener("click", () => runSearch().catch((error) => {
+  $("results").innerHTML = `<li class="result"><span class="message error">${escapeHtml(error.message)}</span></li>`;
+}));
+$("search-query").addEventListener("keydown", (event) => {
+  if (event.key === "Enter") runSearch();
+});
+$("results").addEventListener("click", (event) => {
+  const item = event.target.closest(".result");
+  if (item?.dataset.id) selectResult(item.dataset.id);
+});
+$("save-button").addEventListener("click", saveMemory);
+$("govern-button").addEventListener("click", previewGovernance);
+$("timeline-around-button").addEventListener("click", loadTimelineAround);
+$("timeline-report-button").addEventListener("click", () => loadTimelineReport().catch((error) => {
+  $("timeline-result").textContent = error.message;
+  $("timeline-result").className = "message error";
+}));
+$("workstream-list-button").addEventListener("click", () => loadWorkstreams().catch((error) => {
+  $("workstream-result").textContent = error.message;
+  $("workstream-result").className = "message error";
+}));
+$("workstream-update-button").addEventListener("click", updateWorkstream);
+$("plan-button").addEventListener("click", () => refreshPlan().catch((error) => {
+  $("activation-plan").textContent = error.message;
+}));
+document.querySelectorAll(".tab").forEach((tab) => {
+  tab.addEventListener("click", () => switchView(tab.dataset.view));
+});
+refresh();

--- a/plugins/remem/apps/remem/server.js
+++ b/plugins/remem/apps/remem/server.js
@@ -50,6 +50,20 @@ function readWidgetHtml() {
   return fs.readFileSync(path.join(__dirname, "public", "widget.html"), "utf8");
 }
 
+const PUBLIC_ASSETS = new Map([
+  ["/widget.css", { file: "widget.css", contentType: "text/css; charset=utf-8" }],
+  ["/widget.js", { file: "widget.js", contentType: "text/javascript; charset=utf-8" }]
+]);
+
+function readPublicAsset(pathname) {
+  const asset = PUBLIC_ASSETS.get(pathname);
+  if (!asset) return null;
+  return {
+    content: fs.readFileSync(path.join(__dirname, "public", asset.file), "utf8"),
+    contentType: asset.contentType
+  };
+}
+
 function jsonResponse(res, status, payload) {
   const body = JSON.stringify(payload, null, 2);
   res.writeHead(status, {
@@ -583,6 +597,10 @@ function createServer(options = {}) {
       const url = parseUrl(req);
       if (req.method === "GET" && (url.pathname === "/" || url.pathname === "/widget.html")) {
         return textResponse(res, 200, readWidgetHtml(), "text/html; charset=utf-8");
+      }
+      if (req.method === "GET") {
+        const asset = readPublicAsset(url.pathname);
+        if (asset) return textResponse(res, 200, asset.content, asset.contentType);
       }
       if (req.method === "GET" && url.pathname === "/healthz") {
         return jsonResponse(res, 200, { ok: true, name: "remem-app" });

--- a/plugins/remem/apps/remem/server.test.js
+++ b/plugins/remem/apps/remem/server.test.js
@@ -293,7 +293,20 @@ test("HTTP API serves widget, status, search, memory detail, and save", async ()
   await withServer(async (base) => {
     const widget = await fetch(`${base}/widget.html`);
     assert.equal(widget.status, 200);
-    assert.match(await widget.text(), /Remem Dashboard/);
+    const widgetHtml = await widget.text();
+    assert.match(widgetHtml, /Remem Dashboard/);
+    assert.match(widgetHtml, /href="\/widget\.css"/);
+    assert.match(widgetHtml, /src="\/widget\.js"/);
+
+    const widgetCss = await fetch(`${base}/widget.css`);
+    assert.equal(widgetCss.status, 200);
+    assert.match(widgetCss.headers.get("content-type"), /^text\/css/);
+    assert.match(await widgetCss.text(), /\.shell/);
+
+    const widgetJs = await fetch(`${base}/widget.js`);
+    assert.equal(widgetJs.status, 200);
+    assert.match(widgetJs.headers.get("content-type"), /^text\/javascript/);
+    assert.match(await widgetJs.text(), /window\.openai\.callTool/);
 
     const status = await fetch(`${base}/api/status`).then((response) => response.json());
     assert.equal(status.runtime.selected.schemaVersion, 34);
@@ -431,7 +444,7 @@ test("HTTP write routes reject cross-site browser requests", async () => {
 
 test("widget renders raw archive fallback results", async () => {
   await withServer(async (base) => {
-    const widget = await fetch(`${base}/widget.html`).then((response) => response.text());
+    const widget = await fetch(`${base}/widget.js`).then((response) => response.text());
 
     assert.match(widget, /payload\.raw_hits/);
     assert.match(widget, /raw_archive/);
@@ -441,8 +454,11 @@ test("widget renders raw archive fallback results", async () => {
 
 test("widget routes embedded app actions through host tool calls", async () => {
   await withServer(async (base) => {
-    const widget = await fetch(`${base}/widget.html`).then((response) => response.text());
+    const html = await fetch(`${base}/widget.html`).then((response) => response.text());
+    const widget = await fetch(`${base}/widget.js`).then((response) => response.text());
 
+    assert.match(html, /data-view="timeline"/);
+    assert.match(html, /data-view="workstreams"/);
     assert.match(widget, /window\.openai\.callTool/);
     assert.match(widget, /remem_dashboard/);
     assert.match(widget, /remem_search/);
@@ -450,7 +466,13 @@ test("widget routes embedded app actions through host tool calls", async () => {
     assert.match(widget, /remem_save_memory/);
     assert.match(widget, /remem_activation_plan/);
     assert.match(widget, /remem_governance_preview/);
+    assert.match(widget, /remem_timeline_around/);
+    assert.match(widget, /remem_timeline_report/);
+    assert.match(widget, /remem_workstreams_list/);
+    assert.match(widget, /remem_workstream_update/);
     assert.match(widget, /\/api\/governance-preview/);
+    assert.match(widget, /\/api\/timeline-around/);
+    assert.match(widget, /\/api\/workstream-update/);
   });
 });
 


### PR DESCRIPTION
Refs #390

## Summary
- Split the Remem widget into `widget.html`, `widget.css`, and `widget.js` so the HTML is far below the 800-line cap.
- Add fixed-whitelist static serving for the split CSS/JS assets.
- Add visible Timeline and Workstreams tabs that use the existing app routes and host tools from PR #418.
- Keep workstream updates guarded in the UI with project/id/confirm and at least one mutation field before POST.

## Verification
- `node --check plugins/remem/apps/remem/public/widget.js`
- `node --test --test-concurrency=1 plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `cargo fmt --check`
- `cargo check --message-format=short`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `git diff --check origin/main`
- `cargo test`
- HTTP smoke against local server for `/widget.html`, `/widget.css`, `/widget.js`

## Note
The in-app browser plugin did not expose an `iab` browser instance in this session, so visual screenshot verification was not available. Static HTTP and Node tests verified the assets and UI wiring.