### PR TITLE
Add capture audit trail and spill replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.29"
+version = "0.5.30"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.29": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.29",
+    "0.5.30": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.30",
       "assets": {}
     }
   }

--- a/src/adapter/common.rs
+++ b/src/adapter/common.rs
@@ -423,6 +423,10 @@ fn redact_token(token: &str) -> &str {
         || trimmed.starts_with("ghp_")
         || trimmed.starts_with("github_pat_")
         || trimmed.starts_with("xoxb-")
+        || trimmed.contains("sk-")
+        || trimmed.contains("ghp_")
+        || trimmed.contains("github_pat_")
+        || trimmed.contains("xoxb-")
         || (trimmed.len() >= 32
             && trimmed.chars().any(|ch| ch.is_ascii_alphabetic())
             && trimmed.chars().any(|ch| ch.is_ascii_digit()))

--- a/src/api/handlers/status.rs
+++ b/src/api/handlers/status.rs
@@ -21,12 +21,33 @@ pub(in crate::api) async fn handle_status(State(_state): State<DbState>) -> impl
             .into_response();
         }
     };
+    let capture_spill = match crate::observe::capture_spill_stats() {
+        Ok(stats) => stats,
+        Err(err) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "status_failed",
+                &err.to_string(),
+            )
+            .into_response();
+        }
+    };
 
     Json(serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "memories": stats.active_memories,
         "observations": stats.active_observations,
         "captured_events": stats.captured_events,
+        "capture_audit_events": stats.capture_audit_events,
+        "capture_audit_reasons": stats.capture_audit_reasons
+            .into_iter()
+            .map(|reason| serde_json::json!({
+                "reason": reason.reason,
+                "total": reason.total,
+            }))
+            .collect::<Vec<_>>(),
+        "pending_capture_spill_files": capture_spill.pending_files,
+        "pending_capture_spill_bytes": capture_spill.pending_bytes,
         "pending_extraction_tasks": stats.pending_extraction_tasks,
         "pending_memory_candidates": stats.pending_memory_candidates,
         "pending_graph_candidates": stats.pending_graph_candidates,

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -25,6 +25,7 @@ fn load_status_report() -> Result<StatusReport> {
         .len();
     let version = crate::build_info::version_label();
     let stats = db::query_system_stats(&conn)?;
+    let capture_spill = crate::observe::capture_spill_stats()?;
 
     let today_start = chrono::Local::now()
         .date_naive()
@@ -64,6 +65,27 @@ fn load_status_report() -> Result<StatusReport> {
         },
         capture_pipeline: CapturePipelineStatus {
             captured: stats.captured_events,
+            audited_drops: stats.capture_audit_events,
+            audit_reasons: stats
+                .capture_audit_reasons
+                .into_iter()
+                .map(|reason| CaptureAuditReasonStatus {
+                    reason: reason.reason,
+                    total: reason.total,
+                })
+                .collect(),
+            latest_audit_epoch: stats.latest_capture_audit_epoch,
+            latest_audit_age_secs: stats
+                .latest_capture_audit_epoch
+                .map(|epoch| now.saturating_sub(epoch)),
+            latest_audit_reason: stats.latest_capture_audit_reason,
+            latest_audit_detail: stats.latest_capture_audit_detail,
+            spill_files: capture_spill.pending_files,
+            spill_bytes: capture_spill.pending_bytes,
+            latest_spill_epoch: capture_spill.latest_epoch,
+            latest_spill_age_secs: capture_spill
+                .latest_epoch
+                .map(|epoch| now.saturating_sub(epoch)),
             extract_todo: stats.pending_extraction_tasks,
             extract_running: stats.processing_extraction_tasks,
             extract_failed: stats.failed_extraction_tasks,
@@ -151,6 +173,23 @@ fn print_status_report(report: &StatusReport) {
     println!();
     println!("Capture pipeline:");
     println!("  Captured:     {:>6}", report.capture_pipeline.captured);
+    println!(
+        "  Audit drops:  {:>6}",
+        report.capture_pipeline.audited_drops
+    );
+    println!("  Spill files:  {:>6}", report.capture_pipeline.spill_files);
+    if let Some(reason) = &report.capture_pipeline.latest_audit_reason {
+        println!("  Latest drop:  {}", reason);
+    }
+    if let Some(age_secs) = report.capture_pipeline.latest_audit_age_secs {
+        println!("  Drop age:     {:>6}s", age_secs);
+    }
+    if let Some(age_secs) = report.capture_pipeline.latest_spill_age_secs {
+        println!("  Spill age:    {:>6}s", age_secs);
+    }
+    for reason in &report.capture_pipeline.audit_reasons {
+        println!("  Drop {:<13} {:>6}", reason.reason, reason.total);
+    }
     println!(
         "  Extract todo: {:>6}",
         report.capture_pipeline.extract_todo
@@ -305,6 +344,16 @@ pub(super) struct RawArchiveStatus {
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct CapturePipelineStatus {
     pub captured: i64,
+    pub audited_drops: i64,
+    pub audit_reasons: Vec<CaptureAuditReasonStatus>,
+    pub latest_audit_epoch: Option<i64>,
+    pub latest_audit_age_secs: Option<i64>,
+    pub latest_audit_reason: Option<String>,
+    pub latest_audit_detail: Option<String>,
+    pub spill_files: i64,
+    pub spill_bytes: i64,
+    pub latest_spill_epoch: Option<i64>,
+    pub latest_spill_age_secs: Option<i64>,
     pub extract_todo: i64,
     pub extract_running: i64,
     pub extract_failed: i64,
@@ -312,6 +361,12 @@ pub(super) struct CapturePipelineStatus {
     pub pending_graph_candidates: i64,
     pub oldest_task_epoch: Option<i64>,
     pub oldest_task_age_secs: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct CaptureAuditReasonStatus {
+    pub reason: String,
+    pub total: i64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -393,6 +448,19 @@ mod tests {
             },
             capture_pipeline: CapturePipelineStatus {
                 captured: 5,
+                audited_drops: 2,
+                audit_reasons: vec![CaptureAuditReasonStatus {
+                    reason: "bash_skipped".to_string(),
+                    total: 2,
+                }],
+                latest_audit_epoch: Some(30),
+                latest_audit_age_secs: Some(31),
+                latest_audit_reason: Some("bash_skipped".to_string()),
+                latest_audit_detail: Some("codex bash observe disabled".to_string()),
+                spill_files: 1,
+                spill_bytes: 2048,
+                latest_spill_epoch: Some(32),
+                latest_spill_age_secs: Some(33),
                 extract_todo: 6,
                 extract_running: 7,
                 extract_failed: 8,
@@ -467,6 +535,12 @@ mod tests {
             "/bad/raw.jsonl"
         );
         assert_eq!(parsed["capture_pipeline"]["extract_todo"], 6);
+        assert_eq!(parsed["capture_pipeline"]["audited_drops"], 2);
+        assert_eq!(
+            parsed["capture_pipeline"]["audit_reasons"][0]["reason"],
+            "bash_skipped"
+        );
+        assert_eq!(parsed["capture_pipeline"]["spill_files"], 1);
         assert_eq!(parsed["capture_pipeline"]["pending_graph_candidates"], 10);
         assert_eq!(parsed["pending_observations"]["failed"], 16);
         assert_eq!(

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -61,6 +61,18 @@ pub struct CaptureEventInput<'a> {
     pub task_kind: Option<ExtractionTaskKind>,
 }
 
+pub struct CaptureAuditInput<'a> {
+    pub host: Option<&'a str>,
+    pub adapter: Option<&'a str>,
+    pub session_id: Option<&'a str>,
+    pub project: Option<&'a str>,
+    pub cwd: Option<&'a str>,
+    pub tool_name: Option<&'a str>,
+    pub reason: &'a str,
+    pub detail: Option<&'a str>,
+    pub payload: Option<&'a str>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CaptureEventOutcome {
     pub event_row_id: i64,
@@ -80,11 +92,21 @@ pub fn record_captured_event(
     conn: &Connection,
     input: &CaptureEventInput<'_>,
 ) -> Result<CaptureEventOutcome> {
+    record_captured_event_with_id(conn, input, None)
+}
+
+pub fn record_captured_event_with_id(
+    conn: &Connection,
+    input: &CaptureEventInput<'_>,
+    event_id_override: Option<&str>,
+) -> Result<CaptureEventOutcome> {
     let now = chrono::Utc::now().timestamp();
     let inserted_at = now;
     let sanitized_content = redact_capture_content(input.content);
     let content_hash = exact_hash(&sanitized_content);
-    let event_id = synthesize_event_id(input.event_type, &content_hash);
+    let event_id = event_id_override
+        .map(ToString::to_string)
+        .unwrap_or_else(|| synthesize_event_id(input.event_type, &content_hash));
     let identity = upsert_identity(conn, input, now)?;
     let (content_text, content_blob_id, retention_class) =
         store_content(conn, &sanitized_content, &content_hash, now)?;
@@ -141,6 +163,48 @@ pub fn record_captured_event(
         event_id,
         extraction_task_id,
     })
+}
+
+pub fn record_capture_audit_event(conn: &Connection, input: &CaptureAuditInput<'_>) -> Result<i64> {
+    if input.reason.trim().is_empty() {
+        bail!("capture audit reason must not be empty");
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let (content_hash, payload_preview) = input
+        .payload
+        .map(|payload| {
+            let redacted = redact_capture_content(payload);
+            (
+                Some(exact_hash(&redacted)),
+                Some(crate::db::truncate_str(&redacted, 4096).to_string()),
+            )
+        })
+        .unwrap_or((None, None));
+    let detail = input
+        .detail
+        .map(|detail| crate::db::truncate_str(detail, 512).to_string());
+
+    conn.execute(
+        "INSERT INTO capture_audit_events
+         (created_at_epoch, host, adapter, session_id, project, cwd, tool_name,
+          reason, detail, content_hash, payload_preview)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        params![
+            now,
+            input.host,
+            input.adapter,
+            input.session_id,
+            input.project,
+            input.cwd,
+            input.tool_name,
+            input.reason,
+            detail,
+            content_hash,
+            payload_preview
+        ],
+    )?;
+    Ok(conn.last_insert_rowid())
 }
 
 fn upsert_identity(
@@ -349,6 +413,11 @@ fn coalesce_extraction_task(
 
 fn exact_hash(content: &str) -> String {
     format!("{:016x}", crate::db::deterministic_hash(content.as_bytes()))
+}
+
+pub fn stable_capture_event_id(event_type: &str, content: &str) -> String {
+    let sanitized_content = redact_capture_content(content);
+    format!("{}-{}", event_type, exact_hash(&sanitized_content))
 }
 
 fn synthesize_event_id(event_type: &str, content_hash: &str) -> String {
@@ -589,5 +658,69 @@ mod tests {
         .expect_err("unknown host should fail closed");
 
         assert!(err.to_string().contains("invalid capture host"));
+    }
+
+    #[test]
+    fn capture_audit_redacts_sensitive_payload() -> Result<()> {
+        let conn = setup_conn();
+        let payload = serde_json::json!({
+            "tool_input": {
+                "api_key": "sk-secret-value",
+                "command": "curl -H 'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456'"
+            },
+            "tool_response": {
+                "stdout": "password=hunter2"
+            }
+        })
+        .to_string();
+
+        let row_id = record_capture_audit_event(
+            &conn,
+            &CaptureAuditInput {
+                host: Some("codex-cli"),
+                adapter: Some("codex-cli"),
+                session_id: Some("sess-audit"),
+                project: Some("/tmp/remem"),
+                cwd: Some("/tmp/remem"),
+                tool_name: Some("Bash"),
+                reason: "bash_skipped",
+                detail: Some("codex bash observe disabled"),
+                payload: Some(&payload),
+            },
+        )?;
+
+        let (reason, preview): (String, String) = conn.query_row(
+            "SELECT reason, payload_preview FROM capture_audit_events WHERE id = ?1",
+            params![row_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(reason, "bash_skipped");
+        assert!(preview.contains("[REDACTED]"));
+        assert!(!preview.contains("sk-secret-value"));
+        assert!(!preview.contains("hunter2"));
+        assert!(!preview.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
+        Ok(())
+    }
+
+    #[test]
+    fn capture_audit_rejects_empty_reason() {
+        let conn = setup_conn();
+        let err = record_capture_audit_event(
+            &conn,
+            &CaptureAuditInput {
+                host: None,
+                adapter: None,
+                session_id: None,
+                project: None,
+                cwd: None,
+                tool_name: None,
+                reason: " ",
+                detail: None,
+                payload: None,
+            },
+        )
+        .expect_err("empty reason should fail closed");
+
+        assert!(err.to_string().contains("reason must not be empty"));
     }
 }

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -181,9 +181,10 @@ pub fn record_capture_audit_event(conn: &Connection, input: &CaptureAuditInput<'
             )
         })
         .unwrap_or((None, None));
-    let detail = input
-        .detail
-        .map(|detail| crate::db::truncate_str(detail, 512).to_string());
+    let detail = input.detail.map(|detail| {
+        let redacted = redact_capture_content(detail);
+        crate::db::truncate_str(&redacted, 512).to_string()
+    });
 
     conn.execute(
         "INSERT INTO capture_audit_events
@@ -415,9 +416,17 @@ fn exact_hash(content: &str) -> String {
     format!("{:016x}", crate::db::deterministic_hash(content.as_bytes()))
 }
 
-pub fn stable_capture_event_id(event_type: &str, content: &str) -> String {
+pub fn unique_capture_event_id(event_type: &str, content: &str) -> String {
     let sanitized_content = redact_capture_content(content);
-    format!("{}-{}", event_type, exact_hash(&sanitized_content))
+    let nanos = chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| chrono::Utc::now().timestamp() * 1_000_000_000);
+    format!(
+        "{}-{}-{}",
+        event_type,
+        nanos,
+        exact_hash(&sanitized_content)
+    )
 }
 
 fn synthesize_event_id(event_type: &str, content_hash: &str) -> String {
@@ -431,7 +440,7 @@ fn estimate_tokens(content: &str) -> i64 {
     ((content.len() as i64) + 3) / 4
 }
 
-fn redact_capture_content(content: &str) -> String {
+pub(crate) fn redact_capture_content(content: &str) -> String {
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
         let redacted = crate::adapter::common::redact_sensitive_value(&value);
         return serde_json::to_string(&redacted)
@@ -722,5 +731,36 @@ mod tests {
         .expect_err("empty reason should fail closed");
 
         assert!(err.to_string().contains("reason must not be empty"));
+    }
+
+    #[test]
+    fn capture_audit_redacts_sensitive_detail() -> Result<()> {
+        let conn = setup_conn();
+
+        let row_id = record_capture_audit_event(
+            &conn,
+            &CaptureAuditInput {
+                host: Some("codex-cli"),
+                adapter: Some("codex-cli"),
+                session_id: Some("sess-audit-detail"),
+                project: Some("/tmp/remem"),
+                cwd: None,
+                tool_name: Some("Bash"),
+                reason: "bash_skipped",
+                detail: Some(
+                    "adapter skipped bash command: curl -H 'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456'",
+                ),
+                payload: None,
+            },
+        )?;
+
+        let detail: String = conn.query_row(
+            "SELECT detail FROM capture_audit_events WHERE id = ?1",
+            params![row_id],
+            |row| row.get(0),
+        )?;
+        assert!(detail.contains("[REDACTED]"));
+        assert!(!detail.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
+        Ok(())
     }
 }

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -21,6 +21,11 @@ pub struct SystemStats {
     pub latest_raw_ingest_failure_path: Option<String>,
     pub latest_raw_ingest_failure_message: Option<String>,
     pub captured_events: i64,
+    pub capture_audit_events: i64,
+    pub latest_capture_audit_epoch: Option<i64>,
+    pub latest_capture_audit_reason: Option<String>,
+    pub latest_capture_audit_detail: Option<String>,
+    pub capture_audit_reasons: Vec<CaptureAuditReasonStat>,
     pub pending_extraction_tasks: i64,
     pub processing_extraction_tasks: i64,
     pub failed_extraction_tasks: i64,
@@ -53,6 +58,12 @@ pub struct MemoryFactsStats {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureAuditReasonStat {
+    pub reason: String,
+    pub total: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DailyActivityStats {
     pub memories: i64,
     pub observations: i64,
@@ -75,6 +86,7 @@ pub struct CandidatePromotionStat {
 pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
     let now = chrono::Utc::now().timestamp();
     let raw_ingest = query_raw_ingest_failure_stats(conn)?;
+    let capture_audit = query_capture_audit_stats(conn)?;
     let worker_heartbeat = crate::db::worker::latest_daemon_worker_heartbeat(conn)?;
     let healthy_worker_heartbeat = crate::db::worker::healthy_daemon_worker_heartbeat(
         conn,
@@ -109,6 +121,11 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
         captured_events: conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| {
             row.get(0)
         })?,
+        capture_audit_events: capture_audit.total,
+        latest_capture_audit_epoch: capture_audit.latest_epoch,
+        latest_capture_audit_reason: capture_audit.latest_reason,
+        latest_capture_audit_detail: capture_audit.latest_detail,
+        capture_audit_reasons: capture_audit.reasons,
         pending_extraction_tasks: conn.query_row(
             "SELECT COUNT(*) FROM extraction_tasks WHERE status = 'pending'",
             [],
@@ -249,6 +266,68 @@ pub fn query_memory_facts_stats(conn: &Connection) -> Result<MemoryFactsStats> {
         retrieval_eligible,
         active_memories,
         captured_events,
+    })
+}
+
+#[derive(Debug, Clone, Default)]
+struct CaptureAuditStats {
+    total: i64,
+    latest_epoch: Option<i64>,
+    latest_reason: Option<String>,
+    latest_detail: Option<String>,
+    reasons: Vec<CaptureAuditReasonStat>,
+}
+
+fn query_capture_audit_stats(conn: &Connection) -> Result<CaptureAuditStats> {
+    if !table_exists(conn, "capture_audit_events")? {
+        return Ok(CaptureAuditStats::default());
+    }
+
+    let total = conn.query_row("SELECT COUNT(*) FROM capture_audit_events", [], |row| {
+        row.get(0)
+    })?;
+    let latest = conn
+        .query_row(
+            "SELECT created_at_epoch, reason, detail
+             FROM capture_audit_events
+             ORDER BY created_at_epoch DESC, id DESC
+             LIMIT 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let reasons = {
+        let mut stmt = conn.prepare(
+            "SELECT reason, COUNT(*) AS total
+             FROM capture_audit_events
+             GROUP BY reason
+             ORDER BY total DESC, reason ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(CaptureAuditReasonStat {
+                reason: row.get(0)?,
+                total: row.get(1)?,
+            })
+        })?;
+        collect_rows(rows)?
+    };
+    let (latest_epoch, latest_reason, latest_detail) = match latest {
+        Some((epoch, reason, detail)) => (Some(epoch), Some(reason), detail),
+        None => (None, None, None),
+    };
+
+    Ok(CaptureAuditStats {
+        total,
+        latest_epoch,
+        latest_reason,
+        latest_detail,
+        reasons,
     })
 }
 

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -1,6 +1,8 @@
 use rusqlite::Connection;
 
-use super::{CandidatePromotionStat, DailyActivityStats, ProjectCount, SystemStats};
+use super::{
+    CandidatePromotionStat, CaptureAuditReasonStat, DailyActivityStats, ProjectCount, SystemStats,
+};
 use crate::db::models::{
     AiUsageBreakdown, AiUsageSourceTotals, AiUsageTotals, DailyAiUsage, WeeklyAiUsage,
 };
@@ -41,6 +43,12 @@ fn setup_stats_schema(conn: &Connection) {
         );
         CREATE TABLE captured_events (
             id INTEGER PRIMARY KEY
+        );
+        CREATE TABLE capture_audit_events (
+            id INTEGER PRIMARY KEY,
+            created_at_epoch INTEGER NOT NULL,
+            reason TEXT NOT NULL,
+            detail TEXT
         );
         CREATE TABLE extraction_tasks (
             id INTEGER PRIMARY KEY,
@@ -142,6 +150,18 @@ fn query_system_stats_and_related_views_share_one_definition() {
     conn.execute("INSERT INTO captured_events (id) VALUES (1)", [])
         .expect("captured event insert should succeed");
     conn.execute(
+        "INSERT INTO capture_audit_events (created_at_epoch, reason, detail)
+         VALUES (170, 'bash_skipped', 'codex bash observe disabled')",
+        [],
+    )
+    .expect("capture audit insert should succeed");
+    conn.execute(
+        "INSERT INTO capture_audit_events (created_at_epoch, reason, detail)
+         VALUES (175, 'unclassified', 'missing file_path')",
+        [],
+    )
+    .expect("second capture audit insert should succeed");
+    conn.execute(
         "INSERT INTO extraction_tasks (status, created_at_epoch) VALUES ('pending', 90)",
         [],
     )
@@ -241,6 +261,20 @@ fn query_system_stats_and_related_views_share_one_definition() {
             latest_raw_ingest_failure_path: Some("/bad/transcript.jsonl".to_string()),
             latest_raw_ingest_failure_message: Some("bad jsonl".to_string()),
             captured_events: 1,
+            capture_audit_events: 2,
+            latest_capture_audit_epoch: Some(175),
+            latest_capture_audit_reason: Some("unclassified".to_string()),
+            latest_capture_audit_detail: Some("missing file_path".to_string()),
+            capture_audit_reasons: vec![
+                CaptureAuditReasonStat {
+                    reason: "bash_skipped".to_string(),
+                    total: 1,
+                },
+                CaptureAuditReasonStat {
+                    reason: "unclassified".to_string(),
+                    total: 1,
+                },
+            ],
             pending_extraction_tasks: 1,
             processing_extraction_tasks: 1,
             failed_extraction_tasks: 1,
@@ -335,6 +369,21 @@ fn query_system_stats_defaults_raw_ingest_failures_when_table_is_absent() -> any
     assert_eq!(system.raw_ingest_parse_errors, 0);
     assert_eq!(system.raw_ingest_insert_errors, 0);
     assert_eq!(system.latest_raw_ingest_failure_epoch, None);
+    Ok(())
+}
+
+#[test]
+fn query_system_stats_defaults_capture_audit_when_table_is_absent() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_stats_schema(&conn);
+    conn.execute("DROP TABLE capture_audit_events", [])?;
+
+    let system = query_system_stats(&conn)?;
+
+    assert_eq!(system.capture_audit_events, 0);
+    assert_eq!(system.latest_capture_audit_epoch, None);
+    assert_eq!(system.latest_capture_audit_reason, None);
+    assert!(system.capture_audit_reasons.is_empty());
     Ok(())
 }
 

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -151,6 +151,76 @@ pub(super) fn check_raw_archive_ingest(conn: Option<&Connection>) -> Check {
     Check::new("Raw archive ingest", Status::Warn, detail)
 }
 
+pub(super) fn check_capture_audit(conn: Option<&Connection>) -> Check {
+    let spill = match crate::observe::capture_spill_stats() {
+        Ok(stats) => stats,
+        Err(err) => {
+            return Check::new(
+                "Capture audit",
+                Status::Warn,
+                format!("cannot load capture spill stats: {}", err),
+            );
+        }
+    };
+    let Some(conn) = conn else {
+        if spill.pending_files > 0 {
+            return Check::new(
+                "Capture audit",
+                Status::Warn,
+                format!(
+                    "cannot open database; {} pending spill file(s), {} bytes",
+                    spill.pending_files, spill.pending_bytes
+                ),
+            );
+        }
+        return Check::new("Capture audit", Status::Warn, "cannot open database");
+    };
+
+    let stats = match db::query_system_stats(conn) {
+        Ok(stats) => stats,
+        Err(err) => {
+            return Check::new(
+                "Capture audit",
+                Status::Warn,
+                format!("cannot load capture audit stats: {}", err),
+            );
+        }
+    };
+
+    if stats.capture_audit_events == 0 && spill.pending_files == 0 {
+        return Check::new(
+            "Capture audit",
+            Status::Ok,
+            "no capture drops or spill files",
+        );
+    }
+
+    let mut detail = format!(
+        "{} audited drop(s), {} pending spill file(s), {} spill bytes",
+        stats.capture_audit_events, spill.pending_files, spill.pending_bytes
+    );
+    if !stats.capture_audit_reasons.is_empty() {
+        let reasons = stats
+            .capture_audit_reasons
+            .into_iter()
+            .map(|reason| format!("{}={}", reason.reason, reason.total))
+            .collect::<Vec<_>>()
+            .join(", ");
+        detail.push_str(&format!("; reasons: {reasons}"));
+    }
+    if let Some(reason) = stats.latest_capture_audit_reason {
+        detail.push_str(&format!("; latest={reason}"));
+    }
+    if let Some(latest_detail) = stats.latest_capture_audit_detail {
+        detail.push_str(&format!(
+            " ({})",
+            crate::db::truncate_str(&latest_detail, 160)
+        ));
+    }
+
+    Check::new("Capture audit", Status::Warn, detail)
+}
+
 pub(super) fn check_temporal_facts(conn: Option<&Connection>) -> Check {
     let Some(conn) = conn else {
         return Check::new("Temporal facts", Status::Warn, "cannot open database");

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -187,17 +187,27 @@ pub(super) fn check_capture_audit(conn: Option<&Connection>) -> Check {
         }
     };
 
-    if stats.capture_audit_events == 0 && spill.pending_files == 0 {
+    let actionable_audit_events = stats
+        .capture_audit_reasons
+        .iter()
+        .filter(|reason| capture_audit_reason_is_actionable(&reason.reason))
+        .map(|reason| reason.total)
+        .sum::<i64>();
+
+    if actionable_audit_events == 0 && spill.pending_files == 0 {
         return Check::new(
             "Capture audit",
             Status::Ok,
-            "no capture drops or spill files",
+            format!(
+                "{} expected capture filter event(s), no actionable drops or spill files",
+                stats.capture_audit_events
+            ),
         );
     }
 
     let mut detail = format!(
-        "{} audited drop(s), {} pending spill file(s), {} spill bytes",
-        stats.capture_audit_events, spill.pending_files, spill.pending_bytes
+        "{} actionable drop(s), {} total audited event(s), {} pending spill file(s), {} spill bytes",
+        actionable_audit_events, stats.capture_audit_events, spill.pending_files, spill.pending_bytes
     );
     if !stats.capture_audit_reasons.is_empty() {
         let reasons = stats
@@ -219,6 +229,10 @@ pub(super) fn check_capture_audit(conn: Option<&Connection>) -> Check {
     }
 
     Check::new("Capture audit", Status::Warn, detail)
+}
+
+fn capture_audit_reason_is_actionable(reason: &str) -> bool {
+    !matches!(reason, "tool_skipped" | "bash_skipped" | "spill_replayed")
 }
 
 pub(super) fn check_temporal_facts(conn: Option<&Connection>) -> Check {

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use super::database::{
-    check_database, check_disk_space, check_pending_queue, check_raw_archive_ingest,
-    check_temporal_facts, check_worker_daemon,
+    check_capture_audit, check_database, check_disk_space, check_pending_queue,
+    check_raw_archive_ingest, check_temporal_facts, check_worker_daemon,
 };
 use super::environment::{check_binary, check_hooks, check_install_paths, check_mcp};
 use super::native_memory::check_native_memory_sync;
@@ -84,6 +84,9 @@ fn run_checks(mut on_check: impl FnMut(&Check) -> Result<()>) -> Result<Vec<Chec
     push_checks(&mut checks, &mut on_check, check_mcp)?;
     push_check(&mut checks, &mut on_check, || {
         check_raw_archive_ingest(shared_db.conn())
+    })?;
+    push_check(&mut checks, &mut on_check, || {
+        check_capture_audit(shared_db.conn())
     })?;
     push_check(&mut checks, &mut on_check, || {
         check_temporal_facts(shared_db.conn())

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -283,8 +283,8 @@ fn check_raw_archive_ingest_warns_on_recorded_failures() -> anyhow::Result<()> {
 }
 
 #[test]
-fn check_capture_audit_warns_on_recorded_drops() -> anyhow::Result<()> {
-    let _test_dir = ScopedTestDataDir::new("doctor-capture-audit");
+fn check_capture_audit_stays_ok_for_expected_filter_events() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-audit-expected");
     let conn = db::open_db()?;
     db::record_capture_audit_event(
         &conn,
@@ -303,11 +303,75 @@ fn check_capture_audit_warns_on_recorded_drops() -> anyhow::Result<()> {
 
     let check = check_capture_audit(Some(&conn));
 
-    assert_eq!(check.icon(), "WARN");
-    assert!(check.detail.contains("1 audited drop"), "{}", check.detail);
-    assert!(check.detail.contains("bash_skipped=1"), "{}", check.detail);
+    assert_eq!(check.icon(), "ok");
     assert!(
-        check.detail.contains("codex bash observe disabled"),
+        check.detail.contains("1 expected capture filter event"),
+        "{}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
+fn check_capture_audit_warns_on_actionable_drops() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-audit-actionable");
+    let conn = db::open_db()?;
+    db::record_capture_audit_event(
+        &conn,
+        &db::CaptureAuditInput {
+            host: Some("claude-code"),
+            adapter: Some("claude-code"),
+            session_id: Some("session-a"),
+            project: Some("proj-a"),
+            cwd: Some("proj-a"),
+            tool_name: Some("Edit"),
+            reason: "unclassified",
+            detail: Some("missing file_path"),
+            payload: None,
+        },
+    )?;
+
+    let check = check_capture_audit(Some(&conn));
+
+    assert_eq!(check.icon(), "WARN");
+    assert!(
+        check.detail.contains("1 actionable drop"),
+        "{}",
+        check.detail
+    );
+    assert!(check.detail.contains("unclassified=1"), "{}", check.detail);
+    assert!(
+        check.detail.contains("missing file_path"),
+        "{}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
+fn check_capture_audit_warns_on_adapter_mismatch() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-audit-adapter-mismatch");
+    let conn = db::open_db()?;
+    db::record_capture_audit_event(
+        &conn,
+        &db::CaptureAuditInput {
+            host: Some("codex-cli"),
+            adapter: None,
+            session_id: None,
+            project: None,
+            cwd: None,
+            tool_name: None,
+            reason: "adapter_mismatch",
+            detail: Some("observe hook input did not match a known adapter"),
+            payload: None,
+        },
+    )?;
+
+    let check = check_capture_audit(Some(&conn));
+
+    assert_eq!(check.icon(), "WARN");
+    assert!(
+        check.detail.contains("adapter_mismatch=1"),
         "{}",
         check.detail
     );

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -6,8 +6,8 @@ use crate::db::test_support::{
 use crate::{db, memory};
 
 use super::database::{
-    check_database, check_pending_queue, check_raw_archive_ingest, check_temporal_facts,
-    check_worker_daemon,
+    check_capture_audit, check_database, check_pending_queue, check_raw_archive_ingest,
+    check_temporal_facts, check_worker_daemon,
 };
 use super::health_action::{queue_actions, render_action_block};
 use super::report::{run_doctor_with_writer, DoctorOptions};
@@ -279,6 +279,38 @@ fn check_raw_archive_ingest_warns_on_recorded_failures() -> anyhow::Result<()> {
     assert!(check.detail.contains("1 failure"), "{}", check.detail);
     assert!(check.detail.contains("read_error"), "{}", check.detail);
     assert!(check.detail.contains("/bad/path.jsonl"), "{}", check.detail);
+    Ok(())
+}
+
+#[test]
+fn check_capture_audit_warns_on_recorded_drops() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-audit");
+    let conn = db::open_db()?;
+    db::record_capture_audit_event(
+        &conn,
+        &db::CaptureAuditInput {
+            host: Some("codex-cli"),
+            adapter: Some("codex-cli"),
+            session_id: Some("session-a"),
+            project: Some("proj-a"),
+            cwd: Some("proj-a"),
+            tool_name: Some("Bash"),
+            reason: "bash_skipped",
+            detail: Some("codex bash observe disabled"),
+            payload: None,
+        },
+    )?;
+
+    let check = check_capture_audit(Some(&conn));
+
+    assert_eq!(check.icon(), "WARN");
+    assert!(check.detail.contains("1 audited drop"), "{}", check.detail);
+    assert!(check.detail.contains("bash_skipped=1"), "{}", check.detail);
+    assert!(
+        check.detail.contains("codex bash observe disabled"),
+        "{}",
+        check.detail
+    );
     Ok(())
 }
 

--- a/src/migrate/tests.rs
+++ b/src/migrate/tests.rs
@@ -115,6 +115,7 @@ fn full_migration_on_empty_db() -> Result<()> {
         "memory_embeddings",
         "graph_file_nodes",
         "graph_edges",
+        "capture_audit_events",
     ] {
         let exists: bool = conn
             .query_row(
@@ -143,6 +144,8 @@ fn full_migration_on_empty_db() -> Result<()> {
         "idx_graph_edges_from",
         "idx_graph_edges_to",
         "idx_graph_edges_type",
+        "idx_capture_audit_reason_created",
+        "idx_capture_audit_project_created",
     ] {
         let exists: bool = conn
             .query_row(

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -180,6 +180,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "context_injection_data_version",
         sql: include_str!("../migrations/v035_context_injection_data_version.sql"),
     },
+    Migration {
+        version: 36,
+        name: "capture_audit_events",
+        sql: include_str!("../migrations/v036_capture_audit_events.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v036_capture_audit_events.sql
+++ b/src/migrations/v036_capture_audit_events.sql
@@ -1,0 +1,23 @@
+-- v036_capture_audit_events: durable audit trail for capture inputs that do
+-- not become captured_events.
+
+CREATE TABLE IF NOT EXISTS capture_audit_events (
+    id INTEGER PRIMARY KEY,
+    created_at_epoch INTEGER NOT NULL,
+    host TEXT,
+    adapter TEXT,
+    session_id TEXT,
+    project TEXT,
+    cwd TEXT,
+    tool_name TEXT,
+    reason TEXT NOT NULL,
+    detail TEXT,
+    content_hash TEXT,
+    payload_preview TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_capture_audit_reason_created
+    ON capture_audit_events(reason, created_at_epoch DESC);
+
+CREATE INDEX IF NOT EXISTS idx_capture_audit_project_created
+    ON capture_audit_events(project, created_at_epoch DESC);

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -2,8 +2,10 @@ mod hook;
 mod native;
 mod parse;
 mod path;
+mod spill;
 #[cfg(test)]
 mod tests;
 
 pub use hook::{observe, session_init};
 pub use path::short_path;
+pub(crate) use spill::capture_spill_stats;

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::db;
 
 use super::native::sync_native_memory;
+use super::spill::{replay_capture_spills, write_capture_spill};
 
 pub async fn session_init(host: Option<&str>) -> Result<()> {
     let timer = crate::log::Timer::start("session-init", "");
@@ -13,6 +14,14 @@ pub async fn session_init(host: Option<&str>) -> Result<()> {
     );
 
     let Some(event) = session_init_event(&input, host) else {
+        record_capture_audit_best_effort(
+            host.map(crate::runtime_config::normalize_host),
+            None,
+            None,
+            "adapter_mismatch",
+            Some("session-init hook input did not match a known adapter"),
+            None,
+        );
         timer.done("skipped");
         return Ok(());
     };
@@ -45,21 +54,79 @@ pub async fn observe(host: Option<&str>) -> Result<()> {
 
 async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
     let Some((adapter, event)) = detect_adapter_for_host(input, host) else {
+        record_capture_audit_best_effort(
+            host.map(crate::runtime_config::normalize_host),
+            None,
+            None,
+            "adapter_mismatch",
+            Some("observe hook input did not match a known adapter"),
+            None,
+        );
         return Ok(());
     };
-    if adapter.should_skip(&event) || should_skip_bash_event(adapter, &event) {
+    if let Some((reason, detail)) = skip_reason(adapter, &event) {
+        let payload = capture_audit_payload(&event);
+        record_capture_audit_best_effort(
+            Some(capture_host(host, adapter)),
+            Some(adapter.name()),
+            Some(&event),
+            reason,
+            Some(&detail),
+            Some(&payload),
+        );
         return Ok(());
     }
 
     let Some(summary) = adapter.classify_event(&event) else {
+        let payload = capture_audit_payload(&event);
+        record_capture_audit_best_effort(
+            Some(capture_host(host, adapter)),
+            Some(adapter.name()),
+            Some(&event),
+            "unclassified",
+            Some("adapter accepted event but produced no summary"),
+            Some(&payload),
+        );
         return Ok(());
     };
 
-    let conn = db::open_db()?;
-    let capture_host = host
-        .map(crate::runtime_config::normalize_host)
-        .unwrap_or_else(|| adapter.name().to_string());
-    record_capture_event(&conn, &capture_host, &event, &summary)?;
+    let capture_host = capture_host(host, adapter);
+    let content = build_capture_content(&event, &summary);
+    let conn = match db::open_db() {
+        Ok(conn) => conn,
+        Err(error) => {
+            let spill = write_capture_spill(
+                &capture_host,
+                adapter.name(),
+                &event,
+                &summary,
+                &content,
+                &error.to_string(),
+            )
+            .with_context(|| {
+                format!(
+                    "database open failed and capture spill write failed for session {}",
+                    event.session_id
+                )
+            })?;
+            crate::log::warn(
+                "observe",
+                &format!(
+                    "database open failed; spilled capture event {} to {}",
+                    spill.event_id,
+                    spill.path.display()
+                ),
+            );
+            return Err(error).context("database open failed after capture event was spilled");
+        }
+    };
+    if let Err(error) = replay_capture_spills(&conn) {
+        crate::log::warn(
+            "observe",
+            &format!("capture spill replay failed: {}", error),
+        );
+    }
+    record_capture_event_content(&conn, &capture_host, &event, &summary, &content)?;
     crate::memory::insert_event(
         &conn,
         &event.session_id,
@@ -90,6 +157,20 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
                 sync_native_memory(&conn, &event.session_id, file_path, branch.as_deref())
             {
                 crate::log::warn("observe", &format!("native memory sync failed: {}", error));
+                if let Err(audit_error) = record_capture_audit_for_event(
+                    &conn,
+                    Some(&capture_host),
+                    Some(adapter.name()),
+                    Some(&event),
+                    "native_read_error",
+                    Some(&error.to_string()),
+                    Some(&capture_audit_payload(&event)),
+                ) {
+                    crate::log::warn(
+                        "observe",
+                        &format!("native memory audit failed: {}", audit_error),
+                    );
+                }
             }
         }
     }
@@ -114,14 +195,52 @@ fn detect_adapter_for_host(
         .or_else(|| crate::adapter::detect_adapter(input))
 }
 
+fn capture_host(host: Option<&str>, adapter: &dyn crate::adapter::ToolAdapter) -> String {
+    host.map(crate::runtime_config::normalize_host)
+        .unwrap_or_else(|| adapter.name().to_string())
+}
+
+#[cfg(test)]
 fn record_capture_event(
     conn: &rusqlite::Connection,
     host: &str,
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
 ) -> Result<()> {
+    let content = build_capture_content(event, summary);
+    record_capture_event_content(conn, host, event, summary, &content)
+}
+
+fn record_capture_event_content(
+    conn: &rusqlite::Connection,
+    host: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    _summary: &crate::adapter::EventSummary,
+    content: &str,
+) -> Result<()> {
+    db::record_captured_event(
+        conn,
+        &db::CaptureEventInput {
+            host,
+            session_id: &event.session_id,
+            project: &event.project,
+            cwd: event.cwd.as_deref(),
+            event_type: "tool_result",
+            role: None,
+            tool_name: Some(&event.tool_name),
+            content,
+            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
+        },
+    )?;
+    Ok(())
+}
+
+fn build_capture_content(
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> String {
     let git_branch = event.cwd.as_deref().and_then(db::detect_git_branch);
-    let content = serde_json::json!({
+    serde_json::json!({
         "summary": &summary.summary,
         "event_type": &summary.event_type,
         "detail": summary.detail.as_deref(),
@@ -138,41 +257,131 @@ fn record_capture_event(
             .map(crate::adapter::common::redact_sensitive_value),
         "git_branch": git_branch.as_deref(),
     })
-    .to_string();
-    db::record_captured_event(
+    .to_string()
+}
+
+fn capture_audit_payload(event: &crate::adapter::ParsedHookEvent) -> String {
+    serde_json::json!({
+        "session_id": &event.session_id,
+        "project": &event.project,
+        "cwd": event.cwd.as_deref(),
+        "tool_name": &event.tool_name,
+        "tool_input": event.tool_input.as_ref(),
+        "tool_response": event.tool_response.as_ref(),
+    })
+    .to_string()
+}
+
+fn record_capture_audit_best_effort(
+    host: Option<String>,
+    adapter: Option<&str>,
+    event: Option<&crate::adapter::ParsedHookEvent>,
+    reason: &str,
+    detail: Option<&str>,
+    payload: Option<&str>,
+) {
+    let conn = match db::open_db() {
+        Ok(conn) => conn,
+        Err(error) => {
+            crate::log::warn(
+                "observe",
+                &format!("capture audit unavailable for {reason}: {}", error),
+            );
+            return;
+        }
+    };
+    if let Err(error) = replay_capture_spills(&conn) {
+        crate::log::warn(
+            "observe",
+            &format!("capture spill replay failed: {}", error),
+        );
+    }
+    if let Err(error) = record_capture_audit_for_event(
+        &conn,
+        host.as_deref(),
+        adapter,
+        event,
+        reason,
+        detail,
+        payload,
+    ) {
+        crate::log::warn(
+            "observe",
+            &format!("capture audit write failed for {reason}: {}", error),
+        );
+    }
+}
+
+fn record_capture_audit_for_event(
+    conn: &rusqlite::Connection,
+    host: Option<&str>,
+    adapter: Option<&str>,
+    event: Option<&crate::adapter::ParsedHookEvent>,
+    reason: &str,
+    detail: Option<&str>,
+    payload: Option<&str>,
+) -> Result<()> {
+    db::record_capture_audit_event(
         conn,
-        &db::CaptureEventInput {
+        &db::CaptureAuditInput {
             host,
-            session_id: &event.session_id,
-            project: &event.project,
-            cwd: event.cwd.as_deref(),
-            event_type: "tool_result",
-            role: None,
-            tool_name: Some(&event.tool_name),
-            content: &content,
-            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
+            adapter,
+            session_id: event.map(|event| event.session_id.as_str()),
+            project: event.map(|event| event.project.as_str()),
+            cwd: event.and_then(|event| event.cwd.as_deref()),
+            tool_name: event.map(|event| event.tool_name.as_str()),
+            reason,
+            detail,
+            payload,
         },
     )?;
     Ok(())
 }
 
+#[cfg(test)]
 fn should_skip_bash_event(
     adapter: &dyn crate::adapter::ToolAdapter,
     event: &crate::adapter::ParsedHookEvent,
 ) -> bool {
+    bash_skip_detail(adapter, event).is_some()
+}
+
+fn skip_reason(
+    adapter: &dyn crate::adapter::ToolAdapter,
+    event: &crate::adapter::ParsedHookEvent,
+) -> Option<(&'static str, String)> {
+    if adapter.should_skip(event) {
+        return Some((
+            "tool_skipped",
+            format!("adapter skipped tool {}", event.tool_name),
+        ));
+    }
+    bash_skip_detail(adapter, event).map(|detail| ("bash_skipped", detail))
+}
+
+fn bash_skip_detail(
+    adapter: &dyn crate::adapter::ToolAdapter,
+    event: &crate::adapter::ParsedHookEvent,
+) -> Option<String> {
     if event.tool_name != "Bash" {
-        return false;
+        return None;
     }
 
     if adapter.name() == "codex-cli" && !codex_bash_observe_enabled() {
-        return true;
+        return Some("codex bash observe disabled".to_string());
     }
 
     event
         .tool_input
         .as_ref()
         .and_then(|value| value["command"].as_str())
-        .is_some_and(|command| adapter.should_skip_bash(command))
+        .filter(|command| adapter.should_skip_bash(command))
+        .map(|command| {
+            format!(
+                "adapter skipped bash command: {}",
+                db::truncate_str(command, 120)
+            )
+        })
 }
 
 fn codex_bash_observe_enabled() -> bool {
@@ -201,6 +410,14 @@ mod tests {
             tool_input: Some(serde_json::json!({ "command": "cargo test" })),
             tool_response: Some(serde_json::json!({ "exitCode": 0 })),
         }
+    }
+
+    fn audit_count(conn: &rusqlite::Connection, reason: &str) -> anyhow::Result<i64> {
+        Ok(conn.query_row(
+            "SELECT COUNT(*) FROM capture_audit_events WHERE reason = ?1",
+            [reason],
+            |row| row.get(0),
+        )?)
     }
 
     #[test]
@@ -334,5 +551,75 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&project_dir);
         test_result
+    }
+
+    #[tokio::test]
+    async fn observe_audits_no_adapter_match() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("observe-audit-no-adapter");
+
+        observe_input("{}", Some("claude-code")).await?;
+
+        let conn = db::open_db()?;
+        assert_eq!(audit_count(&conn, "adapter_mismatch")?, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observe_audits_tool_skip() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("observe-audit-tool-skip");
+        let input = serde_json::json!({
+            "session_id": "sess-skip",
+            "cwd": "/tmp/remem",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "src/lib.rs"},
+            "tool_response": {"content": "source"}
+        })
+        .to_string();
+
+        observe_input(&input, Some("claude-code")).await?;
+
+        let conn = db::open_db()?;
+        assert_eq!(audit_count(&conn, "tool_skipped")?, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observe_audits_codex_bash_disabled() -> anyhow::Result<()> {
+        let _guard = ENV_LOCK.lock().expect("env lock should acquire");
+        unsafe { std::env::remove_var("REMEM_ENABLE_CODEX_BASH_OBSERVE") };
+        let _test_dir = ScopedTestDataDir::new("observe-audit-codex-bash");
+        let input = serde_json::json!({
+            "session_id": "sess-bash-skip",
+            "cwd": "/tmp/remem",
+            "tool_name": "Bash",
+            "tool_input": {"command": "cargo test"},
+            "tool_response": {"exitCode": 0}
+        })
+        .to_string();
+
+        observe_input(&input, Some("codex-cli")).await?;
+
+        let conn = db::open_db()?;
+        assert_eq!(audit_count(&conn, "bash_skipped")?, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observe_audits_unclassified_event() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("observe-audit-unclassified");
+        let input = serde_json::json!({
+            "session_id": "sess-unclassified",
+            "cwd": "/tmp/remem",
+            "tool_name": "Edit",
+            "tool_input": {"path": "src/lib.rs"},
+            "tool_response": {"content": "edited"}
+        })
+        .to_string();
+
+        observe_input(&input, Some("claude-code")).await?;
+
+        let conn = db::open_db()?;
+        assert_eq!(audit_count(&conn, "unclassified")?, 1);
+        Ok(())
     }
 }

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -92,10 +92,12 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
 
     let capture_host = capture_host(host, adapter);
     let content = build_capture_content(&event, &summary);
+    let event_id = db::unique_capture_event_id("tool_result", &content);
     let conn = match db::open_db() {
         Ok(conn) => conn,
         Err(error) => {
             let spill = write_capture_spill(
+                &event_id,
                 &capture_host,
                 adapter.name(),
                 &event,
@@ -126,17 +128,34 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
             &format!("capture spill replay failed: {}", error),
         );
     }
-    record_capture_event_content(&conn, &capture_host, &event, &summary, &content)?;
-    crate::memory::insert_event(
-        &conn,
-        &event.session_id,
-        &event.project,
-        &summary.event_type,
-        &summary.summary,
-        summary.detail.as_deref(),
-        summary.files_json.as_deref(),
-        summary.exit_code,
-    )?;
+    if let Err(error) =
+        persist_capture_event(&conn, &capture_host, &event, &summary, &content, &event_id)
+    {
+        let spill = write_capture_spill(
+            &event_id,
+            &capture_host,
+            adapter.name(),
+            &event,
+            &summary,
+            &content,
+            &error.to_string(),
+        )
+        .with_context(|| {
+            format!(
+                "capture persistence failed and spill write failed for session {}",
+                event.session_id
+            )
+        })?;
+        crate::log::warn(
+            "observe",
+            &format!(
+                "capture persistence failed; spilled event {} to {}",
+                spill.event_id,
+                spill.path.display()
+            ),
+        );
+        return Err(error).context("capture persistence failed after event was spilled");
+    }
 
     crate::log::info(
         "observe",
@@ -211,6 +230,7 @@ fn record_capture_event(
     record_capture_event_content(conn, host, event, summary, &content)
 }
 
+#[cfg(test)]
 fn record_capture_event_content(
     conn: &rusqlite::Connection,
     host: &str,
@@ -218,19 +238,56 @@ fn record_capture_event_content(
     _summary: &crate::adapter::EventSummary,
     content: &str,
 ) -> Result<()> {
-    db::record_captured_event(
+    record_capture_event_content_with_id(conn, host, event, content, None)
+}
+
+fn record_capture_event_content_with_id(
+    conn: &rusqlite::Connection,
+    host: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    content: &str,
+    event_id_override: Option<&str>,
+) -> Result<()> {
+    let input = db::CaptureEventInput {
+        host,
+        session_id: &event.session_id,
+        project: &event.project,
+        cwd: event.cwd.as_deref(),
+        event_type: "tool_result",
+        role: None,
+        tool_name: Some(&event.tool_name),
+        content,
+        task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
+    };
+    match event_id_override {
+        Some(event_id) => {
+            db::record_captured_event_with_id(conn, &input, Some(event_id))?;
+        }
+        None => {
+            db::record_captured_event(conn, &input)?;
+        }
+    }
+    Ok(())
+}
+
+fn persist_capture_event(
+    conn: &rusqlite::Connection,
+    host: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+    content: &str,
+    event_id: &str,
+) -> Result<()> {
+    record_capture_event_content_with_id(conn, host, event, content, Some(event_id))?;
+    crate::memory::insert_event(
         conn,
-        &db::CaptureEventInput {
-            host,
-            session_id: &event.session_id,
-            project: &event.project,
-            cwd: event.cwd.as_deref(),
-            event_type: "tool_result",
-            role: None,
-            tool_name: Some(&event.tool_name),
-            content,
-            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
-        },
+        &event.session_id,
+        &event.project,
+        &summary.event_type,
+        &summary.summary,
+        summary.detail.as_deref(),
+        summary.files_json.as_deref(),
+        summary.exit_code,
     )?;
     Ok(())
 }
@@ -551,6 +608,81 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&project_dir);
         test_result
+    }
+
+    #[tokio::test]
+    async fn observe_spills_write_failure_and_replays_without_duplicate_capture(
+    ) -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("observe-persist-failure-spill");
+        let failing_input = serde_json::json!({
+            "session_id": "sess-persist-fail",
+            "cwd": "/tmp/remem",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/lib.rs"},
+            "tool_response": {"content": "edited"}
+        })
+        .to_string();
+
+        let conn = db::open_db()?;
+        conn.execute_batch(
+            "CREATE TRIGGER fail_events_insert
+             BEFORE INSERT ON events
+             BEGIN
+                 SELECT RAISE(FAIL, 'events blocked');
+             END;",
+        )?;
+        drop(conn);
+
+        let err = observe_input(&failing_input, Some("claude-code"))
+            .await
+            .expect_err("failed event insert should spill and return an error");
+        assert!(
+            err.to_string().contains("capture persistence failed"),
+            "{err}"
+        );
+        assert_eq!(crate::observe::capture_spill_stats()?.pending_files, 1);
+
+        let conn = db::open_db()?;
+        let partial_captures: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        let partial_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(partial_captures, 1);
+        assert_eq!(partial_events, 0);
+        conn.execute_batch("DROP TRIGGER fail_events_insert;")?;
+        drop(conn);
+
+        let replay_trigger = serde_json::json!({
+            "session_id": "sess-replay-trigger",
+            "cwd": "/tmp/remem",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/other.rs"},
+            "tool_response": {"content": "edited"}
+        })
+        .to_string();
+        observe_input(&replay_trigger, Some("claude-code")).await?;
+
+        let conn = db::open_db()?;
+        let replayed_captures: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        let replayed_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(replayed_captures, 1);
+        assert_eq!(replayed_events, 1);
+        assert_eq!(crate::observe::capture_spill_stats()?.pending_files, 0);
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/observe/native.rs
+++ b/src/observe/native.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rusqlite::Connection;
 
 use super::parse::parse_native_memory_frontmatter;
@@ -14,10 +14,8 @@ pub(super) fn sync_native_memory(
         return Ok(());
     }
 
-    let content = match std::fs::read_to_string(file_path) {
-        Ok(content) => content,
-        Err(_) => return Ok(()),
-    };
+    let content = std::fs::read_to_string(file_path)
+        .with_context(|| format!("read native memory file {}", file_path))?;
     let (title, memory_type, body) = parse_native_memory_frontmatter(&content);
     if body.trim().is_empty() {
         return Ok(());
@@ -47,6 +45,37 @@ pub(super) fn sync_native_memory(
         &format!("synced native memory: {} → project={}", filename, project),
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sync_native_memory;
+    use crate::db::{self, test_support::ScopedTestDataDir};
+
+    #[test]
+    fn sync_native_memory_ignores_non_native_path() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("native-non-memory");
+        let conn = db::open_db()?;
+
+        sync_native_memory(&conn, "sess", "/tmp/remem/notes.md", None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn sync_native_memory_reports_native_read_error() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("native-read-error");
+        let conn = db::open_db()?;
+        let err = sync_native_memory(
+            &conn,
+            "sess",
+            "/tmp/.claude/projects/remem/memory/missing.md",
+            None,
+        )
+        .expect_err("missing native memory file should error");
+
+        assert!(err.to_string().contains("read native memory file"));
+        Ok(())
+    }
 }
 
 fn is_native_memory_markdown(file_path: &str) -> bool {

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -1,0 +1,357 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CaptureSpillStats {
+    pub pending_files: i64,
+    pub pending_bytes: i64,
+    pub latest_epoch: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CaptureSpillWrite {
+    pub path: PathBuf,
+    pub event_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct CaptureSpillRecord {
+    pub schema_version: u8,
+    pub created_at_epoch: i64,
+    pub event_id: String,
+    pub host: String,
+    pub adapter: String,
+    pub session_id: String,
+    pub project: String,
+    pub cwd: Option<String>,
+    pub event_type: String,
+    pub role: Option<String>,
+    pub tool_name: Option<String>,
+    pub content: String,
+    pub summary_event_type: String,
+    pub summary: String,
+    pub summary_detail: Option<String>,
+    pub summary_files_json: Option<String>,
+    pub summary_exit_code: Option<i32>,
+    pub db_error: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ReplayCaptureSpillStats {
+    pub replayed: usize,
+    pub failed: usize,
+}
+
+const SPILL_SCHEMA_VERSION: u8 = 1;
+
+pub(super) fn write_capture_spill(
+    host: &str,
+    adapter: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+    content: &str,
+    db_error: &str,
+) -> Result<CaptureSpillWrite> {
+    let event_id = crate::db::stable_capture_event_id("tool_result", content);
+    let now = chrono::Utc::now().timestamp();
+    let record = CaptureSpillRecord {
+        schema_version: SPILL_SCHEMA_VERSION,
+        created_at_epoch: now,
+        event_id: event_id.clone(),
+        host: host.to_string(),
+        adapter: adapter.to_string(),
+        session_id: event.session_id.clone(),
+        project: event.project.clone(),
+        cwd: event.cwd.clone(),
+        event_type: "tool_result".to_string(),
+        role: None,
+        tool_name: Some(event.tool_name.clone()),
+        content: content.to_string(),
+        summary_event_type: summary.event_type.clone(),
+        summary: summary.summary.clone(),
+        summary_detail: summary.detail.clone(),
+        summary_files_json: summary.files_json.clone(),
+        summary_exit_code: summary.exit_code,
+        db_error: crate::db::truncate_str(db_error, 512).to_string(),
+    };
+    let dir = capture_spill_dir();
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create capture spill dir {}", dir.display()))?;
+    let path = dir.join(format!(
+        "observe-{}-{}.json",
+        now,
+        sanitize_file_component(&event_id)
+    ));
+    let bytes = serde_json::to_vec_pretty(&record)?;
+    std::fs::write(&path, bytes)
+        .with_context(|| format!("write capture spill {}", path.display()))?;
+    Ok(CaptureSpillWrite { path, event_id })
+}
+
+pub(crate) fn capture_spill_stats() -> Result<CaptureSpillStats> {
+    let dir = capture_spill_dir();
+    if !dir.exists() {
+        return Ok(CaptureSpillStats {
+            pending_files: 0,
+            pending_bytes: 0,
+            latest_epoch: None,
+        });
+    }
+
+    let mut pending_files = 0_i64;
+    let mut pending_bytes = 0_i64;
+    let mut latest_epoch = None;
+    for entry in std::fs::read_dir(&dir)
+        .with_context(|| format!("read capture spill dir {}", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let meta = entry.metadata()?;
+        if !meta.is_file() {
+            continue;
+        }
+        pending_files += 1;
+        pending_bytes += i64::try_from(meta.len()).unwrap_or(i64::MAX);
+        if let Some(epoch) = spill_epoch_from_path(&path) {
+            latest_epoch = Some(latest_epoch.map_or(epoch, |current: i64| current.max(epoch)));
+        }
+    }
+
+    Ok(CaptureSpillStats {
+        pending_files,
+        pending_bytes,
+        latest_epoch,
+    })
+}
+
+pub(super) fn replay_capture_spills(conn: &Connection) -> Result<ReplayCaptureSpillStats> {
+    let dir = capture_spill_dir();
+    if !dir.exists() {
+        return Ok(ReplayCaptureSpillStats {
+            replayed: 0,
+            failed: 0,
+        });
+    }
+
+    let mut paths = Vec::new();
+    for entry in std::fs::read_dir(&dir)
+        .with_context(|| format!("read capture spill dir {}", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) == Some("json")
+            && entry.metadata()?.is_file()
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+
+    let mut stats = ReplayCaptureSpillStats {
+        replayed: 0,
+        failed: 0,
+    };
+    for path in paths {
+        match replay_one_capture_spill(conn, &path) {
+            Ok(()) => stats.replayed += 1,
+            Err(error) => {
+                stats.failed += 1;
+                let detail = format!("{}: {}", path.display(), error);
+                let _ = crate::db::record_capture_audit_event(
+                    conn,
+                    &crate::db::CaptureAuditInput {
+                        host: None,
+                        adapter: None,
+                        session_id: None,
+                        project: None,
+                        cwd: None,
+                        tool_name: None,
+                        reason: "spill_replay_failed",
+                        detail: Some(&detail),
+                        payload: None,
+                    },
+                );
+                crate::log::warn("observe", &format!("capture spill replay failed: {detail}"));
+            }
+        }
+    }
+    Ok(stats)
+}
+
+fn replay_one_capture_spill(conn: &Connection, path: &Path) -> Result<()> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("read capture spill {}", path.display()))?;
+    let record: CaptureSpillRecord = serde_json::from_str(&text)
+        .with_context(|| format!("parse capture spill {}", path.display()))?;
+    anyhow::ensure!(
+        record.schema_version == SPILL_SCHEMA_VERSION,
+        "unsupported spill schema version {}",
+        record.schema_version
+    );
+    crate::db::record_captured_event_with_id(
+        conn,
+        &crate::db::CaptureEventInput {
+            host: &record.host,
+            session_id: &record.session_id,
+            project: &record.project,
+            cwd: record.cwd.as_deref(),
+            event_type: &record.event_type,
+            role: record.role.as_deref(),
+            tool_name: record.tool_name.as_deref(),
+            content: &record.content,
+            task_kind: Some(crate::db::ExtractionTaskKind::ObservationExtract),
+        },
+        Some(&record.event_id),
+    )?;
+    insert_memory_event_once(conn, &record)?;
+    crate::db::record_capture_audit_event(
+        conn,
+        &crate::db::CaptureAuditInput {
+            host: Some(&record.host),
+            adapter: Some(&record.adapter),
+            session_id: Some(&record.session_id),
+            project: Some(&record.project),
+            cwd: record.cwd.as_deref(),
+            tool_name: record.tool_name.as_deref(),
+            reason: "spill_replayed",
+            detail: Some(&record.event_id),
+            payload: Some(&record.content),
+        },
+    )?;
+    std::fs::remove_file(path)
+        .with_context(|| format!("remove replayed capture spill {}", path.display()))?;
+    Ok(())
+}
+
+fn insert_memory_event_once(conn: &Connection, record: &CaptureSpillRecord) -> Result<()> {
+    let exists = conn
+        .query_row(
+            "SELECT 1 FROM events
+             WHERE session_id = ?1
+               AND project = ?2
+               AND event_type = ?3
+               AND summary = ?4
+               AND COALESCE(detail, '') = COALESCE(?5, '')
+               AND COALESCE(files, '') = COALESCE(?6, '')
+               AND COALESCE(exit_code, -2147483648) = COALESCE(?7, -2147483648)
+             LIMIT 1",
+            params![
+                &record.session_id,
+                &record.project,
+                &record.summary_event_type,
+                &record.summary,
+                record.summary_detail.as_deref(),
+                record.summary_files_json.as_deref(),
+                record.summary_exit_code
+            ],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    if !exists {
+        crate::memory::insert_event(
+            conn,
+            &record.session_id,
+            &record.project,
+            &record.summary_event_type,
+            &record.summary,
+            record.summary_detail.as_deref(),
+            record.summary_files_json.as_deref(),
+            record.summary_exit_code,
+        )?;
+    }
+    Ok(())
+}
+
+fn capture_spill_dir() -> PathBuf {
+    crate::db::data_dir().join("capture-spill")
+}
+
+fn spill_epoch_from_path(path: &Path) -> Option<i64> {
+    path.file_name()
+        .and_then(|value| value.to_str())
+        .and_then(|name| name.strip_prefix("observe-"))
+        .and_then(|name| name.split('-').next())
+        .and_then(|epoch| epoch.parse::<i64>().ok())
+}
+
+fn sanitize_file_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::{EventSummary, ParsedHookEvent};
+    use crate::db::{self, test_support::ScopedTestDataDir};
+
+    #[test]
+    fn capture_spill_round_trips_and_replays_once() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-replay");
+        let event = ParsedHookEvent {
+            session_id: "sess-spill".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Edit".to_string(),
+            tool_input: Some(serde_json::json!({ "file_path": "src/lib.rs" })),
+            tool_response: Some(serde_json::json!({ "content": "edited" })),
+        };
+        let summary = EventSummary {
+            event_type: "file_edit".to_string(),
+            summary: "Edit src/lib.rs".to_string(),
+            detail: None,
+            files_json: Some(r#"["src/lib.rs"]"#.to_string()),
+            exit_code: None,
+        };
+        let content = serde_json::json!({
+            "summary": summary.summary,
+            "tool_name": event.tool_name,
+            "tool_input": event.tool_input,
+        })
+        .to_string();
+
+        let written = write_capture_spill(
+            "claude-code",
+            "claude-code",
+            &event,
+            &summary,
+            &content,
+            "db",
+        )?;
+        assert!(written.path.exists());
+        assert_eq!(capture_spill_stats()?.pending_files, 1);
+
+        let conn = db::open_db()?;
+        let stats = replay_capture_spills(&conn)?;
+        assert_eq!(stats.replayed, 1);
+        assert_eq!(stats.failed, 0);
+        assert_eq!(capture_spill_stats()?.pending_files, 0);
+        let captured: i64 =
+            conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))?;
+        let events: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
+        let replayed: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM capture_audit_events WHERE reason = 'spill_replayed'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(captured, 1);
+        assert_eq!(events, 1);
+        assert_eq!(replayed, 1);
+        Ok(())
+    }
+}

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -48,6 +48,7 @@ pub(super) struct ReplayCaptureSpillStats {
 const SPILL_SCHEMA_VERSION: u8 = 1;
 
 pub(super) fn write_capture_spill(
+    event_id: &str,
     host: &str,
     adapter: &str,
     event: &crate::adapter::ParsedHookEvent,
@@ -55,12 +56,18 @@ pub(super) fn write_capture_spill(
     content: &str,
     db_error: &str,
 ) -> Result<CaptureSpillWrite> {
-    let event_id = crate::db::stable_capture_event_id("tool_result", content);
     let now = chrono::Utc::now().timestamp();
+    let redacted_content = crate::db::capture::redact_capture_content(content);
+    let redacted_summary = crate::db::capture::redact_capture_content(&summary.summary);
+    let redacted_detail = summary
+        .detail
+        .as_ref()
+        .map(|detail| crate::db::capture::redact_capture_content(detail));
+    let redacted_error = crate::db::capture::redact_capture_content(db_error);
     let record = CaptureSpillRecord {
         schema_version: SPILL_SCHEMA_VERSION,
         created_at_epoch: now,
-        event_id: event_id.clone(),
+        event_id: event_id.to_string(),
         host: host.to_string(),
         adapter: adapter.to_string(),
         session_id: event.session_id.clone(),
@@ -69,13 +76,13 @@ pub(super) fn write_capture_spill(
         event_type: "tool_result".to_string(),
         role: None,
         tool_name: Some(event.tool_name.clone()),
-        content: content.to_string(),
+        content: redacted_content,
         summary_event_type: summary.event_type.clone(),
-        summary: summary.summary.clone(),
-        summary_detail: summary.detail.clone(),
+        summary: redacted_summary,
+        summary_detail: redacted_detail,
         summary_files_json: summary.files_json.clone(),
         summary_exit_code: summary.exit_code,
-        db_error: crate::db::truncate_str(db_error, 512).to_string(),
+        db_error: crate::db::truncate_str(&redacted_error, 512).to_string(),
     };
     let dir = capture_spill_dir();
     std::fs::create_dir_all(&dir)
@@ -83,12 +90,22 @@ pub(super) fn write_capture_spill(
     let path = dir.join(format!(
         "observe-{}-{}.json",
         now,
-        sanitize_file_component(&event_id)
+        sanitize_file_component(event_id)
     ));
     let bytes = serde_json::to_vec_pretty(&record)?;
-    std::fs::write(&path, bytes)
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .and_then(|mut file| {
+            use std::io::Write;
+            file.write_all(&bytes)
+        })
         .with_context(|| format!("write capture spill {}", path.display()))?;
-    Ok(CaptureSpillWrite { path, event_id })
+    Ok(CaptureSpillWrite {
+        path,
+        event_id: event_id.to_string(),
+    })
 }
 
 pub(crate) fn capture_spill_stats() -> Result<CaptureSpillStats> {
@@ -325,7 +342,9 @@ mod tests {
         })
         .to_string();
 
+        let event_id = db::unique_capture_event_id("tool_result", &content);
         let written = write_capture_spill(
+            &event_id,
             "claude-code",
             "claude-code",
             &event,
@@ -352,6 +371,109 @@ mod tests {
         assert_eq!(captured, 1);
         assert_eq!(events, 1);
         assert_eq!(replayed, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn repeated_identical_spills_get_distinct_files() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-distinct");
+        let event = ParsedHookEvent {
+            session_id: "sess-spill-distinct".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Edit".to_string(),
+            tool_input: Some(serde_json::json!({ "file_path": "src/lib.rs" })),
+            tool_response: None,
+        };
+        let summary = EventSummary {
+            event_type: "file_edit".to_string(),
+            summary: "Edit src/lib.rs".to_string(),
+            detail: None,
+            files_json: Some(r#"["src/lib.rs"]"#.to_string()),
+            exit_code: None,
+        };
+        let content = serde_json::json!({
+            "summary": summary.summary,
+            "tool_name": event.tool_name,
+            "tool_input": event.tool_input,
+        })
+        .to_string();
+
+        let first_id = db::unique_capture_event_id("tool_result", &content);
+        let second_id = db::unique_capture_event_id("tool_result", &content);
+        let first = write_capture_spill(
+            &first_id,
+            "claude-code",
+            "claude-code",
+            &event,
+            &summary,
+            &content,
+            "db",
+        )?;
+        let second = write_capture_spill(
+            &second_id,
+            "claude-code",
+            "claude-code",
+            &event,
+            &summary,
+            &content,
+            "db",
+        )?;
+
+        assert_ne!(first.event_id, second.event_id);
+        assert_ne!(first.path, second.path);
+        assert_eq!(capture_spill_stats()?.pending_files, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn capture_spill_redacts_free_form_fields() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-redacts");
+        let event = ParsedHookEvent {
+            session_id: "sess-spill-redact".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Bash".to_string(),
+            tool_input: Some(serde_json::json!({
+                "command": "curl -H 'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456'"
+            })),
+            tool_response: Some(serde_json::json!({
+                "stderr": "password=hunter2"
+            })),
+        };
+        let summary = EventSummary {
+            event_type: "bash".to_string(),
+            summary: "Run `curl -H 'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456'`"
+                .to_string(),
+            detail: Some("password=hunter2".to_string()),
+            files_json: None,
+            exit_code: Some(1),
+        };
+        let content = serde_json::json!({
+            "summary": summary.summary,
+            "detail": summary.detail,
+            "tool_name": event.tool_name,
+            "tool_input": event.tool_input,
+            "tool_response": event.tool_response,
+        })
+        .to_string();
+        let event_id = db::unique_capture_event_id("tool_result", &content);
+
+        let written = write_capture_spill(
+            &event_id,
+            "codex-cli",
+            "codex-cli",
+            &event,
+            &summary,
+            &content,
+            "database token=github_pat_secret",
+        )?;
+        let stored = std::fs::read_to_string(written.path)?;
+
+        assert!(stored.contains("[REDACTED]"));
+        assert!(!stored.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
+        assert!(!stored.contains("hunter2"));
+        assert!(!stored.contains("github_pat_secret"));
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Refs #363.

This PR makes capture drops visible and recoverable for the primary #363 failure modes:

- adds `capture_audit_events` schema v36 for non-captured hook outcomes
- records audit rows for adapter mismatch, skipped tools, disabled/skipped Bash capture, unclassified accepted events, native read errors, and spill replay results
- adds a redacted file-backed capture spill buffer for `db::open_db()` failures and opportunistic replay after the next successful DB open
- surfaces audit/drop counts and pending spill files in CLI status, API status, and doctor
- changes native memory read failures from silent `Ok(())` to explicit errors that the hook logs/audits
- bumps version to `0.5.30`

The native-memory direct-promotion governance concern in #363 is intentionally left as follow-up rather than hidden behind this PR; this PR does not claim `Fixes #363`.

## Verification

- `cargo fmt --check`
- `cargo check --message-format=short`
- `cargo test`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `git diff --check origin/main..HEAD`
