### PR TITLE
fix: record capture drops and replay spills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.29"
+version = "0.5.30"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.29": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.29",
+    "0.5.30": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.30",
       "assets": {}
     }
   }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -5,6 +5,7 @@ pub mod codex;
 pub(crate) mod common;
 
 /// Normalized event parsed from a hook's raw JSON input.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ParsedHookEvent {
     pub session_id: String,
     pub cwd: Option<String>,
@@ -15,6 +16,7 @@ pub struct ParsedHookEvent {
 }
 
 /// Structured event summary extracted from a tool call.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EventSummary {
     pub event_type: String,
     pub summary: String,

--- a/src/api/handlers/status.rs
+++ b/src/api/handlers/status.rs
@@ -27,6 +27,8 @@ pub(in crate::api) async fn handle_status(State(_state): State<DbState>) -> impl
         "memories": stats.active_memories,
         "observations": stats.active_observations,
         "captured_events": stats.captured_events,
+        "capture_drop_events": stats.capture_drop_events,
+        "unrecovered_capture_spills": stats.unrecovered_capture_spills,
         "pending_extraction_tasks": stats.pending_extraction_tasks,
         "pending_memory_candidates": stats.pending_memory_candidates,
         "pending_graph_candidates": stats.pending_graph_candidates,

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -64,6 +64,14 @@ fn load_status_report() -> Result<StatusReport> {
         },
         capture_pipeline: CapturePipelineStatus {
             captured: stats.captured_events,
+            dropped: stats.capture_drop_events,
+            unrecovered_spills: stats.unrecovered_capture_spills,
+            latest_drop_epoch: stats.latest_capture_drop_epoch,
+            latest_drop_age_secs: stats
+                .latest_capture_drop_epoch
+                .map(|epoch| now.saturating_sub(epoch)),
+            latest_drop_reason: stats.latest_capture_drop_reason,
+            latest_drop_detail: stats.latest_capture_drop_detail,
             extract_todo: stats.pending_extraction_tasks,
             extract_running: stats.processing_extraction_tasks,
             extract_failed: stats.failed_extraction_tasks,
@@ -151,6 +159,19 @@ fn print_status_report(report: &StatusReport) {
     println!();
     println!("Capture pipeline:");
     println!("  Captured:     {:>6}", report.capture_pipeline.captured);
+    println!("  Dropped:      {:>6}", report.capture_pipeline.dropped);
+    if report.capture_pipeline.dropped > 0 {
+        println!(
+            "  Spill open:   {:>6}",
+            report.capture_pipeline.unrecovered_spills
+        );
+        if let Some(reason) = &report.capture_pipeline.latest_drop_reason {
+            println!("  Latest drop:  {}", reason);
+        }
+        if let Some(age_secs) = report.capture_pipeline.latest_drop_age_secs {
+            println!("  Drop age:     {:>6}s", age_secs);
+        }
+    }
     println!(
         "  Extract todo: {:>6}",
         report.capture_pipeline.extract_todo
@@ -305,6 +326,12 @@ pub(super) struct RawArchiveStatus {
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct CapturePipelineStatus {
     pub captured: i64,
+    pub dropped: i64,
+    pub unrecovered_spills: i64,
+    pub latest_drop_epoch: Option<i64>,
+    pub latest_drop_age_secs: Option<i64>,
+    pub latest_drop_reason: Option<String>,
+    pub latest_drop_detail: Option<String>,
     pub extract_todo: i64,
     pub extract_running: i64,
     pub extract_failed: i64,
@@ -393,6 +420,12 @@ mod tests {
             },
             capture_pipeline: CapturePipelineStatus {
                 captured: 5,
+                dropped: 0,
+                unrecovered_spills: 0,
+                latest_drop_epoch: None,
+                latest_drop_age_secs: None,
+                latest_drop_reason: None,
+                latest_drop_detail: None,
                 extract_todo: 6,
                 extract_running: 7,
                 extract_failed: 8,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,5 @@
 pub mod capture;
+pub mod capture_drop;
 pub mod core;
 pub mod crypto;
 mod extraction;
@@ -15,6 +16,7 @@ pub mod usage;
 pub mod worker;
 
 pub use capture::*;
+pub use capture_drop::*;
 pub use core::*;
 pub use crypto::*;
 pub use extraction::*;

--- a/src/db/capture_drop.rs
+++ b/src/db/capture_drop.rs
@@ -1,0 +1,165 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureDropInput<'a> {
+    pub host: Option<&'a str>,
+    pub session_id: Option<&'a str>,
+    pub project: Option<&'a str>,
+    pub tool_name: Option<&'a str>,
+    pub reason: &'a str,
+    pub detail: Option<&'a str>,
+    pub spill_path: Option<&'a str>,
+    pub recovered_event_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CaptureDropStats {
+    pub total: i64,
+    pub unrecovered_spills: i64,
+    pub latest_epoch: Option<i64>,
+    pub latest_reason: Option<String>,
+    pub latest_detail: Option<String>,
+}
+
+pub fn record_capture_drop(conn: &Connection, input: &CaptureDropInput<'_>) -> Result<i64> {
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "INSERT INTO capture_drop_events
+         (host_id, session_id, project, tool_name, reason, detail, spill_path,
+          recovered_event_id, created_at_epoch, recovered_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, CASE WHEN ?8 IS NULL THEN NULL ELSE ?9 END)",
+        params![
+            input.host,
+            input.session_id,
+            input.project,
+            input.tool_name,
+            input.reason,
+            input.detail,
+            input.spill_path,
+            input.recovered_event_id,
+            now,
+        ],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn query_capture_drop_stats(conn: &Connection) -> Result<CaptureDropStats> {
+    if !capture_drop_table_exists(conn)? {
+        return Ok(CaptureDropStats::default());
+    }
+
+    let total = conn.query_row("SELECT COUNT(*) FROM capture_drop_events", [], |row| {
+        row.get(0)
+    })?;
+    let unrecovered_spills = conn.query_row(
+        "SELECT COUNT(*)
+         FROM capture_drop_events
+         WHERE reason = 'db_open_failed' AND recovered_event_id IS NULL",
+        [],
+        |row| row.get(0),
+    )?;
+    let latest = conn
+        .query_row(
+            "SELECT created_at_epoch, reason, detail
+             FROM capture_drop_events
+             ORDER BY created_at_epoch DESC, id DESC
+             LIMIT 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+
+    Ok(match latest {
+        Some((latest_epoch, latest_reason, latest_detail)) => CaptureDropStats {
+            total,
+            unrecovered_spills,
+            latest_epoch: Some(latest_epoch),
+            latest_reason: Some(latest_reason),
+            latest_detail,
+        },
+        None => CaptureDropStats {
+            total,
+            unrecovered_spills,
+            ..CaptureDropStats::default()
+        },
+    })
+}
+
+fn capture_drop_table_exists(conn: &Connection) -> Result<bool> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*)
+         FROM sqlite_master
+         WHERE type = 'table' AND name = ?1",
+        ["capture_drop_events"],
+        |row| row.get(0),
+    )?;
+    Ok(count > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::{query_capture_drop_stats, record_capture_drop, CaptureDropInput};
+
+    #[test]
+    fn capture_drop_stats_default_when_table_missing() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+
+        let stats = query_capture_drop_stats(&conn)?;
+
+        assert_eq!(stats.total, 0);
+        assert_eq!(stats.unrecovered_spills, 0);
+        assert_eq!(stats.latest_reason, None);
+        Ok(())
+    }
+
+    #[test]
+    fn capture_drop_stats_report_latest_and_unrecovered_spills() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE captured_events (id INTEGER PRIMARY KEY);")?;
+        conn.execute_batch(include_str!("../migrations/v036_capture_drop_events.sql"))?;
+
+        record_capture_drop(
+            &conn,
+            &CaptureDropInput {
+                host: Some("codex-cli"),
+                session_id: Some("session-a"),
+                project: Some("/repo"),
+                tool_name: Some("Edit"),
+                reason: "db_open_failed",
+                detail: Some("database is locked"),
+                spill_path: Some("/tmp/spill.jsonl"),
+                recovered_event_id: None,
+            },
+        )?;
+        record_capture_drop(
+            &conn,
+            &CaptureDropInput {
+                host: Some("codex-cli"),
+                session_id: Some("session-b"),
+                project: Some("/repo"),
+                tool_name: Some("Read"),
+                reason: "adapter_skip",
+                detail: Some("read-only tool"),
+                spill_path: None,
+                recovered_event_id: None,
+            },
+        )?;
+
+        let stats = query_capture_drop_stats(&conn)?;
+
+        assert_eq!(stats.total, 2);
+        assert_eq!(stats.unrecovered_spills, 1);
+        assert_eq!(stats.latest_reason.as_deref(), Some("adapter_skip"));
+        assert_eq!(stats.latest_detail.as_deref(), Some("read-only tool"));
+        Ok(())
+    }
+}

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -21,6 +21,11 @@ pub struct SystemStats {
     pub latest_raw_ingest_failure_path: Option<String>,
     pub latest_raw_ingest_failure_message: Option<String>,
     pub captured_events: i64,
+    pub capture_drop_events: i64,
+    pub unrecovered_capture_spills: i64,
+    pub latest_capture_drop_epoch: Option<i64>,
+    pub latest_capture_drop_reason: Option<String>,
+    pub latest_capture_drop_detail: Option<String>,
     pub pending_extraction_tasks: i64,
     pub processing_extraction_tasks: i64,
     pub failed_extraction_tasks: i64,
@@ -75,6 +80,7 @@ pub struct CandidatePromotionStat {
 pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
     let now = chrono::Utc::now().timestamp();
     let raw_ingest = query_raw_ingest_failure_stats(conn)?;
+    let capture_drop = crate::db::query_capture_drop_stats(conn)?;
     let worker_heartbeat = crate::db::worker::latest_daemon_worker_heartbeat(conn)?;
     let healthy_worker_heartbeat = crate::db::worker::healthy_daemon_worker_heartbeat(
         conn,
@@ -109,6 +115,11 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
         captured_events: conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| {
             row.get(0)
         })?,
+        capture_drop_events: capture_drop.total,
+        unrecovered_capture_spills: capture_drop.unrecovered_spills,
+        latest_capture_drop_epoch: capture_drop.latest_epoch,
+        latest_capture_drop_reason: capture_drop.latest_reason,
+        latest_capture_drop_detail: capture_drop.latest_detail,
         pending_extraction_tasks: conn.query_row(
             "SELECT COUNT(*) FROM extraction_tasks WHERE status = 'pending'",
             [],

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -42,6 +42,19 @@ fn setup_stats_schema(conn: &Connection) {
         CREATE TABLE captured_events (
             id INTEGER PRIMARY KEY
         );
+        CREATE TABLE capture_drop_events (
+            id INTEGER PRIMARY KEY,
+            host_id TEXT,
+            session_id TEXT,
+            project TEXT,
+            tool_name TEXT,
+            reason TEXT NOT NULL,
+            detail TEXT,
+            spill_path TEXT,
+            recovered_event_id INTEGER,
+            created_at_epoch INTEGER NOT NULL,
+            recovered_at_epoch INTEGER
+        );
         CREATE TABLE extraction_tasks (
             id INTEGER PRIMARY KEY,
             status TEXT NOT NULL,
@@ -142,6 +155,14 @@ fn query_system_stats_and_related_views_share_one_definition() {
     conn.execute("INSERT INTO captured_events (id) VALUES (1)", [])
         .expect("captured event insert should succeed");
     conn.execute(
+        "INSERT INTO capture_drop_events
+         (host_id, session_id, project, tool_name, reason, detail, created_at_epoch)
+         VALUES ('codex-cli', 'session-drop', 'alpha', 'Bash', 'codex_bash_disabled',
+                 'Codex Bash capture disabled', 170)",
+        [],
+    )
+    .expect("capture drop insert should succeed");
+    conn.execute(
         "INSERT INTO extraction_tasks (status, created_at_epoch) VALUES ('pending', 90)",
         [],
     )
@@ -241,6 +262,11 @@ fn query_system_stats_and_related_views_share_one_definition() {
             latest_raw_ingest_failure_path: Some("/bad/transcript.jsonl".to_string()),
             latest_raw_ingest_failure_message: Some("bad jsonl".to_string()),
             captured_events: 1,
+            capture_drop_events: 1,
+            unrecovered_capture_spills: 0,
+            latest_capture_drop_epoch: Some(170),
+            latest_capture_drop_reason: Some("codex_bash_disabled".to_string()),
+            latest_capture_drop_detail: Some("Codex Bash capture disabled".to_string()),
             pending_extraction_tasks: 1,
             processing_extraction_tasks: 1,
             failed_extraction_tasks: 1,
@@ -335,6 +361,21 @@ fn query_system_stats_defaults_raw_ingest_failures_when_table_is_absent() -> any
     assert_eq!(system.raw_ingest_parse_errors, 0);
     assert_eq!(system.raw_ingest_insert_errors, 0);
     assert_eq!(system.latest_raw_ingest_failure_epoch, None);
+    Ok(())
+}
+
+#[test]
+fn query_system_stats_defaults_capture_drops_when_table_is_absent() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_stats_schema(&conn);
+    conn.execute("DROP TABLE capture_drop_events", [])?;
+
+    let system = query_system_stats(&conn)?;
+
+    assert_eq!(system.capture_drop_events, 0);
+    assert_eq!(system.unrecovered_capture_spills, 0);
+    assert_eq!(system.latest_capture_drop_epoch, None);
+    assert_eq!(system.latest_capture_drop_reason, None);
     Ok(())
 }
 

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -151,6 +151,50 @@ pub(super) fn check_raw_archive_ingest(conn: Option<&Connection>) -> Check {
     Check::new("Raw archive ingest", Status::Warn, detail)
 }
 
+pub(super) fn check_capture_drops(conn: Option<&Connection>) -> Check {
+    let Some(conn) = conn else {
+        return Check::new("Capture drops", Status::Warn, "cannot open database");
+    };
+
+    let stats = match db::query_system_stats(conn) {
+        Ok(stats) => stats,
+        Err(err) => {
+            return Check::new(
+                "Capture drops",
+                Status::Warn,
+                format!("cannot load capture drop stats: {}", err),
+            );
+        }
+    };
+
+    if stats.capture_drop_events == 0 {
+        return Check::new(
+            "Capture drops",
+            Status::Ok,
+            "0 recorded hook skips or drops",
+        );
+    }
+
+    let mut detail = format!(
+        "{} recorded hook skip/drop event(s)",
+        stats.capture_drop_events
+    );
+    if stats.unrecovered_capture_spills > 0 {
+        detail.push_str(&format!(
+            ", {} unrecovered DB-open spill(s)",
+            stats.unrecovered_capture_spills
+        ));
+    }
+    if let Some(reason) = stats.latest_capture_drop_reason {
+        detail.push_str(&format!(", latest reason={reason}"));
+    }
+    if let Some(drop_detail) = stats.latest_capture_drop_detail {
+        detail.push_str(&format!(", detail={}", db::truncate_str(&drop_detail, 160)));
+    }
+
+    Check::new("Capture drops", Status::Warn, detail)
+}
+
 pub(super) fn check_temporal_facts(conn: Option<&Connection>) -> Check {
     let Some(conn) = conn else {
         return Check::new("Temporal facts", Status::Warn, "cannot open database");

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use super::database::{
-    check_database, check_disk_space, check_pending_queue, check_raw_archive_ingest,
-    check_temporal_facts, check_worker_daemon,
+    check_capture_drops, check_database, check_disk_space, check_pending_queue,
+    check_raw_archive_ingest, check_temporal_facts, check_worker_daemon,
 };
 use super::environment::{check_binary, check_hooks, check_install_paths, check_mcp};
 use super::native_memory::check_native_memory_sync;
@@ -84,6 +84,9 @@ fn run_checks(mut on_check: impl FnMut(&Check) -> Result<()>) -> Result<Vec<Chec
     push_checks(&mut checks, &mut on_check, check_mcp)?;
     push_check(&mut checks, &mut on_check, || {
         check_raw_archive_ingest(shared_db.conn())
+    })?;
+    push_check(&mut checks, &mut on_check, || {
+        check_capture_drops(shared_db.conn())
     })?;
     push_check(&mut checks, &mut on_check, || {
         check_temporal_facts(shared_db.conn())

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -6,8 +6,8 @@ use crate::db::test_support::{
 use crate::{db, memory};
 
 use super::database::{
-    check_database, check_pending_queue, check_raw_archive_ingest, check_temporal_facts,
-    check_worker_daemon,
+    check_capture_drops, check_database, check_pending_queue, check_raw_archive_ingest,
+    check_temporal_facts, check_worker_daemon,
 };
 use super::health_action::{queue_actions, render_action_block};
 use super::report::{run_doctor_with_writer, DoctorOptions};
@@ -279,6 +279,36 @@ fn check_raw_archive_ingest_warns_on_recorded_failures() -> anyhow::Result<()> {
     assert!(check.detail.contains("1 failure"), "{}", check.detail);
     assert!(check.detail.contains("read_error"), "{}", check.detail);
     assert!(check.detail.contains("/bad/path.jsonl"), "{}", check.detail);
+    Ok(())
+}
+
+#[test]
+fn check_capture_drops_warns_on_recorded_hook_drops() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-drops");
+    let conn = db::open_db()?;
+    db::record_capture_drop(
+        &conn,
+        &db::CaptureDropInput {
+            host: Some("codex-cli"),
+            session_id: Some("session-a"),
+            project: Some("proj-a"),
+            tool_name: Some("Bash"),
+            reason: "codex_bash_disabled",
+            detail: Some("Codex Bash capture disabled"),
+            spill_path: None,
+            recovered_event_id: None,
+        },
+    )?;
+
+    let check = check_capture_drops(Some(&conn));
+
+    assert_eq!(check.icon(), "WARN");
+    assert!(check.detail.contains("1 recorded"), "{}", check.detail);
+    assert!(
+        check.detail.contains("latest reason=codex_bash_disabled"),
+        "{}",
+        check.detail
+    );
     Ok(())
 }
 

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -594,6 +594,10 @@ fn contains_auto_promote_unsafe_marker(text: &str) -> bool {
         .any(|marker| lower.contains(marker))
 }
 
+pub(crate) fn contains_unsafe_memory_marker(text: &str) -> bool {
+    contains_auto_promote_unsafe_marker(text)
+}
+
 fn normalize_evidence_text(text: &str) -> String {
     text.split_whitespace()
         .collect::<Vec<_>>()

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -180,6 +180,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "context_injection_data_version",
         sql: include_str!("../migrations/v035_context_injection_data_version.sql"),
     },
+    Migration {
+        version: 36,
+        name: "capture_drop_events",
+        sql: include_str!("../migrations/v036_capture_drop_events.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v036_capture_drop_events.sql
+++ b/src/migrations/v036_capture_drop_events.sql
@@ -1,0 +1,22 @@
+-- v036_capture_drop_events: observable capture skip/drop ledger.
+
+CREATE TABLE IF NOT EXISTS capture_drop_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    host_id TEXT,
+    session_id TEXT,
+    project TEXT,
+    tool_name TEXT,
+    reason TEXT NOT NULL,
+    detail TEXT,
+    spill_path TEXT,
+    recovered_event_id INTEGER REFERENCES captured_events(id) ON DELETE SET NULL,
+    created_at_epoch INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    recovered_at_epoch INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_capture_drop_events_reason_time
+    ON capture_drop_events(reason, created_at_epoch);
+
+CREATE INDEX IF NOT EXISTS idx_capture_drop_events_unrecovered_spill
+    ON capture_drop_events(reason, recovered_event_id)
+    WHERE reason = 'db_open_failed';

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -2,6 +2,7 @@ mod hook;
 mod native;
 mod parse;
 mod path;
+mod spill;
 #[cfg(test)]
 mod tests;
 

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use crate::db;
 
 use super::native::sync_native_memory;
+use super::spill::{record_capture_drop_lossy, replay_spilled_capture_events, spill_capture_event};
 
 pub async fn session_init(host: Option<&str>) -> Result<()> {
     let timer = crate::log::Timer::start("session-init", "");
@@ -45,23 +46,67 @@ pub async fn observe(host: Option<&str>) -> Result<()> {
 
 async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
     let Some((adapter, event)) = detect_adapter_for_host(input, host) else {
+        record_capture_drop_lossy(
+            host.map(crate::runtime_config::normalize_host).as_deref(),
+            None,
+            "adapter_mismatch",
+            Some("no capture adapter matched hook input"),
+        );
         return Ok(());
     };
-    if adapter.should_skip(&event) || should_skip_bash_event(adapter, &event) {
+    let capture_host = host
+        .map(crate::runtime_config::normalize_host)
+        .unwrap_or_else(|| adapter.name().to_string());
+    if let Some(reason) = event_skip_reason(adapter, &event) {
+        record_capture_drop_lossy(
+            Some(&capture_host),
+            Some(&event),
+            reason,
+            skip_detail(&event),
+        );
         return Ok(());
     }
 
     let Some(summary) = adapter.classify_event(&event) else {
+        record_capture_drop_lossy(
+            Some(&capture_host),
+            Some(&event),
+            "unclassified_event",
+            Some("adapter did not produce a capture summary"),
+        );
         return Ok(());
     };
 
-    let conn = db::open_db()?;
-    let capture_host = host
-        .map(crate::runtime_config::normalize_host)
-        .unwrap_or_else(|| adapter.name().to_string());
-    record_capture_event(&conn, &capture_host, &event, &summary)?;
+    let conn = match db::open_db() {
+        Ok(conn) => conn,
+        Err(error) => {
+            let path = spill_capture_event(&capture_host, &event, &summary, &error)?;
+            crate::log::error(
+                "observe",
+                &format!(
+                    "database open failed; spilled capture event to {}: {}",
+                    path.display(),
+                    error
+                ),
+            );
+            return Err(error);
+        }
+    };
+    replay_spilled_capture_events(&conn)?;
+    record_observed_event(&conn, &capture_host, &event, &summary)?;
+
+    Ok(())
+}
+
+pub(super) fn record_observed_event(
+    conn: &rusqlite::Connection,
+    capture_host: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> Result<i64> {
+    let capture_event_id = record_capture_event(conn, capture_host, event, summary)?;
     crate::memory::insert_event(
-        &conn,
+        conn,
         &event.session_id,
         &event.project,
         &summary.event_type,
@@ -87,14 +132,14 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
             .and_then(|value| value["file_path"].as_str())
         {
             if let Err(error) =
-                sync_native_memory(&conn, &event.session_id, file_path, branch.as_deref())
+                sync_native_memory(conn, &event.session_id, file_path, branch.as_deref())
             {
                 crate::log::warn("observe", &format!("native memory sync failed: {}", error));
             }
         }
     }
 
-    Ok(())
+    Ok(capture_event_id)
 }
 
 fn detect_adapter_for_host(
@@ -119,7 +164,7 @@ fn record_capture_event(
     host: &str,
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
-) -> Result<()> {
+) -> Result<i64> {
     let git_branch = event.cwd.as_deref().and_then(db::detect_git_branch);
     let content = serde_json::json!({
         "summary": &summary.summary,
@@ -139,7 +184,7 @@ fn record_capture_event(
         "git_branch": git_branch.as_deref(),
     })
     .to_string();
-    db::record_captured_event(
+    let outcome = db::record_captured_event(
         conn,
         &db::CaptureEventInput {
             host,
@@ -153,26 +198,42 @@ fn record_capture_event(
             task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
         },
     )?;
-    Ok(())
+    Ok(outcome.event_row_id)
 }
 
-fn should_skip_bash_event(
+fn event_skip_reason(
     adapter: &dyn crate::adapter::ToolAdapter,
     event: &crate::adapter::ParsedHookEvent,
-) -> bool {
+) -> Option<&'static str> {
+    if adapter.should_skip(event) {
+        return Some("adapter_skip");
+    }
     if event.tool_name != "Bash" {
-        return false;
+        return None;
     }
 
     if adapter.name() == "codex-cli" && !codex_bash_observe_enabled() {
-        return true;
+        return Some("codex_bash_disabled");
     }
 
-    event
+    if event
         .tool_input
         .as_ref()
         .and_then(|value| value["command"].as_str())
         .is_some_and(|command| adapter.should_skip_bash(command))
+    {
+        return Some("bash_read_only");
+    }
+
+    None
+}
+
+fn skip_detail(event: &crate::adapter::ParsedHookEvent) -> Option<&str> {
+    event
+        .tool_input
+        .as_ref()
+        .and_then(|value| value["command"].as_str())
+        .map(|command| db::truncate_str(command, 240))
 }
 
 fn codex_bash_observe_enabled() -> bool {
@@ -188,7 +249,7 @@ mod tests {
     use crate::adapter::{codex::CodexAdapter, EventSummary, ParsedHookEvent};
     use crate::db::{self, test_support::ScopedTestDataDir};
 
-    use super::{observe_input, record_capture_event, session_init_event, should_skip_bash_event};
+    use super::{event_skip_reason, observe_input, record_capture_event, session_init_event};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -208,7 +269,37 @@ mod tests {
         let _guard = ENV_LOCK.lock().expect("env lock should acquire");
         unsafe { std::env::remove_var("REMEM_ENABLE_CODEX_BASH_OBSERVE") };
 
-        assert!(should_skip_bash_event(&CodexAdapter, &codex_bash_event()));
+        assert_eq!(
+            event_skip_reason(&CodexAdapter, &codex_bash_event()),
+            Some("codex_bash_disabled")
+        );
+    }
+
+    #[tokio::test]
+    async fn observe_records_codex_bash_skip_in_drop_ledger() -> anyhow::Result<()> {
+        let _guard = ENV_LOCK.lock().expect("env lock should acquire");
+        unsafe { std::env::remove_var("REMEM_ENABLE_CODEX_BASH_OBSERVE") };
+        let _test_dir = ScopedTestDataDir::new("observe-codex-bash-drop");
+        let input = serde_json::json!({
+            "session_id": "sess-bash-skip",
+            "cwd": "/tmp/remem",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": "cargo test" },
+            "tool_result": { "exitCode": 0 }
+        })
+        .to_string();
+
+        observe_input(&input, Some("codex-cli")).await?;
+
+        let conn = db::open_db()?;
+        let reason: String = conn.query_row(
+            "SELECT reason FROM capture_drop_events WHERE session_id = ?1",
+            ["sess-bash-skip"],
+            |row| row.get(0),
+        )?;
+        assert_eq!(reason, "codex_bash_disabled");
+        Ok(())
     }
 
     #[test]
@@ -216,10 +307,10 @@ mod tests {
         let _guard = ENV_LOCK.lock().expect("env lock should acquire");
         unsafe { std::env::set_var("REMEM_ENABLE_CODEX_BASH_OBSERVE", "1") };
         let event = codex_bash_event();
-        let skipped = should_skip_bash_event(&CodexAdapter, &event);
+        let skipped = event_skip_reason(&CodexAdapter, &event);
         unsafe { std::env::remove_var("REMEM_ENABLE_CODEX_BASH_OBSERVE") };
 
-        assert!(!skipped);
+        assert_eq!(skipped, None);
     }
 
     #[test]

--- a/src/observe/native.rs
+++ b/src/observe/native.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use rusqlite::Connection;
 
 use super::parse::parse_native_memory_frontmatter;
@@ -14,13 +14,14 @@ pub(super) fn sync_native_memory(
         return Ok(());
     }
 
-    let content = match std::fs::read_to_string(file_path) {
-        Ok(content) => content,
-        Err(_) => return Ok(()),
-    };
+    let content = std::fs::read_to_string(file_path)
+        .with_context(|| format!("read native memory {file_path}"))?;
     let (title, memory_type, body) = parse_native_memory_frontmatter(&content);
     if body.trim().is_empty() {
         return Ok(());
+    }
+    if crate::memory_candidate::contains_unsafe_memory_marker(body) {
+        bail!("native memory contains unsafe marker: {file_path}");
     }
 
     let project = extract_project_from_memory_path(file_path);
@@ -47,6 +48,56 @@ pub(super) fn sync_native_memory(
         &format!("synced native memory: {} → project={}", filename, project),
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+    use rusqlite::Connection;
+
+    use crate::db::test_support::ScopedTestDataDir;
+
+    use super::sync_native_memory;
+
+    fn native_path(label: &str) -> String {
+        format!("/tmp/.claude/projects/example/memory/{label}.md")
+    }
+
+    #[test]
+    fn native_memory_read_failure_is_reported() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("native-read-failure");
+        let conn = Connection::open_in_memory()?;
+
+        let err = match sync_native_memory(&conn, "session-a", &native_path("missing"), None) {
+            Ok(()) => anyhow::bail!("missing native memory file should error"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("read native memory"), "{err}");
+        Ok(())
+    }
+
+    #[test]
+    fn native_memory_rejects_unsafe_markers() -> anyhow::Result<()> {
+        let test_dir = ScopedTestDataDir::new("native-unsafe-marker");
+        let path = test_dir
+            .path
+            .join(".claude/projects/example/memory/rule.md");
+        let parent = path
+            .parent()
+            .context("native memory path should have a parent")?;
+        std::fs::create_dir_all(parent)?;
+        std::fs::write(&path, "title: Rule\n\nStore this secret in memory")?;
+        let conn = Connection::open_in_memory()?;
+
+        let err = match sync_native_memory(&conn, "session-a", &path.display().to_string(), None) {
+            Ok(()) => anyhow::bail!("unsafe marker should block native memory sync"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("unsafe marker"), "{err}");
+        Ok(())
+    }
 }
 
 fn is_native_memory_markdown(file_path: &str) -> bool {

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -1,0 +1,228 @@
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::adapter::{EventSummary, ParsedHookEvent};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CaptureSpillRecord {
+    version: u32,
+    host: String,
+    event: ParsedHookEvent,
+    summary: EventSummary,
+    db_error: String,
+    created_at_epoch: i64,
+}
+
+pub(super) fn record_capture_drop_lossy(
+    host: Option<&str>,
+    event: Option<&ParsedHookEvent>,
+    reason: &str,
+    detail: Option<&str>,
+) {
+    let Ok(conn) = crate::db::open_db() else {
+        crate::log::warn(
+            "observe",
+            &format!("capture drop could not be recorded: reason={reason}"),
+        );
+        return;
+    };
+    let result = crate::db::record_capture_drop(
+        &conn,
+        &crate::db::CaptureDropInput {
+            host,
+            session_id: event.map(|event| event.session_id.as_str()),
+            project: event.map(|event| event.project.as_str()),
+            tool_name: event.map(|event| event.tool_name.as_str()),
+            reason,
+            detail,
+            spill_path: None,
+            recovered_event_id: None,
+        },
+    );
+    if let Err(error) = result {
+        crate::log::warn(
+            "observe",
+            &format!("capture drop ledger write failed: {error}"),
+        );
+    }
+}
+
+pub(super) fn spill_capture_event(
+    host: &str,
+    event: &ParsedHookEvent,
+    summary: &EventSummary,
+    db_error: &anyhow::Error,
+) -> Result<PathBuf> {
+    let path = spill_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create capture spill dir {}", parent.display()))?;
+    }
+    let record = CaptureSpillRecord {
+        version: 1,
+        host: host.to_string(),
+        event: sanitize_event(event),
+        summary: summary.clone(),
+        db_error: crate::db::truncate_str(&db_error.to_string(), 1000).to_string(),
+        created_at_epoch: chrono::Utc::now().timestamp(),
+    };
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("open capture spill {}", path.display()))?;
+    serde_json::to_writer(&mut file, &record)?;
+    file.write_all(b"\n")?;
+    Ok(path)
+}
+
+pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> {
+    let path = spill_path();
+    if !path.exists() {
+        return Ok(0);
+    }
+
+    let contents =
+        std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let mut replayed = 0;
+    let failed_path = failed_spill_path();
+    if failed_path.exists() {
+        std::fs::remove_file(&failed_path)
+            .with_context(|| format!("remove stale {}", failed_path.display()))?;
+    }
+
+    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+        match serde_json::from_str::<CaptureSpillRecord>(line) {
+            Ok(record) => match super::hook::record_observed_event(
+                conn,
+                &record.host,
+                &record.event,
+                &record.summary,
+            ) {
+                Ok(event_id) => {
+                    crate::db::record_capture_drop(
+                        conn,
+                        &crate::db::CaptureDropInput {
+                            host: Some(&record.host),
+                            session_id: Some(&record.event.session_id),
+                            project: Some(&record.event.project),
+                            tool_name: Some(&record.event.tool_name),
+                            reason: "db_open_failed",
+                            detail: Some(&record.db_error),
+                            spill_path: Some(&path.display().to_string()),
+                            recovered_event_id: Some(event_id),
+                        },
+                    )?;
+                    replayed += 1;
+                }
+                Err(error) => append_failed_spill(&failed_path, line, &error)?,
+            },
+            Err(error) => append_failed_spill(&failed_path, line, &error.into())?,
+        }
+    }
+
+    std::fs::remove_file(&path).with_context(|| format!("remove {}", path.display()))?;
+    if failed_path.exists() {
+        std::fs::rename(&failed_path, &path).with_context(|| {
+            format!(
+                "move unreplayed capture spill {} to {}",
+                failed_path.display(),
+                path.display()
+            )
+        })?;
+    }
+
+    if replayed > 0 {
+        crate::log::info(
+            "observe",
+            &format!("replayed {replayed} spilled capture event(s)"),
+        );
+    }
+    Ok(replayed)
+}
+
+fn append_failed_spill(path: &PathBuf, line: &str, error: &anyhow::Error) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create failed capture spill dir {}", parent.display()))?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open failed capture spill {}", path.display()))?;
+    writeln!(file, "{line}")?;
+    crate::log::warn("observe", &format!("capture spill replay failed: {error}"));
+    Ok(())
+}
+
+fn sanitize_event(event: &ParsedHookEvent) -> ParsedHookEvent {
+    ParsedHookEvent {
+        session_id: event.session_id.clone(),
+        cwd: event.cwd.clone(),
+        project: event.project.clone(),
+        tool_name: event.tool_name.clone(),
+        tool_input: event
+            .tool_input
+            .as_ref()
+            .map(crate::adapter::common::redact_sensitive_value),
+        tool_response: event
+            .tool_response
+            .as_ref()
+            .map(crate::adapter::common::redact_sensitive_value),
+    }
+}
+
+fn spill_path() -> PathBuf {
+    crate::db::data_dir().join("capture-spill.jsonl")
+}
+
+fn failed_spill_path() -> PathBuf {
+    crate::db::data_dir().join("capture-spill.failed.jsonl")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::adapter::{EventSummary, ParsedHookEvent};
+    use crate::db::{self, test_support::ScopedTestDataDir};
+
+    use super::{replay_spilled_capture_events, spill_capture_event};
+
+    #[test]
+    fn replay_spilled_capture_event_records_capture_and_drop_ledger() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-replay");
+        let err = anyhow::anyhow!("database is locked");
+        let event = ParsedHookEvent {
+            session_id: "session-spill".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Edit".to_string(),
+            tool_input: Some(serde_json::json!({"file_path": "/tmp/remem/src/lib.rs"})),
+            tool_response: Some(serde_json::json!({"ok": true})),
+        };
+        let summary = EventSummary {
+            event_type: "file_edit".to_string(),
+            summary: "Edited src/lib.rs".to_string(),
+            detail: None,
+            files_json: Some("[\"src/lib.rs\"]".to_string()),
+            exit_code: None,
+        };
+        spill_capture_event("codex-cli", &event, &summary, &err)?;
+        let conn = db::open_db()?;
+
+        let replayed = replay_spilled_capture_events(&conn)?;
+
+        assert_eq!(replayed, 1);
+        let captured: i64 =
+            conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))?;
+        let drops: i64 = conn.query_row("SELECT COUNT(*) FROM capture_drop_events", [], |row| {
+            row.get(0)
+        })?;
+        assert_eq!(captured, 1);
+        assert_eq!(drops, 1);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add a `capture_drop_events` ledger plus status/API/doctor visibility for hook skips and drops
- record Codex Bash/default adapter skips instead of silently returning `Ok(())`
- spill parsed capture events to `capture-spill.jsonl` when DB open fails and replay them on the next successful hook DB open
- report native-memory read failures and block unsafe-marker native memory writes
- bump remem/plugin version to 0.5.30

Fixes #363

## Verification
- `cargo check --message-format=short`
- `cargo fmt --check`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js`
- `cargo clippy -- -D warnings`
- `cargo test`