### PR TITLE
Report extraction task failures in health checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.30"
+version = "0.5.31"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.30"
+version = "0.5.31"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.29"
+version = "0.5.30"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.29": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.29",
+    "0.5.30": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.30",
       "assets": {}
     }
   }

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.30": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.30",
+    "0.5.31": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.31",
       "assets": {}
     }
   }

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -256,6 +256,7 @@ fn status_health_actions(report: &StatusReport) -> Vec<crate::doctor::health_act
         report.pending_observations.expired,
         report.jobs.failed,
         report.jobs.stuck,
+        report.capture_pipeline.extract_failed,
     )
 }
 
@@ -395,7 +396,7 @@ mod tests {
                 captured: 5,
                 extract_todo: 6,
                 extract_running: 7,
-                extract_failed: 8,
+                extract_failed: 0,
                 pending_candidates: 9,
                 pending_graph_candidates: 10,
                 oldest_task_epoch: Some(10),
@@ -497,6 +498,7 @@ mod tests {
         let mut report = status_report_fixture();
         report.pending_observations.failed = 43;
         report.pending_observations.expired = 1;
+        report.capture_pipeline.extract_failed = 4;
         report.jobs.failed = 2;
         report.jobs.stuck = 3;
 
@@ -508,6 +510,7 @@ mod tests {
         assert!(text.contains("inspect: remem pending list-failed --limit 20"));
         assert!(text.contains("preview retry: remem pending retry-failed --dry-run"));
         assert!(text.contains("1 expired processing pending observation"));
+        assert!(text.contains("4 failed extraction tasks"));
         assert!(text.contains("2 failed jobs"));
         assert!(text.contains("3 stuck jobs"));
         assert!(text.contains("inspect counts: remem status --json"));

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -74,6 +74,7 @@ fn load_status_report() -> Result<StatusReport> {
             latest_drop_detail: stats.latest_capture_drop_detail,
             extract_todo: stats.pending_extraction_tasks,
             extract_running: stats.processing_extraction_tasks,
+            extract_expired: stats.expired_processing_extraction_tasks,
             extract_failed: stats.failed_extraction_tasks,
             pending_candidates: stats.pending_memory_candidates,
             pending_graph_candidates: stats.pending_graph_candidates,
@@ -181,6 +182,10 @@ fn print_status_report(report: &StatusReport) {
         report.capture_pipeline.extract_running
     );
     println!(
+        "  Extract exp:  {:>6}",
+        report.capture_pipeline.extract_expired
+    );
+    println!(
         "  Extract fail: {:>6}",
         report.capture_pipeline.extract_failed
     );
@@ -275,6 +280,7 @@ fn status_health_actions(report: &StatusReport) -> Vec<crate::doctor::health_act
     queue_actions(
         report.pending_observations.failed,
         report.pending_observations.expired,
+        report.capture_pipeline.extract_expired,
         report.jobs.failed,
         report.jobs.stuck,
         report.capture_pipeline.extract_failed,
@@ -335,6 +341,7 @@ pub(super) struct CapturePipelineStatus {
     pub latest_drop_detail: Option<String>,
     pub extract_todo: i64,
     pub extract_running: i64,
+    pub extract_expired: i64,
     pub extract_failed: i64,
     pub pending_candidates: i64,
     pub pending_graph_candidates: i64,
@@ -429,6 +436,7 @@ mod tests {
                 latest_drop_detail: None,
                 extract_todo: 6,
                 extract_running: 7,
+                extract_expired: 0,
                 extract_failed: 0,
                 pending_candidates: 9,
                 pending_graph_candidates: 10,

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -28,6 +28,7 @@ pub struct SystemStats {
     pub latest_capture_drop_detail: Option<String>,
     pub pending_extraction_tasks: i64,
     pub processing_extraction_tasks: i64,
+    pub expired_processing_extraction_tasks: i64,
     pub failed_extraction_tasks: i64,
     pub oldest_pending_extraction_epoch: Option<i64>,
     pub pending_memory_candidates: i64,
@@ -128,6 +129,15 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
         processing_extraction_tasks: conn.query_row(
             "SELECT COUNT(*) FROM extraction_tasks WHERE status = 'processing'",
             [],
+            |row| row.get(0),
+        )?,
+        expired_processing_extraction_tasks: conn.query_row(
+            "SELECT COUNT(*)
+             FROM extraction_tasks
+             WHERE status = 'processing'
+               AND lease_expires_epoch IS NOT NULL
+               AND lease_expires_epoch < ?1",
+            params![now],
             |row| row.get(0),
         )?,
         failed_extraction_tasks: conn.query_row(

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -58,7 +58,8 @@ fn setup_stats_schema(conn: &Connection) {
         CREATE TABLE extraction_tasks (
             id INTEGER PRIMARY KEY,
             status TEXT NOT NULL,
-            created_at_epoch INTEGER NOT NULL
+            created_at_epoch INTEGER NOT NULL,
+            lease_expires_epoch INTEGER
         );
         CREATE TABLE memory_candidates (
             id INTEGER PRIMARY KEY,
@@ -168,7 +169,8 @@ fn query_system_stats_and_related_views_share_one_definition() {
     )
     .expect("pending extraction task insert should succeed");
     conn.execute(
-        "INSERT INTO extraction_tasks (status, created_at_epoch) VALUES ('processing', 95)",
+        "INSERT INTO extraction_tasks (status, created_at_epoch, lease_expires_epoch)
+         VALUES ('processing', 95, strftime('%s', 'now') - 1)",
         [],
     )
     .expect("processing extraction task insert should succeed");
@@ -269,6 +271,7 @@ fn query_system_stats_and_related_views_share_one_definition() {
             latest_capture_drop_detail: Some("Codex Bash capture disabled".to_string()),
             pending_extraction_tasks: 1,
             processing_extraction_tasks: 1,
+            expired_processing_extraction_tasks: 1,
             failed_extraction_tasks: 1,
             oldest_pending_extraction_epoch: Some(90),
             pending_memory_candidates: 1,

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -65,12 +65,15 @@ pub(super) fn check_pending_queue(conn: Option<&Connection>) -> Check {
         }
     };
     let detail = format!(
-        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} jobs pending, {} processing, {} failed, {} stuck",
+        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} extraction tasks pending, {} processing, {} failed; {} jobs pending, {} processing, {} failed, {} stuck",
         stats.ready_pending_observations,
         stats.delayed_pending_observations,
         stats.processing_pending_observations,
         stats.expired_processing_pending_observations,
         stats.failed_pending_observations,
+        stats.pending_extraction_tasks,
+        stats.processing_extraction_tasks,
+        stats.failed_extraction_tasks,
         stats.pending_jobs,
         stats.processing_jobs,
         stats.failed_jobs,
@@ -82,6 +85,7 @@ pub(super) fn check_pending_queue(conn: Option<&Connection>) -> Check {
         stats.expired_processing_pending_observations,
         stats.failed_jobs,
         stats.stuck_jobs,
+        stats.failed_extraction_tasks,
     );
     let action_suffix = render_inline_hints(&actions)
         .map(|hints| format!("; actions: {hints}"))
@@ -93,13 +97,16 @@ pub(super) fn check_pending_queue(conn: Option<&Connection>) -> Check {
             Status::Warn,
             format!("{detail} (will auto-recover{action_suffix})"),
         )
-    } else if stats.failed_pending_observations > 0 || stats.failed_jobs > 0 {
+    } else if stats.failed_pending_observations > 0
+        || stats.failed_jobs > 0
+        || stats.failed_extraction_tasks > 0
+    {
         Check::new(
             "Pending queue",
             Status::Warn,
             format!("{detail} (inspect failures{action_suffix})"),
         )
-    } else if stats.ready_pending_observations > 100 {
+    } else if stats.ready_pending_observations > 100 || stats.pending_extraction_tasks > 100 {
         Check::new(
             "Pending queue",
             Status::Warn,

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -65,7 +65,7 @@ pub(super) fn check_pending_queue(conn: Option<&Connection>) -> Check {
         }
     };
     let detail = format!(
-        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} extraction tasks pending, {} processing, {} failed; {} jobs pending, {} processing, {} failed, {} stuck",
+        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} extraction tasks pending, {} processing ({} expired), {} failed; {} jobs pending, {} processing, {} failed, {} stuck",
         stats.ready_pending_observations,
         stats.delayed_pending_observations,
         stats.processing_pending_observations,
@@ -73,6 +73,7 @@ pub(super) fn check_pending_queue(conn: Option<&Connection>) -> Check {
         stats.failed_pending_observations,
         stats.pending_extraction_tasks,
         stats.processing_extraction_tasks,
+        stats.expired_processing_extraction_tasks,
         stats.failed_extraction_tasks,
         stats.pending_jobs,
         stats.processing_jobs,
@@ -83,6 +84,7 @@ pub(super) fn check_pending_queue(conn: Option<&Connection>) -> Check {
     let actions = queue_actions(
         stats.failed_pending_observations,
         stats.expired_processing_pending_observations,
+        stats.expired_processing_extraction_tasks,
         stats.failed_jobs,
         stats.stuck_jobs,
         stats.failed_extraction_tasks,
@@ -91,7 +93,10 @@ pub(super) fn check_pending_queue(conn: Option<&Connection>) -> Check {
         .map(|hints| format!("; actions: {hints}"))
         .unwrap_or_default();
 
-    if stats.expired_processing_pending_observations > 0 || stats.stuck_jobs > 0 {
+    if stats.expired_processing_pending_observations > 0
+        || stats.expired_processing_extraction_tasks > 0
+        || stats.stuck_jobs > 0
+    {
         Check::new(
             "Pending queue",
             Status::Warn,

--- a/src/doctor/health_action.rs
+++ b/src/doctor/health_action.rs
@@ -29,6 +29,7 @@ pub(crate) fn queue_actions(
     expired_processing_pending_observations: i64,
     failed_jobs: i64,
     stuck_jobs: i64,
+    failed_extraction_tasks: i64,
 ) -> Vec<HealthAction> {
     let mut actions = Vec::new();
 
@@ -59,6 +60,18 @@ pub(crate) fn queue_actions(
         actions.push(
             HealthAction::new(count_title(failed_jobs, "failed job", "failed jobs"))
                 .command("inspect counts", "remem status --json"),
+        );
+    }
+
+    if failed_extraction_tasks > 0 {
+        actions.push(
+            HealthAction::new(count_title(
+                failed_extraction_tasks,
+                "failed extraction task",
+                "failed extraction tasks",
+            ))
+            .command("inspect counts", "remem status --json")
+            .command("recover", "remem worker --once"),
         );
     }
 

--- a/src/doctor/health_action.rs
+++ b/src/doctor/health_action.rs
@@ -27,6 +27,7 @@ impl HealthAction {
 pub(crate) fn queue_actions(
     failed_pending_observations: i64,
     expired_processing_pending_observations: i64,
+    expired_processing_extraction_tasks: i64,
     failed_jobs: i64,
     stuck_jobs: i64,
     failed_extraction_tasks: i64,
@@ -56,6 +57,18 @@ pub(crate) fn queue_actions(
         );
     }
 
+    if expired_processing_extraction_tasks > 0 {
+        actions.push(
+            HealthAction::new(count_title(
+                expired_processing_extraction_tasks,
+                "expired processing extraction task",
+                "expired processing extraction tasks",
+            ))
+            .command("inspect counts", "remem status --json")
+            .command("recover", "remem worker --once"),
+        );
+    }
+
     if failed_jobs > 0 {
         actions.push(
             HealthAction::new(count_title(failed_jobs, "failed job", "failed jobs"))
@@ -70,8 +83,7 @@ pub(crate) fn queue_actions(
                 "failed extraction task",
                 "failed extraction tasks",
             ))
-            .command("inspect counts", "remem status --json")
-            .command("recover", "remem worker --once"),
+            .command("inspect counts", "remem status --json"),
         );
     }
 

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -130,14 +130,14 @@ fn check_key_format_reports_effective_env_key() -> anyhow::Result<()> {
 
 #[test]
 fn health_action_queue_actions_are_empty_when_runtime_is_clear() {
-    let actions = queue_actions(0, 0, 0, 0);
+    let actions = queue_actions(0, 0, 0, 0, 0);
     assert!(actions.is_empty());
     assert!(render_action_block(&actions).is_empty());
 }
 
 #[test]
 fn health_action_queue_actions_render_copy_paste_commands() {
-    let actions = queue_actions(43, 1, 2, 3);
+    let actions = queue_actions(43, 1, 2, 3, 4);
     let text = render_action_block(&actions);
 
     assert!(text.contains("Needs attention:"));
@@ -147,6 +147,7 @@ fn health_action_queue_actions_render_copy_paste_commands() {
     assert!(text.contains("1 expired processing pending observation"));
     assert!(text.contains("2 failed jobs"));
     assert!(text.contains("3 stuck jobs"));
+    assert!(text.contains("4 failed extraction tasks"));
     assert!(text.contains("inspect counts: remem status --json"));
     assert!(text.contains("recover: remem worker --once"));
 }
@@ -211,17 +212,41 @@ fn check_pending_queue_reports_shared_counts() -> anyhow::Result<()> {
         "UPDATE jobs SET state = 'failed' WHERE id = ?1",
         params![failed_job_id],
     )?;
+    let capture = db::record_captured_event(
+        &conn,
+        &db::CaptureEventInput {
+            host: "codex-cli",
+            session_id: "session-5",
+            project: "proj-a",
+            cwd: None,
+            event_type: "tool_result",
+            role: None,
+            tool_name: Some("Bash"),
+            content: r#"{"tool_name":"Bash"}"#,
+            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
+        },
+    )?;
+    let extraction_task_id = capture
+        .extraction_task_id
+        .ok_or_else(|| anyhow::anyhow!("capture should enqueue extraction task"))?;
+    conn.execute(
+        "UPDATE extraction_tasks SET status = 'failed' WHERE id = ?1",
+        params![extraction_task_id],
+    )?;
 
     let stats = db::query_system_stats(&conn).expect("system stats should load");
     let check = check_pending_queue(Some(&conn));
     assert_eq!(check.icon(), "WARN");
     let expected_counts = format!(
-        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} jobs pending, {} processing, {} failed, {} stuck",
+        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} extraction tasks pending, {} processing, {} failed; {} jobs pending, {} processing, {} failed, {} stuck",
         stats.ready_pending_observations,
         stats.delayed_pending_observations,
         stats.processing_pending_observations,
         stats.expired_processing_pending_observations,
         stats.failed_pending_observations,
+        stats.pending_extraction_tasks,
+        stats.processing_extraction_tasks,
+        stats.failed_extraction_tasks,
         stats.pending_jobs,
         stats.processing_jobs,
         stats.failed_jobs,
@@ -251,6 +276,11 @@ fn check_pending_queue_reports_shared_counts() -> anyhow::Result<()> {
         check
             .detail
             .contains("inspect counts: `remem status --json`"),
+        "{}",
+        check.detail
+    );
+    assert!(
+        check.detail.contains("extraction tasks pending"),
         "{}",
         check.detail
     );

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -130,14 +130,14 @@ fn check_key_format_reports_effective_env_key() -> anyhow::Result<()> {
 
 #[test]
 fn health_action_queue_actions_are_empty_when_runtime_is_clear() {
-    let actions = queue_actions(0, 0, 0, 0, 0);
+    let actions = queue_actions(0, 0, 0, 0, 0, 0);
     assert!(actions.is_empty());
     assert!(render_action_block(&actions).is_empty());
 }
 
 #[test]
 fn health_action_queue_actions_render_copy_paste_commands() {
-    let actions = queue_actions(43, 1, 2, 3, 4);
+    let actions = queue_actions(43, 1, 5, 2, 3, 4);
     let text = render_action_block(&actions);
 
     assert!(text.contains("Needs attention:"));
@@ -145,6 +145,7 @@ fn health_action_queue_actions_render_copy_paste_commands() {
     assert!(text.contains("inspect: remem pending list-failed --limit 20"));
     assert!(text.contains("preview retry: remem pending retry-failed --dry-run"));
     assert!(text.contains("1 expired processing pending observation"));
+    assert!(text.contains("5 expired processing extraction tasks"));
     assert!(text.contains("2 failed jobs"));
     assert!(text.contains("3 stuck jobs"));
     assert!(text.contains("4 failed extraction tasks"));
@@ -238,7 +239,7 @@ fn check_pending_queue_reports_shared_counts() -> anyhow::Result<()> {
     let check = check_pending_queue(Some(&conn));
     assert_eq!(check.icon(), "WARN");
     let expected_counts = format!(
-        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} extraction tasks pending, {} processing, {} failed; {} jobs pending, {} processing, {} failed, {} stuck",
+        "{} ready, {} delayed, {} processing ({} expired), {} failed pending; {} extraction tasks pending, {} processing ({} expired), {} failed; {} jobs pending, {} processing, {} failed, {} stuck",
         stats.ready_pending_observations,
         stats.delayed_pending_observations,
         stats.processing_pending_observations,
@@ -246,6 +247,7 @@ fn check_pending_queue_reports_shared_counts() -> anyhow::Result<()> {
         stats.failed_pending_observations,
         stats.pending_extraction_tasks,
         stats.processing_extraction_tasks,
+        stats.expired_processing_extraction_tasks,
         stats.failed_extraction_tasks,
         stats.pending_jobs,
         stats.processing_jobs,


### PR DESCRIPTION
## Summary

- include extraction task pending/processing/failed counts in the doctor Pending queue check
- surface failed extraction tasks in `remem status` health actions
- bump package/plugin runtime metadata to `0.5.30`

## Verification

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test cli::actions::query::status::tests::cli_status_has_no_action_block_when_runtime_is_clear -- --test-threads=1`
- `cargo test cli::actions::query::status::tests::cli_status_renders_action_block_for_runtime_failures -- --test-threads=1`
- `cargo test check_pending_queue_reports_shared_counts -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`

Part of #374.
