### PR TITLE
Harden capture spill replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.30"
+version = "0.5.31"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.30"
+version = "0.5.31"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.30": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.30",
+    "0.5.31": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.31",
       "assets": {}
     }
   }

--- a/src/adapter/common.rs
+++ b/src/adapter/common.rs
@@ -423,6 +423,10 @@ fn redact_token(token: &str) -> &str {
         || trimmed.starts_with("ghp_")
         || trimmed.starts_with("github_pat_")
         || trimmed.starts_with("xoxb-")
+        || trimmed.contains("sk-")
+        || trimmed.contains("ghp_")
+        || trimmed.contains("github_pat_")
+        || trimmed.contains("xoxb-")
         || (trimmed.len() >= 32
             && trimmed.chars().any(|ch| ch.is_ascii_alphabetic())
             && trimmed.chars().any(|ch| ch.is_ascii_digit()))

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -80,11 +80,21 @@ pub fn record_captured_event(
     conn: &Connection,
     input: &CaptureEventInput<'_>,
 ) -> Result<CaptureEventOutcome> {
+    record_captured_event_with_id(conn, input, None)
+}
+
+pub fn record_captured_event_with_id(
+    conn: &Connection,
+    input: &CaptureEventInput<'_>,
+    event_id_override: Option<&str>,
+) -> Result<CaptureEventOutcome> {
     let now = chrono::Utc::now().timestamp();
     let inserted_at = now;
     let sanitized_content = redact_capture_content(input.content);
     let content_hash = exact_hash(&sanitized_content);
-    let event_id = synthesize_event_id(input.event_type, &content_hash);
+    let event_id = event_id_override
+        .map(ToString::to_string)
+        .unwrap_or_else(|| synthesize_event_id(input.event_type, &content_hash));
     let identity = upsert_identity(conn, input, now)?;
     let (content_text, content_blob_id, retention_class) =
         store_content(conn, &sanitized_content, &content_hash, now)?;
@@ -351,6 +361,19 @@ fn exact_hash(content: &str) -> String {
     format!("{:016x}", crate::db::deterministic_hash(content.as_bytes()))
 }
 
+pub fn unique_capture_event_id(event_type: &str, content: &str) -> String {
+    let sanitized_content = redact_capture_content(content);
+    let nanos = chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| chrono::Utc::now().timestamp() * 1_000_000_000);
+    format!(
+        "{}-{}-{}",
+        event_type,
+        nanos,
+        exact_hash(&sanitized_content)
+    )
+}
+
 fn synthesize_event_id(event_type: &str, content_hash: &str) -> String {
     let nanos = chrono::Utc::now()
         .timestamp_nanos_opt()
@@ -362,7 +385,7 @@ fn estimate_tokens(content: &str) -> i64 {
     ((content.len() as i64) + 3) / 4
 }
 
-fn redact_capture_content(content: &str) -> String {
+pub(crate) fn redact_capture_content(content: &str) -> String {
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
         let redacted = crate::adapter::common::redact_sensitive_value(&value);
         return serde_json::to_string(&redacted)

--- a/src/db/capture_drop.rs
+++ b/src/db/capture_drop.rs
@@ -16,6 +16,7 @@ pub struct CaptureDropInput<'a> {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CaptureDropStats {
     pub total: i64,
+    pub actionable: i64,
     pub unrecovered_spills: i64,
     pub latest_epoch: Option<i64>,
     pub latest_reason: Option<String>,
@@ -24,6 +25,7 @@ pub struct CaptureDropStats {
 
 pub fn record_capture_drop(conn: &Connection, input: &CaptureDropInput<'_>) -> Result<i64> {
     let now = chrono::Utc::now().timestamp();
+    let detail = input.detail.map(crate::db::capture::redact_capture_content);
     conn.execute(
         "INSERT INTO capture_drop_events
          (host_id, session_id, project, tool_name, reason, detail, spill_path,
@@ -35,7 +37,7 @@ pub fn record_capture_drop(conn: &Connection, input: &CaptureDropInput<'_>) -> R
             input.project,
             input.tool_name,
             input.reason,
-            input.detail,
+            detail,
             input.spill_path,
             input.recovered_event_id,
             now,
@@ -52,6 +54,14 @@ pub fn query_capture_drop_stats(conn: &Connection) -> Result<CaptureDropStats> {
     let total = conn.query_row("SELECT COUNT(*) FROM capture_drop_events", [], |row| {
         row.get(0)
     })?;
+    let actionable = conn.query_row(
+        "SELECT COUNT(*)
+         FROM capture_drop_events
+         WHERE reason NOT IN ('adapter_skip', 'codex_bash_disabled', 'bash_read_only')
+           AND NOT (reason = 'db_open_failed' AND recovered_event_id IS NOT NULL)",
+        [],
+        |row| row.get(0),
+    )?;
     let unrecovered_spills = conn.query_row(
         "SELECT COUNT(*)
          FROM capture_drop_events
@@ -79,6 +89,7 @@ pub fn query_capture_drop_stats(conn: &Connection) -> Result<CaptureDropStats> {
     Ok(match latest {
         Some((latest_epoch, latest_reason, latest_detail)) => CaptureDropStats {
             total,
+            actionable,
             unrecovered_spills,
             latest_epoch: Some(latest_epoch),
             latest_reason: Some(latest_reason),
@@ -86,6 +97,7 @@ pub fn query_capture_drop_stats(conn: &Connection) -> Result<CaptureDropStats> {
         },
         None => CaptureDropStats {
             total,
+            actionable,
             unrecovered_spills,
             ..CaptureDropStats::default()
         },
@@ -116,6 +128,7 @@ mod tests {
         let stats = query_capture_drop_stats(&conn)?;
 
         assert_eq!(stats.total, 0);
+        assert_eq!(stats.actionable, 0);
         assert_eq!(stats.unrecovered_spills, 0);
         assert_eq!(stats.latest_reason, None);
         Ok(())
@@ -157,9 +170,42 @@ mod tests {
         let stats = query_capture_drop_stats(&conn)?;
 
         assert_eq!(stats.total, 2);
+        assert_eq!(stats.actionable, 1);
         assert_eq!(stats.unrecovered_spills, 1);
         assert_eq!(stats.latest_reason.as_deref(), Some("adapter_skip"));
         assert_eq!(stats.latest_detail.as_deref(), Some("read-only tool"));
+        Ok(())
+    }
+
+    #[test]
+    fn capture_drop_redacts_sensitive_detail() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE captured_events (id INTEGER PRIMARY KEY);")?;
+        conn.execute_batch(include_str!("../migrations/v036_capture_drop_events.sql"))?;
+
+        record_capture_drop(
+            &conn,
+            &CaptureDropInput {
+                host: Some("codex-cli"),
+                session_id: Some("session-secret"),
+                project: Some("/repo"),
+                tool_name: Some("Bash"),
+                reason: "codex_bash_disabled",
+                detail: Some(
+                    "curl -H 'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456'",
+                ),
+                spill_path: None,
+                recovered_event_id: None,
+            },
+        )?;
+
+        let detail: String = conn.query_row(
+            "SELECT detail FROM capture_drop_events WHERE session_id = 'session-secret'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(detail.contains("[REDACTED]"));
+        assert!(!detail.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
         Ok(())
     }
 }

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -22,6 +22,7 @@ pub struct SystemStats {
     pub latest_raw_ingest_failure_message: Option<String>,
     pub captured_events: i64,
     pub capture_drop_events: i64,
+    pub actionable_capture_drops: i64,
     pub unrecovered_capture_spills: i64,
     pub latest_capture_drop_epoch: Option<i64>,
     pub latest_capture_drop_reason: Option<String>,
@@ -116,6 +117,7 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
             row.get(0)
         })?,
         capture_drop_events: capture_drop.total,
+        actionable_capture_drops: capture_drop.actionable,
         unrecovered_capture_spills: capture_drop.unrecovered_spills,
         latest_capture_drop_epoch: capture_drop.latest_epoch,
         latest_capture_drop_reason: capture_drop.latest_reason,

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -263,6 +263,7 @@ fn query_system_stats_and_related_views_share_one_definition() {
             latest_raw_ingest_failure_message: Some("bad jsonl".to_string()),
             captured_events: 1,
             capture_drop_events: 1,
+            actionable_capture_drops: 0,
             unrecovered_capture_spills: 0,
             latest_capture_drop_epoch: Some(170),
             latest_capture_drop_reason: Some("codex_bash_disabled".to_string()),
@@ -373,6 +374,7 @@ fn query_system_stats_defaults_capture_drops_when_table_is_absent() -> anyhow::R
     let system = query_system_stats(&conn)?;
 
     assert_eq!(system.capture_drop_events, 0);
+    assert_eq!(system.actionable_capture_drops, 0);
     assert_eq!(system.unrecovered_capture_spills, 0);
     assert_eq!(system.latest_capture_drop_epoch, None);
     assert_eq!(system.latest_capture_drop_reason, None);

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -167,17 +167,20 @@ pub(super) fn check_capture_drops(conn: Option<&Connection>) -> Check {
         }
     };
 
-    if stats.capture_drop_events == 0 {
+    if stats.actionable_capture_drops == 0 {
         return Check::new(
             "Capture drops",
             Status::Ok,
-            "0 recorded hook skips or drops",
+            format!(
+                "{} expected hook skip/drop event(s), no actionable capture drops",
+                stats.capture_drop_events
+            ),
         );
     }
 
     let mut detail = format!(
-        "{} recorded hook skip/drop event(s)",
-        stats.capture_drop_events
+        "{} actionable capture drop(s), {} total recorded hook skip/drop event(s)",
+        stats.actionable_capture_drops, stats.capture_drop_events
     );
     if stats.unrecovered_capture_spills > 0 {
         detail.push_str(&format!(

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -283,8 +283,8 @@ fn check_raw_archive_ingest_warns_on_recorded_failures() -> anyhow::Result<()> {
 }
 
 #[test]
-fn check_capture_drops_warns_on_recorded_hook_drops() -> anyhow::Result<()> {
-    let _test_dir = ScopedTestDataDir::new("doctor-capture-drops");
+fn check_capture_drops_is_ok_for_expected_hook_skips() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-drops-expected");
     let conn = db::open_db()?;
     db::record_capture_drop(
         &conn,
@@ -302,10 +302,43 @@ fn check_capture_drops_warns_on_recorded_hook_drops() -> anyhow::Result<()> {
 
     let check = check_capture_drops(Some(&conn));
 
-    assert_eq!(check.icon(), "WARN");
-    assert!(check.detail.contains("1 recorded"), "{}", check.detail);
+    assert_eq!(check.icon(), "ok");
     assert!(
-        check.detail.contains("latest reason=codex_bash_disabled"),
+        check.detail.contains("1 expected hook skip/drop event"),
+        "{}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
+fn check_capture_drops_warns_on_actionable_drops() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-drops-actionable");
+    let conn = db::open_db()?;
+    db::record_capture_drop(
+        &conn,
+        &db::CaptureDropInput {
+            host: Some("codex-cli"),
+            session_id: None,
+            project: None,
+            tool_name: None,
+            reason: "adapter_mismatch",
+            detail: Some("no capture adapter matched hook input"),
+            spill_path: None,
+            recovered_event_id: None,
+        },
+    )?;
+
+    let check = check_capture_drops(Some(&conn));
+
+    assert_eq!(check.icon(), "WARN");
+    assert!(
+        check.detail.contains("1 actionable capture drop"),
+        "{}",
+        check.detail
+    );
+    assert!(
+        check.detail.contains("latest reason=adapter_mismatch"),
         "{}",
         check.detail
     );

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use rusqlite::OptionalExtension;
 
 use crate::db;
 
@@ -77,10 +78,12 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
         return Ok(());
     };
 
+    let content = capture_event_content(&event, &summary);
+    let event_id = db::unique_capture_event_id("tool_result", &content);
     let conn = match db::open_db() {
         Ok(conn) => conn,
         Err(error) => {
-            let path = spill_capture_event(&capture_host, &event, &summary, &error)?;
+            let path = spill_capture_event(&capture_host, &event_id, &event, &summary, &error)?;
             crate::log::error(
                 "observe",
                 &format!(
@@ -93,28 +96,34 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
         }
     };
     replay_spilled_capture_events(&conn)?;
-    record_observed_event(&conn, &capture_host, &event, &summary)?;
+    if let Err(error) =
+        record_observed_event_with_id(&conn, &capture_host, &event_id, &event, &summary)
+    {
+        let path = spill_capture_event(&capture_host, &event_id, &event, &summary, &error)?;
+        crate::log::error(
+            "observe",
+            &format!(
+                "capture persistence failed; spilled capture event to {}: {}",
+                path.display(),
+                error
+            ),
+        );
+        return Err(error);
+    }
 
     Ok(())
 }
 
-pub(super) fn record_observed_event(
+pub(super) fn record_observed_event_with_id(
     conn: &rusqlite::Connection,
     capture_host: &str,
+    event_id: &str,
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
 ) -> Result<i64> {
-    let capture_event_id = record_capture_event(conn, capture_host, event, summary)?;
-    crate::memory::insert_event(
-        conn,
-        &event.session_id,
-        &event.project,
-        &summary.event_type,
-        &summary.summary,
-        summary.detail.as_deref(),
-        summary.files_json.as_deref(),
-        summary.exit_code,
-    )?;
+    let capture_event_id =
+        record_capture_event_with_id(conn, capture_host, event_id, event, summary)?;
+    insert_memory_event_once(conn, event, summary)?;
 
     crate::log::info(
         "observe",
@@ -142,6 +151,50 @@ pub(super) fn record_observed_event(
     Ok(capture_event_id)
 }
 
+fn insert_memory_event_once(
+    conn: &rusqlite::Connection,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> Result<()> {
+    let exists = conn
+        .query_row(
+            "SELECT 1 FROM events
+             WHERE session_id = ?1
+               AND project = ?2
+               AND event_type = ?3
+               AND summary = ?4
+               AND COALESCE(detail, '') = COALESCE(?5, '')
+               AND COALESCE(files, '') = COALESCE(?6, '')
+               AND COALESCE(exit_code, -2147483648) = COALESCE(?7, -2147483648)
+             LIMIT 1",
+            rusqlite::params![
+                &event.session_id,
+                &event.project,
+                &summary.event_type,
+                &summary.summary,
+                summary.detail.as_deref(),
+                summary.files_json.as_deref(),
+                summary.exit_code
+            ],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    if !exists {
+        crate::memory::insert_event(
+            conn,
+            &event.session_id,
+            &event.project,
+            &summary.event_type,
+            &summary.summary,
+            summary.detail.as_deref(),
+            summary.files_json.as_deref(),
+            summary.exit_code,
+        )?;
+    }
+    Ok(())
+}
+
 fn detect_adapter_for_host(
     input: &str,
     host: Option<&str>,
@@ -159,14 +212,50 @@ fn detect_adapter_for_host(
         .or_else(|| crate::adapter::detect_adapter(input))
 }
 
+#[cfg(test)]
 fn record_capture_event(
     conn: &rusqlite::Connection,
     host: &str,
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
 ) -> Result<i64> {
+    let content = capture_event_content(event, summary);
+    let event_id = db::unique_capture_event_id("tool_result", &content);
+    record_capture_event_with_id(conn, host, &event_id, event, summary)
+}
+
+fn record_capture_event_with_id(
+    conn: &rusqlite::Connection,
+    host: &str,
+    event_id: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> Result<i64> {
+    let content = capture_event_content(event, summary);
+    let outcome = db::record_captured_event_with_id(
+        conn,
+        &db::CaptureEventInput {
+            host,
+            session_id: &event.session_id,
+            project: &event.project,
+            cwd: event.cwd.as_deref(),
+            event_type: "tool_result",
+            role: None,
+            tool_name: Some(&event.tool_name),
+            content: &content,
+            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
+        },
+        Some(event_id),
+    )?;
+    Ok(outcome.event_row_id)
+}
+
+fn capture_event_content(
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> String {
     let git_branch = event.cwd.as_deref().and_then(db::detect_git_branch);
-    let content = serde_json::json!({
+    serde_json::json!({
         "summary": &summary.summary,
         "event_type": &summary.event_type,
         "detail": summary.detail.as_deref(),
@@ -183,22 +272,7 @@ fn record_capture_event(
             .map(crate::adapter::common::redact_sensitive_value),
         "git_branch": git_branch.as_deref(),
     })
-    .to_string();
-    let outcome = db::record_captured_event(
-        conn,
-        &db::CaptureEventInput {
-            host,
-            session_id: &event.session_id,
-            project: &event.project,
-            cwd: event.cwd.as_deref(),
-            event_type: "tool_result",
-            role: None,
-            tool_name: Some(&event.tool_name),
-            content: &content,
-            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
-        },
-    )?;
-    Ok(outcome.event_row_id)
+    .to_string()
 }
 
 fn event_skip_reason(
@@ -425,5 +499,76 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&project_dir);
         test_result
+    }
+
+    #[tokio::test]
+    async fn observe_spills_persistence_failure_and_replays_capture_once() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("observe-persist-failure-spill");
+        let failing_input = serde_json::json!({
+            "session_id": "sess-persist-fail",
+            "cwd": "/tmp/remem",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/lib.rs"},
+            "tool_response": {"content": "edited"}
+        })
+        .to_string();
+
+        let conn = db::open_db()?;
+        conn.execute_batch(
+            "CREATE TRIGGER fail_events_insert
+             BEFORE INSERT ON events
+             BEGIN
+                 SELECT RAISE(FAIL, 'events blocked');
+             END;",
+        )?;
+        drop(conn);
+
+        let err = observe_input(&failing_input, Some("claude-code"))
+            .await
+            .expect_err("event insert failure should spill");
+        assert!(err.to_string().contains("events blocked"), "{err}");
+        assert!(crate::db::data_dir().join("capture-spill.jsonl").exists());
+
+        let conn = db::open_db()?;
+        let partial_captures: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        let partial_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(partial_captures, 1);
+        assert_eq!(partial_events, 0);
+        conn.execute_batch("DROP TRIGGER fail_events_insert;")?;
+        drop(conn);
+
+        let replay_trigger = serde_json::json!({
+            "session_id": "sess-replay-trigger",
+            "cwd": "/tmp/remem",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/other.rs"},
+            "tool_response": {"content": "edited"}
+        })
+        .to_string();
+        observe_input(&replay_trigger, Some("claude-code")).await?;
+
+        let conn = db::open_db()?;
+        let replayed_captures: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        let replayed_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(replayed_captures, 1);
+        assert_eq!(replayed_events, 1);
+        assert!(!crate::db::data_dir().join("capture-spill.jsonl").exists());
+        Ok(())
     }
 }

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -9,6 +9,7 @@ use crate::adapter::{EventSummary, ParsedHookEvent};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CaptureSpillRecord {
     version: u32,
+    event_id: String,
     host: String,
     event: ParsedHookEvent,
     summary: EventSummary,
@@ -52,6 +53,7 @@ pub(super) fn record_capture_drop_lossy(
 
 pub(super) fn spill_capture_event(
     host: &str,
+    event_id: &str,
     event: &ParsedHookEvent,
     summary: &EventSummary,
     db_error: &anyhow::Error,
@@ -63,10 +65,15 @@ pub(super) fn spill_capture_event(
     }
     let record = CaptureSpillRecord {
         version: 1,
+        event_id: event_id.to_string(),
         host: host.to_string(),
         event: sanitize_event(event),
-        summary: summary.clone(),
-        db_error: crate::db::truncate_str(&db_error.to_string(), 1000).to_string(),
+        summary: sanitize_summary(summary),
+        db_error: crate::db::truncate_str(
+            &crate::db::capture::redact_capture_content(&db_error.to_string()),
+            1000,
+        )
+        .to_string(),
         created_at_epoch: chrono::Utc::now().timestamp(),
     };
     let mut file = std::fs::OpenOptions::new()
@@ -96,9 +103,10 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
 
     for line in contents.lines().filter(|line| !line.trim().is_empty()) {
         match serde_json::from_str::<CaptureSpillRecord>(line) {
-            Ok(record) => match super::hook::record_observed_event(
+            Ok(record) => match super::hook::record_observed_event_with_id(
                 conn,
                 &record.host,
+                &record.event_id,
                 &record.event,
                 &record.summary,
             ) {
@@ -176,6 +184,19 @@ fn sanitize_event(event: &ParsedHookEvent) -> ParsedHookEvent {
     }
 }
 
+fn sanitize_summary(summary: &EventSummary) -> EventSummary {
+    EventSummary {
+        event_type: summary.event_type.clone(),
+        summary: crate::db::capture::redact_capture_content(&summary.summary),
+        detail: summary
+            .detail
+            .as_ref()
+            .map(|detail| crate::db::capture::redact_capture_content(detail)),
+        files_json: summary.files_json.clone(),
+        exit_code: summary.exit_code,
+    }
+}
+
 fn spill_path() -> PathBuf {
     crate::db::data_dir().join("capture-spill.jsonl")
 }
@@ -210,7 +231,15 @@ mod tests {
             files_json: Some("[\"src/lib.rs\"]".to_string()),
             exit_code: None,
         };
-        spill_capture_event("codex-cli", &event, &summary, &err)?;
+        let content = serde_json::json!({
+            "summary": summary.summary,
+            "tool_name": event.tool_name,
+            "tool_input": event.tool_input,
+            "tool_response": event.tool_response,
+        })
+        .to_string();
+        let event_id = db::unique_capture_event_id("tool_result", &content);
+        spill_capture_event("codex-cli", &event_id, &event, &summary, &err)?;
         let conn = db::open_db()?;
 
         let replayed = replay_spilled_capture_events(&conn)?;
@@ -223,6 +252,83 @@ mod tests {
         })?;
         assert_eq!(captured, 1);
         assert_eq!(drops, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn replay_identical_spills_preserves_distinct_captured_events() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-identical-replay");
+        let err = anyhow::anyhow!("database is locked");
+        let event = ParsedHookEvent {
+            session_id: "session-identical-spill".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Edit".to_string(),
+            tool_input: Some(serde_json::json!({"file_path": "/tmp/remem/src/lib.rs"})),
+            tool_response: Some(serde_json::json!({"ok": true})),
+        };
+        let summary = EventSummary {
+            event_type: "file_edit".to_string(),
+            summary: "Edited src/lib.rs".to_string(),
+            detail: None,
+            files_json: Some("[\"src/lib.rs\"]".to_string()),
+            exit_code: None,
+        };
+
+        spill_capture_event(
+            "codex-cli",
+            "tool_result-identical-a",
+            &event,
+            &summary,
+            &err,
+        )?;
+        spill_capture_event(
+            "codex-cli",
+            "tool_result-identical-b",
+            &event,
+            &summary,
+            &err,
+        )?;
+        let conn = db::open_db()?;
+
+        let replayed = replay_spilled_capture_events(&conn)?;
+
+        assert_eq!(replayed, 2);
+        let captured: i64 =
+            conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))?;
+        assert_eq!(captured, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn spill_redacts_summary_and_database_error() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-redacts");
+        let err = anyhow::anyhow!("database token=github_pat_secret");
+        let event = ParsedHookEvent {
+            session_id: "session-spill-redact".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Bash".to_string(),
+            tool_input: Some(serde_json::json!({
+                "command": "curl -H 'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456'"
+            })),
+            tool_response: Some(serde_json::json!({"stderr": "password=hunter2"})),
+        };
+        let summary = EventSummary {
+            event_type: "bash".to_string(),
+            summary: "Run curl with ghp_abcdefghijklmnopqrstuvwxyz123456".to_string(),
+            detail: Some("password=hunter2".to_string()),
+            files_json: None,
+            exit_code: Some(1),
+        };
+
+        spill_capture_event("codex-cli", "tool_result-redact", &event, &summary, &err)?;
+        let stored = std::fs::read_to_string(crate::db::data_dir().join("capture-spill.jsonl"))?;
+
+        assert!(stored.contains("[REDACTED]"));
+        assert!(!stored.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
+        assert!(!stored.contains("hunter2"));
+        assert!(!stored.contains("github_pat_secret"));
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- preserve a unique spill event_id through replay so repeated identical captured events do not collapse
- spill capture events when persistence fails after DB open, then replay with the same capture id without duplicating recovered captures
- redact drop details, spill summaries/details, spill DB errors, and token-like substrings before persistence/display
- split capture-drop health into expected skips vs actionable drops so default filters do not keep doctor in WARN
- bump remem/plugin runtime version to 0.5.31

Follow-up for #363 after #422. Fixes #363.

## Verification
- cargo fmt --check
- cargo check --message-format=short
- python3 scripts/ci/check_plugin_version_sync.py && python3 scripts/ci/check_version_bump.py origin/main WORKTREE && git diff --check origin/main
- cargo test observe_spills_persistence_failure
- cargo test observe::spill::tests
- cargo test capture_drop
- cargo test check_capture_drops
- cargo test query_system_stats
- cargo clippy -- -D warnings
- cargo test