### PR TITLE
Harden capture spill replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.31"
+version = "0.5.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.31"
+version = "0.5.32"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.31": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.31",
+    "0.5.32": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.32",
       "assets": {}
     }
   }

--- a/src/adapter/common.rs
+++ b/src/adapter/common.rs
@@ -419,14 +419,7 @@ fn is_sensitive_key(key: &str) -> bool {
 fn redact_token(token: &str) -> &str {
     let trimmed =
         token.trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '-' && ch != '_');
-    if trimmed.starts_with("sk-")
-        || trimmed.starts_with("ghp_")
-        || trimmed.starts_with("github_pat_")
-        || trimmed.starts_with("xoxb-")
-        || trimmed.contains("sk-")
-        || trimmed.contains("ghp_")
-        || trimmed.contains("github_pat_")
-        || trimmed.contains("xoxb-")
+    if contains_prefixed_secret(trimmed)
         || (trimmed.len() >= 32
             && trimmed.chars().any(|ch| ch.is_ascii_alphabetic())
             && trimmed.chars().any(|ch| ch.is_ascii_digit()))
@@ -435,6 +428,36 @@ fn redact_token(token: &str) -> &str {
     } else {
         token
     }
+}
+
+fn contains_prefixed_secret(token: &str) -> bool {
+    [("sk-", 8), ("ghp_", 8), ("github_pat_", 4), ("xoxb-", 8)]
+        .iter()
+        .any(|(prefix, min_suffix_len)| {
+            contains_prefixed_secret_with(token, prefix, *min_suffix_len)
+        })
+}
+
+fn contains_prefixed_secret_with(token: &str, prefix: &str, min_suffix_len: usize) -> bool {
+    token.match_indices(prefix).any(|(index, _)| {
+        has_secret_prefix_boundary(token, index)
+            && key_like_suffix_len(&token[index + prefix.len()..]) >= min_suffix_len
+    })
+}
+
+fn has_secret_prefix_boundary(token: &str, index: usize) -> bool {
+    index == 0
+        || token[..index]
+            .chars()
+            .next_back()
+            .is_some_and(|ch| !ch.is_ascii_alphanumeric() && ch != '-' && ch != '_')
+}
+
+fn key_like_suffix_len(suffix: &str) -> usize {
+    suffix
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '-' || *ch == '_')
+        .count()
 }
 
 fn is_read_only_polling_cmd(cmd_lower: &str) -> bool {

--- a/src/adapter/common.rs
+++ b/src/adapter/common.rs
@@ -423,6 +423,10 @@ fn redact_token(token: &str) -> &str {
         || trimmed.starts_with("ghp_")
         || trimmed.starts_with("github_pat_")
         || trimmed.starts_with("xoxb-")
+        || trimmed.contains("sk-")
+        || trimmed.contains("ghp_")
+        || trimmed.contains("github_pat_")
+        || trimmed.contains("xoxb-")
         || (trimmed.len() >= 32
             && trimmed.chars().any(|ch| ch.is_ascii_alphabetic())
             && trimmed.chars().any(|ch| ch.is_ascii_digit()))

--- a/src/adapter/common/tests.rs
+++ b/src/adapter/common/tests.rs
@@ -1,6 +1,9 @@
 use crate::db::test_support::ScopedTestDataDir;
 
-use super::{event_summary, parse_tool_hook, should_skip_bash_command, should_skip_tool};
+use super::{
+    event_summary, parse_tool_hook, redact_and_truncate, redact_token, should_skip_bash_command,
+    should_skip_tool,
+};
 
 fn read_log_tail(scoped: &ScopedTestDataDir) -> String {
     let log_path = scoped.path.join("remem.log");
@@ -142,4 +145,32 @@ fn noisy_commands_still_skip() {
     assert!(should_skip_bash_command("ps aux | grep remem"));
     assert!(should_skip_bash_command("rg event_summary"));
     assert!(should_skip_bash_command("find . -name '*.rs'"));
+}
+
+#[test]
+fn redaction_keeps_benign_words_containing_secret_prefix_fragments() {
+    let text = "flask-app disk-backed risk-aware task-sketch";
+
+    assert_eq!(redact_and_truncate(text, 200), text);
+    assert_eq!(redact_token("--name=flask-app"), "--name=flask-app");
+    assert_eq!(redact_token("disk-backed-cache"), "disk-backed-cache");
+}
+
+#[test]
+fn redaction_catches_key_prefixes_after_shell_and_json_punctuation() {
+    assert_eq!(redact_token("sk-proj-12345678"), "[REDACTED]");
+    assert_eq!(redact_token("--api-key=sk-proj-12345678"), "[REDACTED]");
+    assert_eq!(
+        redact_token(r#""token":"ghp_1234567890abcdef""#),
+        "[REDACTED]"
+    );
+    assert_eq!(
+        redact_token("token='github_pat_1234567890_abcdEFGH'"),
+        "[REDACTED]"
+    );
+    assert_eq!(redact_token("github_pat_secret"), "[REDACTED]");
+    assert_eq!(
+        redact_token("Authorization=Bearer:xoxb-1234567890-abcdefghi"),
+        "[REDACTED]"
+    );
 }

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -80,11 +80,21 @@ pub fn record_captured_event(
     conn: &Connection,
     input: &CaptureEventInput<'_>,
 ) -> Result<CaptureEventOutcome> {
+    record_captured_event_with_id(conn, input, None)
+}
+
+pub fn record_captured_event_with_id(
+    conn: &Connection,
+    input: &CaptureEventInput<'_>,
+    event_id_override: Option<&str>,
+) -> Result<CaptureEventOutcome> {
     let now = chrono::Utc::now().timestamp();
     let inserted_at = now;
     let sanitized_content = redact_capture_content(input.content);
     let content_hash = exact_hash(&sanitized_content);
-    let event_id = synthesize_event_id(input.event_type, &content_hash);
+    let event_id = event_id_override
+        .map(ToString::to_string)
+        .unwrap_or_else(|| synthesize_event_id(input.event_type, &content_hash));
     let identity = upsert_identity(conn, input, now)?;
     let (content_text, content_blob_id, retention_class) =
         store_content(conn, &sanitized_content, &content_hash, now)?;
@@ -351,6 +361,19 @@ fn exact_hash(content: &str) -> String {
     format!("{:016x}", crate::db::deterministic_hash(content.as_bytes()))
 }
 
+pub fn unique_capture_event_id(event_type: &str, content: &str) -> String {
+    let sanitized_content = redact_capture_content(content);
+    let nanos = chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| chrono::Utc::now().timestamp() * 1_000_000_000);
+    format!(
+        "{}-{}-{}",
+        event_type,
+        nanos,
+        exact_hash(&sanitized_content)
+    )
+}
+
 fn synthesize_event_id(event_type: &str, content_hash: &str) -> String {
     let nanos = chrono::Utc::now()
         .timestamp_nanos_opt()
@@ -362,7 +385,7 @@ fn estimate_tokens(content: &str) -> i64 {
     ((content.len() as i64) + 3) / 4
 }
 
-fn redact_capture_content(content: &str) -> String {
+pub(crate) fn redact_capture_content(content: &str) -> String {
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
         let redacted = crate::adapter::common::redact_sensitive_value(&value);
         return serde_json::to_string(&redacted)

--- a/src/db/capture_drop.rs
+++ b/src/db/capture_drop.rs
@@ -46,6 +46,42 @@ pub fn record_capture_drop(conn: &Connection, input: &CaptureDropInput<'_>) -> R
     Ok(conn.last_insert_rowid())
 }
 
+pub fn mark_capture_spill_recovered(
+    conn: &Connection,
+    input: &CaptureDropInput<'_>,
+    recovered_event_id: i64,
+) -> Result<bool> {
+    let now = chrono::Utc::now().timestamp();
+    let updated = conn.execute(
+        "UPDATE capture_drop_events
+         SET recovered_event_id = ?7,
+             recovered_at_epoch = ?8
+         WHERE id = (
+             SELECT id FROM capture_drop_events
+             WHERE recovered_event_id IS NULL
+               AND reason = ?5
+               AND spill_path = ?6
+               AND ((host_id = ?1) OR (host_id IS NULL AND ?1 IS NULL))
+               AND ((session_id = ?2) OR (session_id IS NULL AND ?2 IS NULL))
+               AND ((project = ?3) OR (project IS NULL AND ?3 IS NULL))
+               AND ((tool_name = ?4) OR (tool_name IS NULL AND ?4 IS NULL))
+             ORDER BY created_at_epoch DESC, id DESC
+             LIMIT 1
+         )",
+        params![
+            input.host,
+            input.session_id,
+            input.project,
+            input.tool_name,
+            input.reason,
+            input.spill_path,
+            recovered_event_id,
+            now,
+        ],
+    )?;
+    Ok(updated > 0)
+}
+
 pub fn query_capture_drop_stats(conn: &Connection) -> Result<CaptureDropStats> {
     if !capture_drop_table_exists(conn)? {
         return Ok(CaptureDropStats::default());

--- a/src/db/capture_drop.rs
+++ b/src/db/capture_drop.rs
@@ -16,6 +16,7 @@ pub struct CaptureDropInput<'a> {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CaptureDropStats {
     pub total: i64,
+    pub actionable: i64,
     pub unrecovered_spills: i64,
     pub latest_epoch: Option<i64>,
     pub latest_reason: Option<String>,
@@ -24,6 +25,7 @@ pub struct CaptureDropStats {
 
 pub fn record_capture_drop(conn: &Connection, input: &CaptureDropInput<'_>) -> Result<i64> {
     let now = chrono::Utc::now().timestamp();
+    let detail = input.detail.map(crate::db::capture::redact_capture_content);
     conn.execute(
         "INSERT INTO capture_drop_events
          (host_id, session_id, project, tool_name, reason, detail, spill_path,
@@ -35,7 +37,7 @@ pub fn record_capture_drop(conn: &Connection, input: &CaptureDropInput<'_>) -> R
             input.project,
             input.tool_name,
             input.reason,
-            input.detail,
+            detail,
             input.spill_path,
             input.recovered_event_id,
             now,
@@ -52,6 +54,14 @@ pub fn query_capture_drop_stats(conn: &Connection) -> Result<CaptureDropStats> {
     let total = conn.query_row("SELECT COUNT(*) FROM capture_drop_events", [], |row| {
         row.get(0)
     })?;
+    let actionable = conn.query_row(
+        "SELECT COUNT(*)
+         FROM capture_drop_events
+         WHERE reason NOT IN ('adapter_skip', 'codex_bash_disabled', 'bash_read_only')
+           AND NOT (reason = 'db_open_failed' AND recovered_event_id IS NOT NULL)",
+        [],
+        |row| row.get(0),
+    )?;
     let unrecovered_spills = conn.query_row(
         "SELECT COUNT(*)
          FROM capture_drop_events
@@ -79,6 +89,7 @@ pub fn query_capture_drop_stats(conn: &Connection) -> Result<CaptureDropStats> {
     Ok(match latest {
         Some((latest_epoch, latest_reason, latest_detail)) => CaptureDropStats {
             total,
+            actionable,
             unrecovered_spills,
             latest_epoch: Some(latest_epoch),
             latest_reason: Some(latest_reason),
@@ -86,6 +97,7 @@ pub fn query_capture_drop_stats(conn: &Connection) -> Result<CaptureDropStats> {
         },
         None => CaptureDropStats {
             total,
+            actionable,
             unrecovered_spills,
             ..CaptureDropStats::default()
         },
@@ -116,6 +128,7 @@ mod tests {
         let stats = query_capture_drop_stats(&conn)?;
 
         assert_eq!(stats.total, 0);
+        assert_eq!(stats.actionable, 0);
         assert_eq!(stats.unrecovered_spills, 0);
         assert_eq!(stats.latest_reason, None);
         Ok(())
@@ -157,9 +170,42 @@ mod tests {
         let stats = query_capture_drop_stats(&conn)?;
 
         assert_eq!(stats.total, 2);
+        assert_eq!(stats.actionable, 1);
         assert_eq!(stats.unrecovered_spills, 1);
         assert_eq!(stats.latest_reason.as_deref(), Some("adapter_skip"));
         assert_eq!(stats.latest_detail.as_deref(), Some("read-only tool"));
+        Ok(())
+    }
+
+    #[test]
+    fn capture_drop_redacts_sensitive_detail() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE captured_events (id INTEGER PRIMARY KEY);")?;
+        conn.execute_batch(include_str!("../migrations/v036_capture_drop_events.sql"))?;
+
+        record_capture_drop(
+            &conn,
+            &CaptureDropInput {
+                host: Some("codex-cli"),
+                session_id: Some("session-secret"),
+                project: Some("/repo"),
+                tool_name: Some("Bash"),
+                reason: "codex_bash_disabled",
+                detail: Some(
+                    "curl -H 'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456'",
+                ),
+                spill_path: None,
+                recovered_event_id: None,
+            },
+        )?;
+
+        let detail: String = conn.query_row(
+            "SELECT detail FROM capture_drop_events WHERE session_id = 'session-secret'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(detail.contains("[REDACTED]"));
+        assert!(!detail.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
         Ok(())
     }
 }

--- a/src/db/capture_drop.rs
+++ b/src/db/capture_drop.rs
@@ -58,14 +58,18 @@ pub fn query_capture_drop_stats(conn: &Connection) -> Result<CaptureDropStats> {
         "SELECT COUNT(*)
          FROM capture_drop_events
          WHERE reason NOT IN ('adapter_skip', 'codex_bash_disabled', 'bash_read_only')
-           AND NOT (reason = 'db_open_failed' AND recovered_event_id IS NOT NULL)",
+           AND NOT (
+               reason IN ('db_open_failed', 'capture_persistence_failed')
+               AND recovered_event_id IS NOT NULL
+           )",
         [],
         |row| row.get(0),
     )?;
     let unrecovered_spills = conn.query_row(
         "SELECT COUNT(*)
          FROM capture_drop_events
-         WHERE reason = 'db_open_failed' AND recovered_event_id IS NULL",
+         WHERE reason IN ('db_open_failed', 'capture_persistence_failed')
+           AND recovered_event_id IS NULL",
         [],
         |row| row.get(0),
     )?;
@@ -174,6 +178,49 @@ mod tests {
         assert_eq!(stats.unrecovered_spills, 1);
         assert_eq!(stats.latest_reason.as_deref(), Some("adapter_skip"));
         assert_eq!(stats.latest_detail.as_deref(), Some("read-only tool"));
+        Ok(())
+    }
+
+    #[test]
+    fn capture_drop_stats_treat_recovered_persistence_spills_as_non_actionable(
+    ) -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE captured_events (id INTEGER PRIMARY KEY);")?;
+        conn.execute_batch(include_str!("../migrations/v036_capture_drop_events.sql"))?;
+        conn.execute("INSERT INTO captured_events (id) VALUES (42)", [])?;
+
+        record_capture_drop(
+            &conn,
+            &CaptureDropInput {
+                host: Some("codex-cli"),
+                session_id: Some("session-recovered"),
+                project: Some("/repo"),
+                tool_name: Some("Edit"),
+                reason: "capture_persistence_failed",
+                detail: Some("events insert failed"),
+                spill_path: Some("/tmp/spill.jsonl"),
+                recovered_event_id: Some(42),
+            },
+        )?;
+        record_capture_drop(
+            &conn,
+            &CaptureDropInput {
+                host: Some("codex-cli"),
+                session_id: Some("session-open"),
+                project: Some("/repo"),
+                tool_name: Some("Edit"),
+                reason: "capture_persistence_failed",
+                detail: Some("events still blocked"),
+                spill_path: Some("/tmp/spill.jsonl"),
+                recovered_event_id: None,
+            },
+        )?;
+
+        let stats = query_capture_drop_stats(&conn)?;
+
+        assert_eq!(stats.total, 2);
+        assert_eq!(stats.actionable, 1);
+        assert_eq!(stats.unrecovered_spills, 1);
         Ok(())
     }
 

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -22,6 +22,7 @@ pub struct SystemStats {
     pub latest_raw_ingest_failure_message: Option<String>,
     pub captured_events: i64,
     pub capture_drop_events: i64,
+    pub actionable_capture_drops: i64,
     pub unrecovered_capture_spills: i64,
     pub latest_capture_drop_epoch: Option<i64>,
     pub latest_capture_drop_reason: Option<String>,
@@ -117,6 +118,7 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
             row.get(0)
         })?,
         capture_drop_events: capture_drop.total,
+        actionable_capture_drops: capture_drop.actionable,
         unrecovered_capture_spills: capture_drop.unrecovered_spills,
         latest_capture_drop_epoch: capture_drop.latest_epoch,
         latest_capture_drop_reason: capture_drop.latest_reason,

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -265,6 +265,7 @@ fn query_system_stats_and_related_views_share_one_definition() {
             latest_raw_ingest_failure_message: Some("bad jsonl".to_string()),
             captured_events: 1,
             capture_drop_events: 1,
+            actionable_capture_drops: 0,
             unrecovered_capture_spills: 0,
             latest_capture_drop_epoch: Some(170),
             latest_capture_drop_reason: Some("codex_bash_disabled".to_string()),
@@ -376,6 +377,7 @@ fn query_system_stats_defaults_capture_drops_when_table_is_absent() -> anyhow::R
     let system = query_system_stats(&conn)?;
 
     assert_eq!(system.capture_drop_events, 0);
+    assert_eq!(system.actionable_capture_drops, 0);
     assert_eq!(system.unrecovered_capture_spills, 0);
     assert_eq!(system.latest_capture_drop_epoch, None);
     assert_eq!(system.latest_capture_drop_reason, None);

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -179,17 +179,20 @@ pub(super) fn check_capture_drops(conn: Option<&Connection>) -> Check {
         }
     };
 
-    if stats.capture_drop_events == 0 {
+    if stats.actionable_capture_drops == 0 {
         return Check::new(
             "Capture drops",
             Status::Ok,
-            "0 recorded hook skips or drops",
+            format!(
+                "{} expected hook skip/drop event(s), no actionable capture drops",
+                stats.capture_drop_events
+            ),
         );
     }
 
     let mut detail = format!(
-        "{} recorded hook skip/drop event(s)",
-        stats.capture_drop_events
+        "{} actionable capture drop(s), {} total recorded hook skip/drop event(s)",
+        stats.actionable_capture_drops, stats.capture_drop_events
     );
     if stats.unrecovered_capture_spills > 0 {
         detail.push_str(&format!(

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -196,7 +196,7 @@ pub(super) fn check_capture_drops(conn: Option<&Connection>) -> Check {
     );
     if stats.unrecovered_capture_spills > 0 {
         detail.push_str(&format!(
-            ", {} unrecovered DB-open spill(s)",
+            ", {} unrecovered capture spill(s)",
             stats.unrecovered_capture_spills
         ));
     }

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -315,8 +315,8 @@ fn check_raw_archive_ingest_warns_on_recorded_failures() -> anyhow::Result<()> {
 }
 
 #[test]
-fn check_capture_drops_warns_on_recorded_hook_drops() -> anyhow::Result<()> {
-    let _test_dir = ScopedTestDataDir::new("doctor-capture-drops");
+fn check_capture_drops_is_ok_for_expected_hook_skips() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-drops-expected");
     let conn = db::open_db()?;
     db::record_capture_drop(
         &conn,
@@ -334,10 +334,43 @@ fn check_capture_drops_warns_on_recorded_hook_drops() -> anyhow::Result<()> {
 
     let check = check_capture_drops(Some(&conn));
 
-    assert_eq!(check.icon(), "WARN");
-    assert!(check.detail.contains("1 recorded"), "{}", check.detail);
+    assert_eq!(check.icon(), "ok");
     assert!(
-        check.detail.contains("latest reason=codex_bash_disabled"),
+        check.detail.contains("1 expected hook skip/drop event"),
+        "{}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
+fn check_capture_drops_warns_on_actionable_drops() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-drops-actionable");
+    let conn = db::open_db()?;
+    db::record_capture_drop(
+        &conn,
+        &db::CaptureDropInput {
+            host: Some("codex-cli"),
+            session_id: None,
+            project: None,
+            tool_name: None,
+            reason: "adapter_mismatch",
+            detail: Some("no capture adapter matched hook input"),
+            spill_path: None,
+            recovered_event_id: None,
+        },
+    )?;
+
+    let check = check_capture_drops(Some(&conn));
+
+    assert_eq!(check.icon(), "WARN");
+    assert!(
+        check.detail.contains("1 actionable capture drop"),
+        "{}",
+        check.detail
+    );
+    assert!(
+        check.detail.contains("latest reason=adapter_mismatch"),
         "{}",
         check.detail
     );

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -1,4 +1,4 @@
-use rusqlite::params;
+use rusqlite::{params, Connection};
 
 use crate::db::test_support::{
     reset_runtime_connection_open_count, runtime_connection_open_count, ScopedTestDataDir,
@@ -41,6 +41,26 @@ impl Drop for ScopedCipherKeyEnv {
     }
 }
 
+fn insert_tool_capture(
+    conn: &Connection,
+    session_id: &str,
+    task_kind: Option<db::ExtractionTaskKind>,
+) -> anyhow::Result<db::CaptureEventOutcome> {
+    db::record_captured_event(
+        conn,
+        &db::CaptureEventInput {
+            host: "codex-cli",
+            session_id,
+            project: "proj-a",
+            cwd: None,
+            event_type: "tool_result",
+            role: None,
+            tool_name: Some("Bash"),
+            content: r#"{"tool_name":"test"}"#,
+            task_kind,
+        },
+    )
+}
 #[test]
 fn check_database_reports_shared_active_memory_count() {
     let _test_dir = ScopedTestDataDir::new("doctor-db");
@@ -213,19 +233,10 @@ fn check_pending_queue_reports_shared_counts() -> anyhow::Result<()> {
         "UPDATE jobs SET state = 'failed' WHERE id = ?1",
         params![failed_job_id],
     )?;
-    let capture = db::record_captured_event(
+    let capture = insert_tool_capture(
         &conn,
-        &db::CaptureEventInput {
-            host: "codex-cli",
-            session_id: "session-5",
-            project: "proj-a",
-            cwd: None,
-            event_type: "tool_result",
-            role: None,
-            tool_name: Some("Bash"),
-            content: r#"{"tool_name":"Bash"}"#,
-            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
-        },
+        "session-5",
+        Some(db::ExtractionTaskKind::ObservationExtract),
     )?;
     let extraction_task_id = capture
         .extraction_task_id
@@ -337,6 +348,36 @@ fn check_capture_drops_is_ok_for_expected_hook_skips() -> anyhow::Result<()> {
     assert_eq!(check.icon(), "ok");
     assert!(
         check.detail.contains("1 expected hook skip/drop event"),
+        "{}",
+        check.detail
+    );
+    Ok(())
+}
+
+#[test]
+fn check_capture_drops_is_ok_for_recovered_persistence_spills() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("doctor-capture-drops-recovered-persistence");
+    let conn = db::open_db()?;
+    let recovered_capture = insert_tool_capture(&conn, "session-a", None)?;
+    db::record_capture_drop(
+        &conn,
+        &db::CaptureDropInput {
+            host: Some("codex-cli"),
+            session_id: Some("session-a"),
+            project: Some("proj-a"),
+            tool_name: Some("Edit"),
+            reason: "capture_persistence_failed",
+            detail: Some("events insert failed"),
+            spill_path: Some("/tmp/capture-spill.jsonl"),
+            recovered_event_id: Some(recovered_capture.event_row_id),
+        },
+    )?;
+
+    let check = check_capture_drops(Some(&conn));
+
+    assert_eq!(check.icon(), "ok");
+    assert!(
+        check.detail.contains("no actionable capture drops"),
         "{}",
         check.detail
     );

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -4,7 +4,10 @@ use rusqlite::OptionalExtension;
 use crate::db;
 
 use super::native::sync_native_memory;
-use super::spill::{record_capture_drop_lossy, replay_spilled_capture_events, spill_capture_event};
+use super::spill::{
+    record_capture_drop_lossy, replay_spilled_capture_events, spill_capture_event,
+    SPILL_REASON_CAPTURE_PERSISTENCE_FAILED, SPILL_REASON_DB_OPEN_FAILED,
+};
 
 pub async fn session_init(host: Option<&str>) -> Result<()> {
     let timer = crate::log::Timer::start("session-init", "");
@@ -83,7 +86,14 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
     let conn = match db::open_db() {
         Ok(conn) => conn,
         Err(error) => {
-            let path = spill_capture_event(&capture_host, &event_id, &event, &summary, &error)?;
+            let path = spill_capture_event(
+                &capture_host,
+                &event_id,
+                &event,
+                &summary,
+                SPILL_REASON_DB_OPEN_FAILED,
+                &error,
+            )?;
             crate::log::error(
                 "observe",
                 &format!(
@@ -99,7 +109,14 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
     if let Err(error) =
         record_live_observed_event_with_id(&conn, &capture_host, &event_id, &event, &summary)
     {
-        let path = spill_capture_event(&capture_host, &event_id, &event, &summary, &error)?;
+        let path = spill_capture_event(
+            &capture_host,
+            &event_id,
+            &event,
+            &summary,
+            SPILL_REASON_CAPTURE_PERSISTENCE_FAILED,
+            &error,
+        )?;
         crate::log::error(
             "observe",
             &format!(
@@ -378,7 +395,10 @@ mod tests {
     use crate::db::{self, test_support::ScopedTestDataDir};
 
     use super::super::spill::spill_capture_event;
-    use super::{event_skip_reason, observe_input, record_capture_event, session_init_event};
+    use super::{
+        event_skip_reason, observe_input, record_capture_event, session_init_event,
+        SPILL_REASON_CAPTURE_PERSISTENCE_FAILED,
+    };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -667,6 +687,15 @@ mod tests {
         )?;
         assert_eq!(replayed_captures, 1);
         assert_eq!(replayed_events, 1);
+        let replayed_drop_reason: String = conn.query_row(
+            "SELECT reason FROM capture_drop_events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(
+            replayed_drop_reason,
+            SPILL_REASON_CAPTURE_PERSISTENCE_FAILED
+        );
         assert!(!crate::db::data_dir().join("capture-spill.jsonl").exists());
 
         let replayed_event_id: String = conn.query_row(
@@ -704,6 +733,7 @@ mod tests {
             &replayed_event_id,
             &replayed_event,
             &replayed_summary,
+            SPILL_REASON_CAPTURE_PERSISTENCE_FAILED,
             &anyhow::anyhow!("retry same partial capture"),
         )?;
         observe_input(&replay_trigger, Some("claude-code")).await?;

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use rusqlite::OptionalExtension;
 
 use crate::db;
 
@@ -77,10 +78,12 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
         return Ok(());
     };
 
+    let content = capture_event_content(&event, &summary);
+    let event_id = db::unique_capture_event_id("tool_result", &content);
     let conn = match db::open_db() {
         Ok(conn) => conn,
         Err(error) => {
-            let path = spill_capture_event(&capture_host, &event, &summary, &error)?;
+            let path = spill_capture_event(&capture_host, &event_id, &event, &summary, &error)?;
             crate::log::error(
                 "observe",
                 &format!(
@@ -93,28 +96,34 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
         }
     };
     replay_spilled_capture_events(&conn)?;
-    record_observed_event(&conn, &capture_host, &event, &summary)?;
+    if let Err(error) =
+        record_observed_event_with_id(&conn, &capture_host, &event_id, &event, &summary)
+    {
+        let path = spill_capture_event(&capture_host, &event_id, &event, &summary, &error)?;
+        crate::log::error(
+            "observe",
+            &format!(
+                "capture persistence failed; spilled capture event to {}: {}",
+                path.display(),
+                error
+            ),
+        );
+        return Err(error);
+    }
 
     Ok(())
 }
 
-pub(super) fn record_observed_event(
+pub(super) fn record_observed_event_with_id(
     conn: &rusqlite::Connection,
     capture_host: &str,
+    event_id: &str,
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
 ) -> Result<i64> {
-    let capture_event_id = record_capture_event(conn, capture_host, event, summary)?;
-    crate::memory::insert_event(
-        conn,
-        &event.session_id,
-        &event.project,
-        &summary.event_type,
-        &summary.summary,
-        summary.detail.as_deref(),
-        summary.files_json.as_deref(),
-        summary.exit_code,
-    )?;
+    let capture_event_id =
+        record_capture_event_with_id(conn, capture_host, event_id, event, summary)?;
+    insert_memory_event_once(conn, event, summary)?;
 
     crate::log::info(
         "observe",
@@ -142,6 +151,50 @@ pub(super) fn record_observed_event(
     Ok(capture_event_id)
 }
 
+fn insert_memory_event_once(
+    conn: &rusqlite::Connection,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> Result<()> {
+    let exists = conn
+        .query_row(
+            "SELECT 1 FROM events
+             WHERE session_id = ?1
+               AND project = ?2
+               AND event_type = ?3
+               AND summary = ?4
+               AND COALESCE(detail, '') = COALESCE(?5, '')
+               AND COALESCE(files, '') = COALESCE(?6, '')
+               AND COALESCE(exit_code, -2147483648) = COALESCE(?7, -2147483648)
+             LIMIT 1",
+            rusqlite::params![
+                &event.session_id,
+                &event.project,
+                &summary.event_type,
+                &summary.summary,
+                summary.detail.as_deref(),
+                summary.files_json.as_deref(),
+                summary.exit_code
+            ],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    if !exists {
+        crate::memory::insert_event(
+            conn,
+            &event.session_id,
+            &event.project,
+            &summary.event_type,
+            &summary.summary,
+            summary.detail.as_deref(),
+            summary.files_json.as_deref(),
+            summary.exit_code,
+        )?;
+    }
+    Ok(())
+}
+
 fn detect_adapter_for_host(
     input: &str,
     host: Option<&str>,
@@ -159,14 +212,50 @@ fn detect_adapter_for_host(
         .or_else(|| crate::adapter::detect_adapter(input))
 }
 
+#[cfg(test)]
 fn record_capture_event(
     conn: &rusqlite::Connection,
     host: &str,
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
 ) -> Result<i64> {
+    let content = capture_event_content(event, summary);
+    let event_id = db::unique_capture_event_id("tool_result", &content);
+    record_capture_event_with_id(conn, host, &event_id, event, summary)
+}
+
+fn record_capture_event_with_id(
+    conn: &rusqlite::Connection,
+    host: &str,
+    event_id: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> Result<i64> {
+    let content = capture_event_content(event, summary);
+    let outcome = db::record_captured_event_with_id(
+        conn,
+        &db::CaptureEventInput {
+            host,
+            session_id: &event.session_id,
+            project: &event.project,
+            cwd: event.cwd.as_deref(),
+            event_type: "tool_result",
+            role: None,
+            tool_name: Some(&event.tool_name),
+            content: &content,
+            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
+        },
+        Some(event_id),
+    )?;
+    Ok(outcome.event_row_id)
+}
+
+fn capture_event_content(
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> String {
     let git_branch = event.cwd.as_deref().and_then(db::detect_git_branch);
-    let content = serde_json::json!({
+    serde_json::json!({
         "summary": &summary.summary,
         "event_type": &summary.event_type,
         "detail": summary.detail.as_deref(),
@@ -183,22 +272,7 @@ fn record_capture_event(
             .map(crate::adapter::common::redact_sensitive_value),
         "git_branch": git_branch.as_deref(),
     })
-    .to_string();
-    let outcome = db::record_captured_event(
-        conn,
-        &db::CaptureEventInput {
-            host,
-            session_id: &event.session_id,
-            project: &event.project,
-            cwd: event.cwd.as_deref(),
-            event_type: "tool_result",
-            role: None,
-            tool_name: Some(&event.tool_name),
-            content: &content,
-            task_kind: Some(db::ExtractionTaskKind::ObservationExtract),
-        },
-    )?;
-    Ok(outcome.event_row_id)
+    .to_string()
 }
 
 fn event_skip_reason(
@@ -425,5 +499,76 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&project_dir);
         test_result
+    }
+
+    #[tokio::test]
+    async fn observe_spills_persistence_failure_and_replays_capture_once() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("observe-persist-failure-spill");
+        let failing_input = serde_json::json!({
+            "session_id": "sess-persist-fail",
+            "cwd": "/tmp/remem",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/lib.rs"},
+            "tool_response": {"content": "edited"}
+        })
+        .to_string();
+
+        let conn = db::open_db()?;
+        conn.execute_batch(
+            "CREATE TRIGGER fail_events_insert
+             BEFORE INSERT ON events
+             BEGIN
+                 SELECT RAISE(FAIL, 'events blocked');
+             END;",
+        )?;
+        drop(conn);
+
+        let err = observe_input(&failing_input, Some("claude-code"))
+            .await
+            .expect_err("event insert failure should spill");
+        assert!(err.to_string().contains("events blocked"), "{err}");
+        assert!(crate::db::data_dir().join("capture-spill.jsonl").exists());
+
+        let conn = db::open_db()?;
+        let partial_captures: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        let partial_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(partial_captures, 1);
+        assert_eq!(partial_events, 0);
+        conn.execute_batch("DROP TRIGGER fail_events_insert;")?;
+        drop(conn);
+
+        let replay_trigger = serde_json::json!({
+            "session_id": "sess-replay-trigger",
+            "cwd": "/tmp/remem",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/other.rs"},
+            "tool_response": {"content": "edited"}
+        })
+        .to_string();
+        observe_input(&replay_trigger, Some("claude-code")).await?;
+
+        let conn = db::open_db()?;
+        let replayed_captures: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        let replayed_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(replayed_captures, 1);
+        assert_eq!(replayed_events, 1);
+        assert!(!crate::db::data_dir().join("capture-spill.jsonl").exists());
+        Ok(())
     }
 }

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use rusqlite::OptionalExtension;
 
 use crate::db;
 
@@ -138,14 +137,7 @@ pub(super) fn record_observed_event_with_id(
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
 ) -> Result<i64> {
-    record_observed_event(
-        conn,
-        capture_host,
-        event_id,
-        event,
-        summary,
-        LegacyEventInsert::Deduplicate,
-    )
+    record_observed_event(conn, capture_host, event_id, event, summary)
 }
 
 fn record_live_observed_event_with_id(
@@ -155,19 +147,7 @@ fn record_live_observed_event_with_id(
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
 ) -> Result<i64> {
-    record_observed_event(
-        conn,
-        capture_host,
-        event_id,
-        event,
-        summary,
-        LegacyEventInsert::Append,
-    )
-}
-
-enum LegacyEventInsert {
-    Append,
-    Deduplicate,
+    record_observed_event(conn, capture_host, event_id, event, summary)
 }
 
 fn record_observed_event(
@@ -176,25 +156,19 @@ fn record_observed_event(
     event_id: &str,
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
-    legacy_insert: LegacyEventInsert,
 ) -> Result<i64> {
     let capture_event_id =
         record_capture_event_with_id(conn, capture_host, event_id, event, summary)?;
-    match legacy_insert {
-        LegacyEventInsert::Append => {
-            crate::memory::insert_event(
-                conn,
-                &event.session_id,
-                &event.project,
-                &summary.event_type,
-                &summary.summary,
-                summary.detail.as_deref(),
-                summary.files_json.as_deref(),
-                summary.exit_code,
-            )?;
-        }
-        LegacyEventInsert::Deduplicate => insert_memory_event_once(conn, event, summary)?,
-    }
+    crate::memory::insert_event(
+        conn,
+        &event.session_id,
+        &event.project,
+        &summary.event_type,
+        &summary.summary,
+        summary.detail.as_deref(),
+        summary.files_json.as_deref(),
+        summary.exit_code,
+    )?;
 
     crate::log::info(
         "observe",
@@ -220,50 +194,6 @@ fn record_observed_event(
     }
 
     Ok(capture_event_id)
-}
-
-fn insert_memory_event_once(
-    conn: &rusqlite::Connection,
-    event: &crate::adapter::ParsedHookEvent,
-    summary: &crate::adapter::EventSummary,
-) -> Result<()> {
-    let exists = conn
-        .query_row(
-            "SELECT 1 FROM events
-             WHERE session_id = ?1
-               AND project = ?2
-               AND event_type = ?3
-               AND summary = ?4
-               AND COALESCE(detail, '') = COALESCE(?5, '')
-               AND COALESCE(files, '') = COALESCE(?6, '')
-               AND COALESCE(exit_code, -2147483648) = COALESCE(?7, -2147483648)
-             LIMIT 1",
-            rusqlite::params![
-                &event.session_id,
-                &event.project,
-                &summary.event_type,
-                &summary.summary,
-                summary.detail.as_deref(),
-                summary.files_json.as_deref(),
-                summary.exit_code
-            ],
-            |_| Ok(()),
-        )
-        .optional()?
-        .is_some();
-    if !exists {
-        crate::memory::insert_event(
-            conn,
-            &event.session_id,
-            &event.project,
-            &summary.event_type,
-            &summary.summary,
-            summary.detail.as_deref(),
-            summary.files_json.as_deref(),
-            summary.exit_code,
-        )?;
-    }
-    Ok(())
 }
 
 fn detect_adapter_for_host(

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -97,7 +97,7 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
     };
     replay_spilled_capture_events(&conn)?;
     if let Err(error) =
-        record_observed_event_with_id(&conn, &capture_host, &event_id, &event, &summary)
+        record_live_observed_event_with_id(&conn, &capture_host, &event_id, &event, &summary)
     {
         let path = spill_capture_event(&capture_host, &event_id, &event, &summary, &error)?;
         crate::log::error(
@@ -121,9 +121,63 @@ pub(super) fn record_observed_event_with_id(
     event: &crate::adapter::ParsedHookEvent,
     summary: &crate::adapter::EventSummary,
 ) -> Result<i64> {
+    record_observed_event(
+        conn,
+        capture_host,
+        event_id,
+        event,
+        summary,
+        LegacyEventInsert::Deduplicate,
+    )
+}
+
+fn record_live_observed_event_with_id(
+    conn: &rusqlite::Connection,
+    capture_host: &str,
+    event_id: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+) -> Result<i64> {
+    record_observed_event(
+        conn,
+        capture_host,
+        event_id,
+        event,
+        summary,
+        LegacyEventInsert::Append,
+    )
+}
+
+enum LegacyEventInsert {
+    Append,
+    Deduplicate,
+}
+
+fn record_observed_event(
+    conn: &rusqlite::Connection,
+    capture_host: &str,
+    event_id: &str,
+    event: &crate::adapter::ParsedHookEvent,
+    summary: &crate::adapter::EventSummary,
+    legacy_insert: LegacyEventInsert,
+) -> Result<i64> {
     let capture_event_id =
         record_capture_event_with_id(conn, capture_host, event_id, event, summary)?;
-    insert_memory_event_once(conn, event, summary)?;
+    match legacy_insert {
+        LegacyEventInsert::Append => {
+            crate::memory::insert_event(
+                conn,
+                &event.session_id,
+                &event.project,
+                &summary.event_type,
+                &summary.summary,
+                summary.detail.as_deref(),
+                summary.files_json.as_deref(),
+                summary.exit_code,
+            )?;
+        }
+        LegacyEventInsert::Deduplicate => insert_memory_event_once(conn, event, summary)?,
+    }
 
     crate::log::info(
         "observe",
@@ -323,6 +377,7 @@ mod tests {
     use crate::adapter::{codex::CodexAdapter, EventSummary, ParsedHookEvent};
     use crate::db::{self, test_support::ScopedTestDataDir};
 
+    use super::super::spill::spill_capture_event;
     use super::{event_skip_reason, observe_input, record_capture_event, session_init_event};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -502,6 +557,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn observe_appends_legacy_events_for_identical_normal_events() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("observe-identical-normal-events");
+        let project_dir = std::env::temp_dir().join(format!(
+            "remem-observe-duplicates-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::create_dir_all(&project_dir)?;
+        let input = serde_json::json!({
+            "session_id": "sess-identical-normal",
+            "cwd": project_dir,
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/lib.rs"},
+            "tool_response": {"content": "edited"}
+        })
+        .to_string();
+
+        let test_result = async {
+            observe_input(&input, Some("claude-code")).await?;
+            observe_input(&input, Some("claude-code")).await?;
+
+            let conn = db::open_db()?;
+            let captured_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM captured_events WHERE session_id = 'sess-identical-normal'",
+                [],
+                |row| row.get(0),
+            )?;
+            let legacy_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM events WHERE session_id = 'sess-identical-normal'",
+                [],
+                |row| row.get(0),
+            )?;
+
+            anyhow::ensure!(captured_count == 2, "expected two captured events");
+            anyhow::ensure!(legacy_count == 2, "expected two legacy events");
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+
+        std::fs::remove_dir_all(&project_dir)?;
+        test_result
+    }
+
+    #[tokio::test]
     async fn observe_spills_persistence_failure_and_replays_capture_once() -> anyhow::Result<()> {
         let _test_dir = ScopedTestDataDir::new("observe-persist-failure-spill");
         let failing_input = serde_json::json!({
@@ -569,6 +668,53 @@ mod tests {
         assert_eq!(replayed_captures, 1);
         assert_eq!(replayed_events, 1);
         assert!(!crate::db::data_dir().join("capture-spill.jsonl").exists());
+
+        let replayed_event_id: String = conn.query_row(
+            "SELECT event_id FROM captured_events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        let replayed_summary = conn.query_row(
+            "SELECT event_type, summary, detail, files, exit_code
+             FROM events
+             WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| {
+                Ok(EventSummary {
+                    event_type: row.get(0)?,
+                    summary: row.get(1)?,
+                    detail: row.get(2)?,
+                    files_json: row.get(3)?,
+                    exit_code: row.get(4)?,
+                })
+            },
+        )?;
+        drop(conn);
+
+        let replayed_event = ParsedHookEvent {
+            session_id: "sess-persist-fail".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Edit".to_string(),
+            tool_input: Some(serde_json::json!({"file_path": "src/lib.rs"})),
+            tool_response: Some(serde_json::json!({"content": "edited"})),
+        };
+        spill_capture_event(
+            "claude-code",
+            &replayed_event_id,
+            &replayed_event,
+            &replayed_summary,
+            &anyhow::anyhow!("retry same partial capture"),
+        )?;
+        observe_input(&replay_trigger, Some("claude-code")).await?;
+
+        let conn = db::open_db()?;
+        let retry_replayed_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'sess-persist-fail'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(retry_replayed_events, 1);
         Ok(())
     }
 }

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -116,6 +116,25 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
             SPILL_REASON_CAPTURE_PERSISTENCE_FAILED,
             &error,
         )?;
+        let spill_path = path.display().to_string();
+        if let Err(drop_error) = crate::db::record_capture_drop(
+            &conn,
+            &crate::db::CaptureDropInput {
+                host: Some(&capture_host),
+                session_id: Some(&event.session_id),
+                project: Some(&event.project),
+                tool_name: Some(&event.tool_name),
+                reason: SPILL_REASON_CAPTURE_PERSISTENCE_FAILED,
+                detail: Some(&error.to_string()),
+                spill_path: Some(&spill_path),
+                recovered_event_id: None,
+            },
+        ) {
+            crate::log::warn(
+                "observe",
+                &format!("capture persistence drop ledger write failed: {drop_error}"),
+            );
+        }
         crate::log::error(
             "observe",
             &format!(
@@ -591,6 +610,18 @@ mod tests {
         )?;
         assert_eq!(partial_captures, 1);
         assert_eq!(partial_events, 0);
+        let partial_drop: (i64, i64) = conn.query_row(
+            "SELECT COUNT(*), COUNT(recovered_event_id)
+             FROM capture_drop_events
+             WHERE session_id = 'sess-persist-fail'
+               AND reason = 'capture_persistence_failed'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let partial_stats = db::query_system_stats(&conn)?;
+        assert_eq!(partial_drop, (1, 0));
+        assert_eq!(partial_stats.actionable_capture_drops, 1);
+        assert_eq!(partial_stats.unrecovered_capture_spills, 1);
         conn.execute_batch("DROP TRIGGER fail_events_insert;")?;
         drop(conn);
 
@@ -617,15 +648,18 @@ mod tests {
         )?;
         assert_eq!(replayed_captures, 1);
         assert_eq!(replayed_events, 1);
-        let replayed_drop_reason: String = conn.query_row(
-            "SELECT reason FROM capture_drop_events WHERE session_id = 'sess-persist-fail'",
+        let replayed_drop: (String, Option<i64>) = conn.query_row(
+            "SELECT reason, recovered_event_id
+             FROM capture_drop_events
+             WHERE session_id = 'sess-persist-fail'",
             [],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )?;
-        assert_eq!(
-            replayed_drop_reason,
-            SPILL_REASON_CAPTURE_PERSISTENCE_FAILED
-        );
+        let replayed_stats = db::query_system_stats(&conn)?;
+        assert_eq!(replayed_drop.0, SPILL_REASON_CAPTURE_PERSISTENCE_FAILED);
+        assert!(replayed_drop.1.is_some());
+        assert_eq!(replayed_stats.actionable_capture_drops, 0);
+        assert_eq!(replayed_stats.unrecovered_capture_spills, 0);
         assert!(!crate::db::data_dir().join("capture-spill.jsonl").exists());
 
         let replayed_event_id: String = conn.query_row(

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -17,6 +17,34 @@ struct CaptureSpillRecord {
     created_at_epoch: i64,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct CaptureSpillRecordCompat {
+    version: u32,
+    event_id: Option<String>,
+    host: String,
+    event: ParsedHookEvent,
+    summary: EventSummary,
+    db_error: String,
+    created_at_epoch: i64,
+}
+
+impl From<CaptureSpillRecordCompat> for CaptureSpillRecord {
+    fn from(record: CaptureSpillRecordCompat) -> Self {
+        let content = legacy_spill_event_content(&record.event, &record.summary);
+        Self {
+            version: record.version,
+            event_id: record
+                .event_id
+                .unwrap_or_else(|| crate::db::unique_capture_event_id("tool_result", &content)),
+            host: record.host,
+            event: record.event,
+            summary: record.summary,
+            db_error: record.db_error,
+            created_at_epoch: record.created_at_epoch,
+        }
+    }
+}
+
 pub(super) fn record_capture_drop_lossy(
     host: Option<&str>,
     event: Option<&ParsedHookEvent>,
@@ -102,7 +130,7 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
     }
 
     for line in contents.lines().filter(|line| !line.trim().is_empty()) {
-        match serde_json::from_str::<CaptureSpillRecord>(line) {
+        match parse_spill_record(line) {
             Ok(record) => match super::hook::record_observed_event_with_id(
                 conn,
                 &record.host,
@@ -128,7 +156,7 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
                 }
                 Err(error) => append_failed_spill(&failed_path, line, &error)?,
             },
-            Err(error) => append_failed_spill(&failed_path, line, &error.into())?,
+            Err(error) => append_failed_spill(&failed_path, line, &error)?,
         }
     }
 
@@ -195,6 +223,31 @@ fn sanitize_summary(summary: &EventSummary) -> EventSummary {
         files_json: summary.files_json.clone(),
         exit_code: summary.exit_code,
     }
+}
+
+fn parse_spill_record(line: &str) -> Result<CaptureSpillRecord> {
+    let record: CaptureSpillRecordCompat = serde_json::from_str(line)?;
+    Ok(record.into())
+}
+
+fn legacy_spill_event_content(event: &ParsedHookEvent, summary: &EventSummary) -> String {
+    serde_json::json!({
+        "summary": &summary.summary,
+        "event_type": &summary.event_type,
+        "detail": summary.detail.as_deref(),
+        "files": summary.files_json.as_deref(),
+        "exit_code": summary.exit_code,
+        "tool_name": &event.tool_name,
+        "tool_input": event
+            .tool_input
+            .as_ref()
+            .map(crate::adapter::common::redact_sensitive_value),
+        "tool_response": event
+            .tool_response
+            .as_ref()
+            .map(crate::adapter::common::redact_sensitive_value),
+    })
+    .to_string()
 }
 
 fn spill_path() -> PathBuf {
@@ -297,6 +350,50 @@ mod tests {
         let captured: i64 =
             conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))?;
         assert_eq!(captured, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn replay_legacy_spill_without_event_id() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-legacy-replay");
+        let legacy = serde_json::json!({
+            "version": 1,
+            "host": "codex-cli",
+            "event": {
+                "session_id": "session-legacy-spill",
+                "cwd": "/tmp/remem",
+                "project": "/tmp/remem",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "/tmp/remem/src/lib.rs"},
+                "tool_response": {"ok": true}
+            },
+            "summary": {
+                "event_type": "file_edit",
+                "summary": "Edited src/lib.rs",
+                "detail": null,
+                "files_json": "[\"src/lib.rs\"]",
+                "exit_code": null
+            },
+            "db_error": "database is locked",
+            "created_at_epoch": 1700000000
+        });
+        let path = crate::db::data_dir().join("capture-spill.jsonl");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, format!("{legacy}\n"))?;
+        let conn = db::open_db()?;
+
+        let replayed = replay_spilled_capture_events(&conn)?;
+
+        assert_eq!(replayed, 1);
+        let captured: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'session-legacy-spill'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(captured, 1);
+        assert!(!path.exists());
         Ok(())
     }
 

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -194,19 +194,20 @@ fn replay_spill_record(
         &record.event,
         &record.summary,
     )?;
-    crate::db::record_capture_drop(
-        &tx,
-        &crate::db::CaptureDropInput {
-            host: Some(&record.host),
-            session_id: Some(&record.event.session_id),
-            project: Some(&record.event.project),
-            tool_name: Some(&record.event.tool_name),
-            reason: &record.failure_reason,
-            detail: Some(&record.db_error),
-            spill_path: Some(&spill_path.display().to_string()),
-            recovered_event_id: Some(event_id),
-        },
-    )?;
+    let spill_path = spill_path.display().to_string();
+    let drop_input = crate::db::CaptureDropInput {
+        host: Some(&record.host),
+        session_id: Some(&record.event.session_id),
+        project: Some(&record.event.project),
+        tool_name: Some(&record.event.tool_name),
+        reason: &record.failure_reason,
+        detail: Some(&record.db_error),
+        spill_path: Some(&spill_path),
+        recovered_event_id: Some(event_id),
+    };
+    if !crate::db::mark_capture_spill_recovered(&tx, &drop_input, event_id)? {
+        crate::db::record_capture_drop(&tx, &drop_input)?;
+    }
     tx.commit()
         .context("commit capture spill replay transaction")?;
     Ok(true)

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -9,6 +9,7 @@ use crate::adapter::{EventSummary, ParsedHookEvent};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CaptureSpillRecord {
     version: u32,
+    event_id: String,
     host: String,
     event: ParsedHookEvent,
     summary: EventSummary,
@@ -52,6 +53,7 @@ pub(super) fn record_capture_drop_lossy(
 
 pub(super) fn spill_capture_event(
     host: &str,
+    event_id: &str,
     event: &ParsedHookEvent,
     summary: &EventSummary,
     db_error: &anyhow::Error,
@@ -63,10 +65,15 @@ pub(super) fn spill_capture_event(
     }
     let record = CaptureSpillRecord {
         version: 1,
+        event_id: event_id.to_string(),
         host: host.to_string(),
         event: sanitize_event(event),
-        summary: summary.clone(),
-        db_error: crate::db::truncate_str(&db_error.to_string(), 1000).to_string(),
+        summary: sanitize_summary(summary),
+        db_error: crate::db::truncate_str(
+            &crate::db::capture::redact_capture_content(&db_error.to_string()),
+            1000,
+        )
+        .to_string(),
         created_at_epoch: chrono::Utc::now().timestamp(),
     };
     let mut file = std::fs::OpenOptions::new()
@@ -96,9 +103,10 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
 
     for line in contents.lines().filter(|line| !line.trim().is_empty()) {
         match serde_json::from_str::<CaptureSpillRecord>(line) {
-            Ok(record) => match super::hook::record_observed_event(
+            Ok(record) => match super::hook::record_observed_event_with_id(
                 conn,
                 &record.host,
+                &record.event_id,
                 &record.event,
                 &record.summary,
             ) {
@@ -176,6 +184,19 @@ fn sanitize_event(event: &ParsedHookEvent) -> ParsedHookEvent {
     }
 }
 
+fn sanitize_summary(summary: &EventSummary) -> EventSummary {
+    EventSummary {
+        event_type: summary.event_type.clone(),
+        summary: crate::db::capture::redact_capture_content(&summary.summary),
+        detail: summary
+            .detail
+            .as_ref()
+            .map(|detail| crate::db::capture::redact_capture_content(detail)),
+        files_json: summary.files_json.clone(),
+        exit_code: summary.exit_code,
+    }
+}
+
 fn spill_path() -> PathBuf {
     crate::db::data_dir().join("capture-spill.jsonl")
 }
@@ -210,7 +231,15 @@ mod tests {
             files_json: Some("[\"src/lib.rs\"]".to_string()),
             exit_code: None,
         };
-        spill_capture_event("codex-cli", &event, &summary, &err)?;
+        let content = serde_json::json!({
+            "summary": summary.summary,
+            "tool_name": event.tool_name,
+            "tool_input": event.tool_input,
+            "tool_response": event.tool_response,
+        })
+        .to_string();
+        let event_id = db::unique_capture_event_id("tool_result", &content);
+        spill_capture_event("codex-cli", &event_id, &event, &summary, &err)?;
         let conn = db::open_db()?;
 
         let replayed = replay_spilled_capture_events(&conn)?;
@@ -223,6 +252,83 @@ mod tests {
         })?;
         assert_eq!(captured, 1);
         assert_eq!(drops, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn replay_identical_spills_preserves_distinct_captured_events() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-identical-replay");
+        let err = anyhow::anyhow!("database is locked");
+        let event = ParsedHookEvent {
+            session_id: "session-identical-spill".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Edit".to_string(),
+            tool_input: Some(serde_json::json!({"file_path": "/tmp/remem/src/lib.rs"})),
+            tool_response: Some(serde_json::json!({"ok": true})),
+        };
+        let summary = EventSummary {
+            event_type: "file_edit".to_string(),
+            summary: "Edited src/lib.rs".to_string(),
+            detail: None,
+            files_json: Some("[\"src/lib.rs\"]".to_string()),
+            exit_code: None,
+        };
+
+        spill_capture_event(
+            "codex-cli",
+            "tool_result-identical-a",
+            &event,
+            &summary,
+            &err,
+        )?;
+        spill_capture_event(
+            "codex-cli",
+            "tool_result-identical-b",
+            &event,
+            &summary,
+            &err,
+        )?;
+        let conn = db::open_db()?;
+
+        let replayed = replay_spilled_capture_events(&conn)?;
+
+        assert_eq!(replayed, 2);
+        let captured: i64 =
+            conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))?;
+        assert_eq!(captured, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn spill_redacts_summary_and_database_error() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-redacts");
+        let err = anyhow::anyhow!("database token=github_pat_secret");
+        let event = ParsedHookEvent {
+            session_id: "session-spill-redact".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Bash".to_string(),
+            tool_input: Some(serde_json::json!({
+                "command": "curl -H 'Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456'"
+            })),
+            tool_response: Some(serde_json::json!({"stderr": "password=hunter2"})),
+        };
+        let summary = EventSummary {
+            event_type: "bash".to_string(),
+            summary: "Run curl with ghp_abcdefghijklmnopqrstuvwxyz123456".to_string(),
+            detail: Some("password=hunter2".to_string()),
+            files_json: None,
+            exit_code: Some(1),
+        };
+
+        spill_capture_event("codex-cli", "tool_result-redact", &event, &summary, &err)?;
+        let stored = std::fs::read_to_string(crate::db::data_dir().join("capture-spill.jsonl"))?;
+
+        assert!(stored.contains("[REDACTED]"));
+        assert!(!stored.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
+        assert!(!stored.contains("hunter2"));
+        assert!(!stored.contains("github_pat_secret"));
         Ok(())
     }
 }

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -6,6 +6,9 @@ use std::path::PathBuf;
 
 use crate::adapter::{EventSummary, ParsedHookEvent};
 
+pub(super) const SPILL_REASON_DB_OPEN_FAILED: &str = "db_open_failed";
+pub(super) const SPILL_REASON_CAPTURE_PERSISTENCE_FAILED: &str = "capture_persistence_failed";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CaptureSpillRecord {
     version: u32,
@@ -13,6 +16,7 @@ struct CaptureSpillRecord {
     host: String,
     event: ParsedHookEvent,
     summary: EventSummary,
+    failure_reason: String,
     db_error: String,
     created_at_epoch: i64,
 }
@@ -24,23 +28,24 @@ struct CaptureSpillRecordCompat {
     host: String,
     event: ParsedHookEvent,
     summary: EventSummary,
+    failure_reason: Option<String>,
     db_error: String,
     created_at_epoch: i64,
 }
 
-impl From<CaptureSpillRecordCompat> for CaptureSpillRecord {
-    fn from(record: CaptureSpillRecordCompat) -> Self {
-        let content = legacy_spill_event_content(&record.event, &record.summary);
-        Self {
-            version: record.version,
-            event_id: record
-                .event_id
-                .unwrap_or_else(|| crate::db::unique_capture_event_id("tool_result", &content)),
-            host: record.host,
-            event: record.event,
-            summary: record.summary,
-            db_error: record.db_error,
-            created_at_epoch: record.created_at_epoch,
+impl CaptureSpillRecordCompat {
+    fn into_record(self, fallback_event_id: String) -> CaptureSpillRecord {
+        CaptureSpillRecord {
+            version: self.version,
+            event_id: self.event_id.unwrap_or(fallback_event_id),
+            host: self.host,
+            event: self.event,
+            summary: self.summary,
+            failure_reason: self
+                .failure_reason
+                .unwrap_or_else(|| SPILL_REASON_DB_OPEN_FAILED.to_string()),
+            db_error: self.db_error,
+            created_at_epoch: self.created_at_epoch,
         }
     }
 }
@@ -84,6 +89,7 @@ pub(super) fn spill_capture_event(
     event_id: &str,
     event: &ParsedHookEvent,
     summary: &EventSummary,
+    failure_reason: &str,
     db_error: &anyhow::Error,
 ) -> Result<PathBuf> {
     let path = spill_path();
@@ -97,6 +103,7 @@ pub(super) fn spill_capture_event(
         host: host.to_string(),
         event: sanitize_event(event),
         summary: sanitize_summary(summary),
+        failure_reason: failure_reason.to_string(),
         db_error: crate::db::truncate_str(
             &crate::db::capture::redact_capture_content(&db_error.to_string()),
             1000,
@@ -129,8 +136,12 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
             .with_context(|| format!("remove stale {}", failed_path.display()))?;
     }
 
-    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
-        match parse_spill_record(line) {
+    for (line_index, line) in contents
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .enumerate()
+    {
+        match parse_spill_record(line, line_index) {
             Ok(record) => match super::hook::record_observed_event_with_id(
                 conn,
                 &record.host,
@@ -146,7 +157,7 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
                             session_id: Some(&record.event.session_id),
                             project: Some(&record.event.project),
                             tool_name: Some(&record.event.tool_name),
-                            reason: "db_open_failed",
+                            reason: &record.failure_reason,
                             detail: Some(&record.db_error),
                             spill_path: Some(&path.display().to_string()),
                             recovered_event_id: Some(event_id),
@@ -154,9 +165,9 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
                     )?;
                     replayed += 1;
                 }
-                Err(error) => append_failed_spill(&failed_path, line, &error)?,
+                Err(error) => append_failed_spill_record(&failed_path, &record, &error)?,
             },
-            Err(error) => append_failed_spill(&failed_path, line, &error)?,
+            Err(error) => append_failed_spill_line(&failed_path, line, &error)?,
         }
     }
 
@@ -180,7 +191,7 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
     Ok(replayed)
 }
 
-fn append_failed_spill(path: &PathBuf, line: &str, error: &anyhow::Error) -> Result<()> {
+fn append_failed_spill_line(path: &PathBuf, line: &str, error: &anyhow::Error) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create failed capture spill dir {}", parent.display()))?;
@@ -191,6 +202,26 @@ fn append_failed_spill(path: &PathBuf, line: &str, error: &anyhow::Error) -> Res
         .open(path)
         .with_context(|| format!("open failed capture spill {}", path.display()))?;
     writeln!(file, "{line}")?;
+    crate::log::warn("observe", &format!("capture spill replay failed: {error}"));
+    Ok(())
+}
+
+fn append_failed_spill_record(
+    path: &PathBuf,
+    record: &CaptureSpillRecord,
+    error: &anyhow::Error,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create failed capture spill dir {}", parent.display()))?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open failed capture spill {}", path.display()))?;
+    serde_json::to_writer(&mut file, record)?;
+    file.write_all(b"\n")?;
     crate::log::warn("observe", &format!("capture spill replay failed: {error}"));
     Ok(())
 }
@@ -225,29 +256,17 @@ fn sanitize_summary(summary: &EventSummary) -> EventSummary {
     }
 }
 
-fn parse_spill_record(line: &str) -> Result<CaptureSpillRecord> {
+fn parse_spill_record(line: &str, line_index: usize) -> Result<CaptureSpillRecord> {
     let record: CaptureSpillRecordCompat = serde_json::from_str(line)?;
-    Ok(record.into())
+    Ok(record.into_record(legacy_spill_event_id(line, line_index)))
 }
 
-fn legacy_spill_event_content(event: &ParsedHookEvent, summary: &EventSummary) -> String {
-    serde_json::json!({
-        "summary": &summary.summary,
-        "event_type": &summary.event_type,
-        "detail": summary.detail.as_deref(),
-        "files": summary.files_json.as_deref(),
-        "exit_code": summary.exit_code,
-        "tool_name": &event.tool_name,
-        "tool_input": event
-            .tool_input
-            .as_ref()
-            .map(crate::adapter::common::redact_sensitive_value),
-        "tool_response": event
-            .tool_response
-            .as_ref()
-            .map(crate::adapter::common::redact_sensitive_value),
-    })
-    .to_string()
+fn legacy_spill_event_id(line: &str, line_index: usize) -> String {
+    format!(
+        "tool_result-legacy-spill-{}-{:016x}",
+        line_index + 1,
+        crate::db::deterministic_hash(line.as_bytes())
+    )
 }
 
 fn spill_path() -> PathBuf {
@@ -263,7 +282,7 @@ mod tests {
     use crate::adapter::{EventSummary, ParsedHookEvent};
     use crate::db::{self, test_support::ScopedTestDataDir};
 
-    use super::{replay_spilled_capture_events, spill_capture_event};
+    use super::{replay_spilled_capture_events, spill_capture_event, SPILL_REASON_DB_OPEN_FAILED};
 
     #[test]
     fn replay_spilled_capture_event_records_capture_and_drop_ledger() -> anyhow::Result<()> {
@@ -292,7 +311,14 @@ mod tests {
         })
         .to_string();
         let event_id = db::unique_capture_event_id("tool_result", &content);
-        spill_capture_event("codex-cli", &event_id, &event, &summary, &err)?;
+        spill_capture_event(
+            "codex-cli",
+            &event_id,
+            &event,
+            &summary,
+            SPILL_REASON_DB_OPEN_FAILED,
+            &err,
+        )?;
         let conn = db::open_db()?;
 
         let replayed = replay_spilled_capture_events(&conn)?;
@@ -303,8 +329,13 @@ mod tests {
         let drops: i64 = conn.query_row("SELECT COUNT(*) FROM capture_drop_events", [], |row| {
             row.get(0)
         })?;
+        let drop_reason: String =
+            conn.query_row("SELECT reason FROM capture_drop_events", [], |row| {
+                row.get(0)
+            })?;
         assert_eq!(captured, 1);
         assert_eq!(drops, 1);
+        assert_eq!(drop_reason, SPILL_REASON_DB_OPEN_FAILED);
         Ok(())
     }
 
@@ -333,6 +364,7 @@ mod tests {
             "tool_result-identical-a",
             &event,
             &summary,
+            SPILL_REASON_DB_OPEN_FAILED,
             &err,
         )?;
         spill_capture_event(
@@ -340,6 +372,7 @@ mod tests {
             "tool_result-identical-b",
             &event,
             &summary,
+            SPILL_REASON_DB_OPEN_FAILED,
             &err,
         )?;
         let conn = db::open_db()?;
@@ -398,6 +431,82 @@ mod tests {
     }
 
     #[test]
+    fn replay_legacy_spill_preserves_synthesized_id_after_partial_failure() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-legacy-stable-id");
+        let legacy = serde_json::json!({
+            "version": 1,
+            "host": "codex-cli",
+            "event": {
+                "session_id": "session-legacy-stable",
+                "cwd": "/tmp/remem",
+                "project": "/tmp/remem",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "/tmp/remem/src/lib.rs"},
+                "tool_response": {"ok": true}
+            },
+            "summary": {
+                "event_type": "file_edit",
+                "summary": "Edited src/lib.rs",
+                "detail": null,
+                "files_json": "[\"src/lib.rs\"]",
+                "exit_code": null
+            },
+            "db_error": "database is locked",
+            "created_at_epoch": 1700000000
+        });
+        let path = crate::db::data_dir().join("capture-spill.jsonl");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, format!("{legacy}\n"))?;
+        let conn = db::open_db()?;
+        conn.execute_batch(
+            "CREATE TRIGGER fail_legacy_events_insert
+             BEFORE INSERT ON events
+             BEGIN
+                 SELECT RAISE(FAIL, 'legacy events blocked');
+             END;",
+        )?;
+
+        let replayed = replay_spilled_capture_events(&conn)?;
+
+        assert_eq!(replayed, 0);
+        let partial_captures: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'session-legacy-stable'",
+            [],
+            |row| row.get(0),
+        )?;
+        let partial_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'session-legacy-stable'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(partial_captures, 1);
+        assert_eq!(partial_events, 0);
+        let failed_spill = std::fs::read_to_string(&path)?;
+        assert!(failed_spill.contains(r#""event_id":"tool_result-legacy-spill-1-"#));
+
+        conn.execute_batch("DROP TRIGGER fail_legacy_events_insert;")?;
+        let replayed = replay_spilled_capture_events(&conn)?;
+
+        assert_eq!(replayed, 1);
+        let replayed_captures: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'session-legacy-stable'",
+            [],
+            |row| row.get(0),
+        )?;
+        let replayed_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'session-legacy-stable'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(replayed_captures, 1);
+        assert_eq!(replayed_events, 1);
+        assert!(!path.exists());
+        Ok(())
+    }
+
+    #[test]
     fn spill_redacts_summary_and_database_error() -> anyhow::Result<()> {
         let _test_dir = ScopedTestDataDir::new("capture-spill-redacts");
         let err = anyhow::anyhow!("database token=github_pat_secret");
@@ -419,7 +528,14 @@ mod tests {
             exit_code: Some(1),
         };
 
-        spill_capture_event("codex-cli", "tool_result-redact", &event, &summary, &err)?;
+        spill_capture_event(
+            "codex-cli",
+            "tool_result-redact",
+            &event,
+            &summary,
+            SPILL_REASON_DB_OPEN_FAILED,
+            &err,
+        )?;
         let stored = std::fs::read_to_string(crate::db::data_dir().join("capture-spill.jsonl"))?;
 
         assert!(stored.contains("[REDACTED]"));

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::adapter::{EventSummary, ParsedHookEvent};
 
@@ -39,12 +39,16 @@ impl CaptureSpillRecordCompat {
             version: self.version,
             event_id: self.event_id.unwrap_or(fallback_event_id),
             host: self.host,
-            event: self.event,
-            summary: self.summary,
+            event: sanitize_event(&self.event),
+            summary: sanitize_summary(&self.summary),
             failure_reason: self
                 .failure_reason
                 .unwrap_or_else(|| SPILL_REASON_DB_OPEN_FAILED.to_string()),
-            db_error: self.db_error,
+            db_error: crate::db::truncate_str(
+                &crate::db::capture::redact_capture_content(&self.db_error),
+                1000,
+            )
+            .to_string(),
             created_at_epoch: self.created_at_epoch,
         }
     }
@@ -142,29 +146,9 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
         .enumerate()
     {
         match parse_spill_record(line, line_index) {
-            Ok(record) => match super::hook::record_observed_event_with_id(
-                conn,
-                &record.host,
-                &record.event_id,
-                &record.event,
-                &record.summary,
-            ) {
-                Ok(event_id) => {
-                    crate::db::record_capture_drop(
-                        conn,
-                        &crate::db::CaptureDropInput {
-                            host: Some(&record.host),
-                            session_id: Some(&record.event.session_id),
-                            project: Some(&record.event.project),
-                            tool_name: Some(&record.event.tool_name),
-                            reason: &record.failure_reason,
-                            detail: Some(&record.db_error),
-                            spill_path: Some(&path.display().to_string()),
-                            recovered_event_id: Some(event_id),
-                        },
-                    )?;
-                    replayed += 1;
-                }
+            Ok(record) => match replay_spill_record(conn, &path, &record) {
+                Ok(true) => replayed += 1,
+                Ok(false) => {}
                 Err(error) => append_failed_spill_record(&failed_path, &record, &error)?,
             },
             Err(error) => append_failed_spill_line(&failed_path, line, &error)?,
@@ -189,6 +173,43 @@ pub(super) fn replay_spilled_capture_events(conn: &Connection) -> Result<usize> 
         );
     }
     Ok(replayed)
+}
+
+fn replay_spill_record(
+    conn: &Connection,
+    spill_path: &Path,
+    record: &CaptureSpillRecord,
+) -> Result<bool> {
+    if recovered_spill_exists(conn, record)? {
+        return Ok(false);
+    }
+
+    let tx = conn
+        .unchecked_transaction()
+        .context("start capture spill replay transaction")?;
+    let event_id = super::hook::record_observed_event_with_id(
+        &tx,
+        &record.host,
+        &record.event_id,
+        &record.event,
+        &record.summary,
+    )?;
+    crate::db::record_capture_drop(
+        &tx,
+        &crate::db::CaptureDropInput {
+            host: Some(&record.host),
+            session_id: Some(&record.event.session_id),
+            project: Some(&record.event.project),
+            tool_name: Some(&record.event.tool_name),
+            reason: &record.failure_reason,
+            detail: Some(&record.db_error),
+            spill_path: Some(&spill_path.display().to_string()),
+            recovered_event_id: Some(event_id),
+        },
+    )?;
+    tx.commit()
+        .context("commit capture spill replay transaction")?;
+    Ok(true)
 }
 
 fn append_failed_spill_line(path: &PathBuf, line: &str, error: &anyhow::Error) -> Result<()> {
@@ -259,6 +280,32 @@ fn sanitize_summary(summary: &EventSummary) -> EventSummary {
 fn parse_spill_record(line: &str, line_index: usize) -> Result<CaptureSpillRecord> {
     let record: CaptureSpillRecordCompat = serde_json::from_str(line)?;
     Ok(record.into_record(legacy_spill_event_id(line, line_index)))
+}
+
+fn recovered_spill_exists(conn: &Connection, record: &CaptureSpillRecord) -> Result<bool> {
+    let exists = conn
+        .query_row(
+            "SELECT 1
+             FROM captured_events captured
+             JOIN hosts ON hosts.id = captured.host_id
+             JOIN capture_drop_events drop_event
+               ON drop_event.recovered_event_id = captured.id
+             WHERE hosts.name = ?1
+               AND captured.session_id = ?2
+               AND captured.event_id = ?3
+               AND drop_event.reason = ?4
+             LIMIT 1",
+            rusqlite::params![
+                &record.host,
+                &record.event.session_id,
+                &record.event_id,
+                &record.failure_reason
+            ],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    Ok(exists)
 }
 
 fn legacy_spill_event_id(line: &str, line_index: usize) -> String {
@@ -382,7 +429,85 @@ mod tests {
         assert_eq!(replayed, 2);
         let captured: i64 =
             conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))?;
+        let events: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
         assert_eq!(captured, 2);
+        assert_eq!(events, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn replay_identical_spill_retry_appends_partial_second_legacy_event() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-identical-partial-retry");
+        let err = anyhow::anyhow!("database is locked");
+        let event = ParsedHookEvent {
+            session_id: "session-identical-partial".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Edit".to_string(),
+            tool_input: Some(serde_json::json!({"file_path": "/tmp/remem/src/lib.rs"})),
+            tool_response: Some(serde_json::json!({"ok": true})),
+        };
+        let summary = EventSummary {
+            event_type: "file_edit".to_string(),
+            summary: "Edited src/lib.rs".to_string(),
+            detail: None,
+            files_json: Some("[\"src/lib.rs\"]".to_string()),
+            exit_code: None,
+        };
+        spill_capture_event(
+            "codex-cli",
+            "tool_result-identical-partial-a",
+            &event,
+            &summary,
+            SPILL_REASON_DB_OPEN_FAILED,
+            &err,
+        )?;
+        spill_capture_event(
+            "codex-cli",
+            "tool_result-identical-partial-b",
+            &event,
+            &summary,
+            SPILL_REASON_DB_OPEN_FAILED,
+            &err,
+        )?;
+        let conn = db::open_db()?;
+        conn.execute_batch(
+            "CREATE TRIGGER fail_second_legacy_event
+             BEFORE INSERT ON events
+             WHEN (SELECT COUNT(*) FROM events WHERE session_id = 'session-identical-partial') >= 1
+             BEGIN
+                 SELECT RAISE(FAIL, 'legacy events blocked');
+             END;",
+        )?;
+
+        assert_eq!(replay_spilled_capture_events(&conn)?, 1);
+        let partial_captured: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'session-identical-partial'",
+            [],
+            |row| row.get(0),
+        )?;
+        let partial_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'session-identical-partial'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(partial_captured, 1);
+        assert_eq!(partial_events, 1);
+
+        conn.execute_batch("DROP TRIGGER fail_second_legacy_event;")?;
+        assert_eq!(replay_spilled_capture_events(&conn)?, 1);
+        let replayed_captured: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM captured_events WHERE session_id = 'session-identical-partial'",
+            [],
+            |row| row.get(0),
+        )?;
+        let replayed_events: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM events WHERE session_id = 'session-identical-partial'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(replayed_captured, 2);
+        assert_eq!(replayed_events, 2);
         Ok(())
     }
 
@@ -402,12 +527,12 @@ mod tests {
             },
             "summary": {
                 "event_type": "file_edit",
-                "summary": "Edited src/lib.rs",
-                "detail": null,
+                "summary": "Edited src/lib.rs with ghp_abcdefghijklmnopqrstuvwxyz123456",
+                "detail": "password=hunter2",
                 "files_json": "[\"src/lib.rs\"]",
                 "exit_code": null
             },
-            "db_error": "database is locked",
+            "db_error": "database token=github_pat_secret",
             "created_at_epoch": 1700000000
         });
         let path = crate::db::data_dir().join("capture-spill.jsonl");
@@ -426,6 +551,22 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(captured, 1);
+        let replayed_event: (String, String) = conn.query_row(
+            "SELECT summary, detail FROM events WHERE session_id = 'session-legacy-spill'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let drop_detail: String = conn.query_row(
+            "SELECT detail FROM capture_drop_events WHERE session_id = 'session-legacy-spill'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(replayed_event.0.contains("[REDACTED]"));
+        assert!(!replayed_event
+            .0
+            .contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
+        assert!(!replayed_event.1.contains("hunter2"));
+        assert!(!drop_detail.contains("github_pat_secret"));
         assert!(!path.exists());
         Ok(())
     }
@@ -481,7 +622,7 @@ mod tests {
             [],
             |row| row.get(0),
         )?;
-        assert_eq!(partial_captures, 1);
+        assert_eq!(partial_captures, 0);
         assert_eq!(partial_events, 0);
         let failed_spill = std::fs::read_to_string(&path)?;
         assert!(failed_spill.contains(r#""event_id":"tool_result-legacy-spill-1-"#));


### PR DESCRIPTION
## Summary
- preserve a unique spill event_id through replay so repeated identical captured events do not collapse
- spill capture events when persistence fails after DB open, then replay with the same capture id without duplicating recovered captures
- redact drop details, spill summaries/details, spill DB errors, and token-like substrings before persistence/display
- split capture-drop health into expected skips vs actionable drops so default filters do not keep doctor in WARN
- bump remem/plugin runtime version to 0.5.32 after #423 landed

Follow-up for #363 after #422. Replaces #434. Fixes #363.

## Verification
- cargo fmt --check
- cargo check --message-format=short
- python3 scripts/ci/check_plugin_version_sync.py && python3 scripts/ci/check_version_bump.py origin/main WORKTREE && git diff --check origin/main
- cargo test observe_spills_persistence_failure
- cargo test observe::spill::tests
- cargo test capture_drop
- cargo test check_capture_drops
- cargo test query_system_stats
- cargo clippy -- -D warnings
- cargo test