### PR TITLE
Exclude expired memories from active stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.32"
+version = "0.5.33"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.31"
+version = "0.5.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.32"
+version = "0.5.33"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.31"
+version = "0.5.32"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.32": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.32",
+    "0.5.33": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.33",
       "assets": {}
     }
   }

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.31": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.31",
+    "0.5.32": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.32",
       "assets": {}
     }
   }

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -241,7 +241,10 @@ pub fn query_memory_facts_stats(conn: &Connection) -> Result<MemoryFactsStats> {
              WHERE f.status = 'active'
                AND f.valid_from_epoch IS NOT NULL
                AND m.status = 'active'
-               AND (m.expires_at_epoch IS NULL OR m.expires_at_epoch > strftime('%s', 'now'))",
+               AND (
+                 m.expires_at_epoch IS NULL
+                 OR m.expires_at_epoch > CAST(strftime('%s', 'now') AS INTEGER)
+               )",
             [],
             |row| row.get(0),
         )?

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -92,11 +92,7 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
         .map(|heartbeat| now.saturating_sub(heartbeat.updated_at_epoch));
     let worker_daemon_healthy = healthy_worker_heartbeat.is_some();
     Ok(SystemStats {
-        active_memories: conn.query_row(
-            "SELECT COUNT(*) FROM memories WHERE status = 'active'",
-            [],
-            |row| row.get(0),
-        )?,
+        active_memories: query_current_active_memory_count(conn)?,
         active_observations: conn.query_row(
             "SELECT COUNT(*) FROM observations WHERE status = 'active'",
             [],
@@ -251,11 +247,7 @@ pub fn query_memory_facts_stats(conn: &Connection) -> Result<MemoryFactsStats> {
         0
     };
     let active_memories = if memories_exists {
-        conn.query_row(
-            "SELECT COUNT(*) FROM memories WHERE status = 'active'",
-            [],
-            |row| row.get(0),
-        )?
+        query_current_active_memory_count(conn)?
     } else {
         0
     };
@@ -335,6 +327,20 @@ fn query_raw_ingest_failure_stats(conn: &Connection) -> Result<RawIngestFailureS
     })
 }
 
+fn query_current_active_memory_count(conn: &Connection) -> Result<i64> {
+    Ok(conn.query_row(
+        "SELECT COUNT(*)
+         FROM memories
+         WHERE status = 'active'
+           AND (
+             expires_at_epoch IS NULL
+             OR expires_at_epoch > CAST(strftime('%s', 'now') AS INTEGER)
+           )",
+        [],
+        |row| row.get(0),
+    )?)
+}
+
 fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
     Ok(conn
         .query_row(
@@ -403,7 +409,13 @@ pub fn query_candidate_promotion_stats(
 
 pub fn query_top_projects(conn: &Connection, limit: i64) -> Result<Vec<ProjectCount>> {
     let mut stmt = conn.prepare(
-        "SELECT project, COUNT(*) as cnt FROM memories WHERE status = 'active' \
+        "SELECT project, COUNT(*) as cnt
+         FROM memories
+         WHERE status = 'active'
+           AND (
+             expires_at_epoch IS NULL
+             OR expires_at_epoch > CAST(strftime('%s', 'now') AS INTEGER)
+           )
          GROUP BY project ORDER BY cnt DESC, project ASC LIMIT ?1",
     )?;
     let rows = stmt.query_map(params![limit], |row| {

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -7,7 +7,7 @@ use crate::db::models::{
 use crate::db::query::{
     query_ai_usage_breakdown, query_ai_usage_source_totals, query_ai_usage_totals,
     query_candidate_promotion_stats, query_daily_activity_stats, query_daily_ai_usage,
-    query_system_stats, query_top_projects, query_weekly_ai_usage,
+    query_memory_facts_stats, query_system_stats, query_top_projects, query_weekly_ai_usage,
 };
 
 fn setup_stats_schema(conn: &Connection) {
@@ -42,6 +42,12 @@ fn setup_stats_schema(conn: &Connection) {
         );
         CREATE TABLE captured_events (
             id INTEGER PRIMARY KEY
+        );
+        CREATE TABLE memory_facts (
+            id INTEGER PRIMARY KEY,
+            status TEXT NOT NULL,
+            valid_from_epoch INTEGER,
+            source_memory_id INTEGER
         );
         CREATE TABLE capture_drop_events (
             id INTEGER PRIMARY KEY,
@@ -340,6 +346,37 @@ fn query_system_stats_and_related_views_share_one_definition() {
             },
         ]
     );
+}
+
+#[test]
+fn query_memory_facts_stats_excludes_expired_source_memories() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_stats_schema(&conn);
+
+    conn.execute_batch(
+        "INSERT INTO memories (id, project, status, created_at_epoch, expires_at_epoch)
+         VALUES
+            (1, 'alpha', 'active', 100, NULL),
+            (2, 'alpha', 'active', 110, CAST(strftime('%s', 'now') AS INTEGER) + 3600),
+            (3, 'alpha', 'active', 120, CAST(strftime('%s', 'now') AS INTEGER) - 1),
+            (4, 'alpha', 'archived', 130, NULL);
+         INSERT INTO memory_facts (status, valid_from_epoch, source_memory_id)
+         VALUES
+            ('active', 100, 1),
+            ('active', 110, 2),
+            ('active', 120, 3),
+            ('active', 130, 4),
+            ('active', NULL, 1),
+            ('stale', 140, 1);",
+    )?;
+
+    let stats = query_memory_facts_stats(&conn)?;
+
+    assert!(stats.table_exists);
+    assert_eq!(stats.total, 6);
+    assert_eq!(stats.active_memories, 2);
+    assert_eq!(stats.retrieval_eligible, 2);
+    Ok(())
 }
 
 #[test]

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -16,7 +16,8 @@ fn setup_stats_schema(conn: &Connection) {
             id INTEGER PRIMARY KEY,
             project TEXT NOT NULL,
             status TEXT NOT NULL,
-            created_at_epoch INTEGER NOT NULL
+            created_at_epoch INTEGER NOT NULL,
+            expires_at_epoch INTEGER
         );
         CREATE TABLE observations (
             id INTEGER PRIMARY KEY,
@@ -134,6 +135,20 @@ fn query_system_stats_and_related_views_share_one_definition() {
         [],
     )
     .expect("second active memory insert should succeed");
+    if let Err(err) = conn.execute(
+        "INSERT INTO memories (project, status, created_at_epoch, expires_at_epoch)
+         VALUES ('gamma', 'active', 310, strftime('%s', 'now') - 1)",
+        [],
+    ) {
+        panic!("expired active memory insert should succeed: {err}");
+    }
+    if let Err(err) = conn.execute(
+        "INSERT INTO memories (project, status, created_at_epoch, expires_at_epoch)
+         VALUES ('delta', 'active', 320, CAST(strftime('%s', 'now') AS INTEGER) + 3600)",
+        [],
+    ) {
+        panic!("future-expiring active memory insert should succeed: {err}");
+    }
     conn.execute(
         "INSERT INTO observations (project, status, created_at_epoch) VALUES ('alpha', 'active', 220)",
         [],
@@ -252,7 +267,7 @@ fn query_system_stats_and_related_views_share_one_definition() {
     assert_eq!(
         system,
         SystemStats {
-            active_memories: 2,
+            active_memories: 3,
             active_observations: 1,
             session_summaries: 1,
             raw_messages: 0,
@@ -301,7 +316,7 @@ fn query_system_stats_and_related_views_share_one_definition() {
     assert_eq!(
         daily,
         DailyActivityStats {
-            memories: 2,
+            memories: 4,
             observations: 1,
         }
     );
@@ -316,6 +331,10 @@ fn query_system_stats_and_related_views_share_one_definition() {
             },
             ProjectCount {
                 project: "beta".to_string(),
+                count: 1,
+            },
+            ProjectCount {
+                project: "delta".to_string(),
                 count: 1,
             },
         ]

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -231,7 +231,11 @@ pub(super) fn check_temporal_facts(conn: Option<&Connection>) -> Check {
         );
     }
 
-    if stats.retrieval_eligible == 0 && stats.active_memories == 0 && stats.captured_events == 0 {
+    if stats.total == 0
+        && stats.retrieval_eligible == 0
+        && stats.active_memories == 0
+        && stats.captured_events == 0
+    {
         return Check::new(
             "Temporal facts",
             Status::Ok,


### PR DESCRIPTION
Fixes #420.

## Summary
- Count active memories through a shared current-active helper that excludes TTL-expired rows.
- Keep top-project stats aligned with the same current-active visibility rule.
- Preserve daily activity as creation activity while keeping doctor temporal-fact checks from treating expired fact rows as an empty store.
- Bump version to 0.5.32.

## Verification
- cargo fmt --all -- --check
- cargo check
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- git diff --check origin/main...HEAD
- cargo test -- --test-threads=1