### PR TITLE
Hide stale memories from default search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.31"
+version = "0.5.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.31"
+version = "0.5.32"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.31": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.31",
+    "0.5.32": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.32",
       "assets": {}
     }
   }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -11,7 +11,7 @@ use tower::ServiceExt;
 use crate::db::test_support::ScopedTestDataDir;
 use crate::{db, memory};
 
-use super::handlers::{handle_status, search_request_from_params};
+use super::handlers::{handle_search, handle_status, search_request_from_params};
 use super::types::SearchParams;
 use super::DbState;
 
@@ -45,8 +45,8 @@ fn search_request_from_params_clamps_limit_and_offset() {
 
     assert_eq!(request.limit, 100);
     assert_eq!(request.offset, 0);
-    // Canonical default for `include_stale` is `true` so MCP and REST agree.
-    assert!(request.include_stale);
+    // Canonical default hides stale and archived memories unless callers opt in.
+    assert!(!request.include_stale);
     assert!(!request.multi_hop);
     assert!(!request.explain);
 }
@@ -74,6 +74,73 @@ fn search_request_from_params_preserves_filters() {
     assert_eq!(request.branch.as_deref(), Some("main"));
     assert!(request.multi_hop);
     assert!(request.explain);
+}
+
+#[tokio::test]
+async fn search_handler_hides_archived_memories_by_default() -> anyhow::Result<()> {
+    let _test_dir = ScopedTestDataDir::new("api-search-default-active");
+    let conn = db::open_db()?;
+
+    memory::insert_memory(
+        &conn,
+        Some("session-active"),
+        "proj-a",
+        None,
+        "aurora active",
+        "aurora visible memory",
+        "decision",
+        None,
+    )?;
+    let archived_id = memory::insert_memory(
+        &conn,
+        Some("session-archived"),
+        "proj-a",
+        None,
+        "aurora archived",
+        "aurora hidden memory",
+        "decision",
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memories SET status = 'archived' WHERE id = ?1",
+        params![archived_id],
+    )?;
+    drop(conn);
+
+    let response = handle_search(
+        State(DbState),
+        axum::extract::Query(SearchParams {
+            query: Some("aurora".to_string()),
+            project: Some("proj-a".to_string()),
+            memory_type: None,
+            limit: Some(10),
+            offset: None,
+            include_stale: None,
+            branch: None,
+            multi_hop: None,
+            explain: None,
+        }),
+    )
+    .await
+    .into_response();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await?;
+    let payload: Value = serde_json::from_slice(&body)?;
+    let data = payload["data"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("search response data should be an array"))?;
+    let titles: Vec<&str> = data
+        .iter()
+        .map(|item| {
+            item["title"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("search item title should be a string"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    assert_eq!(titles, vec!["aurora active"]);
+    Ok(())
 }
 
 #[tokio::test]

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -77,7 +77,7 @@ fn search_request_from_params_preserves_filters() {
 }
 
 #[tokio::test]
-async fn search_handler_hides_archived_memories_by_default() -> anyhow::Result<()> {
+async fn search_handler_hides_inactive_memories_by_default() -> anyhow::Result<()> {
     let _test_dir = ScopedTestDataDir::new("api-search-default-active");
     let conn = db::open_db()?;
 
@@ -91,6 +91,16 @@ async fn search_handler_hides_archived_memories_by_default() -> anyhow::Result<(
         "decision",
         None,
     )?;
+    let stale_id = memory::insert_memory(
+        &conn,
+        Some("session-stale"),
+        "proj-a",
+        None,
+        "aurora stale",
+        "aurora stale memory",
+        "decision",
+        None,
+    )?;
     let archived_id = memory::insert_memory(
         &conn,
         Some("session-archived"),
@@ -100,6 +110,10 @@ async fn search_handler_hides_archived_memories_by_default() -> anyhow::Result<(
         "aurora hidden memory",
         "decision",
         None,
+    )?;
+    conn.execute(
+        "UPDATE memories SET status = 'stale' WHERE id = ?1",
+        params![stale_id],
     )?;
     conn.execute(
         "UPDATE memories SET status = 'archived' WHERE id = ?1",

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -289,7 +289,7 @@ mod tests {
     }
 
     #[test]
-    fn search_hides_archived_memories_by_default() -> Result<()> {
+    fn search_hides_inactive_memories_by_default() -> Result<()> {
         let _dir = ScopedTestDataDir::new("mcp-search-default-active");
         let conn = crate::db::open_db()?;
         let active_id = memory::insert_memory(
@@ -302,6 +302,16 @@ mod tests {
             "decision",
             None,
         )?;
+        let stale_id = memory::insert_memory(
+            &conn,
+            Some("session-stale"),
+            "/repo",
+            Some("aurora-stale"),
+            "Aurora stale memory",
+            "The aurora stale decision is hidden by default.",
+            "decision",
+            None,
+        )?;
         let archived_id = memory::insert_memory(
             &conn,
             Some("session-archived"),
@@ -311,6 +321,10 @@ mod tests {
             "The aurora archived decision is hidden by default.",
             "decision",
             None,
+        )?;
+        conn.execute(
+            "UPDATE memories SET status = 'stale' WHERE id = ?1",
+            rusqlite::params![stale_id],
         )?;
         conn.execute(
             "UPDATE memories SET status = 'archived' WHERE id = ?1",

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -236,6 +236,13 @@ mod tests {
         }
     }
 
+    fn default_visibility_search_params() -> SearchParams {
+        SearchParams {
+            include_stale: None,
+            ..base_search_params(None)
+        }
+    }
+
     fn multi_hop_explain_params() -> SearchParams {
         SearchParams {
             multi_hop: Some(true),
@@ -278,6 +285,47 @@ mod tests {
             explain_json["explain"]["results"][0]["memory_id"],
             memory_id
         );
+        Ok(())
+    }
+
+    #[test]
+    fn search_hides_archived_memories_by_default() -> Result<()> {
+        let _dir = ScopedTestDataDir::new("mcp-search-default-active");
+        let conn = crate::db::open_db()?;
+        let active_id = memory::insert_memory(
+            &conn,
+            Some("session-active"),
+            "/repo",
+            Some("aurora-active"),
+            "Aurora active memory",
+            "The aurora active decision remains visible.",
+            "decision",
+            None,
+        )?;
+        let archived_id = memory::insert_memory(
+            &conn,
+            Some("session-archived"),
+            "/repo",
+            Some("aurora-archived"),
+            "Aurora archived memory",
+            "The aurora archived decision is hidden by default.",
+            "decision",
+            None,
+        )?;
+        conn.execute(
+            "UPDATE memories SET status = 'archived' WHERE id = ?1",
+            rusqlite::params![archived_id],
+        )?;
+        drop(conn);
+
+        let server = MemoryServer::new()?;
+        let response = server
+            .search(Parameters(default_visibility_search_params()))
+            .map_err(anyhow::Error::msg)?;
+        let json: Value = serde_json::from_str(&response)?;
+
+        assert_eq!(json["results"].as_array().map(Vec::len), Some(1));
+        assert_eq!(json["results"][0]["id"], active_id);
         Ok(())
     }
 

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -13,7 +13,7 @@ pub(super) struct SearchParams {
     pub r#type: Option<String>,
     #[schemars(description = "Result offset for pagination")]
     pub offset: Option<i64>,
-    #[schemars(description = "Include stale observations (default true, stale ranked lower)")]
+    #[schemars(description = "Include stale or archived memories (default false)")]
     pub include_stale: Option<bool>,
     #[schemars(
         description = "Git branch filter (e.g. 'main', 'feat/auth'). Only returns memories from this branch. Old data without branch info is always included."

--- a/src/memory/service/types.rs
+++ b/src/memory/service/types.rs
@@ -13,10 +13,10 @@ pub struct SearchRequest {
 
 /// Canonical default for `include_stale` across every adapter (MCP, REST, CLI).
 ///
-/// Stale memories are kept by default so callers see the full history. Adapters
-/// that want curated-only results must opt in by passing `Some(false)`.
+/// Default search returns only current curated memories. Callers that need
+/// stale or archived history must opt in explicitly.
 pub fn default_include_stale() -> bool {
-    true
+    false
 }
 
 #[derive(Debug, Clone)]

--- a/tests/rate_limit.rs
+++ b/tests/rate_limit.rs
@@ -193,20 +193,22 @@ fn search_offset_applies_to_memory_pages() -> Result<()> {
 }
 
 #[test]
-fn search_include_stale_controls_archived_memories() -> Result<()> {
+fn search_include_stale_controls_inactive_memories() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     setup_memory_schema(&conn)?;
 
     insert_memory_row(&conn, 1, "proj", "archived", 300, "archived", None)?;
-    insert_memory_row(&conn, 2, "proj", "active", 200, "active", None)?;
+    insert_memory_row(&conn, 2, "proj", "stale", 250, "stale", None)?;
+    insert_memory_row(&conn, 3, "proj", "active", 200, "active", None)?;
 
     let active_only = search::search(&conn, None, Some("proj"), None, 10, 0, false)?;
     assert_eq!(active_only.len(), 1);
     assert_eq!(active_only[0].title, "active");
 
     let with_archived = search::search(&conn, None, Some("proj"), None, 10, 0, true)?;
-    assert_eq!(with_archived.len(), 2);
+    assert_eq!(with_archived.len(), 3);
     assert_eq!(with_archived[0].title, "archived");
+    assert_eq!(with_archived[1].title, "stale");
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #424.

## Summary
- Change the shared include_stale default to curated-only search.
- Keep stale/archived history available through explicit include_stale=true / --include-stale opt-in.
- Update MCP schema wording to match the new default.
- Add REST and MCP regression tests proving archived memories are hidden when callers omit include_stale.
- Bump version to 0.5.32.

## Verification
- cargo fmt --all -- --check
- cargo check
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- git diff --check origin/main...HEAD
- cargo test search_request_from_params_clamps_limit_and_offset -- --test-threads=1
- cargo test search_handler_hides_archived_memories_by_default -- --test-threads=1
- cargo test search_hides_archived_memories_by_default -- --test-threads=1
- cargo test -- --test-threads=1