### PR TITLE
Validate doctor hook commands strictly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.34"
+version = "0.5.35"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.34"
+version = "0.5.35"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.34",
+  "version": "0.5.35",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.34": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.34",
+    "0.5.35": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.35",
       "assets": {}
     }
   }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,6 +1,7 @@
 mod database;
 mod environment;
 pub(crate) mod health_action;
+mod hook_validation;
 mod native_memory;
 mod report;
 mod runtime_config_check;

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -348,9 +348,10 @@ fn configured_mcp_paths(probe: &HostProbe) -> Vec<PathBuf> {
 }
 
 fn expected_hook_executable(doc: &Value, probe: &HostProbe) -> Option<PathBuf> {
-    expected_hook_executable_from_hooks(doc, probe.name)
-        .map(PathBuf::from)
-        .or_else(|| configured_mcp_paths(probe).into_iter().next())
+    configured_mcp_paths(probe)
+        .into_iter()
+        .next()
+        .or_else(|| expected_hook_executable_from_hooks(doc, probe.name).map(PathBuf::from))
 }
 
 fn configured_hook_paths(path: &PathBuf) -> Vec<PathBuf> {
@@ -488,17 +489,17 @@ mod tests {
         });
         assert!(matches!(missing_mcp_check.status, Status::Ok));
 
-        let stale_mcp_path = dir.join("stale.toml");
+        let mismatched_mcp_path = dir.join("mismatch.toml");
         std::fs::write(
-            &stale_mcp_path,
-            "[mcp_servers.remem]\ncommand = \"/stale/remem\"\n",
+            &mismatched_mcp_path,
+            "[mcp_servers.remem]\ncommand = \"/configured/remem\"\n",
         )?;
-        let stale_mcp_check = probe_hooks(HostProbe {
+        let mismatched_mcp_check = probe_hooks(HostProbe {
             name: "codex",
             hooks_path: hooks_path.clone(),
-            mcp_paths: vec![stale_mcp_path],
+            mcp_paths: vec![mismatched_mcp_path],
         });
-        assert!(matches!(stale_mcp_check.status, Status::Ok));
+        assert!(matches!(mismatched_mcp_check.status, Status::Fail));
 
         let mcp_path = dir.join("config.toml");
         std::fs::write(&mcp_path, "[mcp_servers.remem]\ncommand = \"/tmp/remem\"\n")?;

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use toml_edit::DocumentMut;
 
 use super::hook_validation::{
-    event_has_expected_remem_hook, event_has_remem_subcommand_hook, extract_remem_command_path,
-    hook_command_strings, ExpectedHookCommand,
+    event_has_expected_remem_hook, event_has_remem_subcommand_hook, expected_hook_command,
+    expected_hook_events, extract_remem_command_path, hook_command_strings, runtime_host,
 };
 use super::types::{Check, Status};
 
@@ -165,20 +165,26 @@ fn probe_hooks(probe: HostProbe) -> Check {
     };
 
     let events = expected_hook_events(probe.name);
+    let expected_executable = expected_hook_executable(&probe);
     let found = events
         .iter()
         .filter(|event| {
-            expected_hook_command(probe.name, event)
+            expected_executable
+                .as_deref()
+                .and_then(|executable| expected_hook_command(probe.name, event, executable))
                 .is_some_and(|expected| event_has_expected_remem_hook(&doc, event, expected))
         })
         .count();
     let deprecated_codex_observe = probe.name == "codex"
-        && event_has_remem_subcommand_hook(
-            &doc,
-            "PostToolUse",
-            "observe",
-            runtime_host(probe.name),
-        );
+        && expected_executable.as_deref().is_some_and(|executable| {
+            event_has_remem_subcommand_hook(
+                &doc,
+                "PostToolUse",
+                executable,
+                "observe",
+                runtime_host(probe.name),
+            )
+        });
     let legacy_policy = has_legacy_hook_policy(&doc);
 
     if found == events.len() {
@@ -302,40 +308,6 @@ fn display_mcp_paths(paths: &[PathBuf]) -> String {
         .join(" or ")
 }
 
-fn expected_hook_events(host: &str) -> &'static [&'static str] {
-    match host {
-        "codex" => &["SessionStart", "Stop"],
-        _ => &[
-            "PostToolUse",
-            "PreCompact",
-            "Stop",
-            "SessionStart",
-            "UserPromptSubmit",
-        ],
-    }
-}
-
-fn runtime_host(host: &str) -> &'static str {
-    match host {
-        "codex" => "codex-cli",
-        _ => "claude-code",
-    }
-}
-
-fn expected_hook_command(host: &str, event: &str) -> Option<ExpectedHookCommand> {
-    let subcommand = match event {
-        "PostToolUse" => "observe",
-        "PreCompact" | "Stop" => "summarize",
-        "SessionStart" => "context",
-        "UserPromptSubmit" => "session-init",
-        _ => return None,
-    };
-    Some(ExpectedHookCommand {
-        subcommand,
-        host: runtime_host(host),
-    })
-}
-
 fn probe_mcp_path<'a>(
     host: &str,
     path: &'a PathBuf,
@@ -380,6 +352,14 @@ fn configured_mcp_paths(probe: &HostProbe) -> Vec<PathBuf> {
         }
     }
     paths
+}
+
+fn expected_hook_executable(probe: &HostProbe) -> Option<PathBuf> {
+    configured_mcp_paths(probe)
+        .into_iter()
+        .next()
+        .or_else(|| std::env::var_os("REMEM_INSTALL_BINARY").map(PathBuf::from))
+        .or_else(|| std::env::current_exe().ok())
 }
 
 fn configured_hook_paths(path: &PathBuf) -> Vec<PathBuf> {
@@ -466,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn probe_hooks_requires_remem_on_each_event() {
+    fn probe_hooks_requires_remem_on_each_event() -> anyhow::Result<()> {
         let dir = temp_path("doctor-hooks");
         let hooks_path = dir.join("hooks.json");
         std::fs::write(
@@ -479,21 +459,26 @@ mod tests {
     "UserPromptSubmit": [{ "hooks": [{ "command": "other-tool init" }] }]
   }
 }"#,
-        )
-        .unwrap();
+        )?;
+        let mcp_path = dir.join("claude.json");
+        std::fs::write(
+            &mcp_path,
+            r#"{ "mcpServers": { "remem": { "command": "/tmp/remem" } } }"#,
+        )?;
 
         let check = probe_hooks(HostProbe {
             name: "claude",
             hooks_path,
-            mcp_paths: vec![dir.join("config.toml")],
+            mcp_paths: vec![mcp_path],
         });
 
         assert!(matches!(check.status, Status::Warn));
         assert!(check.detail.contains("1/5 registered"), "{}", check.detail);
+        Ok(())
     }
 
     #[test]
-    fn probe_hooks_accepts_codex_strategy() {
+    fn probe_hooks_accepts_codex_strategy() -> anyhow::Result<()> {
         let dir = temp_path("doctor-codex-hooks");
         let hooks_path = dir.join("hooks.json");
         std::fs::write(
@@ -504,17 +489,19 @@ mod tests {
     "Stop": [{ "hooks": [{ "command": "/tmp/remem summarize --host codex-cli" }] }]
   }
 }"#,
-        )
-        .unwrap();
+        )?;
+        let mcp_path = dir.join("config.toml");
+        std::fs::write(&mcp_path, "[mcp_servers.remem]\ncommand = \"/tmp/remem\"\n")?;
 
         let check = probe_hooks(HostProbe {
             name: "codex",
             hooks_path,
-            mcp_paths: vec![dir.join("config.toml")],
+            mcp_paths: vec![mcp_path],
         });
 
         assert!(matches!(check.status, Status::Ok));
         assert!(check.detail.contains("2/2 registered"), "{}", check.detail);
+        Ok(())
     }
 
     #[test]
@@ -566,7 +553,7 @@ mod tests {
     }
 
     #[test]
-    fn probe_hooks_warns_on_codex_posttool_observe() {
+    fn probe_hooks_warns_on_codex_posttool_observe() -> anyhow::Result<()> {
         let dir = temp_path("doctor-codex-observe-warning");
         let hooks_path = dir.join("hooks.json");
         std::fs::write(
@@ -578,13 +565,14 @@ mod tests {
     "Stop": [{ "hooks": [{ "command": "/tmp/remem summarize --host codex-cli" }] }]
   }
 }"#,
-        )
-        .unwrap();
+        )?;
+        let mcp_path = dir.join("config.toml");
+        std::fs::write(&mcp_path, "[mcp_servers.remem]\ncommand = \"/tmp/remem\"\n")?;
 
         let check = probe_hooks(HostProbe {
             name: "codex",
             hooks_path,
-            mcp_paths: vec![dir.join("config.toml")],
+            mcp_paths: vec![mcp_path],
         });
 
         assert!(matches!(check.status, Status::Warn));
@@ -593,6 +581,7 @@ mod tests {
             "{}",
             check.detail
         );
+        Ok(())
     }
 
     #[test]

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -4,7 +4,8 @@ use toml_edit::DocumentMut;
 
 use super::hook_validation::{
     event_has_expected_remem_hook, event_has_remem_subcommand_hook, expected_hook_command,
-    expected_hook_events, extract_remem_command_path, hook_command_strings, runtime_host,
+    expected_hook_events, expected_hook_executable_from_hooks, extract_remem_command_path,
+    hook_command_strings,
 };
 use super::types::{Check, Status};
 
@@ -165,7 +166,7 @@ fn probe_hooks(probe: HostProbe) -> Check {
     };
 
     let events = expected_hook_events(probe.name);
-    let expected_executable = expected_hook_executable(&probe);
+    let expected_executable = expected_hook_executable(&doc, &probe);
     let found = events
         .iter()
         .filter(|event| {
@@ -175,16 +176,8 @@ fn probe_hooks(probe: HostProbe) -> Check {
                 .is_some_and(|expected| event_has_expected_remem_hook(&doc, event, expected))
         })
         .count();
-    let deprecated_codex_observe = probe.name == "codex"
-        && expected_executable.as_deref().is_some_and(|executable| {
-            event_has_remem_subcommand_hook(
-                &doc,
-                "PostToolUse",
-                executable,
-                "observe",
-                runtime_host(probe.name),
-            )
-        });
+    let deprecated_codex_observe =
+        probe.name == "codex" && event_has_remem_subcommand_hook(&doc, "PostToolUse", "observe");
     let legacy_policy = has_legacy_hook_policy(&doc);
 
     if found == events.len() {
@@ -354,8 +347,10 @@ fn configured_mcp_paths(probe: &HostProbe) -> Vec<PathBuf> {
     paths
 }
 
-fn expected_hook_executable(probe: &HostProbe) -> Option<PathBuf> {
-    configured_mcp_paths(probe).into_iter().next()
+fn expected_hook_executable(doc: &Value, probe: &HostProbe) -> Option<PathBuf> {
+    expected_hook_executable_from_hooks(doc, probe.name)
+        .map(PathBuf::from)
+        .or_else(|| configured_mcp_paths(probe).into_iter().next())
 }
 
 fn configured_hook_paths(path: &PathBuf) -> Vec<PathBuf> {
@@ -491,7 +486,7 @@ mod tests {
             hooks_path: hooks_path.clone(),
             mcp_paths: vec![dir.join("missing.toml")],
         });
-        assert!(matches!(missing_mcp_check.status, Status::Fail));
+        assert!(matches!(missing_mcp_check.status, Status::Ok));
 
         let mcp_path = dir.join("config.toml");
         std::fs::write(&mcp_path, "[mcp_servers.remem]\ncommand = \"/tmp/remem\"\n")?;
@@ -566,7 +561,7 @@ mod tests {
             r#"{
   "hooks": {
     "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context --host codex-cli" }] }],
-    "PostToolUse": [{ "hooks": [{ "command": "/tmp/remem observe --host codex-cli" }] }],
+    "PostToolUse": [{ "hooks": [{ "command": "/stale/remem observe --host codex-cli" }] }],
     "Stop": [{ "hooks": [{ "command": "/tmp/remem summarize --host codex-cli" }] }]
   }
 }"#,

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -488,6 +488,18 @@ mod tests {
         });
         assert!(matches!(missing_mcp_check.status, Status::Ok));
 
+        let stale_mcp_path = dir.join("stale.toml");
+        std::fs::write(
+            &stale_mcp_path,
+            "[mcp_servers.remem]\ncommand = \"/stale/remem\"\n",
+        )?;
+        let stale_mcp_check = probe_hooks(HostProbe {
+            name: "codex",
+            hooks_path: hooks_path.clone(),
+            mcp_paths: vec![stale_mcp_path],
+        });
+        assert!(matches!(stale_mcp_check.status, Status::Ok));
+
         let mcp_path = dir.join("config.toml");
         std::fs::write(&mcp_path, "[mcp_servers.remem]\ncommand = \"/tmp/remem\"\n")?;
 

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -1,7 +1,11 @@
 use serde_json::Value;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use toml_edit::DocumentMut;
 
+use super::hook_validation::{
+    event_has_expected_remem_hook, event_has_remem_subcommand_hook, extract_remem_command_path,
+    hook_command_strings, ExpectedHookCommand,
+};
 use super::types::{Check, Status};
 
 pub(super) fn check_binary() -> Check {
@@ -163,10 +167,18 @@ fn probe_hooks(probe: HostProbe) -> Check {
     let events = expected_hook_events(probe.name);
     let found = events
         .iter()
-        .filter(|event| event_has_remem_hook(&doc, event))
+        .filter(|event| {
+            expected_hook_command(probe.name, event)
+                .is_some_and(|expected| event_has_expected_remem_hook(&doc, event, expected))
+        })
         .count();
-    let deprecated_codex_observe =
-        probe.name == "codex" && event_has_remem_observe_hook(&doc, "PostToolUse");
+    let deprecated_codex_observe = probe.name == "codex"
+        && event_has_remem_subcommand_hook(
+            &doc,
+            "PostToolUse",
+            "observe",
+            runtime_host(probe.name),
+        );
     let legacy_policy = has_legacy_hook_policy(&doc);
 
     if found == events.len() {
@@ -303,6 +315,27 @@ fn expected_hook_events(host: &str) -> &'static [&'static str] {
     }
 }
 
+fn runtime_host(host: &str) -> &'static str {
+    match host {
+        "codex" => "codex-cli",
+        _ => "claude-code",
+    }
+}
+
+fn expected_hook_command(host: &str, event: &str) -> Option<ExpectedHookCommand> {
+    let subcommand = match event {
+        "PostToolUse" => "observe",
+        "PreCompact" | "Stop" => "summarize",
+        "SessionStart" => "context",
+        "UserPromptSubmit" => "session-init",
+        _ => return None,
+    };
+    Some(ExpectedHookCommand {
+        subcommand,
+        host: runtime_host(host),
+    })
+}
+
 fn probe_mcp_path<'a>(
     host: &str,
     path: &'a PathBuf,
@@ -378,39 +411,6 @@ fn codex_remem_mcp_command(doc: &DocumentMut) -> Option<&str> {
         .and_then(|command| command.as_str())
 }
 
-fn hook_command_strings(doc: &Value) -> impl Iterator<Item = &str> {
-    doc.get("hooks")
-        .and_then(|hooks| hooks.as_object())
-        .into_iter()
-        .flat_map(|hooks| hooks.values())
-        .filter_map(|entries| entries.as_array())
-        .flatten()
-        .filter_map(|entry| entry.get("hooks").and_then(|hooks| hooks.as_array()))
-        .flatten()
-        .filter_map(|hook| hook.get("command").and_then(|command| command.as_str()))
-}
-
-fn extract_remem_command_path(command: &str) -> Option<&str> {
-    command
-        .split_whitespace()
-        .map(trim_shell_quotes)
-        .find(|token| is_remem_command_token(token))
-}
-
-fn trim_shell_quotes(token: &str) -> &str {
-    token.trim_matches(|c| c == '"' || c == '\'')
-}
-
-fn is_remem_command_token(token: &str) -> bool {
-    if token.contains('=') && !token.contains('/') && !token.contains('\\') {
-        return false;
-    }
-    Path::new(token)
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .is_some_and(|stem| stem == "remem")
-}
-
 fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
     let mut unique = Vec::new();
     for path in paths {
@@ -419,50 +419,6 @@ fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
         }
     }
     unique
-}
-
-fn event_has_remem_hook(doc: &Value, event: &str) -> bool {
-    doc.get("hooks")
-        .and_then(|hooks| hooks.get(event))
-        .and_then(|entries| entries.as_array())
-        .into_iter()
-        .flatten()
-        .any(entry_has_remem_hook)
-}
-
-fn entry_has_remem_hook(entry: &Value) -> bool {
-    entry
-        .get("hooks")
-        .and_then(|hooks| hooks.as_array())
-        .into_iter()
-        .flatten()
-        .any(|hook| {
-            hook.get("command")
-                .and_then(|command| command.as_str())
-                .is_some_and(|command| command.contains("remem"))
-        })
-}
-
-fn event_has_remem_observe_hook(doc: &Value, event: &str) -> bool {
-    doc.get("hooks")
-        .and_then(|hooks| hooks.get(event))
-        .and_then(|entries| entries.as_array())
-        .into_iter()
-        .flatten()
-        .any(entry_has_remem_observe_hook)
-}
-
-fn entry_has_remem_observe_hook(entry: &Value) -> bool {
-    entry
-        .get("hooks")
-        .and_then(|hooks| hooks.as_array())
-        .into_iter()
-        .flatten()
-        .any(|hook| {
-            hook.get("command")
-                .and_then(|command| command.as_str())
-                .is_some_and(|command| command.contains("remem") && command.contains(" observe"))
-        })
 }
 
 fn has_legacy_hook_policy(doc: &Value) -> bool {
@@ -517,7 +473,7 @@ mod tests {
             &hooks_path,
             r#"{
   "hooks": {
-    "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context" }] }],
+    "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context --host claude-code" }] }],
     "Stop": [{ "hooks": [{ "command": "other-tool summarize" }] }],
     "PostToolUse": [{ "hooks": [{ "command": "other-tool observe" }] }],
     "UserPromptSubmit": [{ "hooks": [{ "command": "other-tool init" }] }]
@@ -559,6 +515,54 @@ mod tests {
 
         assert!(matches!(check.status, Status::Ok));
         assert!(check.detail.contains("2/2 registered"), "{}", check.detail);
+    }
+
+    #[test]
+    fn probe_hooks_rejects_wrong_remem_subcommands_and_hosts() -> anyhow::Result<()> {
+        let cases = [
+            (
+                "doctor-codex-wrong-subcommands",
+                r#"{
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "command": "/tmp/remem status --host codex-cli" }] }],
+    "Stop": [{ "hooks": [{ "command": "/tmp/remem context --host codex-cli" }] }]
+  }
+}"#,
+            ),
+            (
+                "doctor-codex-wrong-hosts",
+                r#"{
+  "hooks": {
+    "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context --host claude-code" }] }],
+    "Stop": [{ "hooks": [{ "command": "/tmp/remem summarize --host claude-code" }] }]
+  }
+}"#,
+            ),
+        ];
+
+        for (label, content) in cases {
+            let dir = temp_path(label);
+            let hooks_path = dir.join("hooks.json");
+            std::fs::write(&hooks_path, content)?;
+
+            let check = probe_hooks(HostProbe {
+                name: "codex",
+                hooks_path,
+                mcp_paths: vec![dir.join("config.toml")],
+            });
+
+            assert!(
+                matches!(check.status, Status::Fail),
+                "{label}: {}",
+                check.detail
+            );
+            assert!(
+                check.detail.contains("no remem hooks"),
+                "{label}: {}",
+                check.detail
+            );
+        }
+        Ok(())
     }
 
     #[test]
@@ -673,7 +677,7 @@ command = "/mcp/bin/remem"
             extract_remem_command_path(
                 "REMEM_CONTEXT_HOST=codex-cli '/opt/remem/bin/remem' context --color"
             ),
-            Some("/opt/remem/bin/remem")
+            Some("/opt/remem/bin/remem".to_string())
         );
         assert_eq!(extract_remem_command_path("NOTE=remem echo ok"), None);
     }
@@ -717,8 +721,8 @@ command = "/tmp/remem"
             codex_dir.join("hooks.json"),
             r#"{
   "hooks": {
-    "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context" }] }],
-    "Stop": [{ "hooks": [{ "command": "/tmp/remem summarize" }] }]
+    "SessionStart": [{ "hooks": [{ "command": "/tmp/remem context --host codex-cli" }] }],
+    "Stop": [{ "hooks": [{ "command": "/tmp/remem summarize --host codex-cli" }] }]
   }
 }"#,
         )

--- a/src/doctor/environment.rs
+++ b/src/doctor/environment.rs
@@ -355,11 +355,7 @@ fn configured_mcp_paths(probe: &HostProbe) -> Vec<PathBuf> {
 }
 
 fn expected_hook_executable(probe: &HostProbe) -> Option<PathBuf> {
-    configured_mcp_paths(probe)
-        .into_iter()
-        .next()
-        .or_else(|| std::env::var_os("REMEM_INSTALL_BINARY").map(PathBuf::from))
-        .or_else(|| std::env::current_exe().ok())
+    configured_mcp_paths(probe).into_iter().next()
 }
 
 fn configured_hook_paths(path: &PathBuf) -> Vec<PathBuf> {
@@ -490,6 +486,13 @@ mod tests {
   }
 }"#,
         )?;
+        let missing_mcp_check = probe_hooks(HostProbe {
+            name: "codex",
+            hooks_path: hooks_path.clone(),
+            mcp_paths: vec![dir.join("missing.toml")],
+        });
+        assert!(matches!(missing_mcp_check.status, Status::Fail));
+
         let mcp_path = dir.join("config.toml");
         std::fs::write(&mcp_path, "[mcp_servers.remem]\ncommand = \"/tmp/remem\"\n")?;
 
@@ -531,11 +534,13 @@ mod tests {
             let dir = temp_path(label);
             let hooks_path = dir.join("hooks.json");
             std::fs::write(&hooks_path, content)?;
+            let mcp_path = dir.join("config.toml");
+            std::fs::write(&mcp_path, "[mcp_servers.remem]\ncommand = \"/tmp/remem\"\n")?;
 
             let check = probe_hooks(HostProbe {
                 name: "codex",
                 hooks_path,
-                mcp_paths: vec![dir.join("config.toml")],
+                mcp_paths: vec![mcp_path],
             });
 
             assert!(

--- a/src/doctor/hook_validation.rs
+++ b/src/doctor/hook_validation.rs
@@ -2,19 +2,60 @@ use serde_json::Value;
 use std::path::Path;
 
 #[derive(Clone, Copy)]
-pub(super) struct ExpectedHookCommand {
+pub(super) struct ExpectedHookCommand<'a> {
+    pub executable: &'a Path,
     pub subcommand: &'static str,
     pub host: &'static str,
+}
+
+pub(super) fn expected_hook_events(host: &str) -> &'static [&'static str] {
+    match host {
+        "codex" => &["SessionStart", "Stop"],
+        _ => &[
+            "PostToolUse",
+            "PreCompact",
+            "Stop",
+            "SessionStart",
+            "UserPromptSubmit",
+        ],
+    }
+}
+
+pub(super) fn runtime_host(host: &str) -> &'static str {
+    match host {
+        "codex" => "codex-cli",
+        _ => "claude-code",
+    }
+}
+
+pub(super) fn expected_hook_command<'a>(
+    host: &str,
+    event: &str,
+    executable: &'a Path,
+) -> Option<ExpectedHookCommand<'a>> {
+    let subcommand = match event {
+        "PostToolUse" => "observe",
+        "PreCompact" | "Stop" => "summarize",
+        "SessionStart" => "context",
+        "UserPromptSubmit" => "session-init",
+        _ => return None,
+    };
+    Some(ExpectedHookCommand {
+        executable,
+        subcommand,
+        host: runtime_host(host),
+    })
 }
 
 pub(super) fn event_has_expected_remem_hook(
     doc: &Value,
     event: &str,
-    expected: ExpectedHookCommand,
+    expected: ExpectedHookCommand<'_>,
 ) -> bool {
     hook_commands_for_event(doc, event).any(|command| {
         parse_remem_invocation(command).is_some_and(|invocation| {
-            invocation.subcommand.as_deref() == Some(expected.subcommand)
+            Path::new(&invocation.executable) == expected.executable
+                && invocation.subcommand.as_deref() == Some(expected.subcommand)
                 && invocation.host.as_deref() == Some(expected.host)
         })
     })
@@ -23,12 +64,14 @@ pub(super) fn event_has_expected_remem_hook(
 pub(super) fn event_has_remem_subcommand_hook(
     doc: &Value,
     event: &str,
+    executable: &Path,
     subcommand: &str,
     host: &str,
 ) -> bool {
     hook_commands_for_event(doc, event).any(|command| {
         parse_remem_invocation(command).is_some_and(|invocation| {
-            invocation.subcommand.as_deref() == Some(subcommand)
+            Path::new(&invocation.executable) == executable
+                && invocation.subcommand.as_deref() == Some(subcommand)
                 && invocation.host.as_deref() == Some(host)
         })
     })
@@ -222,5 +265,29 @@ mod tests {
         assert!(parse_remem_invocation("NOTE=remem echo ok").is_none());
         assert!(parse_remem_invocation("echo remem context --host codex-cli").is_none());
         assert!(parse_remem_invocation("/bin/sh -c 'remem context --host codex-cli'").is_none());
+    }
+
+    #[test]
+    fn expected_hook_requires_exact_executable_path() {
+        let doc = serde_json::json!({
+            "hooks": {
+                "SessionStart": [{
+                    "hooks": [{
+                        "command": "/wrong/stale/remem context --host codex-cli"
+                    }]
+                }]
+            }
+        });
+        let Some(expected) =
+            expected_hook_command("codex", "SessionStart", Path::new("/expected/bin/remem"))
+        else {
+            panic!("known hook event should build expected command");
+        };
+
+        assert!(!event_has_expected_remem_hook(
+            &doc,
+            "SessionStart",
+            expected
+        ));
     }
 }

--- a/src/doctor/hook_validation.rs
+++ b/src/doctor/hook_validation.rs
@@ -1,0 +1,224 @@
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Clone, Copy)]
+pub(super) struct ExpectedHookCommand {
+    pub subcommand: &'static str,
+    pub host: &'static str,
+}
+
+pub(super) fn event_has_expected_remem_hook(
+    doc: &Value,
+    event: &str,
+    expected: ExpectedHookCommand,
+) -> bool {
+    hook_commands_for_event(doc, event).any(|command| {
+        parse_remem_invocation(command).is_some_and(|invocation| {
+            invocation.subcommand.as_deref() == Some(expected.subcommand)
+                && invocation.host.as_deref() == Some(expected.host)
+        })
+    })
+}
+
+pub(super) fn event_has_remem_subcommand_hook(
+    doc: &Value,
+    event: &str,
+    subcommand: &str,
+    host: &str,
+) -> bool {
+    hook_commands_for_event(doc, event).any(|command| {
+        parse_remem_invocation(command).is_some_and(|invocation| {
+            invocation.subcommand.as_deref() == Some(subcommand)
+                && invocation.host.as_deref() == Some(host)
+        })
+    })
+}
+
+pub(super) fn hook_command_strings(doc: &Value) -> impl Iterator<Item = &str> {
+    doc.get("hooks")
+        .and_then(|hooks| hooks.as_object())
+        .into_iter()
+        .flat_map(|hooks| hooks.values())
+        .filter_map(|entries| entries.as_array())
+        .flatten()
+        .filter_map(|entry| entry.get("hooks").and_then(|hooks| hooks.as_array()))
+        .flatten()
+        .filter_map(|hook| hook.get("command").and_then(|command| command.as_str()))
+}
+
+pub(super) fn extract_remem_command_path(command: &str) -> Option<String> {
+    parse_remem_invocation(command).map(|invocation| invocation.executable)
+}
+
+fn hook_commands_for_event<'a>(doc: &'a Value, event: &str) -> impl Iterator<Item = &'a str> {
+    doc.get("hooks")
+        .and_then(|hooks| hooks.get(event))
+        .and_then(|entries| entries.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("hooks").and_then(|hooks| hooks.as_array()))
+        .flatten()
+        .filter_map(|hook| hook.get("command").and_then(|command| command.as_str()))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RememInvocation {
+    executable: String,
+    subcommand: Option<String>,
+    host: Option<String>,
+}
+
+fn parse_remem_invocation(command: &str) -> Option<RememInvocation> {
+    let tokens = shell_words(command)?;
+    let command_index = tokens
+        .iter()
+        .position(|token| !is_env_assignment(token) && is_remem_command_token(token))?;
+    let host = find_host_arg(&tokens[command_index + 1..]);
+
+    Some(RememInvocation {
+        executable: tokens[command_index].clone(),
+        subcommand: tokens.get(command_index + 1).cloned(),
+        host,
+    })
+}
+
+fn find_host_arg(tokens: &[String]) -> Option<String> {
+    let mut iter = tokens.iter();
+    while let Some(token) = iter.next() {
+        if token == "--host" {
+            return iter.next().cloned();
+        }
+        if let Some(host) = token.strip_prefix("--host=") {
+            return Some(host.to_string());
+        }
+    }
+    None
+}
+
+fn is_remem_command_token(token: &str) -> bool {
+    Path::new(token)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem == "remem")
+}
+
+fn is_env_assignment(token: &str) -> bool {
+    let Some((name, _)) = token.split_once('=') else {
+        return false;
+    };
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+fn shell_words(command: &str) -> Option<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = command.chars().peekable();
+    let mut quote = Quote::None;
+    let mut in_token = false;
+
+    while let Some(ch) = chars.next() {
+        match quote {
+            Quote::None => match ch {
+                '\'' => {
+                    quote = Quote::Single;
+                    in_token = true;
+                }
+                '"' => {
+                    quote = Quote::Double;
+                    in_token = true;
+                }
+                '\\' => {
+                    in_token = true;
+                    if let Some(next) = chars.next() {
+                        current.push(next);
+                    }
+                }
+                ch if ch.is_whitespace() => {
+                    if in_token {
+                        tokens.push(std::mem::take(&mut current));
+                        in_token = false;
+                    }
+                }
+                _ => {
+                    current.push(ch);
+                    in_token = true;
+                }
+            },
+            Quote::Single => {
+                if ch == '\'' {
+                    quote = Quote::None;
+                } else {
+                    current.push(ch);
+                }
+            }
+            Quote::Double => match ch {
+                '"' => quote = Quote::None,
+                '\\' => {
+                    if let Some(next) = chars.next() {
+                        current.push(next);
+                    }
+                }
+                _ => current.push(ch),
+            },
+        }
+    }
+
+    if quote != Quote::None {
+        return None;
+    }
+    if in_token {
+        tokens.push(current);
+    }
+    Some(tokens)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Quote {
+    None,
+    Single,
+    Double,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_remem_invocation_accepts_env_prefix_and_quotes() {
+        let invocation = parse_remem_invocation(
+            "REMEM_CONTEXT_HOST=codex-cli '/opt/remem bin/remem' context --host codex-cli",
+        )
+        .expect("remem invocation should parse");
+
+        assert_eq!(
+            invocation,
+            RememInvocation {
+                executable: "/opt/remem bin/remem".to_string(),
+                subcommand: Some("context".to_string()),
+                host: Some("codex-cli".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_remem_invocation_handles_single_quote_escaping() {
+        let invocation =
+            parse_remem_invocation("'/tmp/remem'\\''bin/remem' observe --host claude-code")
+                .expect("remem invocation should parse");
+
+        assert_eq!(invocation.executable, "/tmp/remem'bin/remem");
+        assert_eq!(invocation.subcommand.as_deref(), Some("observe"));
+        assert_eq!(invocation.host.as_deref(), Some("claude-code"));
+    }
+
+    #[test]
+    fn parse_remem_invocation_rejects_text_without_remem_executable() {
+        assert!(parse_remem_invocation("NOTE=remem echo ok").is_none());
+        assert!(parse_remem_invocation("/bin/sh -c 'remem context --host codex-cli'").is_none());
+    }
+}

--- a/src/doctor/hook_validation.rs
+++ b/src/doctor/hook_validation.rs
@@ -70,9 +70,10 @@ struct RememInvocation {
 
 fn parse_remem_invocation(command: &str) -> Option<RememInvocation> {
     let tokens = shell_words(command)?;
-    let command_index = tokens
-        .iter()
-        .position(|token| !is_env_assignment(token) && is_remem_command_token(token))?;
+    let command_index = tokens.iter().position(|token| !is_env_assignment(token))?;
+    if !is_remem_command_token(&tokens[command_index]) {
+        return None;
+    }
     let host = find_host_arg(&tokens[command_index + 1..]);
 
     Some(RememInvocation {
@@ -219,6 +220,7 @@ mod tests {
     #[test]
     fn parse_remem_invocation_rejects_text_without_remem_executable() {
         assert!(parse_remem_invocation("NOTE=remem echo ok").is_none());
+        assert!(parse_remem_invocation("echo remem context --host codex-cli").is_none());
         assert!(parse_remem_invocation("/bin/sh -c 'remem context --host codex-cli'").is_none());
     }
 }

--- a/src/doctor/hook_validation.rs
+++ b/src/doctor/hook_validation.rs
@@ -157,10 +157,12 @@ fn find_host_arg(tokens: &[String]) -> Option<String> {
     let mut iter = tokens.iter();
     while let Some(token) = iter.next() {
         if token == "--host" {
-            return iter.next().cloned();
+            return iter
+                .next()
+                .map(|host| crate::runtime_config::normalize_host(host));
         }
         if let Some(host) = token.strip_prefix("--host=") {
-            return Some(host.to_string());
+            return Some(crate::runtime_config::normalize_host(host));
         }
     }
     None
@@ -295,7 +297,7 @@ mod tests {
     #[test]
     fn parse_remem_invocation_accepts_env_prefix_and_quotes() {
         let invocation = parse_remem_invocation(
-            "REMEM_CONTEXT_HOST=codex-cli '/opt/remem bin/remem' context --host codex-cli",
+            "REMEM_CONTEXT_HOST=codex-cli '/opt/remem bin/remem' context --host codex",
         )
         .expect("remem invocation should parse");
 
@@ -312,9 +314,8 @@ mod tests {
 
     #[test]
     fn parse_remem_invocation_handles_single_quote_escaping() {
-        let invocation =
-            parse_remem_invocation("'/tmp/remem'\\''bin/remem' observe --host claude-code")
-                .expect("remem invocation should parse");
+        let invocation = parse_remem_invocation("'/tmp/remem'\\''bin/remem' observe --host=claude")
+            .expect("remem invocation should parse");
 
         assert_eq!(invocation.executable, "/tmp/remem'bin/remem");
         assert_eq!(invocation.subcommand.as_deref(), Some("observe"));

--- a/src/doctor/hook_validation.rs
+++ b/src/doctor/hook_validation.rs
@@ -33,18 +33,36 @@ pub(super) fn expected_hook_command<'a>(
     event: &str,
     executable: &'a Path,
 ) -> Option<ExpectedHookCommand<'a>> {
-    let subcommand = match event {
-        "PostToolUse" => "observe",
-        "PreCompact" | "Stop" => "summarize",
-        "SessionStart" => "context",
-        "UserPromptSubmit" => "session-init",
-        _ => return None,
-    };
+    let subcommand = expected_subcommand(event)?;
     Some(ExpectedHookCommand {
         executable,
         subcommand,
         host: runtime_host(host),
     })
+}
+
+pub(super) fn expected_hook_executable_from_hooks(doc: &Value, host: &str) -> Option<String> {
+    let mut paths = Vec::new();
+    for event in expected_hook_events(host) {
+        let Some(subcommand) = expected_subcommand(event) else {
+            continue;
+        };
+        for command in hook_commands_for_event(doc, event) {
+            let Some(invocation) = parse_remem_invocation(command) else {
+                continue;
+            };
+            if invocation.subcommand.as_deref() == Some(subcommand)
+                && invocation.resolved_host() == Some(runtime_host(host))
+                && !paths.contains(&invocation.executable)
+            {
+                paths.push(invocation.executable);
+            }
+        }
+    }
+    match paths.as_slice() {
+        [path] => Some(path.clone()),
+        _ => None,
+    }
 }
 
 pub(super) fn event_has_expected_remem_hook(
@@ -56,24 +74,15 @@ pub(super) fn event_has_expected_remem_hook(
         parse_remem_invocation(command).is_some_and(|invocation| {
             Path::new(&invocation.executable) == expected.executable
                 && invocation.subcommand.as_deref() == Some(expected.subcommand)
-                && invocation.host.as_deref() == Some(expected.host)
+                && invocation.resolved_host() == Some(expected.host)
         })
     })
 }
 
-pub(super) fn event_has_remem_subcommand_hook(
-    doc: &Value,
-    event: &str,
-    executable: &Path,
-    subcommand: &str,
-    host: &str,
-) -> bool {
+pub(super) fn event_has_remem_subcommand_hook(doc: &Value, event: &str, subcommand: &str) -> bool {
     hook_commands_for_event(doc, event).any(|command| {
-        parse_remem_invocation(command).is_some_and(|invocation| {
-            Path::new(&invocation.executable) == executable
-                && invocation.subcommand.as_deref() == Some(subcommand)
-                && invocation.host.as_deref() == Some(host)
-        })
+        parse_remem_invocation(command)
+            .is_some_and(|invocation| invocation.subcommand.as_deref() == Some(subcommand))
     })
 }
 
@@ -109,6 +118,13 @@ struct RememInvocation {
     executable: String,
     subcommand: Option<String>,
     host: Option<String>,
+    env_host: Option<String>,
+}
+
+impl RememInvocation {
+    fn resolved_host(&self) -> Option<&str> {
+        self.host.as_deref().or(self.env_host.as_deref())
+    }
 }
 
 fn parse_remem_invocation(command: &str) -> Option<RememInvocation> {
@@ -123,7 +139,18 @@ fn parse_remem_invocation(command: &str) -> Option<RememInvocation> {
         executable: tokens[command_index].clone(),
         subcommand: tokens.get(command_index + 1).cloned(),
         host,
+        env_host: find_legacy_host_env(&tokens[..command_index]),
     })
+}
+
+fn expected_subcommand(event: &str) -> Option<&'static str> {
+    match event {
+        "PostToolUse" => Some("observe"),
+        "PreCompact" | "Stop" => Some("summarize"),
+        "SessionStart" => Some("context"),
+        "UserPromptSubmit" => Some("session-init"),
+        _ => None,
+    }
 }
 
 fn find_host_arg(tokens: &[String]) -> Option<String> {
@@ -139,6 +166,34 @@ fn find_host_arg(tokens: &[String]) -> Option<String> {
     None
 }
 
+fn find_legacy_host_env(tokens: &[String]) -> Option<String> {
+    for token in tokens {
+        let Some((name, value)) = env_assignment(token) else {
+            continue;
+        };
+        if matches!(name, "REMEM_HOOK_HOST" | "REMEM_CONTEXT_HOST") {
+            return Some(crate::runtime_config::normalize_host(value));
+        }
+    }
+    for token in tokens {
+        let Some((name, value)) = env_assignment(token) else {
+            continue;
+        };
+        if matches!(name, "REMEM_SUMMARY_EXECUTOR" | "REMEM_EXECUTOR") {
+            match value.trim().to_ascii_lowercase().as_str() {
+                "codex" | "codex-cli" => {
+                    return Some(crate::runtime_config::CODEX_HOST.to_string())
+                }
+                "claude" | "claude-cli" | "cli" => {
+                    return Some(crate::runtime_config::CLAUDE_HOST.to_string());
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
 fn is_remem_command_token(token: &str) -> bool {
     Path::new(token)
         .file_stem()
@@ -147,15 +202,20 @@ fn is_remem_command_token(token: &str) -> bool {
 }
 
 fn is_env_assignment(token: &str) -> bool {
-    let Some((name, _)) = token.split_once('=') else {
-        return false;
-    };
+    env_assignment(token).is_some()
+}
+
+fn env_assignment(token: &str) -> Option<(&str, &str)> {
+    let (name, value) = token.split_once('=')?;
     let mut chars = name.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    (first.is_ascii_alphabetic() || first == '_')
+    let first = chars.next()?;
+    if (first.is_ascii_alphabetic() || first == '_')
         && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+    {
+        Some((name, value))
+    } else {
+        None
+    }
 }
 
 fn shell_words(command: &str) -> Option<Vec<String>> {
@@ -245,6 +305,7 @@ mod tests {
                 executable: "/opt/remem bin/remem".to_string(),
                 subcommand: Some("context".to_string()),
                 host: Some("codex-cli".to_string()),
+                env_host: Some("codex-cli".to_string()),
             }
         );
     }
@@ -285,6 +346,30 @@ mod tests {
         };
 
         assert!(!event_has_expected_remem_hook(
+            &doc,
+            "SessionStart",
+            expected
+        ));
+    }
+
+    #[test]
+    fn expected_hook_accepts_legacy_env_host() {
+        let doc = serde_json::json!({
+            "hooks": {
+                "SessionStart": [{
+                    "hooks": [{
+                        "command": "REMEM_CONTEXT_HOST=codex-cli /tmp/remem context"
+                    }]
+                }]
+            }
+        });
+        let Some(expected) =
+            expected_hook_command("codex", "SessionStart", Path::new("/tmp/remem"))
+        else {
+            panic!("known hook event should build expected command");
+        };
+
+        assert!(event_has_expected_remem_hook(
             &doc,
             "SessionStart",
             expected


### PR DESCRIPTION
Fixes #429.

## Summary
- Add a doctor hook validator that parses hook shell commands instead of using substring checks.
- Require each expected hook event to invoke a remem executable with the expected subcommand and host.
- Keep configured path extraction working for env-prefixed and quoted remem binaries.
- Add negative coverage for inert remem subcommands and wrong host values.
- Bump version to 0.5.35.

## Verification
- cargo fmt --check
- cargo check --message-format=short
- cargo test doctor::hook_validation::tests
- cargo test doctor::environment::tests::probe_hooks
- cargo clippy -- -D warnings
- cargo test
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- git diff --check origin/main...HEAD