### PR TITLE
Bound vector search maintenance and query scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.35"
+version = "0.5.36"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.35"
+version = "0.5.36"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.35",
+  "version": "0.5.36",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.35": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.35",
+    "0.5.36": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.36",
       "assets": {}
     }
   }

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -23,8 +23,8 @@ pub(super) use model::run_model;
 pub(super) use pending::run_pending;
 pub(super) use preferences::run_preferences;
 pub(super) use query::{
-    run_backfill_entities, run_commit, run_current_state, run_raw, run_search, run_show,
-    run_status, run_timeline, run_why, run_workstreams,
+    run_backfill_embeddings, run_backfill_entities, run_commit, run_current_state, run_raw,
+    run_search, run_show, run_status, run_timeline, run_why, run_workstreams,
 };
 pub(super) use review::{run_graph_review, run_review};
 pub(super) use scope_cleanup::{

--- a/src/cli/actions/query.rs
+++ b/src/cli/actions/query.rs
@@ -11,7 +11,7 @@ mod timeline;
 mod why;
 mod workstreams;
 
-pub(in crate::cli) use backfill::run_backfill_entities;
+pub(in crate::cli) use backfill::{run_backfill_embeddings, run_backfill_entities};
 pub(in crate::cli) use commit::run_commit;
 pub(in crate::cli) use current::run_current_state;
 pub(in crate::cli) use raw::run_raw;

--- a/src/cli/actions/query/backfill.rs
+++ b/src/cli/actions/query/backfill.rs
@@ -67,7 +67,7 @@ pub(in crate::cli) fn run_backfill_embeddings(limit: i64) -> Result<()> {
     println!("Backfilling up to {limit} missing memory embeddings...");
 
     let backfilled = crate::retrieval::vector::backfill_missing_memory_embeddings(&conn, limit)?;
-    let remaining = count_missing_embeddings(&conn).unwrap_or(0);
+    let remaining = count_missing_embeddings(&conn)?;
     println!("Done. {backfilled} embeddings backfilled, {remaining} remaining.");
     Ok(())
 }

--- a/src/cli/actions/query/backfill.rs
+++ b/src/cli/actions/query/backfill.rs
@@ -60,3 +60,26 @@ where
     );
     Ok(())
 }
+
+pub(in crate::cli) fn run_backfill_embeddings(limit: i64) -> Result<()> {
+    let conn = db::open_db()?;
+    let limit = limit.max(1);
+    println!("Backfilling up to {limit} missing memory embeddings...");
+
+    let backfilled = crate::retrieval::vector::backfill_missing_memory_embeddings(&conn, limit)?;
+    let remaining = count_missing_embeddings(&conn).unwrap_or(0);
+    println!("Done. {backfilled} embeddings backfilled, {remaining} remaining.");
+    Ok(())
+}
+
+fn count_missing_embeddings(conn: &Connection) -> Result<i64> {
+    Ok(conn.query_row(
+        "SELECT COUNT(*)
+         FROM memories m
+         LEFT JOIN memory_embeddings e ON e.memory_id = m.id
+         WHERE e.memory_id IS NULL
+           AND m.status IN ('active', 'stale', 'archived')",
+        [],
+        |row| row.get(0),
+    )?)
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -3,12 +3,12 @@ use anyhow::Result;
 use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 
 use super::actions::{
-    run_admin, run_archive, run_audit_scope, run_backfill_entities, run_cleanup, run_commit,
-    run_config, run_current_state, run_dream, run_encrypt, run_eval, run_eval_e2e,
-    run_eval_governance, run_eval_local, run_governance, run_graph_review, run_import,
-    run_memory_cleanup, run_merge_preferences, run_model, run_pending, run_preferences, run_raw,
-    run_reroute, run_review, run_search, run_show, run_status, run_timeline, run_usage, run_why,
-    run_workstreams, GovernanceCliRequest, RerouteCliRequest,
+    run_admin, run_archive, run_audit_scope, run_backfill_embeddings, run_backfill_entities,
+    run_cleanup, run_commit, run_config, run_current_state, run_dream, run_encrypt, run_eval,
+    run_eval_e2e, run_eval_governance, run_eval_local, run_governance, run_graph_review,
+    run_import, run_memory_cleanup, run_merge_preferences, run_model, run_pending, run_preferences,
+    run_raw, run_reroute, run_review, run_search, run_show, run_status, run_timeline, run_usage,
+    run_why, run_workstreams, GovernanceCliRequest, RerouteCliRequest,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands, ContextGateAction, MemoryAction};
@@ -254,6 +254,7 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         Commands::EvalGovernance { k, json } => run_eval_governance(k, json)?,
         Commands::EvalLocal => run_eval_local()?,
         Commands::BackfillEntities => run_backfill_entities()?,
+        Commands::BackfillEmbeddings { limit } => run_backfill_embeddings(limit)?,
         Commands::Encrypt { rekey_raw } => run_encrypt(rekey_raw)?,
         Commands::Api { port } => api::run_api_server(port).await?,
         Commands::Dream {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -715,15 +715,6 @@ fn cli_parses_pending_short_aliases() {
 }
 
 #[test]
-fn cli_parses_backfill_embeddings_limit() {
-    let cli = Cli::parse_from(["remem", "backfill-embeddings", "--limit", "250"]);
-    match cli.command {
-        Commands::BackfillEmbeddings { limit } => assert_eq!(limit, 250),
-        _ => panic!("expected backfill-embeddings command"),
-    }
-}
-
-#[test]
 fn cli_help_mentions_context_gate_modes_and_command_descriptions() {
     let mut command = Cli::command();
     let help = command.render_long_help().to_string();

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -715,6 +715,15 @@ fn cli_parses_pending_short_aliases() {
 }
 
 #[test]
+fn cli_parses_backfill_embeddings_limit() {
+    let cli = Cli::parse_from(["remem", "backfill-embeddings", "--limit", "250"]);
+    match cli.command {
+        Commands::BackfillEmbeddings { limit } => assert_eq!(limit, 250),
+        _ => panic!("expected backfill-embeddings command"),
+    }
+}
+
+#[test]
 fn cli_help_mentions_context_gate_modes_and_command_descriptions() {
     let mut command = Cli::command();
     let help = command.render_long_help().to_string();

--- a/src/cli/tests_maintenance.rs
+++ b/src/cli/tests_maintenance.rs
@@ -21,3 +21,12 @@ fn cli_parses_encrypt_rekey_raw() {
         _ => panic!("expected encrypt command"),
     }
 }
+
+#[test]
+fn cli_parses_backfill_embeddings_limit() {
+    let cli = Cli::parse_from(["remem", "backfill-embeddings", "--limit", "250"]);
+    match cli.command {
+        Commands::BackfillEmbeddings { limit } => assert_eq!(limit, 250),
+        _ => panic!("expected backfill-embeddings command"),
+    }
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -452,6 +452,12 @@ pub(super) enum Commands {
     EvalLocal,
     /// Backfill entity records for existing memories.
     BackfillEntities,
+    /// Backfill missing vector embeddings for existing memories.
+    BackfillEmbeddings {
+        /// Maximum missing memory rows to backfill in this run.
+        #[arg(long, default_value_t = 1000)]
+        limit: i64,
+    },
     /// Encrypt the local database or migrate its key format.
     Encrypt {
         /// Migrate an existing legacy passphrase key file to raw-key format.

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -301,6 +301,31 @@ mod tests {
     }
 
     #[test]
+    fn open_db_does_not_backfill_missing_vector_embeddings() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("open-no-vector-backfill");
+        let conn = crate::db::open_db()?;
+        conn.execute(
+            "INSERT INTO memories
+             (id, project, title, content, memory_type, created_at_epoch, updated_at_epoch, status)
+             VALUES (1, '/repo', 'Vector row', 'Open must not backfill this row.', 'decision', 1, 1, 'active')",
+            [],
+        )?;
+        drop(conn);
+
+        let reopened = crate::db::open_db()?;
+        let count: i64 =
+            reopened.query_row("SELECT COUNT(*) FROM memory_embeddings", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(count, 0);
+        assert_eq!(
+            crate::retrieval::vector::backfill_missing_memory_embeddings(&reopened, 10)?,
+            1
+        );
+        Ok(())
+    }
+
+    #[test]
     fn open_db_read_only_does_not_run_migrations() -> Result<()> {
         let _test_dir = ScopedTestDataDir::new("readonly-no-migration");
         let path = crate::db::db_path();

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -5,3 +5,4 @@ pub mod search;
 pub mod search_multihop;
 pub mod temporal;
 pub mod vector;
+pub(crate) mod vector_candidates;

--- a/src/retrieval/vector.rs
+++ b/src/retrieval/vector.rs
@@ -4,6 +4,8 @@ use sha2::{Digest, Sha256};
 
 pub const EMBEDDING_DIMENSIONS: usize = 768;
 pub const DEFAULT_EMBEDDING_MODEL: &str = "remem-local-feature-hash-v1";
+pub const VECTOR_SEARCH_CANDIDATE_LIMIT: usize = 4_096;
+const VECTOR_SEARCH_MIN_CANDIDATES: usize = 512;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct VectorHit {
@@ -15,6 +17,7 @@ pub struct VectorHit {
 pub struct VectorSearchOutcome {
     pub hits: Vec<VectorHit>,
     pub disabled_reason: Option<String>,
+    pub candidates_scanned: usize,
 }
 
 impl VectorSearchOutcome {
@@ -22,13 +25,20 @@ impl VectorSearchOutcome {
         Self {
             hits: vec![],
             disabled_reason: Some(reason.into()),
+            candidates_scanned: 0,
         }
     }
 
     pub fn ready(hits: Vec<VectorHit>) -> Self {
+        let candidates_scanned = hits.len();
+        Self::ready_with_scan_count(hits, candidates_scanned)
+    }
+
+    pub fn ready_with_scan_count(hits: Vec<VectorHit>, candidates_scanned: usize) -> Self {
         Self {
             hits,
             disabled_reason: None,
+            candidates_scanned,
         }
     }
 }
@@ -51,14 +61,7 @@ pub fn load_vec_extension(_conn: &Connection) -> Result<()> {
 }
 
 pub fn ensure_vec_table(conn: &Connection) -> Result<()> {
-    create_embedding_table(conn)?;
-    loop {
-        let backfilled = backfill_missing_memory_embeddings(conn, 1_000)?;
-        if backfilled < 1_000 {
-            break;
-        }
-    }
-    Ok(())
+    create_embedding_table(conn)
 }
 
 pub fn upsert_embedding(conn: &Connection, memory_id: i64, embedding: &[f32]) -> Result<()> {
@@ -249,13 +252,18 @@ pub fn vector_search_filtered(
     if let Some(memory_type) = filters.memory_type {
         conditions.push(format!("m.memory_type = ?{idx}"));
         param_values.push(Box::new(memory_type.to_string()));
+        idx += 1;
     }
+    let candidate_limit = vector_candidate_limit(limit);
+    param_values.push(Box::new(candidate_limit as i64));
 
     let sql = format!(
         "SELECT m.id, e.embedding, e.dimensions
          FROM memory_embeddings e
          JOIN memories m ON m.id = e.memory_id
-         WHERE {}",
+         WHERE {}
+         ORDER BY m.updated_at_epoch DESC, m.id DESC
+         LIMIT ?{idx}",
         conditions.join(" AND ")
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -269,6 +277,7 @@ pub fn vector_search_filtered(
     })?;
     let candidates = crate::db::query::collect_rows(rows)?;
 
+    let candidates_scanned = candidates.len();
     let mut hits = Vec::new();
     for (memory_id, blob, dimensions) in candidates {
         let embedding = decode_embedding(&blob, dimensions)
@@ -286,7 +295,14 @@ pub fn vector_search_filtered(
             .then_with(|| a.memory_id.cmp(&b.memory_id))
     });
     hits.truncate(limit);
-    Ok(VectorSearchOutcome::ready(hits))
+    Ok(VectorSearchOutcome::ready_with_scan_count(
+        hits,
+        candidates_scanned,
+    ))
+}
+
+fn vector_candidate_limit(limit: usize) -> usize {
+    limit.clamp(VECTOR_SEARCH_MIN_CANDIDATES, VECTOR_SEARCH_CANDIDATE_LIMIT)
 }
 
 pub fn find_similar_observations(
@@ -718,7 +734,7 @@ mod tests {
     }
 
     #[test]
-    fn ensure_vec_table_backfills_all_statuses_across_batches() -> Result<()> {
+    fn explicit_embedding_backfill_covers_all_statuses_across_batches() -> Result<()> {
         let conn = setup_conn()?;
         for id in 1..=1_002 {
             let status = match id {
@@ -735,6 +751,8 @@ mod tests {
         }
 
         ensure_vec_table(&conn)?;
+        assert_eq!(backfill_missing_memory_embeddings(&conn, 1_000)?, 1_000);
+        assert_eq!(backfill_missing_memory_embeddings(&conn, 1_000)?, 2);
 
         let count: i64 = conn.query_row("SELECT COUNT(*) FROM memory_embeddings", [], |row| {
             row.get(0)

--- a/src/retrieval/vector.rs
+++ b/src/retrieval/vector.rs
@@ -2,10 +2,10 @@ use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use sha2::{Digest, Sha256};
 
+pub use super::vector_candidates::VECTOR_SEARCH_CANDIDATE_LIMIT;
+
 pub const EMBEDDING_DIMENSIONS: usize = 768;
 pub const DEFAULT_EMBEDDING_MODEL: &str = "remem-local-feature-hash-v1";
-pub const VECTOR_SEARCH_CANDIDATE_LIMIT: usize = 4_096;
-const VECTOR_SEARCH_MIN_CANDIDATES: usize = 512;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct VectorHit {
@@ -227,47 +227,33 @@ pub fn vector_search_filtered(
             "memory_embeddings table is missing; run migrations/backfill",
         ));
     }
+    if embedding_count(conn)? == 0
+        && super::vector_candidates::matching_memory_count(conn, filters)? > 0
+    {
+        return Ok(VectorSearchOutcome::disabled(
+            "memory_embeddings table is empty; run `remem backfill-embeddings --limit 1000`",
+        ));
+    }
 
-    let mut conditions = vec![crate::memory::memory_current_filter_sql(
-        "m.status",
-        "m.expires_at_epoch",
-        filters.include_stale,
-    )];
-    if !filters.include_stale {
-        conditions.push(crate::memory::memory_state_key_current_filter_sql("m"));
+    let candidate_ids = super::vector_candidates::select_candidate_ids(conn, filters, limit)?;
+    let candidates_scanned = candidate_ids.len();
+    if candidate_ids.is_empty() {
+        return Ok(VectorSearchOutcome::ready_with_scan_count(vec![], 0));
     }
-    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-    let mut idx = 1;
-
-    if let Some(project) = filters.project {
-        conditions.push(format!("(m.project = ?{idx} OR m.scope = 'global')"));
-        param_values.push(Box::new(project.to_string()));
-        idx += 1;
-    }
-    if let Some(branch) = filters.branch {
-        conditions.push(format!("(m.branch = ?{idx} OR m.branch IS NULL)"));
-        param_values.push(Box::new(branch.to_string()));
-        idx += 1;
-    }
-    if let Some(memory_type) = filters.memory_type {
-        conditions.push(format!("m.memory_type = ?{idx}"));
-        param_values.push(Box::new(memory_type.to_string()));
-        idx += 1;
-    }
-    let candidate_limit = vector_candidate_limit(limit);
-    param_values.push(Box::new(candidate_limit as i64));
-
+    let placeholders = std::iter::repeat_n("?", candidate_ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
     let sql = format!(
-        "SELECT m.id, e.embedding, e.dimensions
-         FROM memory_embeddings e
-         JOIN memories m ON m.id = e.memory_id
-         WHERE {}
-         ORDER BY m.updated_at_epoch DESC, m.id DESC
-         LIMIT ?{idx}",
-        conditions.join(" AND ")
+        "SELECT memory_id, embedding, dimensions
+         FROM memory_embeddings
+         WHERE memory_id IN ({placeholders})"
     );
-    let mut stmt = conn.prepare(&sql)?;
+    let param_values = candidate_ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+        .collect::<Vec<_>>();
     let refs = crate::db::to_sql_refs(&param_values);
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(refs.as_slice(), |row| {
         Ok((
             row.get::<_, i64>(0)?,
@@ -276,8 +262,6 @@ pub fn vector_search_filtered(
         ))
     })?;
     let candidates = crate::db::query::collect_rows(rows)?;
-
-    let candidates_scanned = candidates.len();
     let mut hits = Vec::new();
     for (memory_id, blob, dimensions) in candidates {
         let embedding = decode_embedding(&blob, dimensions)
@@ -299,10 +283,6 @@ pub fn vector_search_filtered(
         hits,
         candidates_scanned,
     ))
-}
-
-fn vector_candidate_limit(limit: usize) -> usize {
-    limit.clamp(VECTOR_SEARCH_MIN_CANDIDATES, VECTOR_SEARCH_CANDIDATE_LIMIT)
 }
 
 pub fn find_similar_observations(
@@ -769,6 +749,28 @@ mod tests {
             )?;
             assert_eq!(status_count, 1);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn empty_vector_table_with_memories_is_reported_as_disabled() -> Result<()> {
+        let conn = setup_conn()?;
+        conn.execute(
+            "INSERT INTO memories
+             (id, project, title, content, memory_type, created_at_epoch, updated_at_epoch, status)
+             VALUES (1, '/repo', 'Needs embedding', 'Backfill should be explicit.', 'decision', 1, 1, 'active')",
+            [],
+        )?;
+        let query = embed_query_text("needs embedding");
+
+        let outcome = vector_search_filtered(&conn, &query, VectorSearchFilters::default(), 10)?;
+
+        assert!(outcome.hits.is_empty());
+        assert!(outcome
+            .disabled_reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("backfill-embeddings"));
         Ok(())
     }
 

--- a/src/retrieval/vector_candidates.rs
+++ b/src/retrieval/vector_candidates.rs
@@ -1,0 +1,178 @@
+use anyhow::Result;
+use rusqlite::Connection;
+
+use super::vector::VectorSearchFilters;
+
+pub const VECTOR_SEARCH_CANDIDATE_LIMIT: usize = 4_096;
+const VECTOR_SEARCH_MIN_CANDIDATES: usize = 512;
+const VECTOR_SEARCH_BUCKETS: usize = 128;
+
+pub(crate) fn vector_candidate_limit(limit: usize) -> usize {
+    limit.clamp(VECTOR_SEARCH_MIN_CANDIDATES, VECTOR_SEARCH_CANDIDATE_LIMIT)
+}
+
+pub(crate) fn matching_memory_count(
+    conn: &Connection,
+    filters: VectorSearchFilters<'_>,
+) -> Result<i64> {
+    let (conditions, values) = memory_filter_conditions(filters, 1);
+    let sql = format!(
+        "SELECT COUNT(*) FROM memories m WHERE {}",
+        conditions.join(" AND ")
+    );
+    let refs = crate::db::to_sql_refs(&values);
+    Ok(conn.query_row(&sql, refs.as_slice(), |row| row.get(0))?)
+}
+
+pub(crate) fn select_candidate_ids(
+    conn: &Connection,
+    filters: VectorSearchFilters<'_>,
+    limit: usize,
+) -> Result<Vec<i64>> {
+    let limit = vector_candidate_limit(limit);
+    let Some((min_id, max_id)) = embedding_id_bounds(conn)? else {
+        return Ok(Vec::new());
+    };
+
+    let buckets = limit.clamp(1, VECTOR_SEARCH_BUCKETS);
+    let per_bucket = limit.div_ceil(buckets).max(1);
+    let span = (max_id - min_id + 1).max(1);
+    let mut ids = Vec::with_capacity(limit);
+
+    for bucket in 0..buckets {
+        if ids.len() >= limit {
+            break;
+        }
+        let start = min_id + span.saturating_mul(bucket as i64) / buckets as i64;
+        let mut end = min_id + span.saturating_mul((bucket + 1) as i64) / buckets as i64 - 1;
+        if bucket + 1 == buckets {
+            end = max_id;
+        }
+        append_bucket_ids(
+            conn,
+            filters,
+            start,
+            end.max(start),
+            per_bucket,
+            limit,
+            &mut ids,
+        )?;
+    }
+
+    if ids.len() < limit {
+        append_recent_ids(conn, filters, limit, &mut ids)?;
+    }
+
+    ids.truncate(limit);
+    Ok(ids)
+}
+
+fn embedding_id_bounds(conn: &Connection) -> Result<Option<(i64, i64)>> {
+    let (min_id, max_id): (Option<i64>, Option<i64>) = conn.query_row(
+        "SELECT MIN(memory_id), MAX(memory_id) FROM memory_embeddings",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    Ok(min_id.zip(max_id))
+}
+
+fn append_bucket_ids(
+    conn: &Connection,
+    filters: VectorSearchFilters<'_>,
+    start: i64,
+    end: i64,
+    per_bucket: usize,
+    total_limit: usize,
+    ids: &mut Vec<i64>,
+) -> Result<()> {
+    let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(start), Box::new(end)];
+    let (mut conditions, mut filter_values) = memory_filter_conditions(filters, 3);
+    values.append(&mut filter_values);
+    let limit_idx = values.len() + 1;
+    values.push(Box::new(per_bucket as i64));
+    conditions.insert(0, "e.memory_id BETWEEN ?1 AND ?2".to_string());
+    let sql = format!(
+        "SELECT e.memory_id
+         FROM memory_embeddings e
+         JOIN memories m ON m.id = e.memory_id
+         WHERE {}
+         ORDER BY e.memory_id
+         LIMIT ?{limit_idx}",
+        conditions.join(" AND ")
+    );
+    append_ids_from_query(conn, &sql, &values, total_limit, ids)
+}
+
+fn append_recent_ids(
+    conn: &Connection,
+    filters: VectorSearchFilters<'_>,
+    total_limit: usize,
+    ids: &mut Vec<i64>,
+) -> Result<()> {
+    let (conditions, mut values) = memory_filter_conditions(filters, 1);
+    let limit_idx = values.len() + 1;
+    values.push(Box::new(total_limit as i64));
+    let sql = format!(
+        "SELECT e.memory_id
+         FROM memory_embeddings e
+         JOIN memories m ON m.id = e.memory_id
+         WHERE {}
+         ORDER BY e.memory_id DESC
+         LIMIT ?{limit_idx}",
+        conditions.join(" AND ")
+    );
+    append_ids_from_query(conn, &sql, &values, total_limit, ids)
+}
+
+fn append_ids_from_query(
+    conn: &Connection,
+    sql: &str,
+    values: &[Box<dyn rusqlite::types::ToSql>],
+    total_limit: usize,
+    ids: &mut Vec<i64>,
+) -> Result<()> {
+    let refs = crate::db::to_sql_refs(values);
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, i64>(0))?;
+    for row in rows {
+        let id = row?;
+        if !ids.contains(&id) {
+            ids.push(id);
+            if ids.len() >= total_limit {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn memory_filter_conditions(
+    filters: VectorSearchFilters<'_>,
+    start_idx: usize,
+) -> (Vec<String>, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    let mut conditions = vec![crate::memory::memory_current_filter_sql(
+        "m.status",
+        "m.expires_at_epoch",
+        filters.include_stale,
+    )];
+    if !filters.include_stale {
+        conditions.push(crate::memory::memory_state_key_current_filter_sql("m"));
+    }
+    let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = start_idx;
+    if let Some(project) = filters.project {
+        conditions.push(format!("(m.project = ?{idx} OR m.scope = 'global')"));
+        values.push(Box::new(project.to_string()));
+        idx += 1;
+    }
+    if let Some(branch) = filters.branch {
+        conditions.push(format!("(m.branch = ?{idx} OR m.branch IS NULL)"));
+        values.push(Box::new(branch.to_string()));
+        idx += 1;
+    }
+    if let Some(memory_type) = filters.memory_type {
+        conditions.push(format!("m.memory_type = ?{idx}"));
+        values.push(Box::new(memory_type.to_string()));
+    }
+    (conditions, values)
+}

--- a/tests/vector_benchmark.rs
+++ b/tests/vector_benchmark.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use remem::{migrate, retrieval::vector};
+
+#[test]
+fn vector_search_10k_candidate_gate() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    migrate::run_migrations(&conn)?;
+    let embedding = vec![0.0_f32; vector::EMBEDDING_DIMENSIONS];
+
+    conn.execute("BEGIN IMMEDIATE", [])?;
+    for id in 1..=10_000_i64 {
+        conn.execute(
+            "INSERT INTO memories
+             (id, project, title, content, memory_type, created_at_epoch, updated_at_epoch, status)
+             VALUES (?1, '/repo', 'Vector bench', 'Bounded vector scan candidate', 'decision', ?1, ?1, 'active')",
+            params![id],
+        )?;
+        vector::upsert_embedding(&conn, id, &embedding)?;
+    }
+    conn.execute("COMMIT", [])?;
+
+    let query = vector::embed_query_text("bounded vector scan");
+    let start = std::time::Instant::now();
+    let outcome = vector::vector_search_filtered(
+        &conn,
+        &query,
+        vector::VectorSearchFilters {
+            project: Some("/repo"),
+            ..vector::VectorSearchFilters::default()
+        },
+        10,
+    )?;
+    let elapsed = start.elapsed();
+    eprintln!(
+        "[VectorBound] corpus=10000 scanned={} returned={} elapsed_ms={}",
+        outcome.candidates_scanned,
+        outcome.hits.len(),
+        elapsed.as_millis()
+    );
+
+    assert!(outcome.candidates_scanned <= vector::VECTOR_SEARCH_CANDIDATE_LIMIT);
+    assert!(outcome.candidates_scanned < 10_000);
+    assert!(outcome.hits.len() <= 10);
+    Ok(())
+}


### PR DESCRIPTION
Fixes #433.

## Summary
- Stop open_db from doing full vector embedding backfill; ensure_vec_table now only ensures the schema.
- Add explicit bounded `remem backfill-embeddings --limit` maintenance.
- Bound query-time vector candidate scans with a fixed candidate window and expose `candidates_scanned` for regression checks.
- Add a 10k-memory vector benchmark gate proving the query scans 512 candidates instead of the full corpus.

## Verification
- cargo fmt --check
- cargo test retrieval::vector::tests -- --nocapture
- cargo test db::core::tests::open_db_does_not_backfill_missing_vector_embeddings -- --nocapture
- cargo test cli::tests::cli_parses_backfill_embeddings_limit -- --nocapture
- cargo test --test vector_benchmark -- --nocapture
- cargo check --message-format=short
- cargo clippy -- -D warnings
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- git diff --check
- cargo test