### PR TITLE
Restore graph edge candidate provenance integrity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.36"
+version = "0.5.37"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.36": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.36",
+    "0.5.37": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.37",
       "assets": {}
     }
   }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -7,6 +7,7 @@ pub mod facts;
 pub mod format;
 pub mod governance;
 pub mod graph_contract;
+pub(crate) mod graph_provenance;
 pub mod lesson;
 pub mod lifecycle;
 pub mod operation;

--- a/src/memory/graph_contract.rs
+++ b/src/memory/graph_contract.rs
@@ -297,12 +297,11 @@ fn validate_trusted_provenance(
             bail!("trusted graph edge source event id {event_id} does not exist");
         }
     }
-    if provenance.source_candidate_id.is_none() {
-        bail!("trusted graph edge requires source candidate id");
-    }
-    if provenance.source_operation_id.is_none() {
-        bail!("trusted graph edge requires source operation id");
-    }
+    crate::memory::graph_provenance::validate_trusted_source_candidate(
+        conn,
+        provenance.source_candidate_id,
+        provenance.source_operation_id,
+    )?;
     if provenance.confidence.is_none() {
         bail!("trusted graph edge requires confidence");
     }

--- a/src/memory/graph_provenance.rs
+++ b/src/memory/graph_provenance.rs
@@ -1,0 +1,106 @@
+use anyhow::{bail, Result};
+use rusqlite::{Connection, OptionalExtension};
+
+pub(crate) fn validate_trusted_source_candidate(
+    conn: &Connection,
+    source_candidate_id: Option<i64>,
+    source_operation_id: Option<i64>,
+) -> Result<()> {
+    let candidate_id = source_candidate_id
+        .ok_or_else(|| anyhow::anyhow!("trusted graph edge requires source candidate id"))?;
+    let operation_id = source_operation_id
+        .ok_or_else(|| anyhow::anyhow!("trusted graph edge requires source operation id"))?;
+    let operation = conn
+        .query_row(
+            "SELECT source, source_candidate_id FROM memory_operation_log WHERE id = ?1",
+            [operation_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?)),
+        )
+        .optional()?;
+
+    let Some((source, operation_candidate_id)) = operation else {
+        bail!("trusted graph edge source operation id {operation_id} does not exist");
+    };
+    if operation_candidate_id != Some(candidate_id) {
+        bail!(
+            "trusted graph edge source operation {operation_id} references candidate {:?}, not {candidate_id}",
+            operation_candidate_id
+        );
+    }
+
+    match source.as_str() {
+        "memory_candidate" => {
+            ensure_memory_candidate_exists(conn, candidate_id)?;
+        }
+        "graph_candidate" => {
+            ensure_graph_candidate_exists(conn, candidate_id)?;
+        }
+        other => bail!(
+            "trusted graph edge source operation {operation_id} uses unsupported candidate source {other}"
+        ),
+    }
+
+    Ok(())
+}
+
+fn ensure_memory_candidate_exists(conn: &Connection, candidate_id: i64) -> Result<()> {
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM memory_candidates WHERE id = ?1)",
+        [candidate_id],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        bail!("trusted graph edge source memory candidate id {candidate_id} does not exist");
+    }
+    Ok(())
+}
+
+fn ensure_graph_candidate_exists(conn: &Connection, candidate_id: i64) -> Result<()> {
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM graph_candidates WHERE id = ?1)",
+        [candidate_id],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        bail!("trusted graph edge source graph candidate id {candidate_id} does not exist");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_conn() -> Result<Connection> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE memory_candidates (id INTEGER PRIMARY KEY);
+             CREATE TABLE graph_candidates (id INTEGER PRIMARY KEY);
+             CREATE TABLE memory_operation_log (
+                 id INTEGER PRIMARY KEY,
+                 source TEXT NOT NULL,
+                 source_candidate_id INTEGER
+             );",
+        )?;
+        Ok(conn)
+    }
+
+    #[test]
+    fn trusted_source_candidate_requires_operation_candidate_match() -> Result<()> {
+        let conn = test_conn()?;
+        conn.execute("INSERT INTO memory_candidates(id) VALUES (1), (2)", [])?;
+        conn.execute(
+            "INSERT INTO memory_operation_log(id, source, source_candidate_id)
+             VALUES (10, 'memory_candidate', 2)",
+            [],
+        )?;
+
+        let err = validate_trusted_source_candidate(&conn, Some(1), Some(10)).expect_err(
+            "trusted graph provenance must bind operation and edge to the same candidate",
+        );
+        assert!(err
+            .to_string()
+            .contains("references candidate Some(2), not 1"));
+        Ok(())
+    }
+}

--- a/src/migrate/tests_convergence.rs
+++ b/src/migrate/tests_convergence.rs
@@ -174,6 +174,18 @@ fn table_indexes(conn: &Connection, table: &str) -> Result<Vec<String>> {
     Ok(indexes)
 }
 
+/// Return sorted trigger names for a table.
+fn table_triggers(conn: &Connection, table: &str) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=?1 ORDER BY name",
+    )?;
+    let triggers = stmt
+        .query_map([table], |row| row.get::<_, String>(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(triggers)
+}
+
 /// Upgraded v10 DB must have the same columns as a fresh DB for all core tables.
 /// This single test catches ALL future column divergence across ALL tables.
 #[test]
@@ -249,6 +261,55 @@ fn indexes_match_after_upgrade() -> Result<()> {
         "index divergence between fresh and upgraded DB:\n  {}",
         mismatches.join("\n  ")
     );
+    Ok(())
+}
+
+#[test]
+fn graph_edges_candidate_integrity_triggers_match_after_upgrade() -> Result<()> {
+    let fresh = make_fresh_db()?;
+    let upgraded = make_upgraded_v10_db()?;
+
+    for table in [
+        "graph_edges",
+        "memory_candidates",
+        "graph_candidates",
+        "memory_operation_log",
+    ] {
+        let fresh_triggers = table_triggers(&fresh, table)?;
+        let upgraded_triggers = table_triggers(&upgraded, table)?;
+        assert_eq!(
+            fresh_triggers, upgraded_triggers,
+            "{table} triggers must converge between fresh and upgraded DBs"
+        );
+    }
+
+    for (table, trigger) in [
+        (
+            "graph_edges",
+            "graph_edges_validate_source_candidate_insert",
+        ),
+        (
+            "graph_edges",
+            "graph_edges_validate_source_candidate_update",
+        ),
+        ("memory_candidates", "graph_edges_memory_candidates_delete"),
+        (
+            "memory_candidates",
+            "graph_edges_memory_candidates_update_id",
+        ),
+        ("graph_candidates", "graph_edges_graph_candidates_delete"),
+        ("graph_candidates", "graph_edges_graph_candidates_update_id"),
+        (
+            "memory_operation_log",
+            "graph_edges_memory_operation_provenance_update",
+        ),
+    ] {
+        let triggers = table_triggers(&fresh, table)?;
+        assert!(
+            triggers.contains(&trigger.to_string()),
+            "missing graph edge candidate integrity trigger on {table}: {trigger}"
+        );
+    }
     Ok(())
 }
 

--- a/src/migrate/tests_schema.rs
+++ b/src/migrate/tests_schema.rs
@@ -3,6 +3,96 @@ use rusqlite::{params, Connection};
 
 use super::{run_migrations, MIGRATIONS};
 
+struct GraphSchemaFixture {
+    now: i64,
+    project_id: i64,
+    episode_id: i64,
+    memory_id: i64,
+    other_memory_id: i64,
+    candidate_id: i64,
+    operation_id: i64,
+}
+
+fn setup_graph_schema_fixture(conn: &Connection) -> Result<GraphSchemaFixture> {
+    let now = 1_700_000_000_i64;
+    let host_id: i64 =
+        conn.query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |row| {
+            row.get(0)
+        })?;
+    conn.execute(
+        "INSERT INTO workspaces(root_path, git_remote, git_branch, created_at_epoch, updated_at_epoch)
+         VALUES ('/tmp/remem-graph-schema', 'origin', 'main', ?1, ?1)",
+        [now],
+    )?;
+    let workspace_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO projects(workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
+         VALUES (?1, '/tmp/remem-graph-schema', 'tmp-remem-graph-schema', ?2, ?2)",
+        params![workspace_id, now],
+    )?;
+    let project_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO sessions(host_id, workspace_id, project_id, session_id, started_at_epoch,
+                              last_seen_at_epoch, status)
+         VALUES (?1, ?2, ?3, 'session-a', ?4, ?4, 'active')",
+        params![host_id, workspace_id, project_id, now],
+    )?;
+    let session_row_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO captured_events(host_id, workspace_id, project_id, session_row_id,
+                                     session_id, event_id, event_type, content_hash,
+                                     retention_class, created_at_epoch, inserted_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, 'session-a', 'event-a', 'message',
+                 'hash-a', 'default', ?5, ?5)",
+        params![host_id, workspace_id, project_id, session_row_id, now],
+    )?;
+    let episode_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memories(project, topic_key, title, content, memory_type,
+                              created_at_epoch, updated_at_epoch, status)
+         VALUES ('/tmp/remem-graph-schema', 'graph-schema', 'Graph schema',
+                 'Schema rejects graph self-edges.', 'decision', ?1, ?1, 'active')",
+        [now],
+    )?;
+    let memory_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memories(project, topic_key, title, content, memory_type,
+                              created_at_epoch, updated_at_epoch, status)
+         VALUES ('/tmp/remem-graph-schema', 'graph-schema-2', 'Graph schema 2',
+                 'Schema rejects dangling candidate provenance.', 'decision', ?1, ?1, 'active')",
+        [now],
+    )?;
+    let other_memory_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memory_candidates(project_id, scope, memory_type, topic_key, text,
+                                       evidence_event_ids, confidence, risk_class,
+                                       review_status, created_at_epoch, updated_at_epoch)
+         VALUES (?1, 'project', 'decision', 'graph-schema', 'Graph schema.',
+                 ?2, 0.9, 'low', 'accepted', ?3, ?3)",
+        params![project_id, format!("[{episode_id}]"), now],
+    )?;
+    let candidate_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memory_operation_log(operation, planner_version, actor, source,
+                                         source_candidate_id, result_memory_id,
+                                         confidence, reason, created_at_epoch)
+         VALUES ('add', 'graph-schema-test', 'test', 'memory_candidate',
+                 ?1, ?2, 0.9, 'test provenance', ?3)",
+        params![candidate_id, memory_id, now],
+    )?;
+    let operation_id = conn.last_insert_rowid();
+
+    Ok(GraphSchemaFixture {
+        now,
+        project_id,
+        episode_id,
+        memory_id,
+        other_memory_id,
+        candidate_id,
+        operation_id,
+    })
+}
+
 #[test]
 fn memory_ownership_migration_backfills_legacy_rows() -> Result<()> {
     let conn = Connection::open_in_memory()?;
@@ -240,66 +330,36 @@ fn graph_edges_reject_self_edges_at_schema_boundary() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
     run_migrations(&conn)?;
+    let fixture = setup_graph_schema_fixture(&conn)?;
 
-    let now = 1_700_000_000_i64;
-    let host_id: i64 =
-        conn.query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |row| {
-            row.get(0)
-        })?;
-    conn.execute(
-        "INSERT INTO workspaces(root_path, git_remote, git_branch, created_at_epoch, updated_at_epoch)
-         VALUES ('/tmp/remem-graph-schema', 'origin', 'main', ?1, ?1)",
-        [now],
-    )?;
-    let workspace_id = conn.last_insert_rowid();
-    conn.execute(
-        "INSERT INTO projects(workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
-         VALUES (?1, '/tmp/remem-graph-schema', 'tmp-remem-graph-schema', ?2, ?2)",
-        params![workspace_id, now],
-    )?;
-    let project_id = conn.last_insert_rowid();
-    conn.execute(
-        "INSERT INTO sessions(host_id, workspace_id, project_id, session_id, started_at_epoch,
-                              last_seen_at_epoch, status)
-         VALUES (?1, ?2, ?3, 'session-a', ?4, ?4, 'active')",
-        params![host_id, workspace_id, project_id, now],
-    )?;
-    let session_row_id = conn.last_insert_rowid();
-    conn.execute(
-        "INSERT INTO captured_events(host_id, workspace_id, project_id, session_row_id,
-                                     session_id, event_id, event_type, content_hash,
-                                     retention_class, created_at_epoch, inserted_at_epoch)
-         VALUES (?1, ?2, ?3, ?4, 'session-a', 'event-a', 'message',
-                 'hash-a', 'default', ?5, ?5)",
-        params![host_id, workspace_id, project_id, session_row_id, now],
-    )?;
-    let episode_id = conn.last_insert_rowid();
-    conn.execute(
-        "INSERT INTO memories(project, topic_key, title, content, memory_type,
-                              created_at_epoch, updated_at_epoch, status)
-         VALUES ('/tmp/remem-graph-schema', 'graph-schema', 'Graph schema',
-                 'Schema rejects graph self-edges.', 'decision', ?1, ?1, 'active')",
-        [now],
-    )?;
-    let memory_id = conn.last_insert_rowid();
-    conn.execute(
-        "INSERT INTO memory_candidates(project_id, scope, memory_type, topic_key, text,
-                                       evidence_event_ids, confidence, risk_class,
-                                       review_status, created_at_epoch, updated_at_epoch)
-         VALUES (?1, 'project', 'decision', 'graph-schema', 'Graph schema.',
-                 ?2, 0.9, 'low', 'accepted', ?3, ?3)",
-        params![project_id, format!("[{episode_id}]"), now],
-    )?;
-    let candidate_id = conn.last_insert_rowid();
-    conn.execute(
-        "INSERT INTO memory_operation_log(operation, planner_version, actor, source,
-                                         source_candidate_id, result_memory_id,
-                                         confidence, reason, created_at_epoch)
-         VALUES ('add', 'graph-schema-test', 'test', 'memory_candidate',
-                 ?1, ?2, 0.9, 'test provenance', ?3)",
-        params![candidate_id, memory_id, now],
-    )?;
-    let operation_id = conn.last_insert_rowid();
+    let err = conn
+        .execute(
+            "INSERT INTO graph_edges
+             (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+              source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
+             created_at_epoch)
+             VALUES ('duplicates', 'trusted', 'memory', ?1, 'memory', ?1,
+                     ?2, ?3, ?4, 0.9, 'self edge', ?5)",
+            params![
+                fixture.memory_id,
+                format!("[{}]", fixture.episode_id),
+                fixture.candidate_id,
+                fixture.operation_id,
+                fixture.now
+            ],
+        )
+        .expect_err("raw SQL graph self-edge must fail");
+    assert!(err.to_string().contains("CHECK constraint failed"));
+
+    Ok(())
+}
+
+#[test]
+fn graph_edges_reject_dangling_source_candidate_at_schema_boundary() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+    run_migrations(&conn)?;
+    let fixture = setup_graph_schema_fixture(&conn)?;
 
     let err = conn
         .execute(
@@ -307,18 +367,250 @@ fn graph_edges_reject_self_edges_at_schema_boundary() -> Result<()> {
              (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
               source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
               created_at_epoch)
-             VALUES ('duplicates', 'trusted', 'memory', ?1, 'memory', ?1,
-                     ?2, ?3, ?4, 0.9, 'self edge', ?5)",
+             VALUES ('duplicates', 'trusted', 'memory', ?1, 'memory', ?2,
+                     ?3, ?4, ?5, 0.9, 'dangling candidate', ?6)",
             params![
-                memory_id,
-                format!("[{episode_id}]"),
-                candidate_id,
-                operation_id,
-                now
+                fixture.memory_id,
+                fixture.other_memory_id,
+                format!("[{}]", fixture.episode_id),
+                fixture.candidate_id + 10_000,
+                fixture.operation_id,
+                fixture.now
             ],
         )
-        .expect_err("raw SQL graph self-edge must fail");
-    assert!(err.to_string().contains("CHECK constraint failed"));
+        .expect_err("raw SQL graph source_candidate_id must reference an existing candidate");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source candidate missing"));
+
+    conn.execute(
+        "INSERT INTO graph_edges
+         (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+          source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
+          created_at_epoch)
+         VALUES ('duplicates', 'trusted', 'memory', ?1, 'memory', ?2,
+                 ?3, ?4, ?5, 0.9, 'valid candidate', ?6)",
+        params![
+            fixture.memory_id,
+            fixture.other_memory_id,
+            format!("[{}]", fixture.episode_id),
+            fixture.candidate_id,
+            fixture.operation_id,
+            fixture.now
+        ],
+    )?;
+    let edge_id = conn.last_insert_rowid();
+
+    conn.execute(
+        "INSERT INTO memory_candidates(project_id, scope, memory_type, topic_key, text,
+                                       evidence_event_ids, confidence, risk_class,
+                                       review_status, created_at_epoch, updated_at_epoch)
+         VALUES (?1, 'project', 'decision', 'graph-schema-other', 'Other graph schema.',
+                 ?2, 0.9, 'low', 'accepted', ?3, ?3)",
+        params![
+            fixture.project_id,
+            format!("[{}]", fixture.episode_id),
+            fixture.now
+        ],
+    )?;
+    let other_candidate_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memory_operation_log(operation, planner_version, actor, source,
+                                         source_candidate_id, result_memory_id,
+                                         confidence, reason, created_at_epoch)
+         VALUES ('add', 'graph-schema-test', 'test', 'memory_candidate',
+                 ?1, ?2, 0.9, 'mismatched provenance', ?3)",
+        params![other_candidate_id, fixture.memory_id, fixture.now],
+    )?;
+    let mismatched_operation_id = conn.last_insert_rowid();
+    let err = conn
+        .execute(
+            "INSERT INTO graph_edges
+             (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+              source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
+              created_at_epoch)
+             VALUES ('duplicates', 'trusted', 'memory', ?1, 'memory', ?2,
+                     ?3, ?4, ?5, 0.9, 'mismatched operation', ?6)",
+            params![
+                fixture.memory_id,
+                fixture.other_memory_id,
+                format!("[{}]", fixture.episode_id),
+                fixture.candidate_id,
+                mismatched_operation_id,
+                fixture.now
+            ],
+        )
+        .expect_err("operation provenance must reference the same source candidate");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source candidate missing"));
+
+    let err = conn
+        .execute(
+            "UPDATE graph_edges SET source_operation_id = ?1 WHERE id = ?2",
+            params![mismatched_operation_id, edge_id],
+        )
+        .expect_err("retagging edge operation to a different candidate must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source candidate missing"));
+
+    let err = conn
+        .execute(
+            "UPDATE graph_edges SET source_candidate_id = ?1 WHERE id = ?2",
+            params![fixture.candidate_id + 10_000, edge_id],
+        )
+        .expect_err("raw SQL graph source_candidate_id update must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source candidate missing"));
+
+    let err = conn
+        .execute(
+            "UPDATE memory_candidates SET id = ?1 WHERE id = ?2",
+            params![fixture.candidate_id + 10_000, fixture.candidate_id],
+        )
+        .expect_err("updating a candidate used by graph_edges must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source candidate in use"));
+
+    let err = conn
+        .execute(
+            "UPDATE memory_operation_log SET source = 'graph_candidate' WHERE id = ?1",
+            [fixture.operation_id],
+        )
+        .expect_err("retagging operation provenance used by graph_edges must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source operation in use"));
+
+    let err = conn
+        .execute(
+            "UPDATE memory_operation_log SET source_candidate_id = ?1 WHERE id = ?2",
+            params![other_candidate_id, fixture.operation_id],
+        )
+        .expect_err("retagging operation candidate used by graph_edges must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source operation in use"));
+
+    let err = conn
+        .execute(
+            "DELETE FROM memory_candidates WHERE id = ?1",
+            [fixture.candidate_id],
+        )
+        .expect_err("deleting a candidate used by graph_edges must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source candidate in use"));
+
+    conn.execute(
+        "INSERT INTO graph_candidates(project_id, source_project, candidate_type, edge_type,
+                                      from_ref, to_ref, evidence_event_ids, confidence,
+                                      risk_class, reason, review_status, created_at_epoch,
+                                      updated_at_epoch)
+         VALUES (?1, '/tmp/remem-graph-schema', 'edge', 'duplicates',
+                 'memory:1', 'memory:2', ?2, 0.9, 'low', 'graph candidate',
+                 'approved', ?3, ?3)",
+        params![
+            fixture.project_id,
+            format!("[{}]", fixture.episode_id),
+            fixture.now
+        ],
+    )?;
+    let graph_candidate_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memory_operation_log(operation, planner_version, actor, source,
+                                         source_candidate_id, result_memory_id,
+                                         confidence, reason, created_at_epoch)
+         VALUES ('add', 'graph-schema-test', 'test', 'graph_candidate',
+                 ?1, ?2, 0.9, 'graph candidate provenance', ?3)",
+        params![graph_candidate_id, fixture.memory_id, fixture.now],
+    )?;
+    let graph_operation_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO graph_edges
+         (edge_type, edge_trust, from_node_kind, from_node_id, to_node_kind, to_node_id,
+          source_event_ids, source_candidate_id, source_operation_id, confidence, reason,
+          created_at_epoch)
+         VALUES ('duplicates', 'trusted', 'memory', ?1, 'memory', ?2,
+                 ?3, ?4, ?5, 0.9, 'valid graph candidate', ?6)",
+        params![
+            fixture.memory_id,
+            fixture.other_memory_id,
+            format!("[{}]", fixture.episode_id),
+            graph_candidate_id,
+            graph_operation_id,
+            fixture.now
+        ],
+    )?;
+
+    let err = conn
+        .execute(
+            "UPDATE graph_edges SET source_candidate_id = ?1 WHERE source_operation_id = ?2",
+            params![graph_candidate_id + 10_000, graph_operation_id],
+        )
+        .expect_err("raw SQL graph candidate provenance update must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source candidate missing"));
+
+    let err = conn
+        .execute(
+            "UPDATE graph_candidates SET id = ?1 WHERE id = ?2",
+            params![graph_candidate_id + 10_000, graph_candidate_id],
+        )
+        .expect_err("updating a graph candidate used by graph_edges must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source candidate in use"));
+
+    let err = conn
+        .execute(
+            "UPDATE memory_operation_log SET source = 'memory_candidate' WHERE id = ?1",
+            [graph_operation_id],
+        )
+        .expect_err("retagging graph operation provenance used by graph_edges must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source operation in use"));
+
+    let err = conn
+        .execute(
+            "DELETE FROM graph_candidates WHERE id = ?1",
+            [graph_candidate_id],
+        )
+        .expect_err("deleting a graph candidate used by graph_edges must fail closed");
+    assert!(err
+        .to_string()
+        .contains("graph_edges source candidate in use"));
+
+    Ok(())
+}
+
+#[test]
+fn graph_edges_schema_installs_source_candidate_integrity_triggers() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+    run_migrations(&conn)?;
+
+    for trigger in [
+        "graph_edges_validate_source_candidate_insert",
+        "graph_edges_validate_source_candidate_update",
+        "graph_edges_memory_candidates_delete",
+        "graph_edges_memory_candidates_update_id",
+        "graph_edges_graph_candidates_delete",
+        "graph_edges_graph_candidates_update_id",
+        "graph_edges_memory_operation_provenance_update",
+    ] {
+        let sql: String = conn.query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = ?1",
+            [trigger],
+            |row| row.get(0),
+        )?;
+        assert!(sql.contains("graph_edges"));
+    }
 
     Ok(())
 }

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -185,6 +185,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "capture_drop_events",
         sql: include_str!("../migrations/v036_capture_drop_events.sql"),
     },
+    Migration {
+        version: 37,
+        name: "graph_edge_source_candidate_integrity",
+        sql: include_str!("../migrations/v037_graph_edge_source_candidate_integrity.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v037_graph_edge_source_candidate_integrity.sql
+++ b/src/migrations/v037_graph_edge_source_candidate_integrity.sql
@@ -1,0 +1,175 @@
+-- v037_graph_edge_source_candidate_integrity: restore storage-level
+-- provenance integrity for graph_edges.source_candidate_id after the v034 table
+-- rebuild dropped the original v031 invariant. The candidate id is typed by the
+-- required memory_operation_log.source: memory_candidate ids live in
+-- memory_candidates, and graph_candidate ids live in graph_candidates.
+
+DROP TABLE IF EXISTS temp.graph_edge_source_candidate_integrity_check;
+CREATE TEMP TABLE graph_edge_source_candidate_integrity_check (
+    ok INTEGER NOT NULL CHECK(ok = 1)
+);
+
+INSERT INTO graph_edge_source_candidate_integrity_check(ok)
+SELECT 0
+FROM graph_edges e
+WHERE e.source_candidate_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM memory_operation_log op
+      WHERE op.id = e.source_operation_id
+        AND op.source_candidate_id = e.source_candidate_id
+        AND (
+            (
+                op.source = 'memory_candidate'
+                AND EXISTS (
+                    SELECT 1
+                    FROM memory_candidates c
+                    WHERE c.id = e.source_candidate_id
+                )
+            )
+            OR (
+                op.source = 'graph_candidate'
+                AND EXISTS (
+                    SELECT 1
+                    FROM graph_candidates c
+                    WHERE c.id = e.source_candidate_id
+                )
+            )
+        )
+  )
+LIMIT 1;
+
+DROP TABLE temp.graph_edge_source_candidate_integrity_check;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_validate_source_candidate_insert
+BEFORE INSERT ON graph_edges
+WHEN NEW.source_candidate_id IS NOT NULL
+BEGIN
+    SELECT CASE
+        WHEN NOT EXISTS (
+            SELECT 1
+            FROM memory_operation_log op
+            WHERE op.id = NEW.source_operation_id
+              AND op.source_candidate_id = NEW.source_candidate_id
+              AND (
+                  (
+                      op.source = 'memory_candidate'
+                      AND EXISTS (
+                          SELECT 1
+                          FROM memory_candidates c
+                          WHERE c.id = NEW.source_candidate_id
+                      )
+                  )
+                  OR (
+                      op.source = 'graph_candidate'
+                      AND EXISTS (
+                          SELECT 1
+                          FROM graph_candidates c
+                          WHERE c.id = NEW.source_candidate_id
+                      )
+                  )
+              )
+        )
+        THEN RAISE(ABORT, 'graph_edges source candidate missing')
+    END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_validate_source_candidate_update
+BEFORE UPDATE OF source_candidate_id, source_operation_id ON graph_edges
+WHEN NEW.source_candidate_id IS NOT NULL
+BEGIN
+    SELECT CASE
+        WHEN NOT EXISTS (
+            SELECT 1
+            FROM memory_operation_log op
+            WHERE op.id = NEW.source_operation_id
+              AND op.source_candidate_id = NEW.source_candidate_id
+              AND (
+                  (
+                      op.source = 'memory_candidate'
+                      AND EXISTS (
+                          SELECT 1
+                          FROM memory_candidates c
+                          WHERE c.id = NEW.source_candidate_id
+                      )
+                  )
+                  OR (
+                      op.source = 'graph_candidate'
+                      AND EXISTS (
+                          SELECT 1
+                          FROM graph_candidates c
+                          WHERE c.id = NEW.source_candidate_id
+                      )
+                  )
+              )
+        )
+        THEN RAISE(ABORT, 'graph_edges source candidate missing')
+    END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_memory_candidates_delete
+BEFORE DELETE ON memory_candidates
+WHEN EXISTS (
+    SELECT 1
+    FROM graph_edges e
+    JOIN memory_operation_log op ON op.id = e.source_operation_id
+    WHERE e.source_candidate_id = OLD.id
+      AND op.source = 'memory_candidate'
+)
+BEGIN
+    SELECT RAISE(ABORT, 'graph_edges source candidate in use');
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_memory_candidates_update_id
+BEFORE UPDATE OF id ON memory_candidates
+WHEN NEW.id != OLD.id
+  AND EXISTS (
+      SELECT 1
+      FROM graph_edges e
+      JOIN memory_operation_log op ON op.id = e.source_operation_id
+      WHERE e.source_candidate_id = OLD.id
+        AND op.source = 'memory_candidate'
+  )
+BEGIN
+    SELECT RAISE(ABORT, 'graph_edges source candidate in use');
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_graph_candidates_delete
+BEFORE DELETE ON graph_candidates
+WHEN EXISTS (
+    SELECT 1
+    FROM graph_edges e
+    JOIN memory_operation_log op ON op.id = e.source_operation_id
+    WHERE e.source_candidate_id = OLD.id
+      AND op.source = 'graph_candidate'
+)
+BEGIN
+    SELECT RAISE(ABORT, 'graph_edges source candidate in use');
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_graph_candidates_update_id
+BEFORE UPDATE OF id ON graph_candidates
+WHEN NEW.id != OLD.id
+  AND EXISTS (
+      SELECT 1
+      FROM graph_edges e
+      JOIN memory_operation_log op ON op.id = e.source_operation_id
+      WHERE e.source_candidate_id = OLD.id
+        AND op.source = 'graph_candidate'
+  )
+BEGIN
+    SELECT RAISE(ABORT, 'graph_edges source candidate in use');
+END;
+
+CREATE TRIGGER IF NOT EXISTS graph_edges_memory_operation_provenance_update
+BEFORE UPDATE OF source, source_candidate_id ON memory_operation_log
+WHEN (NEW.source != OLD.source OR NEW.source_candidate_id IS NOT OLD.source_candidate_id)
+  AND EXISTS (
+      SELECT 1
+      FROM graph_edges e
+      WHERE e.source_operation_id = OLD.id
+        AND e.source_candidate_id IS NOT NULL
+  )
+BEGIN
+    SELECT RAISE(ABORT, 'graph_edges source operation in use');
+END;


### PR DESCRIPTION
## Summary
- add v037 graph edge provenance integrity migration with typed candidate checks for memory and graph candidates
- validate trusted graph edge provenance in Rust against the operation source and candidate table
- add raw SQL migration drift tests and convergence coverage for trigger installation

Fixes #432

## Verification
- cargo fmt --check
- cargo test migrate::tests_schema::graph_edges_reject_dangling_source_candidate_at_schema_boundary -- --nocapture
- cargo test migrate::tests_schema::graph_edges_schema_installs_source_candidate_integrity_triggers -- --nocapture
- cargo test migrate::tests_convergence::graph_edges_candidate_integrity_triggers_match_after_upgrade -- --nocapture
- cargo test memory::graph_contract::tests -- --nocapture
- cargo test graph_candidate::tests -- --nocapture
- cargo check --message-format=short
- cargo clippy -- -D warnings
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- git diff --check origin/main...HEAD
- cargo test