### PR TITLE
Make runtime and host config writes atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.37"
+version = "0.5.38"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.37"
+version = "0.5.38"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.37",
+  "version": "0.5.38",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.37": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.37",
+    "0.5.38": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.38",
       "assets": {}
     }
   }

--- a/src/atomic_file.rs
+++ b/src/atomic_file.rs
@@ -11,18 +11,18 @@ use anyhow::{Context, Result};
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(test)]
-static FAIL_NEXT_RENAME: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static FAIL_RENAME_PATH: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
 #[cfg(test)]
 static FAILPOINT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 pub(crate) fn write_atomic(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<()> {
-    let path = path.as_ref();
-    let parent = parent_dir(path);
+    let path = resolve_final_path(path.as_ref())?;
+    let parent = parent_dir(&path);
     fs::create_dir_all(parent)
         .with_context(|| format!("create parent directory {}", parent.display()))?;
 
-    let temp_path = temp_path_for(path)?;
-    let result = write_via_temp(path, parent, &temp_path, contents.as_ref());
+    let temp_path = temp_path_for(&path)?;
+    let result = write_via_temp(&path, parent, &temp_path, contents.as_ref());
     if result.is_err() {
         let _ = fs::remove_file(&temp_path);
     }
@@ -43,7 +43,7 @@ fn write_via_temp(path: &Path, parent: &Path, temp_path: &Path, contents: &[u8])
     drop(file);
 
     #[cfg(test)]
-    if FAIL_NEXT_RENAME.swap(false, Ordering::SeqCst) {
+    if should_fail_rename_for_test(path) {
         bail!("injected atomic write failure before rename");
     }
 
@@ -61,6 +61,32 @@ fn copy_permissions_if_present(path: &Path, temp_file: &File) -> Result<()> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err).with_context(|| format!("read metadata {}", path.display())),
     }
+}
+
+fn resolve_final_path(path: &Path) -> Result<PathBuf> {
+    let mut current = path.to_path_buf();
+    for _ in 0..32 {
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                let target = fs::read_link(&current)
+                    .with_context(|| format!("read symlink {}", current.display()))?;
+                current = if target.is_absolute() {
+                    target
+                } else {
+                    parent_dir(&current).join(target)
+                };
+            }
+            Ok(_) => return Ok(current),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(current),
+            Err(err) => {
+                return Err(err).with_context(|| format!("read metadata {}", current.display()));
+            }
+        }
+    }
+    anyhow::bail!(
+        "too many symlink hops while resolving atomic write path {}",
+        path.display()
+    );
 }
 
 fn temp_path_for(path: &Path) -> Result<PathBuf> {
@@ -95,20 +121,42 @@ fn sync_parent_dir(_parent: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
-pub(crate) fn fail_next_rename_for_test() {
-    FAIL_NEXT_RENAME.store(true, Ordering::SeqCst);
+pub(crate) fn fail_next_rename_for_path_for_test(path: impl AsRef<Path>) {
+    let mut fail_path = match FAIL_RENAME_PATH.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    *fail_path = Some(path.as_ref().to_path_buf());
 }
 
 #[cfg(test)]
 pub(crate) fn clear_failpoints_for_test() {
-    FAIL_NEXT_RENAME.store(false, Ordering::SeqCst);
+    let mut fail_path = match FAIL_RENAME_PATH.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    *fail_path = None;
+}
+
+#[cfg(test)]
+fn should_fail_rename_for_test(path: &Path) -> bool {
+    let mut fail_path = match FAIL_RENAME_PATH.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if fail_path.as_deref() == Some(path) {
+        *fail_path = None;
+        return true;
+    }
+    false
 }
 
 #[cfg(test)]
 pub(crate) fn failpoint_test_lock() -> std::sync::MutexGuard<'static, ()> {
-    FAILPOINT_TEST_LOCK
-        .lock()
-        .expect("atomic write failpoint lock should acquire")
+    match FAILPOINT_TEST_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
 }
 
 #[cfg(test)]
@@ -124,7 +172,7 @@ mod tests {
             TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
         fs::write(&path, "old")?;
-        fail_next_rename_for_test();
+        fail_next_rename_for_path_for_test(&path);
 
         let err = write_atomic(&path, "new").expect_err("injected failure must abort");
         assert!(err.to_string().contains("injected atomic write failure"));
@@ -147,6 +195,60 @@ mod tests {
 
         assert_eq!(fs::read_to_string(&path)?, "new");
         let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn rename_failpoint_is_path_scoped() -> Result<()> {
+        let _guard = failpoint_test_lock();
+        let path = std::env::temp_dir().join(format!(
+            "remem-atomic-write-scoped-{}-{}.txt",
+            std::process::id(),
+            TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let other = std::env::temp_dir().join(format!(
+            "remem-atomic-write-other-{}-{}.txt",
+            std::process::id(),
+            TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::write(&path, "old")?;
+        fs::write(&other, "old")?;
+        fail_next_rename_for_path_for_test(&path);
+
+        write_atomic(&other, "new")?;
+        let err = write_atomic(&path, "new").expect_err("targeted failure must abort");
+
+        assert!(err.to_string().contains("injected atomic write failure"));
+        assert_eq!(fs::read_to_string(&other)?, "new");
+        assert_eq!(fs::read_to_string(&path)?, "old");
+        clear_failpoints_for_test();
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_file(other);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_target_is_updated_without_replacing_link() -> Result<()> {
+        let _guard = failpoint_test_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "remem-atomic-write-symlink-{}-{}",
+            std::process::id(),
+            TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir)?;
+        let target = dir.join("target.toml");
+        let link = dir.join("config.toml");
+        fs::write(&target, "old")?;
+        std::os::unix::fs::symlink(&target, &link)?;
+
+        write_atomic(&link, "new")?;
+
+        assert!(fs::symlink_metadata(&link)?.file_type().is_symlink());
+        assert_eq!(fs::read_to_string(&target)?, "new");
+        let _ = fs::remove_file(link);
+        let _ = fs::remove_file(target);
+        let _ = fs::remove_dir(dir);
         Ok(())
     }
 }

--- a/src/atomic_file.rs
+++ b/src/atomic_file.rs
@@ -1,0 +1,152 @@
+use std::ffi::OsString;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(test)]
+use anyhow::bail;
+use anyhow::{Context, Result};
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+static FAIL_NEXT_RENAME: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+#[cfg(test)]
+static FAILPOINT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+pub(crate) fn write_atomic(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<()> {
+    let path = path.as_ref();
+    let parent = parent_dir(path);
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create parent directory {}", parent.display()))?;
+
+    let temp_path = temp_path_for(path)?;
+    let result = write_via_temp(path, parent, &temp_path, contents.as_ref());
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
+}
+
+fn write_via_temp(path: &Path, parent: &Path, temp_path: &Path, contents: &[u8]) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(temp_path)
+        .with_context(|| format!("create temp file {}", temp_path.display()))?;
+    file.write_all(contents)
+        .with_context(|| format!("write temp file {}", temp_path.display()))?;
+    copy_permissions_if_present(path, &file)?;
+    file.sync_all()
+        .with_context(|| format!("sync temp file {}", temp_path.display()))?;
+    drop(file);
+
+    #[cfg(test)]
+    if FAIL_NEXT_RENAME.swap(false, Ordering::SeqCst) {
+        bail!("injected atomic write failure before rename");
+    }
+
+    fs::rename(temp_path, path)
+        .with_context(|| format!("rename {} to {}", temp_path.display(), path.display()))?;
+    sync_parent_dir(parent)?;
+    Ok(())
+}
+
+fn copy_permissions_if_present(path: &Path, temp_file: &File) -> Result<()> {
+    match fs::metadata(path) {
+        Ok(metadata) => temp_file
+            .set_permissions(metadata.permissions())
+            .with_context(|| format!("copy permissions from {}", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("read metadata {}", path.display())),
+    }
+}
+
+fn temp_path_for(path: &Path) -> Result<PathBuf> {
+    let parent = parent_dir(path);
+    let file_name = path
+        .file_name()
+        .with_context(|| format!("atomic write path has no file name: {}", path.display()))?;
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut temp_name = OsString::from(".");
+    temp_name.push(file_name);
+    temp_name.push(format!(".tmp.{}.{}", std::process::id(), counter));
+    Ok(parent.join(temp_name))
+}
+
+fn parent_dir(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+#[cfg(unix)]
+fn sync_parent_dir(parent: &Path) -> Result<()> {
+    let dir =
+        File::open(parent).with_context(|| format!("open parent dir {}", parent.display()))?;
+    dir.sync_all()
+        .with_context(|| format!("sync parent dir {}", parent.display()))
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_parent: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn fail_next_rename_for_test() {
+    FAIL_NEXT_RENAME.store(true, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn clear_failpoints_for_test() {
+    FAIL_NEXT_RENAME.store(false, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn failpoint_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    FAILPOINT_TEST_LOCK
+        .lock()
+        .expect("atomic write failpoint lock should acquire")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injected_failure_preserves_existing_file() -> Result<()> {
+        let _guard = failpoint_test_lock();
+        let path = std::env::temp_dir().join(format!(
+            "remem-atomic-write-{}-{}.txt",
+            std::process::id(),
+            TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::write(&path, "old")?;
+        fail_next_rename_for_test();
+
+        let err = write_atomic(&path, "new").expect_err("injected failure must abort");
+        assert!(err.to_string().contains("injected atomic write failure"));
+        assert_eq!(fs::read_to_string(&path)?, "old");
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn successful_write_replaces_existing_file() -> Result<()> {
+        let _guard = failpoint_test_lock();
+        let path = std::env::temp_dir().join(format!(
+            "remem-atomic-write-success-{}-{}.txt",
+            std::process::id(),
+            TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::write(&path, "old")?;
+
+        write_atomic(&path, "new")?;
+
+        assert_eq!(fs::read_to_string(&path)?, "new");
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+}

--- a/src/atomic_file.rs
+++ b/src/atomic_file.rs
@@ -4,9 +4,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-#[cfg(test)]
-use anyhow::bail;
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -21,20 +19,51 @@ pub(crate) fn write_atomic(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -
     fs::create_dir_all(parent)
         .with_context(|| format!("create parent directory {}", parent.display()))?;
 
-    let temp_path = temp_path_for(&path)?;
-    let result = write_via_temp(&path, parent, &temp_path, contents.as_ref());
+    let (temp_path, file) = create_temp_file(&path)?;
+    let result = write_via_temp(&path, parent, &temp_path, file, contents.as_ref());
     if result.is_err() {
         let _ = fs::remove_file(&temp_path);
     }
     result
 }
 
-fn write_via_temp(path: &Path, parent: &Path, temp_path: &Path, contents: &[u8]) -> Result<()> {
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(temp_path)
-        .with_context(|| format!("create temp file {}", temp_path.display()))?;
+fn create_temp_file(path: &Path) -> Result<(PathBuf, File)> {
+    let mut last_collision = None;
+    for _ in 0..16 {
+        let temp_path = temp_path_for(path)?;
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+        {
+            Ok(file) => return Ok((temp_path, file)),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                last_collision = Some(temp_path);
+            }
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("create temp file {}", temp_path.display()));
+            }
+        }
+    }
+
+    let last = last_collision
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "<none>".to_string());
+    bail!(
+        "create unique temp file for {} failed after repeated collisions; last collision {}",
+        path.display(),
+        last
+    );
+}
+
+fn write_via_temp(
+    path: &Path,
+    parent: &Path,
+    temp_path: &Path,
+    mut file: File,
+    contents: &[u8],
+) -> Result<()> {
     file.write_all(contents)
         .with_context(|| format!("write temp file {}", temp_path.display()))?;
     copy_permissions_if_present(path, &file)?;
@@ -47,8 +76,7 @@ fn write_via_temp(path: &Path, parent: &Path, temp_path: &Path, contents: &[u8])
         bail!("injected atomic write failure before rename");
     }
 
-    fs::rename(temp_path, path)
-        .with_context(|| format!("rename {} to {}", temp_path.display(), path.display()))?;
+    replace_file(temp_path, path)?;
     sync_parent_dir(parent)?;
     Ok(())
 }
@@ -95,9 +123,17 @@ fn temp_path_for(path: &Path) -> Result<PathBuf> {
         .file_name()
         .with_context(|| format!("atomic write path has no file name: {}", path.display()))?;
     let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut nonce = [0u8; 8];
+    getrandom::fill(&mut nonce)
+        .map_err(|err| anyhow::anyhow!("generate atomic temp file nonce: {err}"))?;
+    let nonce = u64::from_ne_bytes(nonce);
     let mut temp_name = OsString::from(".");
     temp_name.push(file_name);
-    temp_name.push(format!(".tmp.{}.{}", std::process::id(), counter));
+    temp_name.push(format!(
+        ".tmp.{}.{}.{nonce:016x}",
+        std::process::id(),
+        counter
+    ));
     Ok(parent.join(temp_name))
 }
 
@@ -118,6 +154,49 @@ fn sync_parent_dir(parent: &Path) -> Result<()> {
 #[cfg(not(unix))]
 fn sync_parent_dir(_parent: &Path) -> Result<()> {
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_file(temp_path: &Path, path: &Path) -> Result<()> {
+    fs::rename(temp_path, path)
+        .with_context(|| format!("rename {} to {}", temp_path.display(), path.display()))
+}
+
+#[cfg(windows)]
+fn replace_file(temp_path: &Path, path: &Path) -> Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        #[link_name = "MoveFileExW"]
+        fn move_file_ex_w(existing: *const u16, new: *const u16, flags: u32) -> i32;
+    }
+
+    let existing = wide_null(temp_path);
+    let new = wide_null(path);
+    let ok = unsafe {
+        move_file_ex_w(
+            existing.as_ptr(),
+            new.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("replace {} with {}", path.display(), temp_path.display()));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn wide_null(path: &Path) -> Vec<u16> {
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -315,7 +315,7 @@ codex_hooks = true
         std::fs::write(&path, "[features]\nhooks = false\n")?;
         let mut doc = DocumentMut::new();
         enable_codex_hooks(&mut doc)?;
-        crate::atomic_file::fail_next_rename_for_test();
+        crate::atomic_file::fail_next_rename_for_path_for_test(&path);
 
         let err = write_toml_doc(&path, &doc).expect_err("injected failure must abort TOML write");
         assert!(format!("{err:?}").contains("injected atomic write failure"));

--- a/src/install/hosts/codex.rs
+++ b/src/install/hosts/codex.rs
@@ -95,11 +95,7 @@ fn read_toml_doc(path: &Path) -> Result<DocumentMut> {
 }
 
 fn write_toml_doc(path: &Path, doc: &DocumentMut) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("创建目录 {} 失败", parent.display()))?;
-    }
-    std::fs::write(path, doc.to_string())
+    crate::atomic_file::write_atomic(path, doc.to_string())
         .with_context(|| format!("写入 {} 失败", path.display()))?;
     Ok(())
 }
@@ -306,6 +302,30 @@ codex_hooks = true
             hooks["Stop"][0]["hooks"][0]["command"],
             "/tmp/remem summarize --host codex-cli"
         );
+    }
+
+    #[test]
+    fn write_toml_failure_preserves_existing_file() -> Result<()> {
+        let _guard = crate::atomic_file::failpoint_test_lock();
+        let path = std::env::temp_dir().join(format!(
+            "remem-codex-toml-{}-{}.toml",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::write(&path, "[features]\nhooks = false\n")?;
+        let mut doc = DocumentMut::new();
+        enable_codex_hooks(&mut doc)?;
+        crate::atomic_file::fail_next_rename_for_test();
+
+        let err = write_toml_doc(&path, &doc).expect_err("injected failure must abort TOML write");
+        assert!(format!("{err:?}").contains("injected atomic write failure"));
+        assert_eq!(
+            std::fs::read_to_string(&path)?,
+            "[features]\nhooks = false\n"
+        );
+        crate::atomic_file::clear_failpoints_for_test();
+        let _ = std::fs::remove_file(path);
+        Ok(())
     }
 
     #[test]

--- a/src/install/json_io.rs
+++ b/src/install/json_io.rs
@@ -31,7 +31,7 @@ mod tests {
             chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
         ));
         std::fs::write(&path, r#"{"existing":true}"#)?;
-        crate::atomic_file::fail_next_rename_for_test();
+        crate::atomic_file::fail_next_rename_for_path_for_test(&path);
 
         let err = write_json_file(&path, &serde_json::json!({"existing": false}))
             .expect_err("injected failure must abort JSON write");

--- a/src/install/json_io.rs
+++ b/src/install/json_io.rs
@@ -13,9 +13,32 @@ pub(in crate::install) fn read_json_file(path: &PathBuf) -> Result<Value> {
 }
 
 pub(in crate::install) fn write_json_file(path: &PathBuf, value: &Value) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let content = serde_json::to_string_pretty(value)?;
-    std::fs::write(path, content).with_context(|| format!("写入 {} 失败", path.display()))
+    crate::atomic_file::write_atomic(path, content)
+        .with_context(|| format!("写入 {} 失败", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_json_failure_preserves_existing_file() -> Result<()> {
+        let _guard = crate::atomic_file::failpoint_test_lock();
+        let path = std::env::temp_dir().join(format!(
+            "remem-json-atomic-{}-{}.json",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::write(&path, r#"{"existing":true}"#)?;
+        crate::atomic_file::fail_next_rename_for_test();
+
+        let err = write_json_file(&path, &serde_json::json!({"existing": false}))
+            .expect_err("injected failure must abort JSON write");
+        assert!(format!("{err:?}").contains("injected atomic write failure"));
+        assert_eq!(std::fs::read_to_string(&path)?, r#"{"existing":true}"#);
+        crate::atomic_file::clear_failpoints_for_test();
+        let _ = std::fs::remove_file(path);
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod adapter;
 pub mod ai;
 pub mod api;
+mod atomic_file;
 mod build_info;
 pub mod cli;
 pub mod context;

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -230,11 +230,8 @@ fn read_config_doc_or_default() -> Result<DocumentMut> {
 }
 
 fn write_config_doc(path: &PathBuf, doc: &DocumentMut) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("create config dir {}", parent.display()))?;
-    }
-    std::fs::write(path, doc.to_string()).with_context(|| format!("write {}", path.display()))
+    crate::atomic_file::write_atomic(path, doc.to_string())
+        .with_context(|| format!("write {}", path.display()))
 }
 
 fn ensure_config_defaults(doc: &mut DocumentMut, hosts: &[&str]) -> Result<()> {
@@ -594,6 +591,26 @@ mod tests {
             assert_eq!(profile.model.as_deref(), Some("custom-mini"));
         });
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn config_write_failure_preserves_existing_runtime_config() -> Result<()> {
+        let path = temp_config_path("runtime-atomic-fail");
+        with_config_path(&path, || -> Result<()> {
+            let _atomic_guard = crate::atomic_file::failpoint_test_lock();
+            init_config()?;
+            let before = std::fs::read_to_string(&path)?;
+            crate::atomic_file::fail_next_rename_for_test();
+
+            let err = set_config_value("memory_ai.profiles.codex.model", "custom-mini")
+                .expect_err("injected atomic write failure must abort config update");
+            assert!(format!("{err:?}").contains("injected atomic write failure"));
+            assert_eq!(std::fs::read_to_string(&path)?, before);
+            crate::atomic_file::clear_failpoints_for_test();
+            Ok(())
+        })?;
+        let _ = std::fs::remove_file(path);
+        Ok(())
     }
 
     #[test]

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -600,7 +600,7 @@ mod tests {
             let _atomic_guard = crate::atomic_file::failpoint_test_lock();
             init_config()?;
             let before = std::fs::read_to_string(&path)?;
-            crate::atomic_file::fail_next_rename_for_test();
+            crate::atomic_file::fail_next_rename_for_path_for_test(&path);
 
             let err = set_config_value("memory_ai.profiles.codex.model", "custom-mini")
                 .expect_err("injected atomic write failure must abort config update");

--- a/src/runtime_config/model.rs
+++ b/src/runtime_config/model.rs
@@ -159,11 +159,9 @@ pub fn rollback_model_config() -> Result<(PathBuf, PathBuf)> {
             backup_path.display()
         );
     }
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("create config dir {}", parent.display()))?;
-    }
-    std::fs::copy(&backup_path, &path)
+    let backup = std::fs::read_to_string(&backup_path)
+        .with_context(|| format!("read model config backup {}", backup_path.display()))?;
+    crate::atomic_file::write_atomic(&path, backup)
         .with_context(|| format!("restore {} from {}", path.display(), backup_path.display()))?;
     Ok((path, backup_path))
 }
@@ -357,6 +355,27 @@ mod tests {
         });
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_file(backup_path_for_config(&path));
+    }
+
+    #[test]
+    fn rollback_failure_preserves_active_config() -> Result<()> {
+        let path = temp_config_path("rollback-atomic-fail");
+        with_config_path(&path, || -> Result<()> {
+            let _atomic_guard = crate::atomic_file::failpoint_test_lock();
+            super::super::init_config()?;
+            set_model(Some(CODEX_HOST), None, "balanced", None, false)?;
+            let before = std::fs::read_to_string(&path)?;
+            crate::atomic_file::fail_next_rename_for_test();
+
+            let err = rollback_model_config().expect_err("injected failure must abort rollback");
+            assert!(format!("{err:?}").contains("injected atomic write failure"));
+            assert_eq!(std::fs::read_to_string(&path)?, before);
+            crate::atomic_file::clear_failpoints_for_test();
+            Ok(())
+        })?;
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(backup_path_for_config(&path));
+        Ok(())
     }
 
     #[test]

--- a/src/runtime_config/model.rs
+++ b/src/runtime_config/model.rs
@@ -365,7 +365,7 @@ mod tests {
             super::super::init_config()?;
             set_model(Some(CODEX_HOST), None, "balanced", None, false)?;
             let before = std::fs::read_to_string(&path)?;
-            crate::atomic_file::fail_next_rename_for_test();
+            crate::atomic_file::fail_next_rename_for_path_for_test(&path);
 
             let err = rollback_model_config().expect_err("injected failure must abort rollback");
             assert!(format!("{err:?}").contains("injected atomic write failure"));


### PR DESCRIPTION
Fixes #431

Summary:
- Add a shared atomic file writer that writes a same-directory temp file, syncs it, renames it into place, and syncs the parent directory on Unix.
- Route runtime config, model rollback, install JSON, and Codex TOML config writes through the atomic helper.
- Add injected rename-failure tests proving existing config files survive aborted writes.

Note:
- This uses atomic replacement semantics for the target path; a symlink target path is replaced at the path rather than followed.

Verification:
- cargo test atomic_file::tests -- --nocapture
- cargo test failure_preserves -- --nocapture
- cargo fmt --check
- python3 scripts/ci/check_plugin_version_sync.py
- node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js
- git diff --check
- cargo check --message-format=short
- cargo clippy -- -D warnings
- cargo test
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- git diff --check origin/main...HEAD