### PR TITLE
Sync npm wrapper with release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check plugin version sync
         run: python3 scripts/ci/check_plugin_version_sync.py
       - name: Test plugin runtime scripts
-        run: node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js
+        run: node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js
       - name: Check version bump
         if: github.event_name == 'pull_request'
         run: python3 scripts/ci/check_version_bump.py "${{ github.event.pull_request.base.sha }}" HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Check version sync
-        run: python3 scripts/ci/check_plugin_version_sync.py
+        run: python3 scripts/ci/check_plugin_version_sync.py --expected-version "${GITHUB_REF_NAME#v}"
       - uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
@@ -92,7 +92,7 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
       - name: Check version sync
-        run: python3 scripts/ci/check_plugin_version_sync.py
+        run: python3 scripts/ci/check_plugin_version_sync.py --expected-version "${GITHUB_REF_NAME#v}"
       - name: Test npm wrapper
         run: node --test npm/remem/scripts/install.test.js
       - name: Publish npm wrapper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      - name: Check version sync
+        run: python3 scripts/ci/check_plugin_version_sync.py
       - uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
@@ -79,3 +81,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Publish crate
         run: cargo publish --locked --token "${{ secrets.CRATES_IO_TOKEN }}"
+
+  publish-npm:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.0.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - name: Check version sync
+        run: python3 scripts/ci/check_plugin_version_sync.py
+      - name: Test npm wrapper
+        run: node --test npm/remem/scripts/install.test.js
+      - name: Publish npm wrapper
+        working-directory: npm/remem
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.38"
+version = "0.5.39"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.38"
+version = "0.5.39"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ brew install majiayu000/tap/remem
 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
 # Pin a specific release or install into a custom bin directory
-REMEM_VERSION=v0.4.5 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
+REMEM_VERSION=v0.5.39 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_NO_CONFIG=1 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
@@ -161,12 +161,8 @@ Currently published:
 - Homebrew: `brew install majiayu000/tap/remem`
 - GitHub Releases: prebuilt binaries for macOS and Linux on x64/arm64
 - crates.io: `cargo install remem-ai --bin remem`
+- npm: `npm install -g @majiayu000/remem`
 - Source build: `cargo build --release`
-
-Prepared but not published:
-
-- npm wrapper package in `npm/remem`; publish requires npm auth or an
-  `NPM_TOKEN` secret
 
 Good next channels:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,7 +37,7 @@ brew install majiayu000/tap/remem
 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
 # 固定版本、指定安装目录，或只安装二进制不改 hooks/MCP
-REMEM_VERSION=v0.4.5 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
+REMEM_VERSION=v0.5.39 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_NO_CONFIG=1 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
@@ -133,12 +133,8 @@ remem status
 - Homebrew：`brew install majiayu000/tap/remem`
 - GitHub Releases：macOS/Linux 的 x64/arm64 预编译二进制
 - crates.io：`cargo install remem-ai --bin remem`
+- npm：`npm install -g @majiayu000/remem`
 - 源码构建：`cargo build --release`
-
-已准备但尚未发布：
-
-- npm wrapper package 位于 `npm/remem`；真正 publish 需要 npm 登录或
-  `NPM_TOKEN` secret
 
 适合继续扩展的渠道：
 

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.4.5",
+  "version": "0.5.39",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -26,7 +26,8 @@
   ],
   "files": [
     "bin/",
-    "scripts/",
+    "scripts/install.js",
+    "scripts/platform.js",
     "README.md"
   ],
   "keywords": [

--- a/npm/remem/scripts/install.js
+++ b/npm/remem/scripts/install.js
@@ -11,26 +11,8 @@ const path = require("node:path");
 
 const { platformKey } = require("./platform");
 
-const VERSION = "0.4.5";
+const VERSION = require("../package.json").version;
 const BASE_URL = `https://github.com/majiayu000/remem/releases/download/v${VERSION}`;
-const ASSETS = {
-  "darwin-arm64": {
-    file: "remem-darwin-arm64.tar.gz",
-    sha256: "35ffef27827c66e96c60149524c20e3af572c75f8f5d597eb740906f97255c22",
-  },
-  "darwin-x64": {
-    file: "remem-darwin-x64.tar.gz",
-    sha256: "71d13ddd4935dd9e13e37c8ec1ff081934fb7a12c1d83c6c7b9b425a7acaab4d",
-  },
-  "linux-arm64": {
-    file: "remem-linux-arm64.tar.gz",
-    sha256: "27ac660646801aa14d89cfcab4fc626d6dbb7992dfc43a4e9000fbd971a4dc61",
-  },
-  "linux-x64": {
-    file: "remem-linux-x64.tar.gz",
-    sha256: "91106ddecc684ab223f343caf089312ca61a39c42e323ea5c6ea57fb82e5100b",
-  },
-};
 
 function download(url, dest, redirects = 0) {
   return new Promise((resolve, reject) => {
@@ -65,10 +47,70 @@ function download(url, dest, redirects = 0) {
   });
 }
 
+function fetchJson(url, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if (
+        response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        response.headers.location
+      ) {
+        response.resume();
+        if (redirects >= 5) {
+          reject(new Error(`Too many redirects while fetching ${url}`));
+          return;
+        }
+        const next = new URL(response.headers.location, url).toString();
+        resolve(fetchJson(next, redirects + 1));
+        return;
+      }
+
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`Manifest fetch failed with HTTP ${response.statusCode}: ${url}`));
+        return;
+      }
+
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        body += chunk;
+      });
+      response.on("end", () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch (error) {
+          reject(new Error(`Invalid release manifest JSON from ${url}: ${error.message}`));
+        }
+      });
+    });
+    request.on("error", reject);
+  });
+}
+
 function sha256(file) {
   const hash = crypto.createHash("sha256");
   hash.update(fs.readFileSync(file));
   return hash.digest("hex");
+}
+
+function resolveAsset(manifest, version, key) {
+  const release = manifest?.versions?.[version];
+  const asset = release?.assets?.[key];
+  if (!asset || typeof asset.file !== "string") {
+    throw new Error(`Release manifest for remem ${version} is missing asset ${key}`);
+  }
+  if (!/^[0-9a-f]{64}$/i.test(asset.sha256 || "")) {
+    throw new Error(`Release manifest asset ${key} is missing a valid sha256`);
+  }
+  const baseUrl = typeof release.base_url === "string" && release.base_url
+    ? release.base_url.replace(/\/$/, "")
+    : BASE_URL;
+  return {
+    file: asset.file,
+    sha256: asset.sha256.toLowerCase(),
+    url: `${baseUrl}/${asset.file}`,
+  };
 }
 
 async function main() {
@@ -78,7 +120,6 @@ async function main() {
   }
 
   const key = platformKey();
-  const asset = ASSETS[key];
   const vendorDir = path.join(__dirname, "..", "vendor", key);
   const binary = path.join(vendorDir, "remem");
   if (process.argv.includes("--skip-existing") && fs.existsSync(binary)) {
@@ -89,12 +130,15 @@ async function main() {
   fs.mkdirSync(vendorDir, { recursive: true, mode: 0o755 });
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "remem-npm-"));
-  const archive = path.join(tmpDir, asset.file);
-  const url = `${BASE_URL}/${asset.file}`;
 
   try {
+    const manifestUrl = `${BASE_URL}/remem-releases.json`;
+    const manifest = await fetchJson(manifestUrl);
+    const asset = resolveAsset(manifest, VERSION, key);
+    const archive = path.join(tmpDir, asset.file);
+
     console.log(`Downloading remem ${VERSION} for ${key}`);
-    await download(url, archive);
+    await download(asset.url, archive);
     const actual = sha256(archive);
     if (actual !== asset.sha256) {
       throw new Error(`Checksum mismatch for ${asset.file}: expected ${asset.sha256}, got ${actual}`);
@@ -113,7 +157,15 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  BASE_URL,
+  VERSION,
+  resolveAsset,
+};

--- a/npm/remem/scripts/install.test.js
+++ b/npm/remem/scripts/install.test.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const packageJson = require("../package.json");
+const { BASE_URL, VERSION, resolveAsset } = require("./install");
+
+test("installer version follows package.json", () => {
+  assert.equal(VERSION, packageJson.version);
+  assert.equal(
+    BASE_URL,
+    `https://github.com/majiayu000/remem/releases/download/v${packageJson.version}`
+  );
+});
+
+test("resolveAsset reads checksummed release manifest asset", () => {
+  const manifest = {
+    versions: {
+      [VERSION]: {
+        base_url: "https://example.test/remem/releases/download/custom",
+        assets: {
+          "linux-x64": {
+            file: "remem-linux-x64.tar.gz",
+            sha256: "a".repeat(64),
+          },
+        },
+      },
+    },
+  };
+
+  assert.deepEqual(resolveAsset(manifest, VERSION, "linux-x64"), {
+    file: "remem-linux-x64.tar.gz",
+    sha256: "a".repeat(64),
+    url: "https://example.test/remem/releases/download/custom/remem-linux-x64.tar.gz",
+  });
+});
+
+test("resolveAsset rejects missing checksums", () => {
+  const manifest = {
+    versions: {
+      [VERSION]: {
+        assets: {
+          "linux-x64": {
+            file: "remem-linux-x64.tar.gz",
+            sha256: "not-a-sha",
+          },
+        },
+      },
+    },
+  };
+
+  assert.throws(
+    () => resolveAsset(manifest, VERSION, "linux-x64"),
+    /missing a valid sha256/
+  );
+});

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.38",
+  "version": "0.5.39",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.38": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.38",
+    "0.5.39": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.39",
       "assets": {}
     }
   }

--- a/scripts/ci/check_plugin_version_sync.py
+++ b/scripts/ci/check_plugin_version_sync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import re
+import argparse
 import sys
 import tomllib
 from pathlib import Path
@@ -100,6 +101,15 @@ def release_versions() -> tuple[set[str], str | None]:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Require release metadata versions to match Cargo.toml."
+    )
+    parser.add_argument(
+        "--expected-version",
+        help="Optional bare version that Cargo.toml and release metadata must match.",
+    )
+    args = parser.parse_args()
+
     cargo = cargo_package_version()
     locked = lock_version()
     plugin = plugin_version()
@@ -107,6 +117,8 @@ def main() -> int:
     releases, base_url = release_versions()
 
     errors: list[str] = []
+    if args.expected_version and cargo != args.expected_version:
+        errors.append(f"Cargo.toml version is {cargo}, expected tag version {args.expected_version}")
     if locked != cargo:
         errors.append(f"Cargo.lock remem-ai version is {locked}, expected {cargo}")
     if plugin != cargo:

--- a/scripts/ci/check_plugin_version_sync.py
+++ b/scripts/ci/check_plugin_version_sync.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 import tomllib
 from pathlib import Path
@@ -14,6 +15,9 @@ CARGO_TOML = ROOT / "Cargo.toml"
 CARGO_LOCK = ROOT / "Cargo.lock"
 PLUGIN_JSON = ROOT / "plugins/remem/.codex-plugin/plugin.json"
 RELEASES_JSON = ROOT / "plugins/remem/runtimes/remem-releases.json"
+NPM_PACKAGE_JSON = ROOT / "npm/remem/package.json"
+NPM_INSTALL_JS = ROOT / "npm/remem/scripts/install.js"
+NPM_INSTALL_VERSION_SOURCE = 'require("../package.json").version'
 
 
 def read_json(path: Path) -> dict:
@@ -58,6 +62,22 @@ def plugin_version() -> str:
     return version
 
 
+def npm_version() -> str:
+    version = read_json(NPM_PACKAGE_JSON).get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError("npm/remem/package.json is missing version")
+    return version
+
+
+def npm_install_version_source_error() -> str | None:
+    source = NPM_INSTALL_JS.read_text(encoding="utf-8")
+    if NPM_INSTALL_VERSION_SOURCE not in source:
+        return "npm/remem/scripts/install.js must read VERSION from package.json"
+    if re.search(r'\bVERSION\s*=\s*["\']', source):
+        return "npm/remem/scripts/install.js must not hardcode a VERSION string"
+    return None
+
+
 def release_versions() -> tuple[set[str], str | None]:
     manifest = read_json(RELEASES_JSON)
     versions = manifest.get("versions")
@@ -83,6 +103,7 @@ def main() -> int:
     cargo = cargo_package_version()
     locked = lock_version()
     plugin = plugin_version()
+    npm = npm_version()
     releases, base_url = release_versions()
 
     errors: list[str] = []
@@ -90,6 +111,11 @@ def main() -> int:
         errors.append(f"Cargo.lock remem-ai version is {locked}, expected {cargo}")
     if plugin != cargo:
         errors.append(f"plugin.json version is {plugin}, expected {cargo}")
+    if npm != cargo:
+        errors.append(f"npm/remem/package.json version is {npm}, expected {cargo}")
+    npm_install_error = npm_install_version_source_error()
+    if npm_install_error is not None:
+        errors.append(npm_install_error)
     if releases != {cargo}:
         rendered = ", ".join(sorted(releases)) or "<none>"
         errors.append(f"remem-releases.json versions are {{{rendered}}}, expected only {{{cargo}}}")
@@ -105,14 +131,14 @@ def main() -> int:
             print(f"  - {error}", file=sys.stderr)
         print(
             "Update Cargo.toml, Cargo.lock, plugins/remem/.codex-plugin/plugin.json, "
-            "and plugins/remem/runtimes/remem-releases.json together.",
+            "plugins/remem/runtimes/remem-releases.json, and npm/remem/package.json together.",
             file=sys.stderr,
         )
         return 1
 
     print(
         "plugin version sync: "
-        f"{cargo} across Cargo.toml, Cargo.lock, plugin.json, and remem-releases.json"
+        f"{cargo} across Cargo.toml, Cargo.lock, plugin.json, remem-releases.json, and npm"
     )
     return 0
 


### PR DESCRIPTION
Fixes #430

Summary:
- Bump npm wrapper, Cargo, plugin, and runtime manifest versions together to 0.5.39.
- Make the npm postinstall script read its version from package.json and fetch the matching release remem-releases.json manifest instead of hardcoding stale asset checksums.
- Extend the CI version sync check to include npm/remem/package.json and reject hardcoded install-script VERSION strings.
- Add npm installer tests and include them in the CI Node test command.

Verification:
- python3 scripts/ci/check_plugin_version_sync.py
- node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js
- cargo fmt --check
- git diff --check
- cargo check --message-format=short
- cargo clippy -- -D warnings
- python3 scripts/ci/check_version_bump.py origin/main WORKTREE
- cargo test
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- git diff --check origin/main...HEAD