### PR TITLE
Initialize encrypted runtime store during install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.39"
+version = "0.5.40"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.39"
+version = "0.5.40"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ brew install majiayu000/tap/remem
 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
 # Pin a specific release or install into a custom bin directory
-REMEM_VERSION=v0.5.39 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
+REMEM_VERSION=v0.5.40 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_NO_CONFIG=1 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,7 +37,7 @@ brew install majiayu000/tap/remem
 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
 # 固定版本、指定安装目录，或只安装二进制不改 hooks/MCP
-REMEM_VERSION=v0.5.39 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
+REMEM_VERSION=v0.5.40 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_NO_CONFIG=1 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.39",
+  "version": "0.5.40",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.39",
+  "version": "0.5.40",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.39": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.39",
+    "0.5.40": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.40",
       "assets": {}
     }
   }

--- a/src/db/test_support.rs
+++ b/src/db/test_support.rs
@@ -14,6 +14,7 @@ pub struct ScopedTestDataDir {
     _guard: MutexGuard<'static, ()>,
     previous: Option<OsString>,
     previous_allow_plaintext: Option<OsString>,
+    previous_cipher_key: Option<OsString>,
     pub path: PathBuf,
 }
 
@@ -22,6 +23,7 @@ impl ScopedTestDataDir {
         let guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var_os("REMEM_DATA_DIR");
         let previous_allow_plaintext = std::env::var_os("REMEM_ALLOW_PLAINTEXT_DB");
+        let previous_cipher_key = std::env::var_os("REMEM_CIPHER_KEY");
         let unique = format!(
             "remem-test-{}-{}-{}",
             label,
@@ -39,6 +41,7 @@ impl ScopedTestDataDir {
             _guard: guard,
             previous,
             previous_allow_plaintext,
+            previous_cipher_key,
             path,
         }
     }
@@ -68,6 +71,11 @@ impl Drop for ScopedTestDataDir {
             std::env::set_var("REMEM_ALLOW_PLAINTEXT_DB", previous);
         } else {
             std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+        }
+        if let Some(previous) = self.previous_cipher_key.as_ref() {
+            std::env::set_var("REMEM_CIPHER_KEY", previous);
+        } else {
+            std::env::remove_var("REMEM_CIPHER_KEY");
         }
         let _ = std::fs::remove_dir_all(&self.path);
     }

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -177,12 +177,28 @@ pub(in crate::install) fn ensure_runtime_store_ready() -> Result<RuntimeStoreRea
     let cipher_key = crate::db::CipherKey::Raw(key);
 
     if db_existed {
-        crate::db::encrypt_database(&cipher_key).with_context(|| {
-            format!(
+        let encrypted_path = db_path.with_extension("db.enc");
+        let backup_path = db_path.with_extension("db.bak");
+        let encrypted_existed = encrypted_path.exists();
+        let backup_existed = backup_path.exists();
+        if let Err(error) = crate::db::encrypt_database(&cipher_key) {
+            let mut error = error.context(format!(
                 "encrypt existing remem database {}; run `remem encrypt` manually and rerun `remem install`",
                 db_path.display()
-            )
-        })?;
+            ));
+            if let Err(rollback_error) = rollback_generated_key_after_encrypt_failure(
+                &key_path,
+                &cipher_key,
+                &db_path,
+                encrypted_existed,
+                backup_existed,
+            ) {
+                error = error.context(format!(
+                    "rollback generated key after failed database encryption: {rollback_error}"
+                ));
+            }
+            return Err(error);
+        }
     }
 
     let conn = crate::db::open_db().with_context(|| {
@@ -220,6 +236,55 @@ fn ensure_env_key_matches_persisted_key_if_set(key_path: &Path) -> Result<()> {
         key_path.display()
     );
     Ok(())
+}
+
+fn rollback_generated_key_after_encrypt_failure(
+    key_path: &Path,
+    generated_key: &crate::db::CipherKey,
+    db_path: &Path,
+    encrypted_existed_before: bool,
+    backup_existed_before: bool,
+) -> Result<()> {
+    let mut errors = Vec::new();
+    let encrypted_path = db_path.with_extension("db.enc");
+    let backup_path = db_path.with_extension("db.bak");
+
+    if !db_path.exists() && !backup_existed_before && backup_path.exists() {
+        if let Err(error) = std::fs::rename(&backup_path, db_path) {
+            errors.push(format!(
+                "restore {} from {}: {}",
+                db_path.display(),
+                backup_path.display(),
+                error
+            ));
+        }
+    }
+
+    if !encrypted_existed_before && encrypted_path.exists() {
+        if let Err(error) = std::fs::remove_file(&encrypted_path) {
+            errors.push(format!("remove {}: {}", encrypted_path.display(), error));
+        }
+    }
+
+    match std::fs::read_to_string(key_path) {
+        Ok(contents) if contents == generated_key.stored_value() => {
+            if let Err(error) = std::fs::remove_file(key_path) {
+                errors.push(format!("remove {}: {}", key_path.display(), error));
+            }
+        }
+        Ok(_) => errors.push(format!(
+            "leave {} because its contents changed after generation",
+            key_path.display()
+        )),
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => errors.push(format!("read {}: {}", key_path.display(), error)),
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        bail!("{}", errors.join("; "))
+    }
 }
 
 fn ensure_existing_db_can_be_encrypted_without_key(db_path: &Path, key_path: &Path) -> Result<()> {

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -155,7 +155,7 @@ pub(in crate::install) fn ensure_runtime_store_ready() -> Result<RuntimeStoreRea
         });
     }
 
-    if std::env::var_os("REMEM_CIPHER_KEY").is_some() {
+    if env_cipher_key_is_set()? {
         bail!(
             "REMEM_CIPHER_KEY is set but {} is missing; unset REMEM_CIPHER_KEY and run `remem install` again to create a persistent key file, or write the same key to {} before running `remem status`",
             key_path.display(),
@@ -166,6 +166,7 @@ pub(in crate::install) fn ensure_runtime_store_ready() -> Result<RuntimeStoreRea
     let db_existed = db_path.exists();
     if db_existed {
         ensure_existing_db_can_be_encrypted_without_key(&db_path, &key_path)?;
+        ensure_auto_encrypt_backup_path_available(&db_path)?;
     }
 
     let key = crate::db::generate_cipher_key().with_context(|| {
@@ -217,6 +218,15 @@ pub(in crate::install) fn ensure_runtime_store_ready() -> Result<RuntimeStoreRea
     })
 }
 
+fn env_cipher_key_is_set() -> Result<bool> {
+    let Some(env_key) = std::env::var_os("REMEM_CIPHER_KEY") else {
+        return Ok(false);
+    };
+    let env_key = env_key.to_string_lossy();
+    let env_key = crate::db::parse_cipher_key(&env_key).context("parse REMEM_CIPHER_KEY")?;
+    Ok(env_key.is_some())
+}
+
 fn ensure_env_key_matches_persisted_key_if_set(key_path: &Path) -> Result<()> {
     let Some(env_key) = std::env::var_os("REMEM_CIPHER_KEY") else {
         return Ok(());
@@ -234,6 +244,16 @@ fn ensure_env_key_matches_persisted_key_if_set(key_path: &Path) -> Result<()> {
         env_key.is_some() && env_key == persisted_key,
         "REMEM_CIPHER_KEY does not match existing SQLCipher key file {}; unset REMEM_CIPHER_KEY or update it to the same persisted key before running `remem install`",
         key_path.display()
+    );
+    Ok(())
+}
+
+fn ensure_auto_encrypt_backup_path_available(db_path: &Path) -> Result<()> {
+    let backup_path = db_path.with_extension("db.bak");
+    ensure!(
+        !backup_path.exists(),
+        "existing remem backup {} would be overwritten by automatic install encryption; move it aside or run `remem encrypt` manually, then rerun `remem install`",
+        backup_path.display()
     );
     Ok(())
 }

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -1,9 +1,22 @@
-use anyhow::{bail, Result};
+use std::{
+    io::{ErrorKind, Read},
+    path::Path,
+};
+
+use anyhow::{bail, ensure, Context, Result};
 
 use crate::install::duplicates::{format_warning_lines, inspect_install_paths};
 use crate::install::host::{HookSupport, InstallTarget};
 use crate::install::hosts::resolve_hosts;
 use crate::install::paths::{binary_path, old_hooks_path, remem_data_dir};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::install) struct RuntimeStoreReady {
+    pub(in crate::install) key_path: std::path::PathBuf,
+    pub(in crate::install) db_path: std::path::PathBuf,
+    pub(in crate::install) created_key: bool,
+    pub(in crate::install) encrypted_existing_db: bool,
+}
 
 pub fn install(target: InstallTarget, dry_run: bool, hooks_only: bool) -> Result<()> {
     let bin = binary_path()?;
@@ -36,6 +49,14 @@ pub fn install(target: InstallTarget, dry_run: bool, hooks_only: bool) -> Result
             crate::runtime_config::config_path().display()
         );
         eprintln!("  data   -> {}", remem_data_dir().display());
+        eprintln!(
+            "  key    -> {} (create if missing)",
+            remem_data_dir().join(".key").display()
+        );
+        eprintln!(
+            "  db     -> {} (initialize encrypted database if missing)",
+            crate::db::db_path().display()
+        );
         print_install_path_warnings(&bin);
         return Ok(());
     }
@@ -45,6 +66,26 @@ pub fn install(target: InstallTarget, dry_run: bool, hooks_only: bool) -> Result
     } else {
         eprintln!("remem install:");
     }
+    let runtime_store = ensure_runtime_store_ready()?;
+    eprintln!(
+        "  key    -> {} ({})",
+        runtime_store.key_path.display(),
+        if runtime_store.created_key {
+            "created"
+        } else {
+            "existing"
+        }
+    );
+    eprintln!(
+        "  db     -> {} ({})",
+        runtime_store.db_path.display(),
+        if runtime_store.encrypted_existing_db {
+            "encrypted existing database"
+        } else {
+            "ready"
+        }
+    );
+
     let runtime_hosts = hosts
         .iter()
         .map(|host| runtime_host_name(host.name()))
@@ -89,6 +130,109 @@ pub fn install(target: InstallTarget, dry_run: bool, hooks_only: bool) -> Result
     eprintln!("  2. remem will automatically capture your sessions (hosts with hook support)");
     eprintln!("  3. Run 'remem status' to check system health");
 
+    Ok(())
+}
+
+pub(in crate::install) fn ensure_runtime_store_ready() -> Result<RuntimeStoreReady> {
+    let data_dir = crate::db::data_dir();
+    let key_path = data_dir.join(".key");
+    let db_path = crate::db::db_path();
+
+    if key_path.exists() {
+        let conn = crate::db::open_db().with_context(|| {
+            format!(
+                "open remem database with existing SQLCipher key {}; run `remem status` after fixing the reported database/key error",
+                key_path.display()
+            )
+        })?;
+        drop(conn);
+        return Ok(RuntimeStoreReady {
+            key_path,
+            db_path,
+            created_key: false,
+            encrypted_existing_db: false,
+        });
+    }
+
+    if std::env::var_os("REMEM_CIPHER_KEY").is_some() {
+        bail!(
+            "REMEM_CIPHER_KEY is set but {} is missing; unset REMEM_CIPHER_KEY and run `remem install` again to create a persistent key file, or write the same key to {} before running `remem status`",
+            key_path.display(),
+            key_path.display()
+        );
+    }
+
+    let db_existed = db_path.exists();
+    if db_existed {
+        ensure_existing_db_can_be_encrypted_without_key(&db_path, &key_path)?;
+    }
+
+    let key = crate::db::generate_cipher_key().with_context(|| {
+        format!(
+            "create SQLCipher key file {}; run `remem encrypt` to initialize the encrypted database manually",
+            key_path.display()
+        )
+    })?;
+    let cipher_key = crate::db::CipherKey::Raw(key);
+
+    if db_existed {
+        crate::db::encrypt_database(&cipher_key).with_context(|| {
+            format!(
+                "encrypt existing remem database {}; run `remem encrypt` manually and rerun `remem install`",
+                db_path.display()
+            )
+        })?;
+    }
+
+    let conn = crate::db::open_db().with_context(|| {
+        format!(
+            "initialize encrypted remem database {}; run `remem encrypt` manually and rerun `remem install`",
+            db_path.display()
+        )
+    })?;
+    drop(conn);
+
+    Ok(RuntimeStoreReady {
+        key_path,
+        db_path,
+        created_key: true,
+        encrypted_existing_db: db_existed,
+    })
+}
+
+fn ensure_existing_db_can_be_encrypted_without_key(db_path: &Path, key_path: &Path) -> Result<()> {
+    let mut file = std::fs::File::open(db_path)
+        .with_context(|| format!("open existing remem database {}", db_path.display()))?;
+    let mut header = [0_u8; 16];
+    if let Err(error) = file.read_exact(&mut header) {
+        if error.kind() == ErrorKind::UnexpectedEof {
+            bail!(
+                "existing remem database {} is too small to identify and {} is missing; restore the matching key file, or move {} aside and run `remem install` again",
+                db_path.display(),
+                key_path.display(),
+                db_path.display()
+            );
+        }
+        return Err(error)
+            .with_context(|| format!("read existing remem database {}", db_path.display()));
+    }
+    ensure!(
+        &header == b"SQLite format 3\0",
+        "existing remem database {} does not look like plaintext SQLite and {} is missing; restore the matching key file, or move {} aside and run `remem install` again",
+        db_path.display(),
+        key_path.display(),
+        db_path.display()
+    );
+
+    let conn = rusqlite::Connection::open(db_path)
+        .with_context(|| format!("open existing plaintext database {}", db_path.display()))?;
+    ensure!(
+        crate::db::can_read_schema(&conn),
+        "existing remem database {} is not readable plaintext SQLite and {} is missing; restore the matching key file, or move {} aside and run `remem install` again",
+        db_path.display(),
+        key_path.display(),
+        db_path.display()
+    );
     Ok(())
 }
 

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -139,6 +139,7 @@ pub(in crate::install) fn ensure_runtime_store_ready() -> Result<RuntimeStoreRea
     let db_path = crate::db::db_path();
 
     if key_path.exists() {
+        ensure_env_key_matches_persisted_key_if_set(&key_path)?;
         let conn = crate::db::open_db().with_context(|| {
             format!(
                 "open remem database with existing SQLCipher key {}; run `remem status` after fixing the reported database/key error",
@@ -198,6 +199,27 @@ pub(in crate::install) fn ensure_runtime_store_ready() -> Result<RuntimeStoreRea
         created_key: true,
         encrypted_existing_db: db_existed,
     })
+}
+
+fn ensure_env_key_matches_persisted_key_if_set(key_path: &Path) -> Result<()> {
+    let Some(env_key) = std::env::var_os("REMEM_CIPHER_KEY") else {
+        return Ok(());
+    };
+    let env_key = env_key.to_string_lossy();
+    if env_key.trim().is_empty() {
+        return Ok(());
+    }
+    let env_key = crate::db::parse_cipher_key(&env_key).context("parse REMEM_CIPHER_KEY")?;
+    let persisted = std::fs::read_to_string(key_path)
+        .with_context(|| format!("read existing SQLCipher key file {}", key_path.display()))?;
+    let persisted_key = crate::db::parse_cipher_key(&persisted)
+        .with_context(|| format!("parse SQLCipher key file {}", key_path.display()))?;
+    ensure!(
+        env_key.is_some() && env_key == persisted_key,
+        "REMEM_CIPHER_KEY does not match existing SQLCipher key file {}; unset REMEM_CIPHER_KEY or update it to the same persisted key before running `remem install`",
+        key_path.display()
+    );
+    Ok(())
 }
 
 fn ensure_existing_db_can_be_encrypted_without_key(db_path: &Path, key_path: &Path) -> Result<()> {

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -1,6 +1,114 @@
 use serde_json::json;
 
 use super::config::{build_hooks, remove_remem_hooks, remove_remem_mcp, HookStrategy};
+use super::runtime::ensure_runtime_store_ready;
+use crate::db::test_support::ScopedTestDataDir;
+
+#[test]
+fn ensure_runtime_store_ready_initializes_encrypted_db_for_status() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("install-runtime-store");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::env::remove_var("REMEM_CIPHER_KEY");
+    test_dir.remove_db_files();
+
+    let ready = ensure_runtime_store_ready()?;
+
+    assert!(ready.created_key);
+    assert!(!ready.encrypted_existing_db);
+    assert_eq!(ready.key_path, test_dir.path.join(".key"));
+    assert_eq!(ready.db_path, test_dir.db_path());
+    let saved_key = std::fs::read_to_string(&ready.key_path)?;
+    assert!(saved_key.starts_with("v2:"), "got: {saved_key}");
+    let header = std::fs::read(&ready.db_path)?;
+    assert_ne!(&header[..16], b"SQLite format 3\0");
+
+    let conn = crate::db::open_db_read_only()?;
+    let stats = crate::db::query_system_stats(&conn)?;
+    assert_eq!(stats.active_memories, 0);
+    Ok(())
+}
+
+#[test]
+fn ensure_runtime_store_ready_encrypts_existing_plaintext_db() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("install-runtime-existing-db");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::env::remove_var("REMEM_CIPHER_KEY");
+    std::fs::create_dir_all(&test_dir.path)?;
+    {
+        let conn = rusqlite::Connection::open(test_dir.db_path())?;
+        conn.execute("CREATE TABLE existing_probe(id INTEGER PRIMARY KEY)", [])?;
+    }
+
+    let ready = ensure_runtime_store_ready()?;
+
+    assert!(ready.created_key);
+    assert!(ready.encrypted_existing_db);
+    assert!(test_dir.path.join("remem.db.bak").exists());
+    let header = std::fs::read(&ready.db_path)?;
+    assert_ne!(&header[..16], b"SQLite format 3\0");
+    let conn = crate::db::open_db_read_only()?;
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'existing_probe'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(count, 1);
+    Ok(())
+}
+
+#[test]
+fn ensure_runtime_store_ready_refuses_existing_non_plaintext_db_without_key() -> anyhow::Result<()>
+{
+    let test_dir = ScopedTestDataDir::new("install-runtime-existing-encrypted-db");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::env::remove_var("REMEM_CIPHER_KEY");
+    std::fs::create_dir_all(&test_dir.path)?;
+    let raw_hex = "7".repeat(64);
+    {
+        let conn = rusqlite::Connection::open(test_dir.db_path())?;
+        crate::db::configure_cipher(&conn, Some(&crate::db::CipherKey::Raw(raw_hex)))?;
+        conn.execute("CREATE TABLE encrypted_probe(id INTEGER PRIMARY KEY)", [])?;
+    }
+
+    let err = ensure_runtime_store_ready()
+        .expect_err("install must not invent a new key for an encrypted database");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("does not look like plaintext SQLite"),
+        "got: {message}"
+    );
+    assert!(
+        !test_dir.path.join(".key").exists(),
+        "failed install must not create a misleading key"
+    );
+    Ok(())
+}
+
+#[test]
+fn ensure_runtime_store_ready_refuses_env_only_key_without_key_file() {
+    let test_dir = ScopedTestDataDir::new("install-runtime-env-only-key");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::env::set_var("REMEM_CIPHER_KEY", "7".repeat(64));
+    test_dir.remove_db_files();
+
+    let err = ensure_runtime_store_ready()
+        .expect_err("install must require a persistent key file for future status");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("REMEM_CIPHER_KEY is set"),
+        "got: {message}"
+    );
+    assert!(
+        !test_dir.path.join(".key").exists(),
+        "env-only failure must not create a key file"
+    );
+    assert!(
+        !test_dir.db_path().exists(),
+        "env-only failure must not create a database"
+    );
+}
 
 #[test]
 fn build_hooks_contains_expected_claude_commands() {

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -111,6 +111,52 @@ fn ensure_runtime_store_ready_refuses_env_only_key_without_key_file() {
 }
 
 #[test]
+fn ensure_runtime_store_ready_rejects_env_key_mismatch_with_persisted_key() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("install-runtime-env-key-mismatch");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::fs::create_dir_all(&test_dir.path)?;
+    std::fs::write(test_dir.path.join(".key"), format!("v2:{}", "7".repeat(64)))?;
+    std::env::set_var("REMEM_CIPHER_KEY", format!("v2:{}", "8".repeat(64)));
+    test_dir.remove_db_files();
+
+    let result = ensure_runtime_store_ready();
+    std::env::remove_var("REMEM_CIPHER_KEY");
+    let err = result.expect_err("install must not initialize DB with a key that differs from .key");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("does not match existing SQLCipher key file"),
+        "got: {message}"
+    );
+    assert!(
+        !test_dir.db_path().exists(),
+        "mismatched env key must not create a database"
+    );
+    Ok(())
+}
+
+#[test]
+fn ensure_runtime_store_ready_treats_empty_env_key_as_unset() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("install-runtime-empty-env-key");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::fs::create_dir_all(&test_dir.path)?;
+    std::fs::write(test_dir.path.join(".key"), format!("v2:{}", "7".repeat(64)))?;
+    std::env::set_var("REMEM_CIPHER_KEY", "");
+    test_dir.remove_db_files();
+
+    let result = ensure_runtime_store_ready();
+    std::env::remove_var("REMEM_CIPHER_KEY");
+    let ready = result?;
+
+    assert!(!ready.created_key);
+    assert!(test_dir.db_path().exists());
+    let conn = crate::db::open_db_read_only()?;
+    let stats = crate::db::query_system_stats(&conn)?;
+    assert_eq!(stats.active_memories, 0);
+    Ok(())
+}
+
+#[test]
 fn build_hooks_contains_expected_claude_commands() {
     let hooks = build_hooks("/tmp/remem", HookStrategy::ClaudeCode);
     assert_eq!(

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -57,6 +57,34 @@ fn ensure_runtime_store_ready_encrypts_existing_plaintext_db() -> anyhow::Result
 }
 
 #[test]
+fn ensure_runtime_store_ready_refuses_to_overwrite_existing_backup() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("install-runtime-existing-backup");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::env::remove_var("REMEM_CIPHER_KEY");
+    std::fs::create_dir_all(&test_dir.path)?;
+    {
+        let conn = rusqlite::Connection::open(test_dir.db_path())?;
+        conn.execute("CREATE TABLE existing_probe(id INTEGER PRIMARY KEY)", [])?;
+    }
+    let backup_path = test_dir.db_path().with_extension("db.bak");
+    std::fs::write(&backup_path, b"existing backup")?;
+
+    let err = ensure_runtime_store_ready()
+        .expect_err("install must not overwrite an existing database backup");
+
+    let message = err.to_string();
+    assert!(message.contains("would be overwritten"), "got: {message}");
+    assert!(
+        !test_dir.path.join(".key").exists(),
+        "backup preflight failure must not create a key file"
+    );
+    assert_eq!(std::fs::read(&backup_path)?, b"existing backup");
+    let header = std::fs::read(test_dir.db_path())?;
+    assert_eq!(&header[..16], b"SQLite format 3\0");
+    Ok(())
+}
+
+#[test]
 fn ensure_runtime_store_ready_rolls_back_key_when_encryption_fails() -> anyhow::Result<()> {
     let test_dir = ScopedTestDataDir::new("install-runtime-existing-db-encrypt-fail");
     std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
@@ -191,6 +219,23 @@ fn ensure_runtime_store_ready_treats_empty_env_key_as_unset() -> anyhow::Result<
     let conn = crate::db::open_db_read_only()?;
     let stats = crate::db::query_system_stats(&conn)?;
     assert_eq!(stats.active_memories, 0);
+    Ok(())
+}
+
+#[test]
+fn ensure_runtime_store_ready_allows_empty_env_key_fresh() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("install-runtime-empty-env-key-fresh");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::env::set_var("REMEM_CIPHER_KEY", "");
+    test_dir.remove_db_files();
+
+    let ready = ensure_runtime_store_ready()?;
+
+    assert!(ready.created_key);
+    assert!(test_dir.path.join(".key").exists());
+    assert!(test_dir.db_path().exists());
+    let header = std::fs::read(test_dir.db_path())?;
+    assert_ne!(&header[..16], b"SQLite format 3\0");
     Ok(())
 }
 

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -57,6 +57,44 @@ fn ensure_runtime_store_ready_encrypts_existing_plaintext_db() -> anyhow::Result
 }
 
 #[test]
+fn ensure_runtime_store_ready_rolls_back_key_when_encryption_fails() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("install-runtime-existing-db-encrypt-fail");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::env::remove_var("REMEM_CIPHER_KEY");
+    std::fs::create_dir_all(&test_dir.path)?;
+    {
+        let conn = rusqlite::Connection::open(test_dir.db_path())?;
+        conn.execute("CREATE TABLE existing_probe(id INTEGER PRIMARY KEY)", [])?;
+    }
+    let encrypted_temp_path = test_dir.db_path().with_extension("db.enc");
+    std::fs::create_dir(&encrypted_temp_path)?;
+
+    let err = ensure_runtime_store_ready()
+        .expect_err("install must fail when the encrypted temp database path is blocked");
+
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("encrypt existing remem database"),
+        "got: {message}"
+    );
+    assert!(
+        !test_dir.path.join(".key").exists(),
+        "failed encryption must remove the generated key file"
+    );
+    assert!(
+        test_dir.db_path().exists(),
+        "failed encryption must leave the source database in place"
+    );
+    let header = std::fs::read(test_dir.db_path())?;
+    assert_eq!(&header[..16], b"SQLite format 3\0");
+    assert!(
+        encrypted_temp_path.is_dir(),
+        "pre-existing temp path must not be removed by rollback"
+    );
+    Ok(())
+}
+
+#[test]
 fn ensure_runtime_store_ready_refuses_existing_non_plaintext_db_without_key() -> anyhow::Result<()>
 {
     let test_dir = ScopedTestDataDir::new("install-runtime-existing-encrypted-db");

--- a/tests/install_status.rs
+++ b/tests/install_status.rs
@@ -1,0 +1,69 @@
+use std::process::Command;
+
+fn install_status_temp_root() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "remem-install-status-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos()
+    ))
+}
+
+#[test]
+fn status_works_after_recommended_install_path() {
+    let root = install_status_temp_root();
+    let home = root.join("home");
+    let data_dir = root.join("data");
+    std::fs::create_dir_all(&home).expect("create temp home");
+
+    let remem_bin = env!("CARGO_BIN_EXE_remem");
+    let install = Command::new(remem_bin)
+        .args(["install", "--target", "codex", "--hooks-only"])
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("REMEM_DATA_DIR", &data_dir)
+        .env("REMEM_INSTALL_BINARY", remem_bin)
+        .env_remove("REMEM_ALLOW_PLAINTEXT_DB")
+        .env_remove("REMEM_CIPHER_KEY")
+        .output()
+        .expect("run remem install");
+
+    assert!(
+        install.status.success(),
+        "install failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+    assert!(data_dir.join(".key").exists(), "install should create key");
+    assert!(
+        data_dir.join("remem.db").exists(),
+        "install should create database"
+    );
+
+    let status = Command::new(remem_bin)
+        .args(["status", "--json"])
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("REMEM_DATA_DIR", &data_dir)
+        .env_remove("REMEM_ALLOW_PLAINTEXT_DB")
+        .env_remove("REMEM_CIPHER_KEY")
+        .output()
+        .expect("run remem status");
+
+    assert!(
+        status.status.success(),
+        "status failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&status.stdout).expect("status emits JSON");
+    assert_eq!(
+        report["database"]["path"].as_str(),
+        Some(data_dir.join("remem.db").to_string_lossy().as_ref())
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary
- initialize or verify the encrypted runtime store during non-dry-run `remem install` before reporting success
- create the SQLCipher key and encrypted database for fresh installs, migrate readable plaintext DBs, and fail closed for env-only keys or non-plaintext DBs without a key
- add install/status smoke coverage proving `remem status --json` works after the recommended install path
- bump release metadata to 0.5.40

## Verification
- `cargo fmt --check`
- `cargo test install::tests::ensure_runtime_store_ready -- --nocapture`
- `cargo test --test install_status -- --nocapture`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_plugin_version_sync.py --expected-version 0.5.40`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `git diff --check`
- `cargo check --message-format=short`
- `cargo clippy -- -D warnings`
- `cargo test`

Fixes #428