### PR TITLE
Surface context memory query load errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.40"
+version = "0.5.41"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.40"
+version = "0.5.41"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ brew install majiayu000/tap/remem
 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
 # Pin a specific release or install into a custom bin directory
-REMEM_VERSION=v0.5.40 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
+REMEM_VERSION=v0.5.41 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_NO_CONFIG=1 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,7 +37,7 @@ brew install majiayu000/tap/remem
 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 
 # 固定版本、指定安装目录，或只安装二进制不改 hooks/MCP
-REMEM_VERSION=v0.5.40 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
+REMEM_VERSION=v0.5.41 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 REMEM_NO_CONFIG=1 curl -fsSL https://raw.githubusercontent.com/majiayu000/remem/main/install.sh | sh
 

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.40",
+  "version": "0.5.41",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.40",
+  "version": "0.5.41",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.40": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.40",
+    "0.5.41": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.41",
       "assets": {}
     }
   }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,7 @@
 pub mod claude_memory;
 mod debug;
 mod diagnostics;
+mod filters;
 mod format;
 mod host;
 mod injection_gate;

--- a/src/context/diagnostics.rs
+++ b/src/context/diagnostics.rs
@@ -85,8 +85,13 @@ fn count_context_candidate_pool(
     let mut conditions = Vec::new();
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
     let mut idx = 1;
-    super::query::push_owner_included_filter(project, &mut idx, &mut conditions, &mut params);
-    super::query::push_excluded_type_filter(excluded_types, &mut idx, &mut conditions, &mut params);
+    super::filters::push_owner_included_filter(project, &mut idx, &mut conditions, &mut params);
+    super::filters::push_excluded_type_filter(
+        excluded_types,
+        &mut idx,
+        &mut conditions,
+        &mut params,
+    );
 
     let sql = format!(
         "SELECT COUNT(*) FROM memories WHERE {}",
@@ -110,8 +115,13 @@ fn query_context_lifecycle_exclusions(
     let mut conditions = Vec::new();
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
     let mut idx = 1;
-    super::query::push_owner_included_filter(project, &mut idx, &mut conditions, &mut params);
-    super::query::push_excluded_type_filter(excluded_types, &mut idx, &mut conditions, &mut params);
+    super::filters::push_owner_included_filter(project, &mut idx, &mut conditions, &mut params);
+    super::filters::push_excluded_type_filter(
+        excluded_types,
+        &mut idx,
+        &mut conditions,
+        &mut params,
+    );
     conditions.push(
         "(status IN ('stale', 'superseded') \
           OR (status = 'active' AND expires_at_epoch IS NOT NULL \

--- a/src/context/filters.rs
+++ b/src/context/filters.rs
@@ -1,0 +1,90 @@
+pub(super) fn push_owner_included_filter(
+    project: &str,
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    let owner_key_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let target_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let legacy_project_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    conditions.push(format!(
+        "((owner_scope = 'repo' AND owner_key = ?{owner_key_idx}) \
+          OR (owner_scope = 'repo' AND target_project = ?{target_idx}) \
+          OR (owner_scope IS NULL AND project = ?{legacy_project_idx} \
+              AND COALESCE(scope, 'project') != 'global'))"
+    ));
+}
+
+pub(super) fn push_owner_excluded_filter(
+    project: &str,
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    let owner_key_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let target_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let legacy_project_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    conditions.push(format!(
+        "NOT ((owner_scope = 'repo' AND owner_key = ?{owner_key_idx}) \
+              OR (owner_scope = 'repo' AND target_project = ?{target_idx}) \
+              OR (owner_scope IS NULL AND project = ?{legacy_project_idx} \
+                  AND COALESCE(scope, 'project') != 'global'))"
+    ));
+}
+
+pub(super) fn push_context_related_filter(
+    project: &str,
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    let project_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let source_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let target_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    let owner_idx = *idx;
+    params.push(Box::new(project.to_string()));
+    *idx += 1;
+    conditions.push(format!(
+        "(project = ?{project_idx} OR source_project = ?{source_idx} \
+          OR target_project = ?{target_idx} OR owner_key = ?{owner_idx})"
+    ));
+}
+
+pub(super) fn push_excluded_type_filter(
+    excluded_types: &[&str],
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    if excluded_types.is_empty() {
+        return;
+    }
+    let placeholders: Vec<String> = excluded_types
+        .iter()
+        .map(|memory_type| {
+            let placeholder = format!("?{idx}");
+            params.push(Box::new((*memory_type).to_string()));
+            *idx += 1;
+            placeholder
+        })
+        .collect();
+    conditions.push(format!("memory_type NOT IN ({})", placeholders.join(", ")));
+}

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -5,6 +5,10 @@ use rusqlite::Connection;
 
 use crate::memory::{self, Memory};
 
+use super::filters::{
+    push_context_related_filter, push_excluded_type_filter, push_owner_excluded_filter,
+    push_owner_included_filter,
+};
 use super::memory_traits::{is_memory_self_diagnostic, is_self_diagnostic_text};
 use super::ownership::{startup_memory_owner_decision, OwnerCounts, OwnerMetadata, OwnerTrace};
 use super::policy::{ContextPolicy, SectionKind};
@@ -33,8 +37,9 @@ pub(super) fn load_context_data_with_policy(
     collect_diagnostics: bool,
 ) -> LoadedContext {
     let mut errors = Vec::new();
-    let memory_selection =
+    let mut memory_selection =
         load_project_memories(conn, project, current_branch, policy, collect_diagnostics);
+    errors.append(&mut memory_selection.errors);
     let mut memories = memory_selection.memories;
     sort_memories_by_branch(&mut memories, current_branch);
     let lessons = memory::lesson::list_lessons_for_context(
@@ -79,6 +84,7 @@ pub(super) fn load_context_data_with_policy(
 
 struct ContextMemorySelection {
     memories: Vec<Memory>,
+    errors: Vec<ContextLoadError>,
     owner_traces: Vec<OwnerTrace>,
     owner_counts: OwnerCounts,
     diagnostics: super::types::ContextDiagnostics,
@@ -97,6 +103,7 @@ fn load_project_memories(
     collect_diagnostics: bool,
 ) -> ContextMemorySelection {
     let mut memories = Vec::new();
+    let mut errors = Vec::new();
     let mut traces = Vec::new();
     let mut seen_ids = HashSet::new();
 
@@ -113,10 +120,9 @@ fn load_project_memories(
         policy.limits.candidate_fetch_limit as i64,
     )
     .unwrap_or_else(|e| {
-        crate::log::error(
-            "context",
-            &format!("failed to load recent context memories for {project}: {e}"),
-        );
+        let message = format!("failed to load recent context memories for {project}: {e}");
+        crate::log::error("context", &message);
+        errors.push(ContextLoadError::new("memories", message));
         Vec::new()
     });
     for row in recent {
@@ -141,10 +147,11 @@ fn load_project_memories(
                 }
             }
         }
-        Err(e) => crate::log::error(
-            "context",
-            &format!("failed to search context memories for {project}: {e}"),
-        ),
+        Err(e) => {
+            let message = format!("failed to search context memories for {project}: {e}");
+            crate::log::error("context", &message);
+            errors.push(ContextLoadError::new("memories", message));
+        }
     }
 
     memories
@@ -195,6 +202,7 @@ fn load_project_memories(
 
     ContextMemorySelection {
         memories: selected,
+        errors,
         owner_traces: traces,
         owner_counts,
         diagnostics: if collect_diagnostics {
@@ -356,97 +364,6 @@ fn map_context_memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ContextMe
         memory: memory::map_memory_row_pub(row)?,
         owner: OwnerMetadata::from_memory_row(row, 13)?,
     })
-}
-
-pub(super) fn push_owner_included_filter(
-    project: &str,
-    idx: &mut usize,
-    conditions: &mut Vec<String>,
-    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
-) {
-    let owner_key_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    let target_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    let legacy_project_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    conditions.push(format!(
-        "((owner_scope = 'repo' AND owner_key = ?{owner_key_idx}) \
-          OR (owner_scope = 'repo' AND target_project = ?{target_idx}) \
-          OR (owner_scope IS NULL AND project = ?{legacy_project_idx} \
-              AND COALESCE(scope, 'project') != 'global'))"
-    ));
-}
-
-fn push_owner_excluded_filter(
-    project: &str,
-    idx: &mut usize,
-    conditions: &mut Vec<String>,
-    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
-) {
-    let owner_key_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    let target_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    let legacy_project_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    conditions.push(format!(
-        "NOT ((owner_scope = 'repo' AND owner_key = ?{owner_key_idx}) \
-              OR (owner_scope = 'repo' AND target_project = ?{target_idx}) \
-              OR (owner_scope IS NULL AND project = ?{legacy_project_idx} \
-                  AND COALESCE(scope, 'project') != 'global'))"
-    ));
-}
-
-fn push_context_related_filter(
-    project: &str,
-    idx: &mut usize,
-    conditions: &mut Vec<String>,
-    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
-) {
-    let project_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    let source_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    let target_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    let owner_idx = *idx;
-    params.push(Box::new(project.to_string()));
-    *idx += 1;
-    conditions.push(format!(
-        "(project = ?{project_idx} OR source_project = ?{source_idx} \
-          OR target_project = ?{target_idx} OR owner_key = ?{owner_idx})"
-    ));
-}
-
-pub(super) fn push_excluded_type_filter(
-    excluded_types: &[&str],
-    idx: &mut usize,
-    conditions: &mut Vec<String>,
-    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
-) {
-    if excluded_types.is_empty() {
-        return;
-    }
-    let placeholders: Vec<String> = excluded_types
-        .iter()
-        .map(|memory_type| {
-            let placeholder = format!("?{idx}");
-            params.push(Box::new((*memory_type).to_string()));
-            *idx += 1;
-            placeholder
-        })
-        .collect();
-    conditions.push(format!("memory_type NOT IN ({})", placeholders.join(", ")));
 }
 
 fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -1,4 +1,3 @@
-use crate::db::test_support::ScopedTestDataDir;
 use crate::memory::lesson::{save_lesson, SaveLessonRequest};
 use rusqlite::Connection;
 
@@ -8,24 +7,30 @@ use super::super::render::{enforce_total_char_limit, enforce_total_char_limit_pr
 use super::{insert_global_memory, insert_memory, insert_memory_with_branch, setup_context_schema};
 
 #[test]
-fn load_context_data_logs_primary_memory_query_failures() {
-    let data_dir = ScopedTestDataDir::new("context-primary-memory-error-log");
+fn load_context_data_records_primary_memory_query_failures() {
     let conn = match Connection::open_in_memory() {
         Ok(conn) => conn,
         Err(error) => panic!("in-memory connection should open: {error}"),
     };
+    setup_context_schema(&conn);
+    conn.execute("DROP TABLE memories", []).unwrap();
     let policy = ContextPolicy::from_limits(ContextLimits::default());
 
     let loaded = load_context_data_with_policy(&conn, "/tmp/remem", None, &policy, true);
 
     assert!(loaded.memories.is_empty());
-    let log_path = data_dir.path.join("remem.log");
-    let log = match std::fs::read_to_string(&log_path) {
-        Ok(log) => log,
-        Err(error) => panic!("log should be readable at {}: {error}", log_path.display()),
-    };
-    assert!(log.contains("[ERROR] [context] failed to load recent context memories"));
-    assert!(log.contains("[ERROR] [context] failed to search context memories"));
+    let memory_errors = loaded
+        .errors
+        .iter()
+        .filter(|error| error.section == "memories")
+        .collect::<Vec<_>>();
+    assert_eq!(memory_errors.len(), 2);
+    assert!(memory_errors.iter().any(|error| error
+        .message
+        .contains("failed to load recent context memories")));
+    assert!(memory_errors
+        .iter()
+        .any(|error| error.message.contains("failed to search context memories")));
 }
 
 #[test]

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -569,6 +569,37 @@ fn render_context_output_exposes_lesson_query_failures() {
 }
 
 #[test]
+fn render_context_output_exposes_primary_memory_query_failures() {
+    let _data_dir = crate::db::test_support::ScopedTestDataDir::new("context-memory-error");
+    let conn = crate::db::test_support::runtime_connection().unwrap();
+    conn.execute("DROP TABLE memories", []).unwrap();
+    drop(conn);
+
+    let rendered = render_context_output(
+        &ContextRequest {
+            cwd: "/tmp/remem".to_string(),
+            project: "/tmp/remem".to_string(),
+            session_id: None,
+            hook_source: Some("session_start".to_string()),
+            current_branch: Some("main".to_string()),
+            host: HostKind::CodexCli,
+            use_colors: false,
+        },
+        false,
+    )
+    .unwrap();
+
+    assert!(rendered.output.contains("## Context Load Errors"));
+    assert!(rendered
+        .output
+        .contains("- memories: failed to load recent context memories for /tmp/remem"));
+    assert!(rendered
+        .output
+        .contains("- memories: failed to search context memories for /tmp/remem"));
+    assert!(!rendered.output.contains("No previous sessions found."));
+}
+
+#[test]
 fn strict_context_pipeline_opens_one_database_connection() -> anyhow::Result<()> {
     let data_dir = crate::db::test_support::ScopedTestDataDir::new("context-single-db-open");
     let setup = crate::db::test_support::runtime_connection()?;


### PR DESCRIPTION
## Summary
- surface primary and basename memory-query failures through LoadedContext.errors
- keep context rendering unchanged so the existing Context Load Errors section displays memory failures
- move context owner SQL filter helpers into a small context::filters module to keep query.rs below the hard line limit
- bump release metadata to 0.5.41 for CI version gates

Fixes #427

## Verification
- cargo fmt --check
- git diff --check
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_plugin_version_sync.py --expected-version 0.5.41
- python3 scripts/ci/check_version_bump.py origin/main WORKTREE
- cargo check --message-format=short
- node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js
- cargo clippy -- -D warnings
- cargo test context::tests::load::load_context_data_records_primary_memory_query_failures -- --nocapture
- cargo test context::tests::render::render_context_output_exposes_primary_memory_query_failures -- --nocapture
- cargo test context::tests::load:: -- --nocapture
- cargo test context::tests::render::render_context_output_exposes -- --nocapture
- cargo test
