### PR TITLE
Add explicit legacy pending migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.42"
+version = "0.5.43"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,9 +40,9 @@
 ```
 
 Codex legacy `PostToolUse(Bash)` observe hooks are treated as opt-in only:
-they are skipped unless `REMEM_ENABLE_CODEX_BASH_OBSERVE=1` is set. This keeps
-Bash-heavy sessions from creating an unbounded pending-observation backlog
-before the coalesced capture path is enabled.
+they are skipped unless `REMEM_ENABLE_CODEX_BASH_OBSERVE=1` is set. Accepted
+events still enter the coalesced capture ledger; they do not create legacy
+`pending_observations` rows.
 
 The capture path is now present in the main database as a first production
 slice: hooks write append-only `captured_events`, large evidence goes to
@@ -58,7 +58,7 @@ promotion.
 | `memory.rs` | 838 | Memory CRUD, auto-promotion from summaries, FTS search |
 | `db.rs` | 728 | Data model + write ops + encryption + cleanup |
 | `db_query.rs` | 680 | Read queries: FTS search, timeline, shared status stats |
-| `observe_flush.rs` | 609 | Batch flush: pending→observations via AI |
+| `observe_flush.rs` | 609 | Legacy pending-observation flush support |
 | `workstream.rs` | 581 | WorkStream tracking across sessions (auto-create + fuzzy match) |
 | `mcp/server.rs` | 565 | MCP service runtime: tools, server lifecycle, tests |
 | `summarize.rs` | 501 | 3-gate + background worker + session summary + compression |
@@ -66,8 +66,8 @@ promotion.
 | `cli/actions.rs` | 385 | CLI command implementations and formatted output |
 | `context.rs` | 368 | Context rendering: preferences + core + index + workstreams + sessions |
 | `preference.rs` | 352 | Preference management: query, render, CLI ops |
-| `observe.rs` | 287 | Bash filter + event queuing + type checks |
-| `db_pending.rs` | 261 | Pending observations management |
+| `observe.rs` | 287 | Bash filter + capture ledger writes + type checks |
+| `db_pending.rs` | 261 | Legacy pending observations management |
 | `search.rs` | 251 | Search entry: filtered retrieval + pagination |
 | `ai.rs` | 244 | AI calls: HTTP-first + CLI fallback + model mapping |
 | `db_job.rs` | 244 | Background job queue |
@@ -101,10 +101,10 @@ Hook/session payload
 This path is intentionally light: it does not call an LLM and it does not
 create one job per tool call.
 
-### 2. Legacy Observation Capture (Claude PostToolUse → observe)
+### 2. Observation Capture (Claude PostToolUse → observe)
 
 ```
-Tool call ──→ Type check ──→ Bash filter ──→ Queue to SQLite
+Tool call ──→ Type check ──→ Bash filter ──→ captured_events
                │              │
                │              └─ Skip: git status/log/diff, ls, cat,
                │                      npm install, cargo build (read-only)
@@ -113,28 +113,32 @@ Tool call ──→ Type check ──→ Bash filter ──→ Queue to SQLite
                   Skip: Read, Glob, Grep, metadata-only tools
 ```
 
-Each queued event stores: session_id, project, tool_name, tool_input, tool_response (truncated to 4KB).
+Accepted events store normalized host/workspace/project/session identity plus
+redacted tool evidence in `captured_events`; large payloads spill to
+`event_blobs`. The write also coalesces one `observation_extract`
+`extraction_tasks` row per host/project/session/task kind.
 
-### 3. Batch Distillation (Stop → summarize → flush)
+### 3. Background Distillation (Stop → summarize + worker)
 
 ```
 Stop hook fires
        │
-       ├─ Gate 1: pending < 3 → skip (filter short sessions)
-       ├─ Gate 2: project cooldown 300s → skip (prevent duplicates)
-       ├─ Gate 3: message hash match → skip (prevent duplicate content)
-       │
-       ▼ pass all gates
-  spawn background worker (6ms return)
-       │
-       ├─ Worker re-checks Gate 2+3 (prevent parallel races)
-       ├─ Pre-record cooldown (claim slot)
+       ├─ Enqueue summary/compress/dream jobs
+       └─ Spawn background worker (6ms return)
        │
        ▼
-  flush_pending (≤15 events/batch)
+  summary worker claims job
        │
-       ├─ Inject existing memories (delta dedup)
-       ├─ Single AI call → structured observations
+       ├─ Gate 1: summary evidence too small → skip
+       ├─ Gate 2: project cooldown 300s → skip (prevent duplicates)
+       ├─ Gate 3: message hash match → skip (prevent duplicate content)
+       ├─ Acquire summarize_locks row (prevent parallel AI calls)
+       │
+       ▼
+  process extraction_tasks
+       │
+       ├─ Load captured_events range
+       ├─ Single AI call → structured observations/candidates
        ├─ File overlap detection → mark old observations stale
        │
        ▼
@@ -163,7 +167,7 @@ coverage columns; they may coexist in `session_summaries`, but recent-session
 context queries exclude rows with `session_row_id IS NOT NULL` so the two
 pipelines cannot surface duplicate user-facing session summaries.
 
-### 3. Context Injection (SessionStart → context)
+### 4. Context Injection (SessionStart → context)
 
 ```
 New session starts
@@ -193,7 +197,7 @@ New session starts
        └─ Recent session summaries (request/completed)
 ```
 
-### 4. Legacy Pending Queue Recovery
+### 5. Legacy Pending Queue Recovery
 
 Runtime capture no longer writes `pending_observations`, and `session-init`
 does not auto-flush that legacy queue. Old pending rows and expired legacy
@@ -235,7 +239,7 @@ session_summaries ──→ memories (auto-promoted)
                     "Your Preferences" section + Core + Index
 ```
 
-- **Incremental delta**: During flush, inject latest 10 existing memories so AI skips duplicates
+- **Incremental delta**: During extraction, inject latest 10 existing memories so AI skips duplicates
 - **File overlap staleness**: When new operations overwrite old files, old observations auto-marked stale
 - **Time decay**: FTS search ranked by relevance × time decay, stale observations further penalized
 - **Auto compression**: Projects with >100 observations: keep newest 50, merge oldest 30 into 1-2 summaries
@@ -245,17 +249,19 @@ session_summaries ──→ memories (auto-promoted)
 
 ## Rate Limiting
 
-Short-lived process model (each hook = independent process) cannot dedup via in-memory state. remem uses SQLite to implement 3-gate rate limiting:
+Short-lived process model (each hook = independent process) cannot dedup via
+in-memory state. remem uses SQLite state to rate-limit summary workers:
 
 | Gate | Mechanism | Intercepts |
 |------|-----------|------------|
-| Gate 1 | `pending < 3` skip | Short sessions (1-2 operations then exit) |
-| Gate 2 | Project cooldown 300s | Same-project rapid summarize |
-| Gate 3 | Message hash dedup | Identical assistant messages |
-| Worker double-check | Re-verify Gate 2+3 on entry | Parallel worker races |
-| Pre-claim | Record cooldown before AI call | Prevent parallel workers passing gate simultaneously |
+| Gate 1 | Empty/small assistant evidence skip | Metadata-only or contentless Stop payloads |
+| Gate 2 | `summarize_cooldown` after successful finalization | Same-project rapid summarize |
+| Gate 3 | Last message hash dedup | Identical assistant messages |
+| Worker lock | `summarize_locks` before AI call | Parallel worker races |
 
-`summarize_cooldown` table stores each project's last summarize time and message hash.
+`summarize_cooldown` stores each project's last successful summarize time and
+message hash. `summarize_locks` is the temporary per-project claim used while a
+summary AI call is in flight.
 
 ## AI Calls
 
@@ -536,7 +542,7 @@ memories_fts (title, content)                                    -- FTS5 trigram
 - **Executor-specific AI calls**: Anthropic HTTP is preferred when API credentials exist; Codex hosts can use `codex exec` with explicit model control
 - **Stop hook async**: Dispatcher returns in 6ms, `std::process::Command` spawns independent worker
 - **SQLite single-file + WAL**: Zero dependencies, FTS5 full-text search, WAL concurrent read/write
-- **Queue batch processing**: Claude Code PostToolUse only queues (<1ms), Stop processes ≤15 events in one AI call
+- **Coalesced capture processing**: Claude Code PostToolUse records capture evidence quickly; workers process coalesced extraction tasks
 - **Decision priority**: Summary fields ordered decisions > completed > learned, architectural knowledge most valuable
 - **Schema version control**: `PRAGMA user_version` skips repeated migration, reduces per-hook DB overhead
 - **Stable project key**: `parent/dirname@hash12`, readable prefix + canonical path hash, eliminates same-name directory collisions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,25 +193,25 @@ New session starts
        └─ Recent session summaries (request/completed)
 ```
 
-### 4. Stale Queue Recovery (Claude Code UserPromptSubmit → session_init)
+### 4. Legacy Pending Queue Recovery
 
-```
-New message submitted
-       │
-       ├─ Register/update session
-       │
-       ▼
-  Scan same-project pending older than 10 minutes
-       │
-       └─ Auto flush → prevent low-activity session observation loss
-```
+Runtime capture no longer writes `pending_observations`, and `session-init`
+does not auto-flush that legacy queue. Old pending rows have an explicit replay
+path instead: `remem pending migrate-legacy` records equivalent
+`captured_events`, enqueues `observation_extract` tasks, then marks the legacy
+rows `migrated`. Rows stored with `host = unknown` require `--host
+claude-code|codex-cli` so replayed evidence has a valid v2 capture identity.
+Failed legacy rows stay visible through pending admin commands; retry them back
+to `pending` before migration or purge them explicitly.
 
 ## Memory Lifecycle
 
 ```
-Tool operations ──→ pending_observations (raw queue, ≤4KB/event)
+Tool operations ──→ captured_events (raw capture ledger)
                          │
-                         ▼ flush (≤15 events/batch, single AI call)
+                         ▼ extraction_tasks (coalesced reliable work)
+                         │
+                         ▼ observation_extract (single AI call per range)
                   observations (structured memory)
                          │
              ┌───────────┼───────────┐
@@ -470,9 +470,21 @@ Retention matrix:
 ## Database Schema
 
 ```sql
--- Tool event queue
+-- Raw capture ledger
+captured_events (host_id, workspace_id, project_id, session_row_id, session_id,
+                 event_id, event_type, role, tool_name, content_text,
+                 content_blob_id, content_hash, created_at_epoch)
+
+-- Reliable extraction scheduler
+extraction_tasks (task_kind, host_id, workspace_id, project_id, session_row_id,
+                  status, idempotency_key, cursor_event_id,
+                  high_watermark_event_id, attempts, lease_owner,
+                  lease_expires_epoch)
+
+-- Legacy queue kept only for explicit admin migration/replay
 pending_observations (session_id, project, tool_name, tool_input, tool_response, cwd,
-                      created_at_epoch, lease_owner, lease_expires_epoch)
+                      created_at_epoch, status[pending|processing|failed|migrated],
+                      lease_owner, lease_expires_epoch)
 
 -- Structured observations (AI-distilled from tool events)
 observations (memory_session_id, project, type, title, subtitle, narrative, facts, concepts,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@
 ┌──────────────────────┐  ┌──────────────────────────────────┐
 │  MCP Server (stdio)  │  │  Background Worker (detached)     │
 │                      │  │                                    │
-│  search              │  │  1. flush (batch→obs, ≤15/batch)  │
+│  search              │  │  1. extract (capture→derived)       │
 │  get_observations    │  │  2. compress (>100→auto merge)     │
 │  timeline            │  │  3. summarize (session summary)    │
 │  timeline_report     │  │  4. candidate (summary→review)      │
@@ -32,7 +32,7 @@
 ┌───────────────────────────────────────────────────────────┐
 │              ~/.remem/remem.db (SQLite + WAL)              │
 │                                                            │
-│  pending_observations → observations → compressed          │
+│  captured_events → extraction_tasks → observations         │
 │  memories (decision/bugfix/preference/discovery/...)       │
 │  session_summaries    workstreams    FTS5 full-text index   │
 │  summarize_cooldown   ai_usage_events                      │
@@ -196,10 +196,11 @@ New session starts
 ### 4. Legacy Pending Queue Recovery
 
 Runtime capture no longer writes `pending_observations`, and `session-init`
-does not auto-flush that legacy queue. Old pending rows have an explicit replay
-path instead: `remem pending migrate-legacy` records equivalent
-`captured_events`, enqueues `observation_extract` tasks, then marks the legacy
-rows `migrated`. Rows stored with `host = unknown` require `--host
+does not auto-flush that legacy queue. Old pending rows and expired legacy
+processing rows have an explicit replay path instead: `remem pending
+migrate-legacy` records equivalent `captured_events` with the legacy event
+timestamp, enqueues `observation_extract` tasks, then marks the legacy rows
+`migrated`. Rows stored with `host = unknown` require `--host
 claude-code|codex-cli` so replayed evidence has a valid v2 capture identity.
 Failed legacy rows stay visible through pending admin commands; retry them back
 to `pending` before migration or purge them explicitly.

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.42": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.42",
+    "0.5.43": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.43",
       "assets": {}
     }
   }

--- a/src/cli/actions/pending.rs
+++ b/src/cli/actions/pending.rs
@@ -2,7 +2,11 @@ use anyhow::Result;
 use serde::Serialize;
 
 use crate::cli::types::PendingAction;
-use crate::db::{self, pending::admin::FailedPendingRow, ExtractionReplayRange};
+use crate::db::{
+    self,
+    pending::admin::{FailedPendingRow, LegacyPendingMigration},
+    ExtractionReplayRange,
+};
 
 pub(in crate::cli) fn run_pending(action: PendingAction) -> Result<()> {
     match action {
@@ -89,6 +93,59 @@ pub(in crate::cli) fn run_pending(action: PendingAction) -> Result<()> {
                     "Purged {} failed rows older than {} day(s).",
                     count, older_than_days
                 );
+            }
+        }
+        PendingAction::MigrateLegacy {
+            project,
+            host,
+            limit,
+            dry_run,
+            json,
+        } => {
+            if dry_run {
+                let conn = db::open_db_read_only()?;
+                let count = db::pending::admin::count_legacy_migration_candidates(
+                    &conn,
+                    project.as_deref(),
+                    limit,
+                )?;
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&PendingMigrateLegacyJson {
+                            project,
+                            limit: limit.max(1),
+                            count,
+                            migrated: Vec::new(),
+                        })?
+                    );
+                } else {
+                    println!("Would migrate {} legacy pending row(s).", count);
+                }
+            } else {
+                let mut conn = db::open_db()?;
+                let migrated = db::pending::admin::migrate_legacy_pending(
+                    &mut conn,
+                    project.as_deref(),
+                    host.as_deref(),
+                    limit,
+                )?;
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&PendingMigrateLegacyJson {
+                            project,
+                            limit: limit.max(1),
+                            count: migrated.len(),
+                            migrated,
+                        })?
+                    );
+                } else {
+                    println!(
+                        "Migrated {} legacy pending row(s) into captured_events.",
+                        migrated.len()
+                    );
+                }
             }
         }
         PendingAction::ListExtractionRanges {
@@ -184,6 +241,14 @@ struct PendingListFailedJson {
 }
 
 #[derive(Debug, Clone, Serialize)]
+struct PendingMigrateLegacyJson {
+    project: Option<String>,
+    limit: i64,
+    count: usize,
+    migrated: Vec<LegacyPendingMigration>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 struct PendingExtractionRangesJson {
     project: Option<String>,
     limit: i64,
@@ -221,6 +286,33 @@ mod tests {
         assert_eq!(parsed["project"], "proj");
         assert_eq!(parsed["count"], 1);
         assert_eq!(parsed["failed"][0]["tool_name"], "Bash");
+        Ok(())
+    }
+
+    #[test]
+    fn cli_pending_migrate_legacy_json_is_machine_parseable(
+    ) -> std::result::Result<(), serde_json::Error> {
+        let output = PendingMigrateLegacyJson {
+            project: Some("proj".to_string()),
+            limit: 1,
+            count: 1,
+            migrated: vec![LegacyPendingMigration {
+                pending_id: 7,
+                event_id: "legacy-pending-7".to_string(),
+                captured_event_id: 11,
+                extraction_task_id: 13,
+                host: "codex-cli".to_string(),
+                project: "proj".to_string(),
+                session_id: "session-1".to_string(),
+            }],
+        };
+
+        let text = serde_json::to_string(&output)?;
+        let parsed: Value = serde_json::from_str(&text)?;
+
+        assert_eq!(parsed["count"], 1);
+        assert_eq!(parsed["migrated"][0]["event_id"], "legacy-pending-7");
+        assert_eq!(parsed["migrated"][0]["host"], "codex-cli");
         Ok(())
     }
 }

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -685,6 +685,23 @@ pub(in crate::cli) enum PendingAction {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Replay legacy pending rows into captured_events/extraction_tasks.
+    MigrateLegacy {
+        /// Restrict rows to one project path.
+        #[arg(long, short)]
+        project: Option<String>,
+        /// Host to use for rows stored with legacy host=unknown.
+        #[arg(long)]
+        host: Option<String>,
+        /// Maximum pending rows to migrate.
+        #[arg(long, short = 'n', default_value = "100")]
+        limit: i64,
+        /// Preview migration count without mutating rows.
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long)]
+        json: bool,
+    },
     /// List exhausted extraction event ranges.
     ListExtractionRanges {
         #[arg(long, short)]

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -89,6 +89,26 @@ pub fn record_captured_event_with_id(
     event_id_override: Option<&str>,
 ) -> Result<CaptureEventOutcome> {
     let now = chrono::Utc::now().timestamp();
+    record_captured_event_inner(conn, input, event_id_override, now, now)
+}
+
+pub fn record_captured_event_with_id_and_created_at(
+    conn: &Connection,
+    input: &CaptureEventInput<'_>,
+    event_id_override: Option<&str>,
+    created_at_epoch: i64,
+) -> Result<CaptureEventOutcome> {
+    let now = chrono::Utc::now().timestamp();
+    record_captured_event_inner(conn, input, event_id_override, created_at_epoch, now)
+}
+
+fn record_captured_event_inner(
+    conn: &Connection,
+    input: &CaptureEventInput<'_>,
+    event_id_override: Option<&str>,
+    created_at_epoch: i64,
+    now: i64,
+) -> Result<CaptureEventOutcome> {
     let inserted_at = now;
     let sanitized_content = redact_capture_content(input.content);
     let content_hash = exact_hash(&sanitized_content);
@@ -123,7 +143,7 @@ pub fn record_captured_event_with_id(
             content_hash,
             token_estimate,
             retention_class,
-            now,
+            created_at_epoch,
             inserted_at
         ],
     )?;

--- a/src/db/pending/admin.rs
+++ b/src/db/pending/admin.rs
@@ -1,9 +1,13 @@
+mod migration;
 mod mutate;
 mod query;
 #[cfg(test)]
 mod tests;
 mod types;
 
+pub use migration::{
+    count_legacy_migration_candidates, migrate_legacy_pending, LegacyPendingMigration,
+};
 pub use mutate::{purge_failed, retry_failed};
 pub use query::{count_failed_purge_candidates, count_failed_retry_candidates, list_failed};
 pub use types::FailedPendingRow;

--- a/src/db/pending/admin/migration.rs
+++ b/src/db/pending/admin/migration.rs
@@ -1,0 +1,259 @@
+use anyhow::{bail, Result};
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+use crate::db::{self, CaptureEventInput, ExtractionTaskKind};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct LegacyPendingMigration {
+    pub pending_id: i64,
+    pub event_id: String,
+    pub captured_event_id: i64,
+    pub extraction_task_id: i64,
+    pub host: String,
+    pub project: String,
+    pub session_id: String,
+}
+
+struct LegacyPendingRow {
+    id: i64,
+    host: String,
+    session_id: String,
+    project: String,
+    tool_name: String,
+    tool_input: Option<String>,
+    tool_response: Option<String>,
+    cwd: Option<String>,
+    created_at_epoch: i64,
+}
+
+pub fn count_legacy_migration_candidates(
+    conn: &Connection,
+    project: Option<&str>,
+    limit: i64,
+) -> Result<usize> {
+    let limit = limit.max(1);
+    let count: i64 = if let Some(project) = project {
+        conn.query_row(
+            "SELECT COUNT(*) FROM (
+                 SELECT id FROM pending_observations
+                 WHERE status = 'pending' AND project = ?1
+                 ORDER BY created_at_epoch ASC, id ASC
+                 LIMIT ?2
+             )",
+            params![project, limit],
+            |row| row.get(0),
+        )?
+    } else {
+        conn.query_row(
+            "SELECT COUNT(*) FROM (
+                 SELECT id FROM pending_observations
+                 WHERE status = 'pending'
+                 ORDER BY created_at_epoch ASC, id ASC
+                 LIMIT ?1
+             )",
+            params![limit],
+            |row| row.get(0),
+        )?
+    };
+    Ok(count.max(0) as usize)
+}
+
+pub fn migrate_legacy_pending(
+    conn: &mut Connection,
+    project: Option<&str>,
+    fallback_host: Option<&str>,
+    limit: i64,
+) -> Result<Vec<LegacyPendingMigration>> {
+    let fallback_host = fallback_host.map(normalize_capture_host).transpose()?;
+    let tx = conn.transaction()?;
+    let rows = select_legacy_pending_rows(&tx, project, limit)?;
+    let mut migrated = Vec::new();
+
+    for row in rows {
+        let host = capture_host_for_row(&row.host, fallback_host)?;
+        let event_id = legacy_event_id(row.id);
+        let content = legacy_capture_content(&row);
+        let outcome = db::record_captured_event_with_id(
+            &tx,
+            &CaptureEventInput {
+                host,
+                session_id: &row.session_id,
+                project: &row.project,
+                cwd: row.cwd.as_deref(),
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some(&row.tool_name),
+                content: &content,
+                task_kind: Some(ExtractionTaskKind::ObservationExtract),
+            },
+            Some(&event_id),
+        )?;
+        let extraction_task_id = outcome.extraction_task_id.ok_or_else(|| {
+            anyhow::anyhow!("legacy pending migration did not enqueue extraction")
+        })?;
+        let changed = tx.execute(
+            "UPDATE pending_observations
+             SET status = 'migrated',
+                 lease_owner = NULL,
+                 lease_expires_epoch = NULL,
+                 next_retry_epoch = NULL,
+                 last_error = NULL,
+                 updated_at_epoch = ?2
+             WHERE id = ?1 AND status = 'pending'",
+            params![row.id, chrono::Utc::now().timestamp()],
+        )?;
+        if changed != 1 {
+            bail!("legacy pending row {} changed while migrating", row.id);
+        }
+        migrated.push(LegacyPendingMigration {
+            pending_id: row.id,
+            event_id,
+            captured_event_id: outcome.event_row_id,
+            extraction_task_id,
+            host: host.to_string(),
+            project: row.project,
+            session_id: row.session_id,
+        });
+    }
+
+    tx.commit()?;
+    Ok(migrated)
+}
+
+fn select_legacy_pending_rows(
+    conn: &Connection,
+    project: Option<&str>,
+    limit: i64,
+) -> Result<Vec<LegacyPendingRow>> {
+    let limit = limit.max(1);
+    let sql = if project.is_some() {
+        "SELECT id, host, session_id, project, tool_name, tool_input, tool_response, cwd, created_at_epoch
+         FROM pending_observations
+         WHERE status = 'pending' AND project = ?1
+         ORDER BY created_at_epoch ASC, id ASC
+         LIMIT ?2"
+    } else {
+        "SELECT id, host, session_id, project, tool_name, tool_input, tool_response, cwd, created_at_epoch
+         FROM pending_observations
+         WHERE status = 'pending'
+         ORDER BY created_at_epoch ASC, id ASC
+         LIMIT ?1"
+    };
+    let mut stmt = conn.prepare(sql)?;
+    let rows = if let Some(project) = project {
+        stmt.query_map(params![project, limit], row_from_db)?
+    } else {
+        stmt.query_map(params![limit], row_from_db)?
+    };
+    rows.collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn row_from_db(row: &rusqlite::Row<'_>) -> rusqlite::Result<LegacyPendingRow> {
+    Ok(LegacyPendingRow {
+        id: row.get(0)?,
+        host: row.get(1)?,
+        session_id: row.get(2)?,
+        project: row.get(3)?,
+        tool_name: row.get(4)?,
+        tool_input: row.get(5)?,
+        tool_response: row.get(6)?,
+        cwd: row.get(7)?,
+        created_at_epoch: row.get(8)?,
+    })
+}
+
+fn capture_host_for_row<'a>(row_host: &'a str, fallback_host: Option<&'a str>) -> Result<&'a str> {
+    match normalize_capture_host(row_host) {
+        Ok(host) => Ok(host),
+        Err(_) => fallback_host
+            .ok_or_else(|| anyhow::anyhow!("legacy pending row has host='{row_host}'; pass --host claude-code or --host codex-cli")),
+    }
+}
+
+fn normalize_capture_host(host: &str) -> Result<&str> {
+    match host {
+        crate::runtime_config::CLAUDE_HOST | crate::runtime_config::CODEX_HOST => Ok(host),
+        _ => bail!("invalid capture host '{host}'"),
+    }
+}
+
+fn legacy_event_id(id: i64) -> String {
+    format!("legacy-pending-{id}")
+}
+
+fn legacy_capture_content(row: &LegacyPendingRow) -> String {
+    let git_branch = row.cwd.as_deref().and_then(db::detect_git_branch);
+    serde_json::json!({
+        "summary": format!("Recovered legacy {} event", row.tool_name),
+        "event_type": "legacy_pending_observation",
+        "detail": format!(
+            "Recovered from pending_observations id={} created_at_epoch={}",
+            row.id, row.created_at_epoch
+        ),
+        "files": serde_json::Value::Null,
+        "exit_code": serde_json::Value::Null,
+        "tool_name": row.tool_name,
+        "tool_input": parse_jsonish(row.tool_input.as_deref()),
+        "tool_response": parse_jsonish(row.tool_response.as_deref()),
+        "git_branch": git_branch,
+    })
+    .to_string()
+}
+
+fn parse_jsonish(value: Option<&str>) -> serde_json::Value {
+    match value {
+        Some(value) => serde_json::from_str(value)
+            .unwrap_or_else(|_| serde_json::Value::String(value.to_string())),
+        None => serde_json::Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_host_count_is_queryable() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE pending_observations (
+                id INTEGER PRIMARY KEY,
+                host TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                project TEXT NOT NULL,
+                tool_name TEXT NOT NULL,
+                tool_input TEXT,
+                tool_response TEXT,
+                cwd TEXT,
+                created_at_epoch INTEGER NOT NULL,
+                updated_at_epoch INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                attempt_count INTEGER NOT NULL,
+                next_retry_epoch INTEGER,
+                last_error TEXT,
+                lease_owner TEXT,
+                lease_expires_epoch INTEGER
+            );",
+        )?;
+        conn.execute(
+            "INSERT INTO pending_observations
+             (host, session_id, project, tool_name, created_at_epoch, updated_at_epoch, status, attempt_count)
+             VALUES ('unknown', 's', 'p', 'Edit', 1, 1, 'pending', 0)",
+            [],
+        )?;
+
+        assert_eq!(count_legacy_migration_candidates(&conn, Some("p"), 10)?, 1);
+        assert_eq!(
+            count_legacy_migration_candidates(&conn, Some("other"), 10)?,
+            0
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_event_id_is_stable() {
+        assert_eq!(legacy_event_id(42), "legacy-pending-42");
+    }
+}

--- a/src/db/pending/admin/migration.rs
+++ b/src/db/pending/admin/migration.rs
@@ -33,15 +33,19 @@ pub fn count_legacy_migration_candidates(
     limit: i64,
 ) -> Result<usize> {
     let limit = limit.max(1);
+    let now = chrono::Utc::now().timestamp();
     let count: i64 = if let Some(project) = project {
         conn.query_row(
             "SELECT COUNT(*) FROM (
                  SELECT id FROM pending_observations
-                 WHERE status = 'pending' AND project = ?1
+                 WHERE project = ?1
+                   AND (status = 'pending'
+                        OR (status = 'processing'
+                            AND (lease_expires_epoch IS NULL OR lease_expires_epoch < ?3)))
                  ORDER BY created_at_epoch ASC, id ASC
                  LIMIT ?2
              )",
-            params![project, limit],
+            params![project, limit, now],
             |row| row.get(0),
         )?
     } else {
@@ -49,10 +53,12 @@ pub fn count_legacy_migration_candidates(
             "SELECT COUNT(*) FROM (
                  SELECT id FROM pending_observations
                  WHERE status = 'pending'
+                    OR (status = 'processing'
+                        AND (lease_expires_epoch IS NULL OR lease_expires_epoch < ?2))
                  ORDER BY created_at_epoch ASC, id ASC
                  LIMIT ?1
              )",
-            params![limit],
+            params![limit, now],
             |row| row.get(0),
         )?
     };
@@ -74,7 +80,7 @@ pub fn migrate_legacy_pending(
         let host = capture_host_for_row(&row.host, fallback_host)?;
         let event_id = legacy_event_id(row.id);
         let content = legacy_capture_content(&row);
-        let outcome = db::record_captured_event_with_id(
+        let outcome = db::record_captured_event_with_id_and_created_at(
             &tx,
             &CaptureEventInput {
                 host,
@@ -88,10 +94,12 @@ pub fn migrate_legacy_pending(
                 task_kind: Some(ExtractionTaskKind::ObservationExtract),
             },
             Some(&event_id),
+            row.created_at_epoch,
         )?;
         let extraction_task_id = outcome.extraction_task_id.ok_or_else(|| {
             anyhow::anyhow!("legacy pending migration did not enqueue extraction")
         })?;
+        let now = chrono::Utc::now().timestamp();
         let changed = tx.execute(
             "UPDATE pending_observations
              SET status = 'migrated',
@@ -100,8 +108,11 @@ pub fn migrate_legacy_pending(
                  next_retry_epoch = NULL,
                  last_error = NULL,
                  updated_at_epoch = ?2
-             WHERE id = ?1 AND status = 'pending'",
-            params![row.id, chrono::Utc::now().timestamp()],
+             WHERE id = ?1
+               AND (status = 'pending'
+                    OR (status = 'processing'
+                        AND (lease_expires_epoch IS NULL OR lease_expires_epoch < ?3)))",
+            params![row.id, now, now],
         )?;
         if changed != 1 {
             bail!("legacy pending row {} changed while migrating", row.id);
@@ -127,24 +138,30 @@ fn select_legacy_pending_rows(
     limit: i64,
 ) -> Result<Vec<LegacyPendingRow>> {
     let limit = limit.max(1);
+    let now = chrono::Utc::now().timestamp();
     let sql = if project.is_some() {
         "SELECT id, host, session_id, project, tool_name, tool_input, tool_response, cwd, created_at_epoch
          FROM pending_observations
-         WHERE status = 'pending' AND project = ?1
+         WHERE project = ?1
+           AND (status = 'pending'
+                OR (status = 'processing'
+                    AND (lease_expires_epoch IS NULL OR lease_expires_epoch < ?3)))
          ORDER BY created_at_epoch ASC, id ASC
          LIMIT ?2"
     } else {
         "SELECT id, host, session_id, project, tool_name, tool_input, tool_response, cwd, created_at_epoch
          FROM pending_observations
          WHERE status = 'pending'
+            OR (status = 'processing'
+                AND (lease_expires_epoch IS NULL OR lease_expires_epoch < ?2))
          ORDER BY created_at_epoch ASC, id ASC
          LIMIT ?1"
     };
     let mut stmt = conn.prepare(sql)?;
     let rows = if let Some(project) = project {
-        stmt.query_map(params![project, limit], row_from_db)?
+        stmt.query_map(params![project, limit, now], row_from_db)?
     } else {
-        stmt.query_map(params![limit], row_from_db)?
+        stmt.query_map(params![limit, now], row_from_db)?
     };
     rows.collect::<std::result::Result<Vec<_>, _>>()
         .map_err(Into::into)

--- a/src/db/pending/admin/tests.rs
+++ b/src/db/pending/admin/tests.rs
@@ -220,6 +220,19 @@ fn migrate_legacy_pending_replays_rows_into_capture_pipeline() {
         .expect("capture counts should query");
     assert_eq!(captured, 1);
     assert_eq!(tasks, 1);
+    let captured_created_at: i64 = conn
+        .query_row("SELECT created_at_epoch FROM captured_events", [], |row| {
+            row.get(0)
+        })
+        .expect("captured timestamp should query");
+    let legacy_created_at: i64 = conn
+        .query_row(
+            "SELECT created_at_epoch FROM pending_observations WHERE id = ?1",
+            params![id],
+            |row| row.get(0),
+        )
+        .expect("legacy timestamp should query");
+    assert_eq!(captured_created_at, legacy_created_at);
 }
 
 #[test]
@@ -292,4 +305,68 @@ fn migrate_legacy_pending_uses_fallback_host_and_is_idempotent() {
         .query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))
         .expect("capture count should query");
     assert_eq!(captured, 1);
+}
+
+#[test]
+fn migrate_legacy_pending_replays_expired_processing_rows() {
+    let mut conn = setup_conn();
+    let expired_id = db::enqueue_pending(
+        &conn,
+        "codex-cli",
+        "sess-expired",
+        "alpha",
+        "Edit",
+        Some(r#"{"file_path":"src/lib.rs"}"#),
+        None,
+        Some("/tmp/remem"),
+    )
+    .expect("expired row should enqueue");
+    let active_id = db::enqueue_pending(
+        &conn,
+        "codex-cli",
+        "sess-active",
+        "alpha",
+        "Edit",
+        Some(r#"{"file_path":"src/main.rs"}"#),
+        None,
+        Some("/tmp/remem"),
+    )
+    .expect("active row should enqueue");
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "UPDATE pending_observations
+         SET status = 'processing', lease_owner = 'old-worker', lease_expires_epoch = ?2
+         WHERE id = ?1",
+        params![expired_id, now - 1],
+    )
+    .expect("expired row should update");
+    conn.execute(
+        "UPDATE pending_observations
+         SET status = 'processing', lease_owner = 'live-worker', lease_expires_epoch = ?2
+         WHERE id = ?1",
+        params![active_id, now + 300],
+    )
+    .expect("active row should update");
+
+    let migrated = migrate_legacy_pending(&mut conn, Some("alpha"), None, 10)
+        .expect("expired processing row should migrate");
+
+    assert_eq!(migrated.len(), 1);
+    assert_eq!(migrated[0].pending_id, expired_id);
+    let statuses = conn
+        .prepare("SELECT id, status FROM pending_observations ORDER BY id ASC")
+        .expect("status select should prepare")
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })
+        .expect("status rows should query")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("status rows should collect");
+    assert_eq!(
+        statuses,
+        vec![
+            (expired_id, "migrated".to_string()),
+            (active_id, "processing".to_string())
+        ]
+    );
 }

--- a/src/db/pending/admin/tests.rs
+++ b/src/db/pending/admin/tests.rs
@@ -1,7 +1,8 @@
 use rusqlite::{params, Connection};
 
 use super::{
-    count_failed_purge_candidates, count_failed_retry_candidates, list_failed, purge_failed,
+    count_failed_purge_candidates, count_failed_retry_candidates,
+    count_legacy_migration_candidates, list_failed, migrate_legacy_pending, purge_failed,
     retry_failed,
 };
 use crate::{db, migrate::MIGRATIONS};
@@ -176,4 +177,119 @@ fn purge_failed_dry_run_count_respects_cutoff_without_deleting() {
         )
         .expect("old alpha should remain");
     assert_eq!(status, "failed");
+}
+
+#[test]
+fn migrate_legacy_pending_replays_rows_into_capture_pipeline() {
+    let mut conn = setup_conn();
+    let id = db::enqueue_pending(
+        &conn,
+        "codex-cli",
+        "sess-legacy",
+        "alpha",
+        "Edit",
+        Some(r#"{"file_path":"src/lib.rs"}"#),
+        Some("edited"),
+        Some("/tmp/remem"),
+    )
+    .expect("legacy row should enqueue");
+
+    let migrated = migrate_legacy_pending(&mut conn, Some("alpha"), None, 10)
+        .expect("legacy migration should succeed");
+
+    assert_eq!(migrated.len(), 1);
+    assert_eq!(migrated[0].pending_id, id);
+    assert_eq!(migrated[0].event_id, format!("legacy-pending-{id}"));
+    assert_eq!(migrated[0].host, "codex-cli");
+    let status: String = conn
+        .query_row(
+            "SELECT status FROM pending_observations WHERE id = ?1",
+            params![id],
+            |row| row.get(0),
+        )
+        .expect("legacy row should remain auditable");
+    assert_eq!(status, "migrated");
+    let (captured, tasks): (i64, i64) = conn
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM captured_events),
+                (SELECT COUNT(*) FROM extraction_tasks)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("capture counts should query");
+    assert_eq!(captured, 1);
+    assert_eq!(tasks, 1);
+}
+
+#[test]
+fn migrate_legacy_pending_requires_host_for_unknown_rows() {
+    let mut conn = setup_conn();
+    let id = db::enqueue_pending(
+        &conn,
+        "unknown",
+        "sess-legacy",
+        "alpha",
+        "Edit",
+        Some(r#"{"file_path":"src/lib.rs"}"#),
+        None,
+        Some("/tmp/remem"),
+    )
+    .expect("legacy row should enqueue");
+
+    let error = migrate_legacy_pending(&mut conn, Some("alpha"), None, 10)
+        .expect_err("unknown legacy host should fail closed");
+
+    assert!(error.to_string().contains("--host"));
+    let (status, captured): (String, i64) = conn
+        .query_row(
+            "SELECT
+                (SELECT status FROM pending_observations WHERE id = ?1),
+                (SELECT COUNT(*) FROM captured_events)",
+            params![id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("rows should query");
+    assert_eq!(status, "pending");
+    assert_eq!(captured, 0);
+}
+
+#[test]
+fn migrate_legacy_pending_uses_fallback_host_and_is_idempotent() {
+    let mut conn = setup_conn();
+    let id = db::enqueue_pending(
+        &conn,
+        "unknown",
+        "sess-legacy",
+        "alpha",
+        "Bash",
+        Some(r#"{"command":"cargo test"}"#),
+        Some(r#"{"exitCode":0}"#),
+        Some("/tmp/remem"),
+    )
+    .expect("legacy row should enqueue");
+
+    assert_eq!(
+        count_legacy_migration_candidates(&conn, Some("alpha"), 10)
+            .expect("dry run count should query"),
+        1
+    );
+    let migrated = migrate_legacy_pending(&mut conn, Some("alpha"), Some("claude-code"), 10)
+        .expect("fallback host migration should succeed");
+    let second = migrate_legacy_pending(&mut conn, Some("alpha"), Some("claude-code"), 10)
+        .expect("second migration should be a no-op");
+
+    assert_eq!(migrated.len(), 1);
+    assert_eq!(migrated[0].pending_id, id);
+    assert_eq!(migrated[0].host, "claude-code");
+    assert!(second.is_empty());
+    assert_eq!(
+        count_legacy_migration_candidates(&conn, Some("alpha"), 10)
+            .expect("dry run count should query"),
+        0
+    );
+    let captured: i64 = conn
+        .query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))
+        .expect("capture count should query");
+    assert_eq!(captured, 1);
 }

--- a/src/db/pending/admin/tests.rs
+++ b/src/db/pending/admin/tests.rs
@@ -308,6 +308,94 @@ fn migrate_legacy_pending_uses_fallback_host_and_is_idempotent() {
 }
 
 #[test]
+fn migrate_legacy_pending_dry_run_counts_expired_processing_rows() {
+    let conn = setup_conn();
+    let expired_id = db::enqueue_pending(
+        &conn,
+        "codex-cli",
+        "sess-expired",
+        "alpha",
+        "Edit",
+        Some(r#"{"file_path":"src/lib.rs"}"#),
+        None,
+        Some("/tmp/remem"),
+    )
+    .expect("expired row should enqueue");
+    let active_id = db::enqueue_pending(
+        &conn,
+        "codex-cli",
+        "sess-active",
+        "alpha",
+        "Edit",
+        Some(r#"{"file_path":"src/main.rs"}"#),
+        None,
+        Some("/tmp/remem"),
+    )
+    .expect("active row should enqueue");
+    let beta_id = db::enqueue_pending(
+        &conn,
+        "codex-cli",
+        "sess-beta",
+        "beta",
+        "Edit",
+        Some(r#"{"file_path":"src/db.rs"}"#),
+        None,
+        Some("/tmp/remem"),
+    )
+    .expect("beta row should enqueue");
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "UPDATE pending_observations
+         SET status = 'processing', lease_owner = 'old-worker', lease_expires_epoch = ?2
+         WHERE id = ?1",
+        params![expired_id, now - 1],
+    )
+    .expect("expired row should update");
+    conn.execute(
+        "UPDATE pending_observations
+         SET status = 'processing', lease_owner = 'live-worker', lease_expires_epoch = ?2
+         WHERE id = ?1",
+        params![active_id, now + 300],
+    )
+    .expect("active row should update");
+    conn.execute(
+        "UPDATE pending_observations
+         SET status = 'processing', lease_owner = 'old-worker', lease_expires_epoch = ?2
+         WHERE id = ?1",
+        params![beta_id, now - 1],
+    )
+    .expect("beta row should update");
+
+    assert_eq!(
+        count_legacy_migration_candidates(&conn, Some("alpha"), 10)
+            .expect("alpha dry-run count should query"),
+        1
+    );
+    assert_eq!(
+        count_legacy_migration_candidates(&conn, None, 10)
+            .expect("global dry-run count should query"),
+        2
+    );
+    let statuses = conn
+        .prepare("SELECT id, status FROM pending_observations ORDER BY id ASC")
+        .expect("status select should prepare")
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })
+        .expect("status rows should query")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("status rows should collect");
+    assert_eq!(
+        statuses,
+        vec![
+            (expired_id, "processing".to_string()),
+            (active_id, "processing".to_string()),
+            (beta_id, "processing".to_string())
+        ]
+    );
+}
+
+#[test]
 fn migrate_legacy_pending_replays_expired_processing_rows() {
     let mut conn = setup_conn();
     let expired_id = db::enqueue_pending(


### PR DESCRIPTION
## Summary
- replace the stale architecture claim that session-init auto-flushes legacy pending_observations with the current v2 capture/extraction flow
- add `remem pending migrate-legacy` to replay legacy pending rows into `captured_events` plus `observation_extract` tasks, then mark source rows `migrated`
- require a valid fallback host for legacy `host=unknown` rows and keep failed rows on the existing retry/purge admin path
- bump package/plugin/npm version to 0.5.43

Fixes #425.

## Verification
- cargo fmt --check
- git diff --check
- cargo check --message-format=short
- cargo clippy -- -D warnings
- cargo test db::pending::admin::tests:: -- --nocapture
- cargo test cli::actions::pending::tests:: -- --nocapture
- cargo test
- node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js
- python3 scripts/ci/check_plugin_version_sync.py --expected-version 0.5.43
- python3 scripts/ci/check_version_bump.py origin/main HEAD