### PR TITLE
Add packaged Remem plugin hooks

### DIFF
--- a/plugins/remem/README.md
+++ b/plugins/remem/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a local Codex plugin wrapper for remem.
 
-The plugin exposes `remem mcp` to Codex and provides a Remem skill for retrieval, saving, governance, and activation workflows. It does not silently install hooks. Automatic SessionStart context injection and Stop summarization require an explicit activation step.
+The plugin exposes `remem mcp` to Codex and provides a Remem skill for retrieval, saving, governance, and activation workflows. It does not silently install hooks. Automatic SessionStart context injection and Stop summarization require explicit hook trust or activation.
 
 This is a development foundation. The plugin now manages a version-matched
 local runtime under plugin storage for local checkout testing, so it no longer
@@ -79,6 +79,29 @@ The same server exposes `/mcp` with tool descriptors and the
 `ui://remem/dashboard.html` resource for Apps SDK-style testing. Do not add
 `apps` to `.codex-plugin/plugin.json` until `.app.json` can point at a real app
 id.
+
+## Packaged Hooks
+
+The plugin ships reviewable Codex hook definitions in
+`hooks/hooks.json`. Those hooks call the plugin wrapper, not a global remem
+binary:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/remem-hook.js" session-start
+node "${PLUGIN_ROOT}/scripts/remem-hook.js" stop
+```
+
+`remem-hook.js` resolves the version-matched plugin runtime and delegates to:
+
+```bash
+remem context --host codex-cli
+remem summarize --host codex-cli
+```
+
+The plugin manifest intentionally does not add a top-level `hooks` field
+because current plugin validation rejects that field. Keep these hook files as
+the trust-review source until Codex plugin hook ingestion accepts a manifest
+hook pointer.
 
 ## Hook Activation
 

--- a/plugins/remem/apps/remem/README.md
+++ b/plugins/remem/apps/remem/README.md
@@ -13,7 +13,7 @@ This app surface provides:
 - traceability: commit lookup and session-to-commit links
 - timeline: project report and around-anchor/query browsing
 - workstreams: status filtering plus confirmed status/next-action/blocker updates
-- activation: hooks-only dry-run plan without writing Codex config
+- activation: packaged hook review plus hooks-only dry-run plan without writing Codex config
 
 ## Surface map
 
@@ -31,7 +31,7 @@ This app surface provides:
 | Timeline report | `remem_timeline_report` | `GET /api/timeline-report` | `remem timeline report --json` |
 | Workstreams | `remem_workstreams_list` | `GET /api/workstreams` | `remem workstreams list --json` |
 | Workstream update | `remem_workstream_update` | `POST /api/workstream-update` | `remem workstreams update --json --confirm` |
-| Activation plan | `remem_activation_plan` | `GET /api/activation-plan` | `remem install --target codex --hooks-only --dry-run` |
+| Activation plan | `remem_activation_plan` | `GET /api/activation-plan` | `hooks/hooks.json` review and `remem install --target codex --hooks-only --dry-run` |
 
 Timeline and workstream backend routes are wired for app and MCP callers through
 machine-readable Rust CLI bridges. The visible widget is split into HTML, CSS,

--- a/plugins/remem/apps/remem/public/widget.js
+++ b/plugins/remem/apps/remem/public/widget.js
@@ -131,11 +131,17 @@ function renderCounts(status) {
 }
 function renderActivation(activation) {
   const stateClass = activation?.mentions_hooks ? "warn" : "ok";
+  const hookLines = activation?.packaged_hooks?.commands?.map(
+    (hook) => `${hook.event}: ${hook.command}`
+  ) || [];
   $("activation-summary").innerHTML = `
     <span class="pill ${stateClass}">${activation?.mentions_hooks ? "hooks preview" : "no hook plan"}</span>
     <div class="subtle">${activation?.line_count || 0} dry-run line(s)</div>
   `;
-  $("activation-plan").textContent = activation?.plan_text || "";
+  $("activation-plan").textContent = [
+    activation?.plan_text || "",
+    hookLines.length ? `Packaged plugin hooks:\n${hookLines.join("\n")}` : ""
+  ].filter(Boolean).join("\n\n");
 }
 function renderHealth(snapshot) {
   const doctor = snapshot.doctor || {};

--- a/plugins/remem/apps/remem/server.js
+++ b/plugins/remem/apps/remem/server.js
@@ -323,8 +323,27 @@ function activationSummary(text) {
     line_count: lines.length,
     writes_config: lines.some((line) => /write|would write|update|install/i.test(line)),
     mentions_hooks: lines.some((line) => /hook/i.test(line)),
-    mentions_mcp: lines.some((line) => /mcp/i.test(line))
+    mentions_mcp: lines.some((line) => /mcp/i.test(line)),
+    packaged_hooks: packagedHooksSummary()
   };
+}
+
+function packagedHooksSummary(options = {}) {
+  const hooksPath = path.join(pluginRoot(options), "hooks", "hooks.json");
+  try {
+    const config = readJson(hooksPath);
+    const hooks = config.hooks && typeof config.hooks === "object" ? config.hooks : {};
+    const commands = Object.entries(hooks).flatMap(([event, entries]) =>
+      (Array.isArray(entries) ? entries : []).flatMap((entry) =>
+        (Array.isArray(entry.hooks) ? entry.hooks : [])
+          .filter((hook) => typeof hook.command === "string")
+          .map((hook) => ({ event, command: hook.command, timeout: hook.timeout }))
+      )
+    );
+    return { available: true, path: hooksPath, events: Object.keys(hooks), commands };
+  } catch (error) {
+    return { available: false, path: hooksPath, error: error.message, events: [], commands: [] };
+  }
 }
 
 function createBackend(options = {}) {
@@ -735,6 +754,7 @@ module.exports = {
   dataDir,
   handleJsonRpc,
   isLoopbackHost,
+  packagedHooksSummary,
   parseArgs,
   readJson,
   runProcess,

--- a/plugins/remem/apps/remem/server.test.js
+++ b/plugins/remem/apps/remem/server.test.js
@@ -10,6 +10,7 @@ const {
   buildSnapshot,
   createServer,
   handleJsonRpc,
+  packagedHooksSummary,
   parseArgs,
   toolDescriptors,
   UI_RESOURCE
@@ -470,6 +471,7 @@ test("widget routes embedded app actions through host tool calls", async () => {
     assert.match(widget, /remem_timeline_report/);
     assert.match(widget, /remem_workstreams_list/);
     assert.match(widget, /remem_workstream_update/);
+    assert.match(widget, /Packaged plugin hooks/);
     assert.match(widget, /\/api\/governance-preview/);
     assert.match(widget, /\/api\/timeline-around/);
     assert.match(widget, /\/api\/workstream-update/);
@@ -692,4 +694,23 @@ test("activation summary is explicit about dry-run content", () => {
   assert.equal(summary.mentions_mcp, true);
   assert.equal(summary.writes_config, true);
   assert.equal(summary.line_count, 2);
+  assert.equal(summary.packaged_hooks.available, true);
+  assert.deepEqual(summary.packaged_hooks.events, ["SessionStart", "Stop"]);
+  assert.deepEqual(
+    summary.packaged_hooks.commands.map((hook) => [hook.event, hook.command]),
+    [
+      ["SessionStart", 'node "${PLUGIN_ROOT}/scripts/remem-hook.js" session-start'],
+      ["Stop", 'node "${PLUGIN_ROOT}/scripts/remem-hook.js" stop']
+    ]
+  );
+});
+
+test("packaged hooks summary reads reviewable plugin hook definitions", () => {
+  const summary = packagedHooksSummary();
+
+  assert.equal(summary.available, true);
+  assert.match(summary.path, /plugins\/remem\/hooks\/hooks\.json$/);
+  assert.deepEqual(summary.events, ["SessionStart", "Stop"]);
+  assert.equal(summary.commands[0].timeout, 15);
+  assert.equal(summary.commands[1].timeout, 120);
 });

--- a/plugins/remem/hooks/hooks.json
+++ b/plugins/remem/hooks/hooks.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/remem-hook.js\" session-start",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/remem-hook.js\" stop",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/remem/scripts/remem-hook.js
+++ b/plugins/remem/scripts/remem-hook.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+"use strict";
+
+const { runRememAsync } = require("./remem-runtime");
+
+const ACTIONS = new Map([
+  ["session-start", ["context", "--host", "codex-cli"]],
+  ["stop", ["summarize", "--host", "codex-cli"]]
+]);
+
+async function main(argv) {
+  const [action, ...extra] = argv;
+  if (!ACTIONS.has(action) || extra.length > 0) {
+    const supported = Array.from(ACTIONS.keys()).join("|");
+    throw new Error(`Usage: remem-hook.js ${supported}`);
+  }
+  return runRememAsync(ACTIONS.get(action), {
+    allowDownload: false
+  });
+}
+
+module.exports = {
+  ACTIONS,
+  main
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2))
+    .then((status) => process.exit(status))
+    .catch((error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/remem/scripts/remem-runtime.test.js
+++ b/plugins/remem/scripts/remem-runtime.test.js
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 const test = require("node:test");
 
 const {
@@ -12,6 +13,7 @@ const {
   copyRuntime,
   ensureRuntimeSync,
   ensureRuntime,
+  expectedVersion,
   installRuntime,
   inspectRuntime,
   managedBinaryPath,
@@ -41,6 +43,29 @@ function writeFakeRemem(file, version) {
       `  printf 'remem ${version} (schema v34)\\n'`,
       "  exit 0",
       "fi",
+      "exit 0",
+      ""
+    ].join("\n")
+  );
+  fs.chmodSync(file, 0o755);
+}
+
+function shellQuote(value) {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function writeRecordingRemem(file, version, argsPath, stdinPath) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    [
+      "#!/bin/sh",
+      "if [ \"$1\" = \"--version\" ]; then",
+      `  printf 'remem ${version} (schema v34)\\n'`,
+      "  exit 0",
+      "fi",
+      `printf '%s\\n' "$@" > ${shellQuote(argsPath)}`,
+      `cat > ${shellQuote(stdinPath)}`,
       "exit 0",
       ""
     ].join("\n")
@@ -235,6 +260,83 @@ test("activation dry-run uses local runtime without writing plugin runtime files
   assert.equal(status, 0);
   assert.equal(fs.existsSync(managedBinaryPath(fx)), false);
   assert.equal(fs.existsSync(runtimeMetadataPath(fx)), false);
+});
+
+test("packaged Codex hooks call the plugin runtime hook wrapper", () => {
+  const hooksPath = path.join(__dirname, "..", "hooks", "hooks.json");
+  const hooks = JSON.parse(fs.readFileSync(hooksPath, "utf8"));
+
+  assert.equal(
+    hooks.hooks.SessionStart[0].hooks[0].command,
+    'node "${PLUGIN_ROOT}/scripts/remem-hook.js" session-start'
+  );
+  assert.equal(hooks.hooks.SessionStart[0].hooks[0].timeout, 15);
+  assert.equal(
+    hooks.hooks.Stop[0].hooks[0].command,
+    'node "${PLUGIN_ROOT}/scripts/remem-hook.js" stop'
+  );
+  assert.equal(hooks.hooks.Stop[0].hooks[0].timeout, 120);
+  assert.equal(hooks.hooks.PostToolUse, undefined);
+});
+
+test("remem-hook session-start delegates to Codex context through explicit runtime", () => {
+  const dir = tempDir("remem-plugin-hook-");
+  const fake = path.join(dir, "remem");
+  const argsPath = path.join(dir, "args.txt");
+  const stdinPath = path.join(dir, "stdin.json");
+  writeRecordingRemem(fake, expectedVersion(), argsPath, stdinPath);
+
+  const input = '{"session_id":"sess-1","cwd":"/tmp/remem"}';
+  const result = spawnSync(process.execPath, [path.join(__dirname, "remem-hook.js"), "session-start"], {
+    encoding: "utf8",
+    input,
+    env: {
+      ...process.env,
+      REMEM_BINARY: fake,
+      REMEM_PLUGIN_DATA: path.join(dir, "data")
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(fs.readFileSync(argsPath, "utf8").trim().split(/\n/), [
+    "context",
+    "--host",
+    "codex-cli"
+  ]);
+  assert.equal(fs.readFileSync(stdinPath, "utf8"), input);
+});
+
+test("remem-hook stop delegates to Codex summarize and rejects unknown actions", () => {
+  const dir = tempDir("remem-plugin-hook-");
+  const fake = path.join(dir, "remem");
+  const argsPath = path.join(dir, "args.txt");
+  const stdinPath = path.join(dir, "stdin.json");
+  const env = {
+    ...process.env,
+    REMEM_BINARY: fake,
+    REMEM_PLUGIN_DATA: path.join(dir, "data")
+  };
+  writeRecordingRemem(fake, expectedVersion(), argsPath, stdinPath);
+
+  const ok = spawnSync(process.execPath, [path.join(__dirname, "remem-hook.js"), "stop"], {
+    encoding: "utf8",
+    input: '{"session_id":"sess-2"}',
+    env
+  });
+
+  assert.equal(ok.status, 0, ok.stderr);
+  assert.deepEqual(fs.readFileSync(argsPath, "utf8").trim().split(/\n/), [
+    "summarize",
+    "--host",
+    "codex-cli"
+  ]);
+
+  const rejected = spawnSync(process.execPath, [path.join(__dirname, "remem-hook.js"), "observe"], {
+    encoding: "utf8",
+    env
+  });
+  assert.equal(rejected.status, 1);
+  assert.match(rejected.stderr, /Usage: remem-hook\.js session-start\|stop/);
 });
 
 test("darwin arm64 runtimes require ad-hoc codesign", () => {

--- a/plugins/remem/skills/remem/SKILL.md
+++ b/plugins/remem/skills/remem/SKILL.md
@@ -32,8 +32,11 @@ user preferences.
 
 The plugin exposes MCP tools as soon as Codex loads `.mcp.json` and the runtime
 manager can resolve a matching `remem` binary. Automatic context injection and
-Stop summarization require explicit hook activation because they modify
-`~/.codex/config.toml` and `~/.codex/hooks.json`.
+Stop summarization require explicit hook trust or activation. Packaged hook
+definitions live in `plugins/remem/hooks/hooks.json` and call
+`plugins/remem/scripts/remem-hook.js`, which resolves the plugin-managed
+runtime before delegating to `remem context --host codex-cli` and
+`remem summarize --host codex-cli`.
 
 For a local repo checkout, activate with:
 


### PR DESCRIPTION
## Summary

Refs #390.

This PR delivers the unblocked plugin-hook slice for the Remem Apps SDK work:

- Adds reviewable packaged Codex hook definitions under `plugins/remem/hooks/hooks.json`.
- Adds `plugins/remem/scripts/remem-hook.js`, a runtime-resolving wrapper that delegates:
  - `SessionStart` to `remem context --host codex-cli`
  - `Stop` to `remem summarize --host codex-cli`
- Exposes the packaged hook commands in the Apps SDK activation payload and widget so users can inspect what would be trusted.
- Updates plugin/app/skill docs to describe hook activation and the current manifest boundary.

## Deliberate boundaries

- Does not add `.app.json`; that still needs a real Apps SDK app/connector id and should not be invented.
- Does not add a top-level `hooks` field to `.codex-plugin/plugin.json`; the current plugin validator rejects that shape, so hooks are packaged as reviewable files instead.

## Verification

- `node --check plugins/remem/scripts/remem-hook.js`
- `node --check plugins/remem/apps/remem/public/widget.js`
- `node --test plugins/remem/scripts/remem-runtime.test.js`
- `node --test plugins/remem/apps/remem/server.test.js`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js`
- `cargo fmt --check`
- `cargo check --message-format=short`
- `cargo clippy -- -D warnings`
- `cargo test`
- `python3 /Users/lifcc/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/remem`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `git diff --check`

Independent read-only review found no merge-blocking issues after confirming the new hook files are included in this commit.
