### PR TITLE
Fix Codex rollout raw archive capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.43"
+version = "0.5.44"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.43"
+version = "0.5.44"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.43",
+  "version": "0.5.44",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.43",
+  "version": "0.5.44",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.43": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.43",
+    "0.5.44": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.44",
       "assets": {}
     }
   }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,3 +1,4 @@
+mod capture_capability;
 mod database;
 mod environment;
 pub(crate) mod health_action;

--- a/src/doctor/capture_capability.rs
+++ b/src/doctor/capture_capability.rs
@@ -1,0 +1,78 @@
+use std::path::PathBuf;
+
+use super::types::{Check, Status};
+
+pub(super) fn check_capture_capabilities() -> Vec<Check> {
+    check_capture_capabilities_for(&active_capture_hosts())
+}
+
+fn active_capture_hosts() -> Vec<&'static str> {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let mut hosts = Vec::new();
+    if home.join(".claude").exists() || home.join(".claude.json").exists() {
+        hosts.push("claude");
+    }
+    if home.join(".codex").exists() {
+        hosts.push("codex");
+    }
+    hosts
+}
+
+fn check_capture_capabilities_for(hosts: &[&'static str]) -> Vec<Check> {
+    if hosts.is_empty() {
+        return vec![Check::new(
+            "Capture capability",
+            Status::Warn,
+            "capture=none; no supported host detected",
+        )];
+    }
+    hosts.iter().map(|host| capture_capability(host)).collect()
+}
+
+fn capture_capability(host: &'static str) -> Check {
+    match host {
+        "claude" => Check::new(
+            "Capture capability (claude)",
+            Status::Ok,
+            "capture=full; PostToolUse observe plus Stop/PreCompact transcript drain",
+        ),
+        "codex" => Check::new(
+            "Capture capability (codex)",
+            Status::Ok,
+            "capture=drain-only; SessionStart context and Stop transcript drain; PostToolUse observe is intentionally unsupported",
+        ),
+        _ => Check::new(
+            "Capture capability",
+            Status::Warn,
+            "capture=none; unsupported host",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_supported_host_capture_capabilities() {
+        let checks = check_capture_capabilities_for(&["claude", "codex"]);
+
+        assert_eq!(checks.len(), 2);
+        assert_eq!(checks[0].name, "Capture capability (claude)");
+        assert!(matches!(checks[0].status, Status::Ok));
+        assert!(checks[0].detail.contains("capture=full"));
+        assert_eq!(checks[1].name, "Capture capability (codex)");
+        assert!(matches!(checks[1].status, Status::Ok));
+        assert!(checks[1].detail.contains("capture=drain-only"));
+    }
+
+    #[test]
+    fn labels_absent_hosts_as_no_capture() {
+        let checks = check_capture_capabilities_for(&[]);
+
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "Capture capability");
+        assert!(matches!(checks[0].status, Status::Warn));
+        assert!(checks[0].detail.contains("capture=none"));
+    }
+}

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::Result;
 use rusqlite::Connection;
 
+use super::capture_capability::check_capture_capabilities;
 use super::database::{
     check_capture_drops, check_database, check_disk_space, check_pending_queue,
     check_raw_archive_ingest, check_temporal_facts, check_worker_daemon,
@@ -81,6 +82,7 @@ fn run_checks(mut on_check: impl FnMut(&Check) -> Result<()>) -> Result<Vec<Chec
     push_check(&mut checks, &mut on_check, check_install_paths)?;
     push_check(&mut checks, &mut on_check, check_runtime_config)?;
     push_checks(&mut checks, &mut on_check, check_hooks)?;
+    push_checks(&mut checks, &mut on_check, check_capture_capabilities)?;
     push_checks(&mut checks, &mut on_check, check_mcp)?;
     push_check(&mut checks, &mut on_check, || {
         check_raw_archive_ingest(shared_db.conn())

--- a/src/install/config.rs
+++ b/src/install/config.rs
@@ -26,24 +26,6 @@ impl HookStrategy {
         }
     }
 
-    fn include_observe(self) -> bool {
-        matches!(self, Self::ClaudeCode)
-    }
-
-    fn observe_matcher(self) -> &'static str {
-        match self {
-            Self::ClaudeCode => "Write|Edit|NotebookEdit|Bash|Grep|Glob|Task",
-            Self::Codex => "Bash",
-        }
-    }
-
-    fn observe_timeout_ms(self) -> i64 {
-        match self {
-            Self::ClaudeCode => 120000,
-            Self::Codex => 3000,
-        }
-    }
-
     fn runtime_host(self) -> &'static str {
         match self {
             Self::ClaudeCode => "claude-code",
@@ -96,12 +78,12 @@ pub(in crate::install) fn build_hooks(bin: &str, strategy: HookStrategy) -> Valu
         );
     }
 
-    if strategy.include_observe() {
+    if matches!(strategy, HookStrategy::ClaudeCode) {
         hooks.insert(
             "PostToolUse".to_string(),
             json!([{
-                "matcher": strategy.observe_matcher(),
-                "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "observe"), "timeout": strategy.observe_timeout_ms() }]
+                "matcher": "Write|Edit|NotebookEdit|Bash|Grep|Glob|Task",
+                "hooks": [{ "type": "command", "command": hook_command(bin, strategy, "observe"), "timeout": 120000 }]
             }]),
         );
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -15,6 +15,7 @@ pub mod preference;
 pub mod procedure;
 pub mod promote;
 pub mod raw_archive;
+pub(crate) mod raw_transcript;
 pub mod scope_cleanup;
 pub mod search_context;
 pub mod service;

--- a/src/memory/raw_archive.rs
+++ b/src/memory/raw_archive.rs
@@ -179,16 +179,11 @@ pub fn drain_transcript(
             report.parse_errors += 1;
             continue;
         };
-        let role = match value["type"].as_str() {
-            Some("user") => ROLE_USER,
-            Some("assistant") => ROLE_ASSISTANT,
-            _ => {
-                report.skipped_messages += 1;
-                continue;
-            }
+        let Some(message) = crate::memory::raw_transcript::parse_transcript_message(&value) else {
+            report.skipped_messages += 1;
+            continue;
         };
-        let text = extract_message_text(&value);
-        if text.trim().is_empty() {
+        if message.text.trim().is_empty() {
             report.empty_messages += 1;
             continue;
         }
@@ -197,8 +192,8 @@ pub fn drain_transcript(
             conn,
             session_id,
             project,
-            role,
-            &text,
+            message.role,
+            &message.text,
             SOURCE_TRANSCRIPT,
             branch,
             cwd,
@@ -259,27 +254,6 @@ pub fn record_raw_ingest_failure(
         ],
     )?;
     Ok(())
-}
-
-fn extract_message_text(value: &serde_json::Value) -> String {
-    let content = &value["message"]["content"];
-    if let Some(array) = content.as_array() {
-        let parts: Vec<String> = array
-            .iter()
-            .filter_map(|entry| {
-                match entry["type"].as_str() {
-                    Some("text") => entry["text"].as_str().map(|s| s.to_string()),
-                    // user messages can carry plain strings under `content` too
-                    _ => None,
-                }
-            })
-            .collect();
-        return parts.join("\n");
-    }
-    if let Some(text) = content.as_str() {
-        return text.to_string();
-    }
-    String::new()
 }
 
 #[derive(Debug, Clone)]
@@ -651,6 +625,47 @@ mod tests {
         )?;
         assert_eq!(kind, "insert_errors");
         assert_eq!(insert_errors, 1);
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn drain_transcript_parses_codex_rollout_response_items() -> Result<()> {
+        let conn = setup_conn();
+        let path = write_temp_transcript(
+            "codex-rollout",
+            include_str!("../../tests/fixtures/codex-rollout-minimal.jsonl"),
+        )?;
+
+        let report = drain_transcript(
+            &conn,
+            path.to_string_lossy().as_ref(),
+            "codex-session",
+            "/proj",
+            None,
+            Some("/tmp/remem-codex-fixture"),
+        )?;
+
+        assert_eq!(report.inserted, 2, "{report:?}");
+        assert_eq!(report.parse_errors, 0);
+        assert_eq!(report.insert_errors, 0);
+
+        let rows = search_raw_messages(
+            &conn,
+            &RawSearchRequest {
+                query: "Codex rollout".to_string(),
+                project: Some("/proj".to_string()),
+                branch: None,
+                role: None,
+                limit: 10,
+                offset: 0,
+            },
+        )?;
+        assert_eq!(rows.len(), 2, "{rows:?}");
+        assert!(rows.iter().any(|row| row.role == ROLE_USER));
+        assert!(rows.iter().any(|row| row.role == ROLE_ASSISTANT));
+        assert!(rows.iter().all(|row| row.source == SOURCE_TRANSCRIPT
+            && row.cwd.as_deref() == Some("/tmp/remem-codex-fixture")));
         std::fs::remove_file(path)?;
         Ok(())
     }

--- a/src/memory/raw_transcript.rs
+++ b/src/memory/raw_transcript.rs
@@ -1,0 +1,102 @@
+use serde_json::Value;
+
+use super::raw_archive::{ROLE_ASSISTANT, ROLE_USER};
+
+pub(crate) struct ParsedTranscriptMessage {
+    pub role: &'static str,
+    pub text: String,
+}
+
+pub(crate) fn parse_transcript_message(value: &Value) -> Option<ParsedTranscriptMessage> {
+    match value.get("type").and_then(Value::as_str)? {
+        "user" => Some(ParsedTranscriptMessage {
+            role: ROLE_USER,
+            text: extract_content_text(&value["message"]["content"]),
+        }),
+        "assistant" => Some(ParsedTranscriptMessage {
+            role: ROLE_ASSISTANT,
+            text: extract_content_text(&value["message"]["content"]),
+        }),
+        "response_item" => parse_codex_response_item(value),
+        _ => None,
+    }
+}
+
+fn parse_codex_response_item(value: &Value) -> Option<ParsedTranscriptMessage> {
+    let payload = value.get("payload")?;
+    if payload.get("type").and_then(Value::as_str) != Some("message") {
+        return None;
+    }
+    Some(ParsedTranscriptMessage {
+        role: transcript_role(payload.get("role").and_then(Value::as_str)?)?,
+        text: extract_content_text(&payload["content"]),
+    })
+}
+
+fn transcript_role(role: &str) -> Option<&'static str> {
+    match role {
+        "user" => Some(ROLE_USER),
+        "assistant" => Some(ROLE_ASSISTANT),
+        _ => None,
+    }
+}
+
+fn extract_content_text(content: &Value) -> String {
+    if let Some(array) = content.as_array() {
+        let parts: Vec<String> = array
+            .iter()
+            .filter_map(|entry| match entry.get("type").and_then(Value::as_str) {
+                Some("text" | "input_text" | "output_text") => entry
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                _ => None,
+            })
+            .collect();
+        return parts.join("\n");
+    }
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_legacy_claude_message_shape() {
+        let value: Value = serde_json::from_str(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"kept"}]}}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_transcript_message(&value).expect("message should parse");
+
+        assert_eq!(parsed.role, ROLE_ASSISTANT);
+        assert_eq!(parsed.text, "kept");
+    }
+
+    #[test]
+    fn parses_codex_rollout_response_item_shape() {
+        let mut roles = Vec::new();
+        let mut texts = Vec::new();
+        for line in include_str!("../../tests/fixtures/codex-rollout-minimal.jsonl").lines() {
+            let value: Value = serde_json::from_str(line).unwrap();
+            if let Some(parsed) = parse_transcript_message(&value) {
+                roles.push(parsed.role);
+                texts.push(parsed.text);
+            }
+        }
+
+        assert_eq!(roles, vec![ROLE_USER, ROLE_ASSISTANT]);
+        assert_eq!(
+            texts,
+            vec![
+                "Codex rollout user text should enter the raw archive.",
+                "Codex rollout assistant text should enter the raw archive."
+            ]
+        );
+    }
+}

--- a/tests/fixtures/codex-rollout-minimal.jsonl
+++ b/tests/fixtures/codex-rollout-minimal.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2026-06-12T00:00:00.000Z","type":"session_meta","payload":{"id":"019eba00-sanitized","timestamp":"2026-06-12T00:00:00.000Z","cwd":"/tmp/remem-codex-fixture","originator":"codex_cli_rs","cli_version":"0.0.0-test","source":"sanitized-fixture"}}
+{"timestamp":"2026-06-12T00:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Codex rollout user text should enter the raw archive."}]}}
+{"timestamp":"2026-06-12T00:00:02.000Z","type":"response_item","payload":{"type":"reasoning","summary":[],"encrypted_content":"redacted"}}
+{"timestamp":"2026-06-12T00:00:03.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final","content":[{"type":"output_text","text":"Codex rollout assistant text should enter the raw archive."}]}}
+{"timestamp":"2026-06-12T00:00:04.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{}","call_id":"call_sanitized"}}


### PR DESCRIPTION
## Summary

Closes #379.

This PR fixes the Codex capture truth gap:

- Adds a sanitized Codex rollout fixture covering `session_meta` and `response_item` records.
- Teaches raw transcript draining to parse Codex `response_item` message payloads, including `input_text` and `output_text`, so Codex `raw_messages` are non-empty.
- Keeps the legacy Claude transcript shape supported through the same parser.
- Removes the dead Codex observe hook helper path from install config; Codex remains SessionStart/Stop only.
- Adds `remem doctor` capture capability labels:
  - Claude: `capture=full`
  - Codex: `capture=drain-only`
  - no detected host: `capture=none`
- Bumps version metadata to `0.5.44` because this changes `src/` behavior.

## Reproduction

Before the parser change, the new Codex fixture produced:

`RawIngestReport { inserted: 0, skipped_messages: 5, ... }`

After the fix, `drain_transcript_parses_codex_rollout_response_items` inserts 2 rows, one user and one assistant message.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check --message-format=short`
- `cargo clippy -- -D warnings`
- `cargo test memory::raw_archive::tests::drain_transcript_parses_codex_rollout_response_items -- --nocapture`
- `cargo test memory::raw_transcript::tests:: -- --nocapture`
- `cargo test doctor::capture_capability::tests:: -- --nocapture`
- `cargo test install::tests::build_hooks_contains_expected_codex_commands -- --nocapture`
- `cargo test install::tests::build_hooks_contains_expected_claude_commands -- --nocapture`
- `cargo test`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `python3 /Users/lifcc/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/remem`
- `node --test npm/remem/scripts/install.test.js`

Independent read-only review found no blocking issues. Residual non-blocking test gap: this fixture is covered at parser/drain level, not through the queued `summarize` production path.
