### PR TITLE
Add doctor capture liveness probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.44"
+version = "0.5.45"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.44"
+version = "0.5.45"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.44",
+  "version": "0.5.45",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.44",
+  "version": "0.5.45",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.44": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.44",
+    "0.5.45": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.45",
       "assets": {}
     }
   }

--- a/src/api/handlers/status.rs
+++ b/src/api/handlers/status.rs
@@ -26,12 +26,32 @@ pub(in crate::api) async fn handle_status(State(_state): State<DbState>) -> impl
         "version": env!("CARGO_PKG_VERSION"),
         "memories": stats.active_memories,
         "observations": stats.active_observations,
+        "total_observations": stats.total_observations,
         "captured_events": stats.captured_events,
         "capture_drop_events": stats.capture_drop_events,
         "unrecovered_capture_spills": stats.unrecovered_capture_spills,
         "pending_extraction_tasks": stats.pending_extraction_tasks,
         "pending_memory_candidates": stats.pending_memory_candidates,
         "pending_graph_candidates": stats.pending_graph_candidates,
+        "promotion_funnel": {
+            "captured_events": stats.captured_events,
+            "observations": stats.total_observations,
+            "observation_rate_percent": percent(stats.total_observations, stats.captured_events),
+            "candidates": stats.total_memory_candidates,
+            "candidate_rate_percent": percent(stats.total_memory_candidates, stats.total_observations),
+            "promoted": stats.promoted_memory_candidates,
+            "promoted_rate_percent": percent(stats.promoted_memory_candidates, stats.total_memory_candidates),
+            "pending_review": stats.pending_review_memory_candidates,
+            "pending_review_rate_percent": percent(stats.pending_review_memory_candidates, stats.total_memory_candidates),
+        },
     }))
     .into_response()
+}
+
+fn percent(numerator: i64, denominator: i64) -> f64 {
+    if denominator <= 0 {
+        0.0
+    } else {
+        (numerator as f64 * 100.0) / denominator as f64
+    }
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -391,6 +391,7 @@ async fn status_handler_matches_shared_system_stats() {
     assert_eq!(payload["memories"], stats.active_memories);
     assert_eq!(payload["observations"], stats.active_observations);
     assert_eq!(payload["captured_events"], stats.captured_events);
+    assert_eq!(payload["total_observations"], stats.total_observations);
     assert_eq!(
         payload["pending_extraction_tasks"],
         stats.pending_extraction_tasks
@@ -399,4 +400,60 @@ async fn status_handler_matches_shared_system_stats() {
         payload["pending_graph_candidates"],
         stats.pending_graph_candidates
     );
+    assert_eq!(
+        payload["promotion_funnel"]["captured_events"],
+        stats.captured_events
+    );
+    assert_eq!(
+        payload["promotion_funnel"]["observations"],
+        stats.total_observations
+    );
+    assert_eq!(
+        payload["promotion_funnel"]["candidates"],
+        stats.total_memory_candidates
+    );
+    assert_eq!(
+        payload["promotion_funnel"]["promoted"],
+        stats.promoted_memory_candidates
+    );
+    assert_eq!(
+        payload["promotion_funnel"]["pending_review"],
+        stats.pending_review_memory_candidates
+    );
+    assert_eq!(
+        payload["promotion_funnel"]["observation_rate_percent"],
+        serde_json::json!(expected_percent(
+            stats.total_observations,
+            stats.captured_events
+        ))
+    );
+    assert_eq!(
+        payload["promotion_funnel"]["candidate_rate_percent"],
+        serde_json::json!(expected_percent(
+            stats.total_memory_candidates,
+            stats.total_observations
+        ))
+    );
+    assert_eq!(
+        payload["promotion_funnel"]["promoted_rate_percent"],
+        serde_json::json!(expected_percent(
+            stats.promoted_memory_candidates,
+            stats.total_memory_candidates
+        ))
+    );
+    assert_eq!(
+        payload["promotion_funnel"]["pending_review_rate_percent"],
+        serde_json::json!(expected_percent(
+            stats.pending_review_memory_candidates,
+            stats.total_memory_candidates
+        ))
+    );
+}
+
+fn expected_percent(numerator: i64, denominator: i64) -> f64 {
+    if denominator <= 0 {
+        0.0
+    } else {
+        (numerator as f64 * 100.0) / denominator as f64
+    }
 }

--- a/src/cli/actions/query/status.rs
+++ b/src/cli/actions/query/status.rs
@@ -86,6 +86,26 @@ fn load_status_report() -> Result<StatusReport> {
                 .oldest_pending_extraction_epoch
                 .map(|epoch| now.saturating_sub(epoch)),
         },
+        promotion_funnel: PromotionFunnelStatus {
+            captured_events: stats.captured_events,
+            observations: stats.total_observations,
+            observation_rate_percent: percent(stats.total_observations, stats.captured_events),
+            candidates: stats.total_memory_candidates,
+            candidate_rate_percent: percent(
+                stats.total_memory_candidates,
+                stats.total_observations,
+            ),
+            promoted: stats.promoted_memory_candidates,
+            promoted_rate_percent: percent(
+                stats.promoted_memory_candidates,
+                stats.total_memory_candidates,
+            ),
+            pending_review: stats.pending_review_memory_candidates,
+            pending_review_rate_percent: percent(
+                stats.pending_review_memory_candidates,
+                stats.total_memory_candidates,
+            ),
+        },
         pending_observations: PendingObservationStatus {
             ready: stats.ready_pending_observations,
             delayed: stats.delayed_pending_observations,
@@ -216,6 +236,32 @@ fn print_status_report(report: &StatusReport) {
         println!("  Oldest task:  {:>6}s", age_secs);
     }
     println!();
+    println!("Promotion funnel:");
+    println!(
+        "  Events -> obs: {:>6}/{:<6} ({:>5.1}%)",
+        report.promotion_funnel.observations,
+        report.promotion_funnel.captured_events,
+        report.promotion_funnel.observation_rate_percent
+    );
+    println!(
+        "  Obs -> cand:   {:>6}/{:<6} ({:>5.1}%)",
+        report.promotion_funnel.candidates,
+        report.promotion_funnel.observations,
+        report.promotion_funnel.candidate_rate_percent
+    );
+    println!(
+        "  Cand promoted:{:>6}/{:<6} ({:>5.1}%)",
+        report.promotion_funnel.promoted,
+        report.promotion_funnel.candidates,
+        report.promotion_funnel.promoted_rate_percent
+    );
+    println!(
+        "  Cand pending: {:>6}/{:<6} ({:>5.1}%)",
+        report.promotion_funnel.pending_review,
+        report.promotion_funnel.candidates,
+        report.promotion_funnel.pending_review_rate_percent
+    );
+    println!();
     println!("Pending observations:");
     println!("  Ready:        {:>6}", report.pending_observations.ready);
     println!("  Delayed:      {:>6}", report.pending_observations.delayed);
@@ -291,6 +337,14 @@ fn worker_health_tag(healthy: bool, heartbeat_age_secs: Option<i64>) -> &'static
     }
 }
 
+fn percent(numerator: i64, denominator: i64) -> f64 {
+    if denominator <= 0 {
+        0.0
+    } else {
+        (numerator as f64 * 100.0) / denominator as f64
+    }
+}
+
 fn status_health_actions(report: &StatusReport) -> Vec<crate::doctor::health_action::HealthAction> {
     queue_actions_with_replay(
         report.pending_observations.failed,
@@ -310,6 +364,7 @@ pub(super) struct StatusReport {
     pub totals: StatusTotals,
     pub raw_archive: RawArchiveStatus,
     pub capture_pipeline: CapturePipelineStatus,
+    pub promotion_funnel: PromotionFunnelStatus,
     pub pending_observations: PendingObservationStatus,
     pub candidate_promotion: Vec<CandidatePromotionStatus>,
     pub jobs: JobStatus,
@@ -366,6 +421,19 @@ pub(super) struct CapturePipelineStatus {
     pub pending_graph_candidates: i64,
     pub oldest_task_epoch: Option<i64>,
     pub oldest_task_age_secs: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct PromotionFunnelStatus {
+    pub captured_events: i64,
+    pub observations: i64,
+    pub observation_rate_percent: f64,
+    pub candidates: i64,
+    pub candidate_rate_percent: f64,
+    pub promoted: i64,
+    pub promoted_rate_percent: f64,
+    pub pending_review: i64,
+    pub pending_review_rate_percent: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -465,6 +533,17 @@ mod tests {
                 oldest_task_epoch: Some(10),
                 oldest_task_age_secs: Some(11),
             },
+            promotion_funnel: PromotionFunnelStatus {
+                captured_events: 5,
+                observations: 4,
+                observation_rate_percent: 80.0,
+                candidates: 3,
+                candidate_rate_percent: 75.0,
+                promoted: 2,
+                promoted_rate_percent: 66.66666666666667,
+                pending_review: 1,
+                pending_review_rate_percent: 33.333333333333336,
+            },
             pending_observations: PendingObservationStatus {
                 ready: 12,
                 delayed: 13,
@@ -532,6 +611,11 @@ mod tests {
         );
         assert_eq!(parsed["capture_pipeline"]["extract_todo"], 6);
         assert_eq!(parsed["capture_pipeline"]["pending_graph_candidates"], 10);
+        assert_eq!(parsed["promotion_funnel"]["captured_events"], 5);
+        assert_eq!(parsed["promotion_funnel"]["observations"], 4);
+        assert_eq!(parsed["promotion_funnel"]["candidates"], 3);
+        assert_eq!(parsed["promotion_funnel"]["promoted"], 2);
+        assert_eq!(parsed["promotion_funnel"]["pending_review"], 1);
         assert_eq!(parsed["pending_observations"]["failed"], 16);
         assert_eq!(
             parsed["candidate_promotion"][0]["review_status"],

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -11,6 +11,7 @@ use super::shared::collect_rows;
 pub struct SystemStats {
     pub active_memories: i64,
     pub active_observations: i64,
+    pub total_observations: i64,
     pub session_summaries: i64,
     pub raw_messages: i64,
     pub raw_ingest_failures: i64,
@@ -21,6 +22,8 @@ pub struct SystemStats {
     pub latest_raw_ingest_failure_path: Option<String>,
     pub latest_raw_ingest_failure_message: Option<String>,
     pub captured_events: i64,
+    pub latest_captured_event_epoch: Option<i64>,
+    pub latest_capture_activity_epoch: Option<i64>,
     pub capture_drop_events: i64,
     pub actionable_capture_drops: i64,
     pub unrecovered_capture_spills: i64,
@@ -36,6 +39,9 @@ pub struct SystemStats {
     pub quarantined_extraction_replay_ranges: i64,
     pub oldest_pending_extraction_epoch: Option<i64>,
     pub pending_memory_candidates: i64,
+    pub total_memory_candidates: i64,
+    pub promoted_memory_candidates: i64,
+    pub pending_review_memory_candidates: i64,
     pub pending_graph_candidates: i64,
     pub pending_observations: i64,
     pub ready_pending_observations: i64,
@@ -86,6 +92,26 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
     let now = chrono::Utc::now().timestamp();
     let raw_ingest = query_raw_ingest_failure_stats(conn)?;
     let capture_drop = crate::db::query_capture_drop_stats(conn)?;
+    let captured_events =
+        conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| row.get(0))?;
+    let latest_captured_event_epoch = conn.query_row(
+        "SELECT MAX(inserted_at_epoch) FROM captured_events",
+        [],
+        |row| row.get(0),
+    )?;
+    let latest_raw_message_epoch = conn.query_row(
+        "SELECT MAX(created_at_epoch) FROM raw_messages",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    let latest_capture_activity_epoch = [
+        latest_captured_event_epoch,
+        capture_drop.latest_epoch,
+        latest_raw_message_epoch,
+    ]
+    .into_iter()
+    .flatten()
+    .max();
     let replay_ranges = query_extraction_replay_range_stats(conn)?;
     let worker_heartbeat = crate::db::worker::latest_daemon_worker_heartbeat(conn)?;
     let healthy_worker_heartbeat = crate::db::worker::healthy_daemon_worker_heartbeat(
@@ -103,6 +129,9 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
             [],
             |row| row.get(0),
         )?,
+        total_observations: conn.query_row("SELECT COUNT(*) FROM observations", [], |row| {
+            row.get(0)
+        })?,
         session_summaries: conn.query_row("SELECT COUNT(*) FROM session_summaries", [], |row| {
             row.get(0)
         })?,
@@ -114,9 +143,9 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
         latest_raw_ingest_failure_kind: raw_ingest.latest_kind,
         latest_raw_ingest_failure_path: raw_ingest.latest_path,
         latest_raw_ingest_failure_message: raw_ingest.latest_message,
-        captured_events: conn.query_row("SELECT COUNT(*) FROM captured_events", [], |row| {
-            row.get(0)
-        })?,
+        captured_events,
+        latest_captured_event_epoch,
+        latest_capture_activity_epoch,
         capture_drop_events: capture_drop.total,
         actionable_capture_drops: capture_drop.actionable,
         unrecovered_capture_spills: capture_drop.unrecovered_spills,
@@ -156,6 +185,20 @@ pub fn query_system_stats(conn: &Connection) -> Result<SystemStats> {
             |row| row.get(0),
         )?,
         pending_memory_candidates: conn.query_row(
+            "SELECT COUNT(*) FROM memory_candidates WHERE review_status = 'pending_review'",
+            [],
+            |row| row.get(0),
+        )?,
+        total_memory_candidates: conn.query_row("SELECT COUNT(*) FROM memory_candidates", [], |row| {
+            row.get(0)
+        })?,
+        promoted_memory_candidates: conn.query_row(
+            "SELECT COUNT(*) FROM memory_candidates
+             WHERE review_status IN ('auto_promoted', 'approved', 'edited')",
+            [],
+            |row| row.get(0),
+        )?,
+        pending_review_memory_candidates: conn.query_row(
             "SELECT COUNT(*) FROM memory_candidates WHERE review_status = 'pending_review'",
             [],
             |row| row.get(0),

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -29,7 +29,8 @@ fn setup_stats_schema(conn: &Connection) {
             id INTEGER PRIMARY KEY
         );
         CREATE TABLE raw_messages (
-            id INTEGER PRIMARY KEY
+            id INTEGER PRIMARY KEY,
+            created_at_epoch INTEGER NOT NULL
         );
         CREATE TABLE raw_ingest_failures (
             id INTEGER PRIMARY KEY,
@@ -41,7 +42,9 @@ fn setup_stats_schema(conn: &Connection) {
             created_at_epoch INTEGER NOT NULL
         );
         CREATE TABLE captured_events (
-            id INTEGER PRIMARY KEY
+            id INTEGER PRIMARY KEY,
+            created_at_epoch INTEGER NOT NULL,
+            inserted_at_epoch INTEGER NOT NULL
         );
         CREATE TABLE memory_facts (
             id INTEGER PRIMARY KEY,
@@ -179,8 +182,11 @@ fn query_system_stats_and_related_views_share_one_definition() {
         [],
     )
     .expect("raw ingest failure insert should succeed");
-    conn.execute("INSERT INTO captured_events (id) VALUES (1)", [])
-        .expect("captured event insert should succeed");
+    conn.execute(
+        "INSERT INTO captured_events (id, created_at_epoch, inserted_at_epoch) VALUES (1, 120, 130)",
+        [],
+    )
+    .expect("captured event insert should succeed");
     conn.execute(
         "INSERT INTO capture_drop_events
          (host_id, session_id, project, tool_name, reason, detail, created_at_epoch)
@@ -285,6 +291,7 @@ fn query_system_stats_and_related_views_share_one_definition() {
         SystemStats {
             active_memories: 3,
             active_observations: 1,
+            total_observations: 2,
             session_summaries: 1,
             raw_messages: 0,
             raw_ingest_failures: 1,
@@ -295,6 +302,8 @@ fn query_system_stats_and_related_views_share_one_definition() {
             latest_raw_ingest_failure_path: Some("/bad/transcript.jsonl".to_string()),
             latest_raw_ingest_failure_message: Some("bad jsonl".to_string()),
             captured_events: 1,
+            latest_captured_event_epoch: Some(130),
+            latest_capture_activity_epoch: Some(170),
             capture_drop_events: 1,
             actionable_capture_drops: 0,
             unrecovered_capture_spills: 0,
@@ -310,6 +319,9 @@ fn query_system_stats_and_related_views_share_one_definition() {
             quarantined_extraction_replay_ranges: 1,
             oldest_pending_extraction_epoch: Some(90),
             pending_memory_candidates: 1,
+            total_memory_candidates: 1,
+            promoted_memory_candidates: 0,
+            pending_review_memory_candidates: 1,
             pending_graph_candidates: 2,
             pending_observations: 2,
             ready_pending_observations: 1,

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,4 +1,5 @@
 mod capture_capability;
+mod capture_liveness;
 mod database;
 mod environment;
 pub(crate) mod health_action;

--- a/src/doctor/capture_liveness.rs
+++ b/src/doctor/capture_liveness.rs
@@ -1,0 +1,424 @@
+use anyhow::Result;
+use rusqlite::{Connection, OptionalExtension};
+
+use super::types::{Check, Status};
+use crate::db;
+
+const STALE_CAPTURE_HEARTBEAT_SECS: i64 = 7 * 24 * 60 * 60;
+const SUMMARY_HEARTBEAT_GRACE_SECS: i64 = 60;
+
+pub(super) fn check_capture_liveness(conn: Option<&Connection>, setup_checks: &[Check]) -> Check {
+    let setup_findings = capture_setup_findings(setup_checks);
+    let mut failures: Vec<String> = setup_findings
+        .iter()
+        .filter(|finding| matches!(finding.status, Status::Fail))
+        .map(|finding| finding.detail.clone())
+        .collect();
+    let warnings: Vec<String> = setup_findings
+        .iter()
+        .filter(|finding| matches!(finding.status, Status::Warn))
+        .map(|finding| finding.detail.clone())
+        .collect();
+
+    let Some(conn) = conn else {
+        if failures.is_empty() {
+            return Check::new("Capture liveness", Status::Warn, "cannot open database");
+        }
+        return Check::new("Capture liveness", Status::Fail, failures.join("; "));
+    };
+
+    let stats = match db::query_system_stats(conn) {
+        Ok(stats) => stats,
+        Err(err) => {
+            if failures.is_empty() {
+                return Check::new(
+                    "Capture liveness",
+                    Status::Warn,
+                    format!("cannot load capture stats: {}", err),
+                );
+            }
+            failures.push(format!("cannot load capture stats: {err}"));
+            return Check::new("Capture liveness", Status::Fail, failures.join("; "));
+        }
+    };
+
+    if stats.failed_pending_observations > 0 || stats.failed_extraction_tasks > 0 {
+        failures.push(format!(
+            "failed-observation backlog: {} failed pending observations, {} failed extraction tasks; run `remem pending list-failed --limit 20` and `remem worker --once`",
+            stats.failed_pending_observations, stats.failed_extraction_tasks
+        ));
+    }
+    if stats.actionable_capture_drops > 0 {
+        failures.push(format!(
+            "{} actionable capture drop(s); latest reason={}",
+            stats.actionable_capture_drops,
+            stats
+                .latest_capture_drop_reason
+                .as_deref()
+                .unwrap_or("unknown")
+        ));
+    }
+
+    let liveness = match query_liveness_rows(conn) {
+        Ok(liveness) => liveness,
+        Err(err) => {
+            if failures.is_empty() {
+                return Check::new(
+                    "Capture liveness",
+                    Status::Warn,
+                    format!("cannot load capture liveness rows: {}", err),
+                );
+            }
+            failures.push(format!("cannot load capture liveness rows: {err}"));
+            return Check::new("Capture liveness", Status::Fail, failures.join("; "));
+        }
+    };
+    if let Some(gap) = liveness.hosted_summary_without_capture {
+        failures.push(format!(
+            "{} hosted session summary row(s) have no captured_events heartbeat; latest session_row_id={} host={}",
+            gap.count,
+            gap.latest_session_row_id.unwrap_or_default(),
+            gap.latest_host.unwrap_or_else(|| "unknown".to_string())
+        ));
+    }
+    if stats.session_summaries > 0 && stats.latest_capture_activity_epoch.is_none() {
+        failures.push(format!(
+            "{} completed session summary row(s), but no captured_events/raw_messages/capture_drop_events heartbeat; hooks are not recording capture activity",
+            stats.session_summaries
+        ));
+    }
+    if let (Some(summary_epoch), Some(heartbeat_epoch)) = (
+        liveness.latest_session_summary_epoch,
+        stats.latest_capture_activity_epoch,
+    ) {
+        if summary_epoch.saturating_sub(heartbeat_epoch) > SUMMARY_HEARTBEAT_GRACE_SECS {
+            failures.push(format!(
+                "completed session summary is newer than latest capture heartbeat by {}s; hooks may be missing or stale",
+                summary_epoch.saturating_sub(heartbeat_epoch)
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        return Check::new("Capture liveness", Status::Fail, failures.join("; "));
+    }
+    if stats.latest_capture_activity_epoch.is_none() {
+        return Check::new(
+            "Capture liveness",
+            Status::Warn,
+            join_detail(
+                &warnings,
+                "no capture heartbeat yet; run one host session and re-run doctor",
+            ),
+        );
+    }
+
+    let heartbeat_age_secs = chrono::Utc::now()
+        .timestamp()
+        .saturating_sub(stats.latest_capture_activity_epoch.unwrap_or_default());
+    let detail = format!(
+        "latest capture heartbeat {}s ago; captured_events={}, raw_messages={}, expected drops={}",
+        heartbeat_age_secs, stats.captured_events, stats.raw_messages, stats.capture_drop_events
+    );
+    if heartbeat_age_secs > STALE_CAPTURE_HEARTBEAT_SECS {
+        return Check::new(
+            "Capture liveness",
+            Status::Warn,
+            join_detail(
+                &warnings,
+                &format!(
+                    "{detail}; stale capture heartbeat exceeds {}s, run one host session and re-run doctor",
+                    STALE_CAPTURE_HEARTBEAT_SECS
+                ),
+            ),
+        );
+    }
+    if !warnings.is_empty() {
+        return Check::new(
+            "Capture liveness",
+            Status::Warn,
+            join_detail(&warnings, &detail),
+        );
+    }
+
+    Check::new("Capture liveness", Status::Ok, detail)
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct SetupFinding {
+    status: Status,
+    detail: String,
+}
+
+fn capture_setup_findings(checks: &[Check]) -> Vec<SetupFinding> {
+    checks
+        .iter()
+        .filter_map(|check| {
+            if check.name.starts_with("Hooks") {
+                return hook_setup_finding(check);
+            }
+            if check.name == "Install paths" {
+                return install_path_setup_finding(check);
+            }
+            None
+        })
+        .collect()
+}
+
+fn hook_setup_finding(check: &Check) -> Option<SetupFinding> {
+    match check.status {
+        Status::Fail => Some(SetupFinding {
+            status: Status::Fail,
+            detail: format!("{} failed: {}", check.name, check.detail),
+        }),
+        Status::Warn if hook_warning_blocks_capture(&check.detail) => Some(SetupFinding {
+            status: Status::Fail,
+            detail: format!("{} stale or incomplete: {}", check.name, check.detail),
+        }),
+        _ => None,
+    }
+}
+
+fn hook_warning_blocks_capture(detail: &str) -> bool {
+    detail.contains(" registered (run `remem install --target")
+}
+
+fn install_path_setup_finding(check: &Check) -> Option<SetupFinding> {
+    match check.status {
+        Status::Fail | Status::Warn => Some(SetupFinding {
+            status: Status::Fail,
+            detail: format!(
+                "Install paths stale or mismatched: {}; hooks may execute a stale binary",
+                check.detail
+            ),
+        }),
+        Status::Ok => None,
+    }
+}
+
+fn join_detail(prefixes: &[String], detail: &str) -> String {
+    if prefixes.is_empty() {
+        detail.to_string()
+    } else {
+        format!("{}; {detail}", prefixes.join("; "))
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct CaptureLivenessRows {
+    latest_session_summary_epoch: Option<i64>,
+    hosted_summary_without_capture: Option<HostedSummaryGap>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HostedSummaryGap {
+    count: i64,
+    latest_session_row_id: Option<i64>,
+    latest_host: Option<String>,
+}
+
+fn query_liveness_rows(conn: &Connection) -> Result<CaptureLivenessRows> {
+    let latest_session_summary_epoch = conn.query_row(
+        "SELECT MAX(created_at_epoch)
+         FROM session_summaries
+         WHERE created_at_epoch IS NOT NULL",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    let hosted_summary_without_capture = query_hosted_summary_without_capture(conn)?;
+    Ok(CaptureLivenessRows {
+        latest_session_summary_epoch,
+        hosted_summary_without_capture,
+    })
+}
+
+fn query_hosted_summary_without_capture(conn: &Connection) -> Result<Option<HostedSummaryGap>> {
+    let count = conn.query_row(
+        "SELECT COUNT(*)
+         FROM session_summaries ss
+         WHERE ss.session_row_id IS NOT NULL
+           AND NOT EXISTS (
+               SELECT 1 FROM captured_events ce
+               WHERE ce.session_row_id = ss.session_row_id
+           )",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    if count == 0 {
+        return Ok(None);
+    }
+    let latest = conn
+        .query_row(
+            "SELECT ss.session_row_id, h.name
+             FROM session_summaries ss
+             LEFT JOIN hosts h ON h.id = ss.host_id
+             WHERE ss.session_row_id IS NOT NULL
+               AND NOT EXISTS (
+                   SELECT 1 FROM captured_events ce
+                   WHERE ce.session_row_id = ss.session_row_id
+               )
+             ORDER BY ss.created_at_epoch DESC, ss.id DESC
+             LIMIT 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, Option<i64>>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                ))
+            },
+        )
+        .optional()?;
+    Ok(Some(HostedSummaryGap {
+        count,
+        latest_session_row_id: latest.as_ref().and_then(|row| row.0),
+        latest_host: latest.and_then(|row| row.1),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use super::*;
+
+    fn setup_liveness_conn() -> anyhow::Result<Connection> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        Ok(conn)
+    }
+
+    fn record_liveness_capture(conn: &Connection) -> anyhow::Result<()> {
+        crate::db::record_captured_event(
+            conn,
+            &crate::db::CaptureEventInput {
+                host: "codex-cli",
+                session_id: "sess-doctor",
+                project: "/tmp/remem-doctor",
+                cwd: Some("/tmp/remem-doctor"),
+                event_type: "message",
+                role: Some("user"),
+                tool_name: None,
+                content: "captured event",
+                task_kind: None,
+            },
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn capture_liveness_fails_on_failed_observation_backlog() -> anyhow::Result<()> {
+        let conn = setup_liveness_conn()?;
+        let id = crate::db::enqueue_pending(
+            &conn,
+            "codex-cli",
+            "sess-failed",
+            "/tmp/remem",
+            "Bash",
+            Some("{}"),
+            Some("{}"),
+            Some("/tmp/remem"),
+        )?;
+        conn.execute(
+            "UPDATE pending_observations SET status = 'failed' WHERE id = ?1",
+            [id],
+        )?;
+
+        let check = check_capture_liveness(Some(&conn), &[]);
+
+        assert!(matches!(check.status, Status::Fail));
+        assert!(check.detail.contains("failed-observation backlog"));
+        assert!(check.detail.contains("failed pending observations"));
+        Ok(())
+    }
+
+    #[test]
+    fn capture_liveness_fails_when_summary_is_newer_than_heartbeat() -> anyhow::Result<()> {
+        let conn = setup_liveness_conn()?;
+        record_liveness_capture(&conn)?;
+        conn.execute(
+            "INSERT INTO session_summaries
+             (memory_session_id, project, request, completed, created_at_epoch)
+             VALUES ('legacy-newer-summary', '/tmp/remem-doctor', 'done', 'done', strftime('%s', 'now') + 120)",
+            [],
+        )?;
+
+        let check = check_capture_liveness(Some(&conn), &[]);
+
+        assert!(matches!(check.status, Status::Fail));
+        assert!(check
+            .detail
+            .contains("summary is newer than latest capture heartbeat"));
+        Ok(())
+    }
+
+    #[test]
+    fn capture_liveness_fails_when_hosted_summary_has_no_capture() -> anyhow::Result<()> {
+        let conn = setup_liveness_conn()?;
+        conn.execute(
+            "INSERT OR IGNORE INTO hosts(name, enabled, created_at_epoch)
+             VALUES ('codex-cli', 1, strftime('%s', 'now'))",
+            [],
+        )?;
+        let host_id: i64 =
+            conn.query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |row| {
+                row.get(0)
+            })?;
+        conn.execute(
+            "INSERT INTO session_summaries
+             (memory_session_id, project, request, completed, created_at_epoch, host_id, session_row_id)
+             VALUES ('hosted-without-capture', '/tmp/remem-doctor', 'done', 'done',
+                     strftime('%s', 'now'), ?1, 9876)",
+            params![host_id],
+        )?;
+
+        let check = check_capture_liveness(Some(&conn), &[]);
+
+        assert!(matches!(check.status, Status::Fail));
+        assert!(check.detail.contains("hosted session summary"));
+        assert!(check.detail.contains("session_row_id=9876"));
+        Ok(())
+    }
+
+    #[test]
+    fn capture_liveness_fails_on_missing_hook_setup() {
+        let setup = vec![Check::new(
+            "Hooks (codex)",
+            Status::Fail,
+            "no remem hooks (run `remem install --target codex`)",
+        )];
+
+        let check = check_capture_liveness(None, &setup);
+
+        assert!(matches!(check.status, Status::Fail));
+        assert!(check.detail.contains("Hooks (codex) failed"));
+    }
+
+    #[test]
+    fn capture_liveness_fails_on_partial_hook_setup() {
+        let setup = vec![Check::new(
+            "Hooks (codex)",
+            Status::Warn,
+            "1/2 registered (run `remem install --target codex` to fix)",
+        )];
+
+        let check = check_capture_liveness(None, &setup);
+
+        assert!(matches!(check.status, Status::Fail));
+        assert!(check.detail.contains("stale or incomplete"));
+    }
+
+    #[test]
+    fn capture_liveness_fails_on_stale_install_path_setup() {
+        let setup = vec![Check::new(
+            "Install paths",
+            Status::Warn,
+            "2 remem executable(s) found; configured /opt/remem; candidates: /usr/local/bin/remem (0.5.1); fix: remove or upgrade stale installs",
+        )];
+
+        let check = check_capture_liveness(None, &setup);
+
+        assert!(matches!(check.status, Status::Fail));
+        assert!(check.detail.contains("Install paths stale or mismatched"));
+        assert!(check.detail.contains("stale binary"));
+    }
+}

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -3,7 +3,7 @@ use crate::db;
 use crate::doctor::health_action::{
     queue_actions, queue_actions_with_replay, render_inline_hints, worker_once_fallback_detail,
 };
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 
 pub(super) fn check_database(conn: Option<&Connection>, open_error: Option<&str>) -> Check {
     let db_path = db::db_path();
@@ -237,6 +237,123 @@ pub(super) fn check_capture_drops(conn: Option<&Connection>) -> Check {
     Check::new("Capture drops", Status::Warn, detail)
 }
 
+pub(super) fn check_declared_empty_surfaces(conn: Option<&Connection>) -> Check {
+    let Some(conn) = conn else {
+        return Check::new(
+            "Declared-empty surfaces",
+            Status::Warn,
+            "cannot open database",
+        );
+    };
+
+    let stats = match db::query_system_stats(conn) {
+        Ok(stats) => stats,
+        Err(err) => {
+            return Check::new(
+                "Declared-empty surfaces",
+                Status::Warn,
+                format!("cannot load stats: {}", err),
+            );
+        }
+    };
+    let memory_facts = match table_count(conn, "memory_facts") {
+        Ok(count) => count,
+        Err(err) => {
+            return Check::new(
+                "Declared-empty surfaces",
+                Status::Warn,
+                format!("cannot count memory_facts: {err}"),
+            );
+        }
+    };
+    let graph_edges = match table_count(conn, "graph_edges") {
+        Ok(count) => count,
+        Err(err) => {
+            return Check::new(
+                "Declared-empty surfaces",
+                Status::Warn,
+                format!("cannot count graph_edges: {err}"),
+            );
+        }
+    };
+    let rule_candidates = match table_count(conn, "rule_candidates") {
+        Ok(count) => count,
+        Err(err) => {
+            return Check::new(
+                "Declared-empty surfaces",
+                Status::Warn,
+                format!("cannot count rule_candidates: {err}"),
+            );
+        }
+    };
+
+    let mut findings = Vec::new();
+    if memory_facts == 0 && (stats.active_memories > 0 || stats.captured_events > 0) {
+        findings.push("memory_facts=0 despite memory/event source data");
+    }
+    if graph_edges == 0 && (stats.active_memories > 0 || stats.captured_events > 0) {
+        findings.push("graph_edges=0 despite graph schema/read path");
+    }
+    if rule_candidates == 0 && stats.captured_events > 0 {
+        findings.push("rule_candidates=0 despite captured_events source data");
+    }
+
+    if findings.is_empty() {
+        Check::new(
+            "Declared-empty surfaces",
+            Status::Ok,
+            "no declared-but-empty production surface found",
+        )
+    } else {
+        Check::new("Declared-empty surfaces", Status::Warn, findings.join("; "))
+    }
+}
+
+pub(super) fn check_promotion_funnel(conn: Option<&Connection>) -> Check {
+    let Some(conn) = conn else {
+        return Check::new("Promotion funnel", Status::Warn, "cannot open database");
+    };
+
+    let stats = match db::query_system_stats(conn) {
+        Ok(stats) => stats,
+        Err(err) => {
+            return Check::new(
+                "Promotion funnel",
+                Status::Warn,
+                format!("cannot load funnel stats: {}", err),
+            );
+        }
+    };
+    let detail = format!(
+        "captured_events={} -> observations={} ({:.1}%) -> candidates={} ({:.1}%) -> promoted={} ({:.1}%), pending_review={} ({:.1}%)",
+        stats.captured_events,
+        stats.total_observations,
+        percent(stats.total_observations, stats.captured_events),
+        stats.total_memory_candidates,
+        percent(stats.total_memory_candidates, stats.total_observations),
+        stats.promoted_memory_candidates,
+        percent(stats.promoted_memory_candidates, stats.total_memory_candidates),
+        stats.pending_review_memory_candidates,
+        percent(stats.pending_review_memory_candidates, stats.total_memory_candidates),
+    );
+
+    if stats.captured_events > 0 && stats.total_observations == 0 {
+        Check::new(
+            "Promotion funnel",
+            Status::Warn,
+            format!("{detail}; extraction is not producing observations"),
+        )
+    } else if stats.total_observations > 0 && stats.total_memory_candidates == 0 {
+        Check::new(
+            "Promotion funnel",
+            Status::Warn,
+            format!("{detail}; promotion is not producing candidates"),
+        )
+    } else {
+        Check::new("Promotion funnel", Status::Ok, detail)
+    }
+}
+
 pub(super) fn check_temporal_facts(conn: Option<&Connection>) -> Check {
     let Some(conn) = conn else {
         return Check::new("Temporal facts", Status::Warn, "cannot open database");
@@ -292,6 +409,30 @@ pub(super) fn check_temporal_facts(conn: Option<&Connection>) -> Check {
             stats.retrieval_eligible
         ),
     )
+}
+
+fn percent(numerator: i64, denominator: i64) -> f64 {
+    if denominator <= 0 {
+        0.0
+    } else {
+        (numerator as f64 * 100.0) / denominator as f64
+    }
+}
+
+fn table_count(conn: &Connection, table: &str) -> Result<i64, rusqlite::Error> {
+    let exists: Option<i64> = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [table],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if exists.is_none() {
+        return Ok(0);
+    }
+    conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+        row.get(0)
+    })
 }
 
 pub(super) fn check_worker_daemon(conn: Option<&Connection>) -> Check {
@@ -372,5 +513,88 @@ pub(super) fn check_disk_space() -> Check {
                 log_size as f64 / 1_048_576.0
             ),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_conn() -> anyhow::Result<Connection> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        Ok(conn)
+    }
+
+    fn record_capture(conn: &Connection) -> anyhow::Result<()> {
+        crate::db::record_captured_event(
+            conn,
+            &crate::db::CaptureEventInput {
+                host: "codex-cli",
+                session_id: "sess-doctor",
+                project: "/tmp/remem-doctor",
+                cwd: Some("/tmp/remem-doctor"),
+                event_type: "message",
+                role: Some("user"),
+                tool_name: None,
+                content: "captured event",
+                task_kind: None,
+            },
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn declared_empty_surfaces_warns_when_source_data_exists_without_rows() -> anyhow::Result<()> {
+        let conn = setup_conn()?;
+        crate::memory::insert_memory(
+            &conn,
+            Some("sess"),
+            "/tmp/remem",
+            None,
+            "decision",
+            "source memory",
+            "decision",
+            None,
+        )?;
+        record_capture(&conn)?;
+
+        let check = check_declared_empty_surfaces(Some(&conn));
+
+        assert!(matches!(check.status, Status::Warn));
+        assert!(check.detail.contains("memory_facts=0"));
+        assert!(check.detail.contains("graph_edges=0"));
+        assert!(check.detail.contains("rule_candidates=0"));
+        Ok(())
+    }
+
+    #[test]
+    fn promotion_funnel_warns_when_observations_do_not_create_candidates() -> anyhow::Result<()> {
+        let conn = setup_conn()?;
+        record_capture(&conn)?;
+        crate::db::insert_observation(
+            &conn,
+            "sess-doctor",
+            "/tmp/remem-doctor",
+            "feature",
+            Some("observed feature"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            1,
+        )?;
+
+        let check = check_promotion_funnel(Some(&conn));
+
+        assert!(matches!(check.status, Status::Warn));
+        assert!(check.detail.contains("captured_events=1 -> observations=1"));
+        assert!(check
+            .detail
+            .contains("promotion is not producing candidates"));
+        Ok(())
     }
 }

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -7,9 +7,11 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use super::capture_capability::check_capture_capabilities;
+use super::capture_liveness::check_capture_liveness;
 use super::database::{
-    check_capture_drops, check_database, check_disk_space, check_pending_queue,
-    check_raw_archive_ingest, check_temporal_facts, check_worker_daemon,
+    check_capture_drops, check_database, check_declared_empty_surfaces, check_disk_space,
+    check_pending_queue, check_promotion_funnel, check_raw_archive_ingest, check_temporal_facts,
+    check_worker_daemon,
 };
 use super::environment::{check_binary, check_hooks, check_install_paths, check_mcp};
 use super::native_memory::check_native_memory_sync;
@@ -84,11 +86,21 @@ fn run_checks(mut on_check: impl FnMut(&Check) -> Result<()>) -> Result<Vec<Chec
     push_checks(&mut checks, &mut on_check, check_hooks)?;
     push_checks(&mut checks, &mut on_check, check_capture_capabilities)?;
     push_checks(&mut checks, &mut on_check, check_mcp)?;
+    let started = Instant::now();
+    let check = check_capture_liveness(shared_db.conn(), &checks)
+        .with_duration_ms(duration_ms(started.elapsed()));
+    push_ready_check(&mut checks, &mut on_check, check)?;
     push_check(&mut checks, &mut on_check, || {
         check_raw_archive_ingest(shared_db.conn())
     })?;
     push_check(&mut checks, &mut on_check, || {
         check_capture_drops(shared_db.conn())
+    })?;
+    push_check(&mut checks, &mut on_check, || {
+        check_declared_empty_surfaces(shared_db.conn())
+    })?;
+    push_check(&mut checks, &mut on_check, || {
+        check_promotion_funnel(shared_db.conn())
     })?;
     push_check(&mut checks, &mut on_check, || {
         check_temporal_facts(shared_db.conn())


### PR DESCRIPTION
Closes #374.

## Summary
- Add a doctor capture-liveness probe for missing or partial hook setup, stale install paths, failed observation backlog, capture drops, stale heartbeat, and hosted session summaries without captured events.
- Add declared-empty and promotion-funnel doctor checks so wired-but-empty memory surfaces and capture-to-promotion gaps are visible.
- Surface promotion funnel counters in CLI/API status output and bump package/plugin versions to 0.5.45.

## Verification
- cargo fmt --check
- cargo check --message-format=short
- cargo clippy -- -D warnings
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- git diff --check
- cargo test
