### PR TITLE
Wire memory facts for promoted candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.45"
+version = "0.5.46"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.45"
+version = "0.5.46"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.45",
+  "version": "0.5.46",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.45",
+  "version": "0.5.46",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.45": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.45",
+    "0.5.46": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.46",
       "assets": {}
     }
   }

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -76,13 +76,25 @@ pub struct TemporalFact {
 pub fn insert_temporal_fact(conn: &mut Connection, input: &TemporalFactInput<'_>) -> Result<i64> {
     validate_input(input)?;
     let now = chrono::Utc::now().timestamp();
+
+    let tx = conn.transaction()?;
+    let id = insert_temporal_fact_in_current_tx(&tx, input, now)?;
+    tx.commit()?;
+    Ok(id)
+}
+
+pub(crate) fn insert_temporal_fact_in_current_tx(
+    conn: &Connection,
+    input: &TemporalFactInput<'_>,
+    now: i64,
+) -> Result<i64> {
+    validate_input(input)?;
     let learned_at = input.learned_at_epoch.unwrap_or(now);
     let superseded_at = input.valid_from_epoch.unwrap_or(learned_at);
     let source_event_ids = serde_json::to_string(input.source_event_ids)?;
 
-    let tx = conn.transaction()?;
     if let Some(old_id) = input.supersedes_fact_id {
-        let old_fact: Option<(String, Option<i64>)> = tx
+        let old_fact: Option<(String, Option<i64>)> = conn
             .query_row(
                 "SELECT project, valid_from_epoch FROM memory_facts WHERE id = ?1",
                 [old_id],
@@ -106,7 +118,7 @@ pub fn insert_temporal_fact(conn: &mut Connection, input: &TemporalFactInput<'_>
             ),
             None => bail!("cannot supersede missing memory fact {old_id}"),
         }
-        tx.execute(
+        conn.execute(
             "UPDATE memory_facts
              SET status = 'stale',
                  valid_to_epoch = CASE
@@ -119,7 +131,7 @@ pub fn insert_temporal_fact(conn: &mut Connection, input: &TemporalFactInput<'_>
         )?;
     }
 
-    tx.execute(
+    conn.execute(
         "INSERT INTO memory_facts
          (project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
           learned_at_epoch, source_memory_id, source_observation_id, source_event_ids,
@@ -141,8 +153,7 @@ pub fn insert_temporal_fact(conn: &mut Connection, input: &TemporalFactInput<'_>
             now
         ],
     )?;
-    let id = tx.last_insert_rowid();
-    tx.commit()?;
+    let id = conn.last_insert_rowid();
     Ok(id)
 }
 

--- a/src/memory_candidate/apply.rs
+++ b/src/memory_candidate/apply.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use super::{candidate_title, CandidateRoute, ParsedMemoryCandidate};
 use crate::memory::lifecycle::MemoryLifecycleOp;
@@ -155,6 +155,16 @@ pub(super) fn promote_candidate_to_memory_with_route(
                 ..Default::default()
             },
         )?;
+        insert_candidate_event_time_fact(
+            conn,
+            &memory_project,
+            memory_id,
+            candidate,
+            &evidence_event_ids,
+        )
+        .with_context(|| {
+            format!("failed to write temporal fact for promoted candidate id={candidate_id}")
+        })?;
         Ok(CandidateApplyOutcome {
             memory_id: Some(memory_id),
             promoted: true,
@@ -411,6 +421,55 @@ fn insert_routed_memory(
     refresh_memory_entities(conn, memory_id, title, &candidate.text)?;
     crate::retrieval::vector::upsert_memory_embedding_for_row(conn, memory_id)?;
     Ok(memory_id)
+}
+
+fn insert_candidate_event_time_fact(
+    conn: &Connection,
+    memory_project: &str,
+    memory_id: i64,
+    candidate: &ParsedMemoryCandidate,
+    evidence_event_ids: &[i64],
+) -> Result<i64> {
+    let valid_from_epoch = evidence_valid_from_epoch(conn, evidence_event_ids)?;
+    crate::memory::facts::insert_temporal_fact_in_current_tx(
+        conn,
+        &crate::memory::facts::TemporalFactInput {
+            project: memory_project,
+            subject: &candidate.topic_key,
+            predicate: crate::memory::facts::FactPredicate::AffectsProject,
+            object: memory_project,
+            valid_from_epoch: Some(valid_from_epoch),
+            valid_to_epoch: None,
+            learned_at_epoch: None,
+            source_memory_id: Some(memory_id),
+            source_observation_id: None,
+            source_event_ids: evidence_event_ids,
+            confidence: candidate.confidence,
+            supersedes_fact_id: None,
+        },
+        chrono::Utc::now().timestamp(),
+    )
+}
+
+fn evidence_valid_from_epoch(conn: &Connection, evidence_event_ids: &[i64]) -> Result<i64> {
+    if evidence_event_ids.is_empty() {
+        bail!("candidate promotion requires evidence_event_ids for temporal fact");
+    }
+    let mut earliest = None;
+    for event_id in evidence_event_ids {
+        let epoch: i64 = conn
+            .query_row(
+                "SELECT created_at_epoch FROM captured_events WHERE id = ?1",
+                [event_id],
+                |row| row.get(0),
+            )
+            .optional()?
+            .with_context(|| {
+                format!("candidate evidence event id={event_id} missing for temporal fact")
+            })?;
+        earliest = Some(earliest.map_or(epoch, |current: i64| current.min(epoch)));
+    }
+    earliest.context("candidate promotion requires evidence_event_ids for temporal fact")
 }
 
 fn insert_lesson_metadata(

--- a/src/memory_candidate/review.rs
+++ b/src/memory_candidate/review.rs
@@ -469,6 +469,25 @@ mod tests {
         )?;
         assert_eq!(status, "approved");
         assert_eq!(source_candidate_id, id);
+        let (fact_predicate, fact_source_memory_id, fact_evidence): (String, i64, String) = conn
+            .query_row(
+                "SELECT predicate, source_memory_id, source_event_ids
+                 FROM memory_facts
+                 WHERE source_memory_id = ?1",
+                params![memory_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
+        let candidate_evidence: String = conn.query_row(
+            "SELECT evidence_event_ids FROM memory_candidates WHERE id = ?1",
+            params![id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(fact_predicate, "affects_project");
+        assert_eq!(fact_source_memory_id, memory_id);
+        assert_eq!(
+            serde_json::from_str::<Vec<i64>>(&fact_evidence)?,
+            serde_json::from_str::<Vec<i64>>(&candidate_evidence)?
+        );
         Ok(())
     }
 

--- a/src/memory_candidate/tests.rs
+++ b/src/memory_candidate/tests.rs
@@ -287,6 +287,65 @@ async fn memory_candidate_auto_promotes_low_risk_project_candidate() -> Result<(
     assert_eq!(memory_owner_key, "/tmp/remem");
     assert_eq!(memory_state_key, "decision-worker-loop");
     assert_eq!(current_memory_id, memory_id);
+    let event_epoch: i64 = conn.query_row(
+        "SELECT created_at_epoch FROM captured_events WHERE id = ?1",
+        params![task
+            .high_watermark_event_id
+            .ok_or_else(|| anyhow::anyhow!("task watermark"))?],
+        |row| row.get(0),
+    )?;
+    let (
+        fact_project,
+        fact_subject,
+        fact_predicate,
+        fact_object,
+        fact_valid_from,
+        fact_source_memory_id,
+        fact_evidence,
+        fact_confidence,
+        fact_status,
+    ): (
+        String,
+        String,
+        String,
+        String,
+        i64,
+        i64,
+        String,
+        f64,
+        String,
+    ) = conn.query_row(
+        "SELECT project, subject, predicate, object, valid_from_epoch,
+                source_memory_id, source_event_ids, confidence, status
+         FROM memory_facts
+         WHERE source_memory_id = ?1",
+        params![memory_id],
+        |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+                row.get(7)?,
+                row.get(8)?,
+            ))
+        },
+    )?;
+    assert_eq!(fact_project, "/tmp/remem");
+    assert_eq!(fact_subject, "decision-worker-loop");
+    assert_eq!(fact_predicate, "affects_project");
+    assert_eq!(fact_object, "/tmp/remem");
+    assert_eq!(fact_valid_from, event_epoch);
+    assert_eq!(fact_source_memory_id, memory_id);
+    assert_eq!(
+        serde_json::from_str::<Vec<i64>>(&fact_evidence)?,
+        serde_json::from_str::<Vec<i64>>(&evidence)?
+    );
+    assert_eq!(fact_confidence, 0.92);
+    assert_eq!(fact_status, "active");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add a transaction-aware temporal fact insert helper so candidate promotion can write memory_facts inside the existing savepoint
- write an event-time affects_project fact for every newly promoted memory candidate, using the earliest captured evidence event as valid_from_epoch
- cover auto-promotion and manual review approval paths, plus bump remem package/plugin versions to 0.5.46

Closes #359

## Verification
- cargo fmt --check
- git diff --check
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- cargo clippy -- -D warnings
- cargo test
- independent threads reviewer: no blocking findings

## Notes
- This wires the production write path for newly promoted candidates. Historical backfill for old memories that were promoted before this write path existed is left out of this PR scope.