### PR TITLE
Weight retrieval fusion channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.46"
+version = "0.5.47"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.46"
+version = "0.5.47"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.46",
+  "version": "0.5.47",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.46",
+  "version": "0.5.47",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.46": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.46",
+    "0.5.47": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.47",
       "assets": {}
     }
   }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -24,8 +24,8 @@ pub mod store;
 pub mod types;
 
 pub use crate::retrieval::memory_search::{
-    search_memories_fts, search_memories_fts_filtered, search_memories_like,
-    search_memories_like_filtered,
+    search_memories_fts, search_memories_fts_filtered, search_memories_fts_hits_filtered,
+    search_memories_like, search_memories_like_filtered, FtsMemoryHit,
 };
 pub use promote::{promote_summary_to_memory_candidates, slugify_for_topic};
 

--- a/src/retrieval/memory_search.rs
+++ b/src/retrieval/memory_search.rs
@@ -5,5 +5,8 @@ mod like;
 mod tests;
 
 pub use filters::{project_or_global_clause, push_project_filter, push_project_filter_required};
-pub use fts::{search_memories_fts, search_memories_fts_filtered};
+pub use fts::{
+    search_memories_fts, search_memories_fts_filtered, search_memories_fts_hits_filtered,
+    FtsMemoryHit,
+};
 pub use like::{search_memories_like, search_memories_like_filtered};

--- a/src/retrieval/memory_search/fts.rs
+++ b/src/retrieval/memory_search/fts.rs
@@ -5,6 +5,12 @@ use crate::db;
 use crate::memory::{map_memory_row_pub, Memory};
 use crate::retrieval::memory_search::filters::{push_branch_filter, push_project_filter};
 
+#[derive(Debug, Clone)]
+pub struct FtsMemoryHit {
+    pub memory: Memory,
+    pub score: f64,
+}
+
 /// FTS5 trigram search on memories.
 pub fn search_memories_fts(
     conn: &Connection,
@@ -36,6 +42,31 @@ pub fn search_memories_fts_filtered(
     include_inactive: bool,
     branch: Option<&str>,
 ) -> Result<Vec<Memory>> {
+    Ok(search_memories_fts_hits_filtered(
+        conn,
+        query,
+        project,
+        memory_type,
+        limit,
+        offset,
+        include_inactive,
+        branch,
+    )?
+    .into_iter()
+    .map(|hit| hit.memory)
+    .collect())
+}
+
+pub fn search_memories_fts_hits_filtered(
+    conn: &Connection,
+    query: &str,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_inactive: bool,
+    branch: Option<&str>,
+) -> Result<Vec<FtsMemoryHit>> {
     let mut conditions = vec!["memories_fts MATCH ?1".to_string()];
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(query.to_string())];
 
@@ -64,12 +95,20 @@ pub fn search_memories_fts_filtered(
     param_values.push(Box::new(offset));
 
     let sql = format!(
-        "SELECT m.id, m.session_id, m.project, m.topic_key, m.title, m.content, \
-         m.memory_type, m.files, m.created_at_epoch, m.updated_at_epoch, m.status, m.branch, m.scope \
-         FROM memories m \
-         JOIN memories_fts ON memories_fts.rowid = m.id \
-         WHERE {} \
-         ORDER BY (bm25(memories_fts, 10.0, 1.0, 3.0) * CASE WHEN m.memory_type IN ('decision','bugfix') THEN 1.5 ELSE 1.0 END) \
+        "WITH ranked AS (
+             SELECT m.id, m.session_id, m.project, m.topic_key, m.title, m.content,
+                    m.memory_type, m.files, m.created_at_epoch, m.updated_at_epoch,
+                    m.status, m.branch, m.scope,
+                    (bm25(memories_fts, 10.0, 1.0, 3.0) * CASE WHEN m.memory_type IN ('decision','bugfix') THEN 1.5 ELSE 1.0 END) AS rank_score
+             FROM memories m
+             JOIN memories_fts ON memories_fts.rowid = m.id
+             WHERE {}
+         )
+         SELECT id, session_id, project, topic_key, title, content,
+                memory_type, files, created_at_epoch, updated_at_epoch,
+                status, branch, scope, rank_score
+         FROM ranked
+         ORDER BY rank_score
          LIMIT ?{} OFFSET ?{}",
         conditions.join(" AND "),
         idx,
@@ -78,7 +117,12 @@ pub fn search_memories_fts_filtered(
 
     let mut stmt = conn.prepare(&sql)?;
     let refs = db::to_sql_refs(&param_values);
-    let rows = stmt.query_map(refs.as_slice(), map_memory_row_pub)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok(FtsMemoryHit {
+            memory: map_memory_row_pub(row)?,
+            score: row.get(13)?,
+        })
+    })?;
     crate::db::query::collect_rows(rows)
 }
 

--- a/src/retrieval/search/common.rs
+++ b/src/retrieval/search/common.rs
@@ -17,16 +17,44 @@ pub(super) fn sanitize_fts_query(raw: &str) -> String {
     }
 }
 
-pub(super) fn rrf_fuse(channels: &[Vec<i64>], k: f64) -> Vec<(i64, f64)> {
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WeightedRankedHit {
+    pub id: i64,
+    pub normalized_score: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WeightedRankedChannel<'a> {
+    pub weight: f64,
+    pub hits: &'a [WeightedRankedHit],
+}
+
+pub(super) fn weighted_ranked_fuse(
+    channels: &[WeightedRankedChannel<'_>],
+    k: f64,
+) -> Vec<(i64, f64)> {
     let mut scores: HashMap<i64, f64> = HashMap::new();
     for channel in channels {
-        for (rank, &id) in channel.iter().enumerate() {
-            *scores.entry(id).or_default() += 1.0 / (k + rank as f64 + 1.0);
+        if channel.weight <= 0.0 {
+            continue;
+        }
+        for (rank, hit) in channel.hits.iter().enumerate() {
+            *scores.entry(hit.id).or_default() +=
+                weighted_rank_score(channel.weight, k, rank, hit.normalized_score);
         }
     }
     let mut results: Vec<_> = scores.into_iter().collect();
-    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
     results
+}
+
+pub(super) fn weighted_rank_score(weight: f64, k: f64, rank: usize, normalized_score: f64) -> f64 {
+    let rank_score = 1.0 / (k + rank as f64 + 1.0);
+    weight * rank_score * (1.0 + normalized_score.clamp(0.0, 1.0))
 }
 
 pub(super) fn paginate_memories(memories: Vec<Memory>, limit: i64, offset: i64) -> Vec<Memory> {
@@ -36,4 +64,84 @@ pub(super) fn paginate_memories(memories: Vec<Memory>, limit: i64, offset: i64) 
     }
     let end = (start + limit.max(0) as usize).min(memories.len());
     memories[start..end].to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn weighted_ranked_fusion_prefers_one_strong_channel_over_many_weak_hits() {
+        let strong = [WeightedRankedHit {
+            id: 1,
+            normalized_score: 1.0,
+        }];
+        let weak_a = [WeightedRankedHit {
+            id: 2,
+            normalized_score: 0.0,
+        }];
+        let weak_b = [WeightedRankedHit {
+            id: 2,
+            normalized_score: 0.0,
+        }];
+        let weak_c = [WeightedRankedHit {
+            id: 2,
+            normalized_score: 0.0,
+        }];
+
+        let fused = weighted_ranked_fuse(
+            &[
+                WeightedRankedChannel {
+                    weight: 3.0,
+                    hits: &strong,
+                },
+                WeightedRankedChannel {
+                    weight: 1.0,
+                    hits: &weak_a,
+                },
+                WeightedRankedChannel {
+                    weight: 1.0,
+                    hits: &weak_b,
+                },
+                WeightedRankedChannel {
+                    weight: 1.0,
+                    hits: &weak_c,
+                },
+            ],
+            60.0,
+        );
+
+        assert_eq!(fused.first().map(|(id, _)| *id), Some(1));
+    }
+
+    #[test]
+    fn weighted_ranked_fusion_breaks_equal_scores_by_memory_id() {
+        let a = [WeightedRankedHit {
+            id: 20,
+            normalized_score: 0.0,
+        }];
+        let b = [WeightedRankedHit {
+            id: 10,
+            normalized_score: 0.0,
+        }];
+
+        let fused = weighted_ranked_fuse(
+            &[
+                WeightedRankedChannel {
+                    weight: 1.0,
+                    hits: &a,
+                },
+                WeightedRankedChannel {
+                    weight: 1.0,
+                    hits: &b,
+                },
+            ],
+            60.0,
+        );
+
+        assert_eq!(
+            fused.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![10, 20]
+        );
+    }
 }

--- a/src/retrieval/search/memory/tests.rs
+++ b/src/retrieval/search/memory/tests.rs
@@ -111,6 +111,23 @@ fn search_explain_reports_channels_scores_and_visibility() -> Result<()> {
         .results
         .iter()
         .any(|result| result.visibility == "global-overlay"));
+    let like = explain
+        .channels
+        .iter()
+        .find(|channel| channel.name == "like_fallback")
+        .context("like_fallback channel should be reported")?;
+    assert!(!like.enabled);
+    assert!(like
+        .disabled_reason
+        .as_deref()
+        .unwrap_or("")
+        .contains("stronger retrieval channels returned hits"));
+    assert!(explain.results.iter().all(|result| {
+        result
+            .contributions
+            .iter()
+            .all(|contribution| contribution.channel != "like_fallback")
+    }));
     assert!(explain.results.iter().all(|result| {
         !result.contributions.is_empty()
             && result
@@ -118,6 +135,56 @@ fn search_explain_reports_channels_scores_and_visibility() -> Result<()> {
                 .iter()
                 .all(|contribution| contribution.score > 0.0)
     }));
+    Ok(())
+}
+
+#[test]
+fn like_fallback_only_participates_when_stronger_channels_are_empty() -> Result<()> {
+    let conn = setup_explain_conn()?;
+    insert_explain_memory(
+        &conn,
+        &ExplainMemory {
+            id: 1,
+            project: "/repo",
+            title: "DB schema migration",
+            content: "Updated AI model",
+            scope: "project",
+            updated_at_epoch: 100,
+        },
+    )?;
+    insert_explain_memory(
+        &conn,
+        &ExplainMemory {
+            id: 2,
+            project: "/repo",
+            title: "Other topic entirely",
+            content: "Nothing relevant",
+            scope: "project",
+            updated_at_epoch: 90,
+        },
+    )?;
+
+    let (memories, explain) =
+        search_with_branch_explain(&conn, Some("DB"), Some("/repo"), None, 5, 0, false, None)?;
+    let explain = explain.context("query explain should be present")?;
+
+    assert_eq!(memories.first().map(|memory| memory.id), Some(1));
+    let like = explain
+        .channels
+        .iter()
+        .find(|channel| channel.name == "like_fallback")
+        .context("like_fallback channel should be reported")?;
+    assert!(like.enabled, "{like:#?}");
+    assert_eq!(like.hits.first().map(|hit| hit.memory_id), Some(1));
+    let result = explain
+        .results
+        .iter()
+        .find(|result| result.memory_id == 1)
+        .context("LIKE fallback result should be explained")?;
+    assert!(result
+        .contributions
+        .iter()
+        .any(|contribution| contribution.channel == "like_fallback" && contribution.score > 0.0));
     Ok(())
 }
 

--- a/src/retrieval/search/memory/text.rs
+++ b/src/retrieval/search/memory/text.rs
@@ -5,13 +5,21 @@ use rusqlite::Connection;
 
 use crate::memory::{self, Memory};
 
-use super::super::common::{paginate_memories, rrf_fuse, sanitize_fts_query};
+use super::super::common::{
+    paginate_memories, sanitize_fts_query, weighted_rank_score, weighted_ranked_fuse,
+    WeightedRankedChannel, WeightedRankedHit,
+};
 use super::{
     ChannelContribution, ChannelHit, SearchExplain, SearchExplainChannel, SearchExplainResult,
 };
 
 const RRF_K: f64 = 60.0;
 const MAX_VECTOR_DISTANCE: f32 = 0.51;
+const FTS_WEIGHT: f64 = 2.5;
+const VECTOR_WEIGHT: f64 = 3.0;
+const ENTITY_WEIGHT: f64 = 1.25;
+const TEMPORAL_WEIGHT: f64 = 1.0;
+const LIKE_FALLBACK_WEIGHT: f64 = 0.25;
 
 pub(super) struct QuerySearchWithExplain {
     pub memories: Vec<Memory>,
@@ -30,29 +38,48 @@ struct QuerySearchPlan {
 
 struct NamedChannel {
     name: &'static str,
+    weight: f64,
     disabled_reason: Option<String>,
-    ids: Vec<i64>,
+    hits: Vec<WeightedRankedHit>,
 }
 
 impl NamedChannel {
-    fn enabled(name: &'static str, ids: Vec<i64>) -> Self {
+    fn enabled(name: &'static str, weight: f64, ids: Vec<i64>) -> Self {
+        let hits = ids
+            .into_iter()
+            .enumerate()
+            .map(|(rank, id)| WeightedRankedHit {
+                id,
+                normalized_score: rank_normalized_score(rank),
+            })
+            .collect();
+        Self::enabled_with_hits(name, weight, hits)
+    }
+
+    fn enabled_with_hits(name: &'static str, weight: f64, hits: Vec<WeightedRankedHit>) -> Self {
         Self {
             name,
+            weight,
             disabled_reason: None,
-            ids,
+            hits,
         }
     }
 
-    fn disabled(name: &'static str, reason: impl Into<String>) -> Self {
+    fn disabled(name: &'static str, weight: f64, reason: impl Into<String>) -> Self {
         Self {
             name,
+            weight,
             disabled_reason: Some(reason.into()),
-            ids: vec![],
+            hits: vec![],
         }
     }
 
     fn is_enabled(&self) -> bool {
         self.disabled_reason.is_none()
+    }
+
+    fn has_hits(&self) -> bool {
+        self.is_enabled() && !self.hits.is_empty()
     }
 }
 
@@ -92,12 +119,8 @@ pub(super) fn search_with_query(
         return Ok(vec![]);
     }
 
-    let channel_ids: Vec<Vec<i64>> = plan
-        .channels
-        .iter()
-        .map(|channel| channel.ids.clone())
-        .collect();
-    let final_ids: Vec<i64> = rrf_fuse(&channel_ids, RRF_K)
+    let channel_inputs = weighted_channel_inputs(&plan.channels);
+    let final_ids: Vec<i64> = weighted_ranked_fuse(&channel_inputs, RRF_K)
         .iter()
         .map(|(id, _)| *id)
         .collect();
@@ -151,12 +174,8 @@ pub(super) fn search_with_query_explain(
         });
     }
 
-    let channel_ids: Vec<Vec<i64>> = plan
-        .channels
-        .iter()
-        .map(|channel| channel.ids.clone())
-        .collect();
-    let fused = rrf_fuse(&channel_ids, RRF_K);
+    let channel_inputs = weighted_channel_inputs(&plan.channels);
+    let fused = weighted_ranked_fuse(&channel_inputs, RRF_K);
     let final_ids: Vec<i64> = fused.iter().map(|(id, _)| *id).collect();
     let ordered = load_ordered_memories(conn, &final_ids)?;
     let paged = paginate_memories(ordered, limit, offset);
@@ -208,7 +227,7 @@ fn build_query_search_plan(
     if !long_tokens.is_empty() {
         let safe_query = sanitize_fts_query(&long_tokens.join(" "));
         fts_query = Some(safe_query.clone());
-        let fts = memory::search_memories_fts_filtered(
+        let fts = memory::search_memories_fts_hits_filtered(
             conn,
             &safe_query,
             project,
@@ -218,9 +237,12 @@ fn build_query_search_plan(
             include_stale,
             branch,
         )?;
-        let ids: Vec<i64> = fts.iter().map(|memory| memory.id).collect();
-        if !ids.is_empty() {
-            channels.push(NamedChannel::enabled("fts", ids));
+        if !fts.is_empty() {
+            channels.push(NamedChannel::enabled_with_hits(
+                "fts",
+                FTS_WEIGHT,
+                fts_normalized_hits(&fts),
+            ));
         }
     }
 
@@ -234,7 +256,7 @@ fn build_query_search_plan(
         include_stale,
     )?;
     if !entity_ids.is_empty() {
-        channels.push(NamedChannel::enabled("entity", entity_ids));
+        channels.push(NamedChannel::enabled("entity", ENTITY_WEIGHT, entity_ids));
     }
 
     if let Some(temporal_constraint) = crate::retrieval::temporal::extract_temporal(query_text) {
@@ -253,7 +275,11 @@ fn build_query_search_plan(
             include_stale,
         )?;
         if !temporal_ids.is_empty() {
-            channels.push(NamedChannel::enabled("temporal", temporal_ids));
+            channels.push(NamedChannel::enabled(
+                "temporal",
+                TEMPORAL_WEIGHT,
+                temporal_ids,
+            ));
         }
     }
 
@@ -270,34 +296,60 @@ fn build_query_search_plan(
         fetch as usize,
     )?;
     if let Some(reason) = vector_outcome.disabled_reason {
-        channels.push(NamedChannel::disabled("vector", reason));
+        channels.push(NamedChannel::disabled("vector", VECTOR_WEIGHT, reason));
     } else {
-        channels.push(NamedChannel::enabled(
+        let hits = vector_outcome
+            .hits
+            .into_iter()
+            .filter(|hit| hit.distance <= MAX_VECTOR_DISTANCE)
+            .map(|hit| WeightedRankedHit {
+                id: hit.memory_id,
+                normalized_score: vector_similarity_score(hit.distance),
+            })
+            .collect();
+        channels.push(NamedChannel::enabled_with_hits(
             "vector",
-            vector_outcome
-                .hits
-                .into_iter()
-                .filter(|hit| hit.distance <= MAX_VECTOR_DISTANCE)
-                .map(|hit| hit.memory_id)
-                .collect(),
+            VECTOR_WEIGHT,
+            hits,
         ));
     }
 
-    let like = memory::search_memories_like_filtered(
-        conn,
-        &core_refs,
-        project,
-        memory_type,
-        fetch,
-        0,
-        include_stale,
-        branch,
-    )?;
-    if !like.is_empty() {
-        channels.push(NamedChannel::enabled(
+    if core_refs.is_empty() {
+        channels.push(NamedChannel::disabled(
             "like_fallback",
-            like.iter().map(|memory| memory.id).collect(),
+            LIKE_FALLBACK_WEIGHT,
+            "no core terms for LIKE fallback",
         ));
+    } else if channels.iter().any(NamedChannel::has_hits) {
+        channels.push(NamedChannel::disabled(
+            "like_fallback",
+            LIKE_FALLBACK_WEIGHT,
+            "stronger retrieval channels returned hits",
+        ));
+    } else {
+        let like = memory::search_memories_like_filtered(
+            conn,
+            &core_refs,
+            project,
+            memory_type,
+            fetch,
+            0,
+            include_stale,
+            branch,
+        )?;
+        if like.is_empty() {
+            channels.push(NamedChannel::disabled(
+                "like_fallback",
+                LIKE_FALLBACK_WEIGHT,
+                "LIKE fallback returned no hits",
+            ));
+        } else {
+            channels.push(NamedChannel::enabled(
+                "like_fallback",
+                LIKE_FALLBACK_WEIGHT,
+                like.iter().map(|memory| memory.id).collect(),
+            ));
+        }
     }
 
     Ok(QuerySearchPlan {
@@ -332,11 +384,11 @@ fn build_explain(
             enabled: channel.is_enabled(),
             disabled_reason: channel.disabled_reason.clone(),
             hits: channel
-                .ids
+                .hits
                 .iter()
                 .enumerate()
-                .map(|(index, id)| ChannelHit {
-                    memory_id: *id,
+                .map(|(index, hit)| ChannelHit {
+                    memory_id: hit.id,
                     rank: index + 1,
                 })
                 .collect(),
@@ -383,14 +435,64 @@ fn contributions_for(memory_id: i64, channels: &[NamedChannel]) -> Vec<ChannelCo
         .iter()
         .filter_map(|channel| {
             channel
-                .ids
+                .hits
                 .iter()
-                .position(|id| *id == memory_id)
+                .position(|hit| hit.id == memory_id)
                 .map(|index| ChannelContribution {
                     channel: channel.name.to_string(),
                     rank: index + 1,
-                    score: 1.0 / (RRF_K + index as f64 + 1.0),
+                    score: weighted_rank_score(
+                        channel.weight,
+                        RRF_K,
+                        index,
+                        channel.hits[index].normalized_score,
+                    ),
                 })
+        })
+        .collect()
+}
+
+fn weighted_channel_inputs(channels: &[NamedChannel]) -> Vec<WeightedRankedChannel<'_>> {
+    channels
+        .iter()
+        .filter(|channel| channel.has_hits())
+        .map(|channel| WeightedRankedChannel {
+            weight: channel.weight,
+            hits: &channel.hits,
+        })
+        .collect()
+}
+
+fn rank_normalized_score(rank: usize) -> f64 {
+    1.0 / (rank as f64 + 1.0)
+}
+
+fn vector_similarity_score(distance: f32) -> f64 {
+    let threshold = f64::from(MAX_VECTOR_DISTANCE);
+    ((threshold - f64::from(distance)) / threshold).clamp(0.0, 1.0)
+}
+
+fn fts_normalized_hits(
+    hits: &[crate::retrieval::memory_search::FtsMemoryHit],
+) -> Vec<WeightedRankedHit> {
+    let best = hits
+        .iter()
+        .map(|hit| hit.score)
+        .fold(f64::INFINITY, f64::min);
+    let worst = hits
+        .iter()
+        .map(|hit| hit.score)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let spread = worst - best;
+    hits.iter()
+        .enumerate()
+        .map(|(rank, hit)| WeightedRankedHit {
+            id: hit.memory.id,
+            normalized_score: if spread.abs() < f64::EPSILON {
+                rank_normalized_score(rank)
+            } else {
+                ((worst - hit.score) / spread).clamp(0.0, 1.0)
+            },
         })
         .collect()
 }


### PR DESCRIPTION
## Summary
- replace equal-weight rank-only RRF with deterministic weighted fusion over per-channel normalized scores
- keep FTS BM25-derived rank scores and vector cosine similarity in the fusion path
- demote like_fallback so it only participates when stronger retrieval channels have no hits, while keeping short-token fallback behavior
- extend tests for fusion ordering, LIKE fallback gating, FTS compatibility, and explain output
- bump remem package/plugin versions to 0.5.47

Closes #361

## Verification
- cargo check --message-format=short
- cargo fmt --check
- git diff --check
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- cargo clippy -- -D warnings
- cargo test retrieval::search::common::tests:: -- --nocapture
- cargo test retrieval::search::memory::tests:: -- --nocapture
- cargo test retrieval::memory_search::fts::tests:: -- --nocapture
- cargo test like_fallback -- --nocapture
- cargo test
- independent threads reviewer: no blocking findings

## Notes
- FTS/vector raw scores are retained for fusion and surfaced via weighted contribution scores. The existing explain hit shape remains compatible; it still reports hit rank per channel.
