### PR TITLE
Wire SessionStart through hybrid retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.47"
+version = "0.5.48"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.47"
+version = "0.5.48"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.47",
+  "version": "0.5.48",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.47",
+  "version": "0.5.48",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.47": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.47",
+    "0.5.48": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.48",
       "assets": {}
     }
   }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,12 @@
 pub mod claude_memory;
+mod commit_signals;
 mod debug;
 mod diagnostics;
 mod filters;
 mod format;
 mod host;
+mod hybrid_context;
+mod implicit_query;
 mod injection_gate;
 mod invocation;
 mod memory_traits;

--- a/src/context/commit_signals.rs
+++ b/src/context/commit_signals.rs
@@ -1,0 +1,136 @@
+use anyhow::Result;
+use rusqlite::{Connection, OptionalExtension};
+
+pub(super) fn query_recent_commit_messages(
+    conn: &Connection,
+    project: &str,
+    current_branch: Option<&str>,
+    limit: usize,
+) -> Result<Vec<String>> {
+    let commits_table_exists = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'git_commits' LIMIT 1",
+            [],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    if limit == 0 || !commits_table_exists {
+        return Ok(vec![]);
+    }
+
+    let mut conditions = vec![
+        "project = ?1".to_string(),
+        "message IS NOT NULL".to_string(),
+        "length(trim(message)) > 0".to_string(),
+    ];
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(project.to_string())];
+    let mut idx = 2;
+    if let Some(branch) = current_branch.filter(|branch| !branch.trim().is_empty()) {
+        conditions.push(format!("(branch = ?{idx} OR branch IS NULL)"));
+        params.push(Box::new(branch.to_string()));
+        idx += 1;
+    }
+    params.push(Box::new(limit as i64));
+
+    let sql = format!(
+        "SELECT message
+         FROM git_commits
+         WHERE {}
+         ORDER BY COALESCE(authored_at_epoch, updated_at_epoch) DESC, id DESC
+         LIMIT ?{idx}",
+        conditions.join(" AND ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(0))?;
+    Ok(rows
+        .collect::<rusqlite::Result<Vec<_>>>()?
+        .into_iter()
+        .map(|message| message.trim().to_string())
+        .filter(|message| !message.is_empty())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recent_commit_messages_return_empty_when_table_is_absent() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+
+        let messages = query_recent_commit_messages(&conn, "/tmp/remem", Some("main"), 3)?;
+
+        assert!(messages.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn recent_commit_messages_filter_project_and_branch() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE git_commits (
+                id INTEGER PRIMARY KEY,
+                project TEXT NOT NULL,
+                repo_path TEXT NOT NULL,
+                sha TEXT NOT NULL,
+                short_sha TEXT NOT NULL,
+                branch TEXT,
+                message TEXT,
+                authored_at_epoch INTEGER,
+                changed_files TEXT NOT NULL DEFAULT '[]',
+                created_at_epoch INTEGER NOT NULL,
+                updated_at_epoch INTEGER NOT NULL
+            );",
+        )?;
+        insert_commit(&conn, 1, "/tmp/remem", None, "Keep branchless context", 10)?;
+        insert_commit(
+            &conn,
+            2,
+            "/tmp/remem",
+            Some("feature/context"),
+            "Wire context retrieval",
+            30,
+        )?;
+        insert_commit(&conn, 3, "/tmp/other", Some("feature/context"), "Other", 40)?;
+        insert_commit(&conn, 4, "/tmp/remem", Some("other"), "Wrong branch", 50)?;
+
+        let messages =
+            query_recent_commit_messages(&conn, "/tmp/remem", Some("feature/context"), 3)?;
+
+        assert_eq!(
+            messages,
+            vec![
+                "Wire context retrieval".to_string(),
+                "Keep branchless context".to_string()
+            ]
+        );
+        Ok(())
+    }
+
+    fn insert_commit(
+        conn: &Connection,
+        id: i64,
+        project: &str,
+        branch: Option<&str>,
+        message: &str,
+        updated_at_epoch: i64,
+    ) -> anyhow::Result<()> {
+        conn.execute(
+            "INSERT INTO git_commits
+             (id, project, repo_path, sha, short_sha, branch, message,
+              authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch)
+             VALUES (?1, ?2, ?2, ?3, ?3, ?4, ?5, ?6, '[]', ?6, ?6)",
+            rusqlite::params![
+                id,
+                project,
+                format!("sha{id}"),
+                branch,
+                message,
+                updated_at_epoch
+            ],
+        )?;
+        Ok(())
+    }
+}

--- a/src/context/hybrid_context.rs
+++ b/src/context/hybrid_context.rs
@@ -1,0 +1,649 @@
+use anyhow::Result;
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::memory::{self, Memory};
+use crate::retrieval::search::common::{
+    rank_normalized_score, sanitize_fts_query, weighted_ranked_fuse, WeightedRankedChannel,
+    WeightedRankedHit,
+};
+
+use super::filters::{push_excluded_type_filter, push_owner_included_filter};
+
+const RRF_K: f64 = 60.0;
+const MAX_VECTOR_DISTANCE: f32 = 0.51;
+const FTS_WEIGHT: f64 = 2.5;
+const VECTOR_WEIGHT: f64 = 3.0;
+const ENTITY_WEIGHT: f64 = 1.25;
+const TEMPORAL_WEIGHT: f64 = 1.0;
+const LIKE_FALLBACK_WEIGHT: f64 = 0.25;
+const MIN_HYBRID_FETCH_LIMIT: i64 = 20;
+
+struct ContextChannel {
+    weight: f64,
+    hits: Vec<WeightedRankedHit>,
+}
+
+pub(super) fn query_hybrid_context_memories(
+    conn: &Connection,
+    project: &str,
+    query: &str,
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<Memory>> {
+    if limit <= 0 || query.trim().is_empty() {
+        return Ok(vec![]);
+    }
+
+    let fetch_limit = limit.saturating_mul(3).max(MIN_HYBRID_FETCH_LIMIT);
+    let mut channels = Vec::new();
+    push_channel(
+        &mut channels,
+        FTS_WEIGHT,
+        query_local_fts_channel(
+            conn,
+            project,
+            query,
+            current_branch,
+            excluded_types,
+            fetch_limit,
+        )?,
+    );
+    push_channel(
+        &mut channels,
+        ENTITY_WEIGHT,
+        query_local_entity_channel(
+            conn,
+            project,
+            query,
+            current_branch,
+            excluded_types,
+            fetch_limit,
+        )?,
+    );
+    push_channel(
+        &mut channels,
+        TEMPORAL_WEIGHT,
+        query_local_temporal_channel(
+            conn,
+            project,
+            query,
+            current_branch,
+            excluded_types,
+            fetch_limit,
+        )?,
+    );
+    push_channel(
+        &mut channels,
+        VECTOR_WEIGHT,
+        query_local_vector_channel(conn, project, query, current_branch, excluded_types)?,
+    );
+
+    if channels.is_empty() {
+        push_channel(
+            &mut channels,
+            LIKE_FALLBACK_WEIGHT,
+            query_local_like_channel(
+                conn,
+                project,
+                query,
+                current_branch,
+                excluded_types,
+                fetch_limit,
+            )?,
+        );
+    }
+    if channels.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let channel_inputs = channels
+        .iter()
+        .map(|channel| WeightedRankedChannel {
+            weight: channel.weight,
+            hits: &channel.hits,
+        })
+        .collect::<Vec<_>>();
+    let ids = weighted_ranked_fuse(&channel_inputs, RRF_K)
+        .into_iter()
+        .take(limit as usize)
+        .map(|(id, _)| id)
+        .collect::<Vec<_>>();
+    query_owner_included_memories_by_ids(conn, project, &ids, current_branch, excluded_types)
+}
+
+fn push_channel(channels: &mut Vec<ContextChannel>, weight: f64, hits: Vec<WeightedRankedHit>) {
+    if !hits.is_empty() {
+        channels.push(ContextChannel { weight, hits });
+    }
+}
+
+fn query_owner_included_memories_by_ids(
+    conn: &Connection,
+    project: &str,
+    ids: &[i64],
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+) -> Result<Vec<Memory>> {
+    if ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let placeholders = (1..=ids.len())
+        .map(|idx| format!("?{idx}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut conditions = vec![format!("id IN ({placeholders})")];
+    let mut params = ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+        .collect::<Vec<_>>();
+    let mut idx = ids.len() + 1;
+    push_context_memory_filters(
+        project,
+        current_branch,
+        excluded_types,
+        "",
+        &mut idx,
+        &mut conditions,
+        &mut params,
+    );
+
+    let sql = format!(
+        "SELECT {} FROM memories WHERE {}",
+        memory::MEMORY_COLS,
+        conditions.join(" AND ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), memory::map_memory_row_pub)?;
+    let mut rows_by_id = crate::db::query::collect_rows(rows)?
+        .into_iter()
+        .map(|memory| (memory.id, memory))
+        .collect::<std::collections::HashMap<_, _>>();
+    Ok(ids.iter().filter_map(|id| rows_by_id.remove(id)).collect())
+}
+
+fn query_local_fts_channel(
+    conn: &Connection,
+    project: &str,
+    query: &str,
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<WeightedRankedHit>> {
+    let expanded = crate::retrieval::query_expand::expand_query(query);
+    let long_tokens = expanded
+        .iter()
+        .filter(|token| token.chars().count() >= 3)
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    if long_tokens.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let safe_query = sanitize_fts_query(&long_tokens.join(" "));
+    let mut conditions = vec!["memories_fts MATCH ?1".to_string()];
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(safe_query)];
+    let mut idx = 2;
+    push_context_memory_filters(
+        project,
+        current_branch,
+        excluded_types,
+        "m",
+        &mut idx,
+        &mut conditions,
+        &mut params,
+    );
+    params.push(Box::new(limit));
+
+    let sql = format!(
+        "SELECT m.id, bm25(memories_fts, 10.0, 1.0, 3.0) AS rank_score
+         FROM memories m
+         JOIN memories_fts ON memories_fts.rowid = m.id
+         WHERE {}
+         ORDER BY rank_score ASC, m.updated_at_epoch DESC, m.id ASC
+         LIMIT ?{idx}",
+        conditions.join(" AND ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?))
+    })?;
+    let hits = crate::db::query::collect_rows(rows)?;
+    Ok(fts_ranked_hits(&hits))
+}
+
+fn query_local_entity_channel(
+    conn: &Connection,
+    project: &str,
+    query: &str,
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<WeightedRankedHit>> {
+    let entities = crate::retrieval::entity::extract_entities(query, "");
+    if entities.is_empty() {
+        query_local_entity_like_channel(conn, project, query, current_branch, excluded_types, limit)
+    } else {
+        query_local_entity_exact_channel(
+            conn,
+            project,
+            &entities,
+            current_branch,
+            excluded_types,
+            limit,
+        )
+    }
+}
+
+fn query_local_entity_exact_channel(
+    conn: &Connection,
+    project: &str,
+    entities: &[String],
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<WeightedRankedHit>> {
+    let placeholders = (1..=entities.len())
+        .map(|idx| format!("?{idx}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut conditions = vec![format!(
+        "e.canonical_name COLLATE NOCASE IN ({placeholders})"
+    )];
+    let mut params = entities
+        .iter()
+        .map(|entity| Box::new(entity.to_string()) as Box<dyn rusqlite::types::ToSql>)
+        .collect::<Vec<_>>();
+    let mut idx = entities.len() + 1;
+    query_local_entity_ids(
+        conn,
+        project,
+        current_branch,
+        excluded_types,
+        limit,
+        &mut idx,
+        &mut conditions,
+        &mut params,
+    )
+}
+
+fn query_local_entity_like_channel(
+    conn: &Connection,
+    project: &str,
+    query: &str,
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<WeightedRankedHit>> {
+    let terms = query
+        .split_whitespace()
+        .filter(|term| term.chars().count() >= 2)
+        .take(8)
+        .collect::<Vec<_>>();
+    if terms.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut conditions = Vec::new();
+    let mut params = Vec::new();
+    let mut like_clauses = Vec::new();
+    let mut idx = 1;
+    for term in terms {
+        like_clauses.push(format!("e.canonical_name LIKE ?{idx} COLLATE NOCASE"));
+        params.push(Box::new(format!("%{term}%")) as Box<dyn rusqlite::types::ToSql>);
+        idx += 1;
+    }
+    conditions.push(format!("({})", like_clauses.join(" OR ")));
+    query_local_entity_ids(
+        conn,
+        project,
+        current_branch,
+        excluded_types,
+        limit,
+        &mut idx,
+        &mut conditions,
+        &mut params,
+    )
+}
+
+fn query_local_entity_ids(
+    conn: &Connection,
+    project: &str,
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+    limit: i64,
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) -> Result<Vec<WeightedRankedHit>> {
+    push_context_memory_filters(
+        project,
+        current_branch,
+        excluded_types,
+        "m",
+        idx,
+        conditions,
+        params,
+    );
+    params.push(Box::new(limit));
+    let sql = format!(
+        "SELECT me.memory_id, COUNT(DISTINCT me.entity_id) AS shared_count
+         FROM memory_entities me
+         JOIN entities e ON e.id = me.entity_id
+         JOIN memories m ON m.id = me.memory_id
+         WHERE {}
+         GROUP BY me.memory_id
+         ORDER BY shared_count DESC, m.updated_at_epoch DESC, me.memory_id DESC
+         LIMIT ?{idx}",
+        conditions.join(" AND ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(params);
+    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, i64>(0))?;
+    Ok(rank_ordered_hits(crate::db::query::collect_rows(rows)?))
+}
+
+fn query_local_temporal_channel(
+    conn: &Connection,
+    project: &str,
+    query: &str,
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<WeightedRankedHit>> {
+    let Some(constraint) = crate::retrieval::temporal::extract_temporal(query) else {
+        return Ok(vec![]);
+    };
+    let has_memory_facts = sqlite_table_available(conn, "memory_facts")?;
+    let (temporal_condition, order_epoch) = local_temporal_sql(constraint.field, has_memory_facts);
+    let mut conditions = vec![temporal_condition];
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+        Box::new(constraint.start_epoch),
+        Box::new(constraint.end_epoch),
+    ];
+    let mut idx = 3;
+    push_context_memory_filters(
+        project,
+        current_branch,
+        excluded_types,
+        "m",
+        &mut idx,
+        &mut conditions,
+        &mut params,
+    );
+    params.push(Box::new(limit));
+
+    let sql = format!(
+        "SELECT m.id
+         FROM memories m
+         WHERE {}
+         ORDER BY {order_epoch} DESC, m.id DESC
+         LIMIT ?{idx}",
+        conditions.join(" AND ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, i64>(0))?;
+    Ok(rank_ordered_hits(crate::db::query::collect_rows(rows)?))
+}
+
+fn query_local_vector_channel(
+    conn: &Connection,
+    project: &str,
+    query: &str,
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+) -> Result<Vec<WeightedRankedHit>> {
+    if !sqlite_table_available(conn, "memory_embeddings")? {
+        return Ok(vec![]);
+    }
+
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    push_context_memory_filters(
+        project,
+        current_branch,
+        excluded_types,
+        "m",
+        &mut idx,
+        &mut conditions,
+        &mut params,
+    );
+    params.push(Box::new(
+        crate::retrieval::vector::VECTOR_SEARCH_CANDIDATE_LIMIT as i64,
+    ));
+
+    let sql = format!(
+        "SELECT e.memory_id, e.embedding, e.dimensions
+         FROM memory_embeddings e
+         JOIN memories m ON m.id = e.memory_id
+         WHERE {}
+         ORDER BY m.updated_at_epoch DESC, e.memory_id DESC
+         LIMIT ?{idx}",
+        conditions.join(" AND ")
+    );
+    let refs = crate::db::to_sql_refs(&params);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, Vec<u8>>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+    let query_embedding = crate::retrieval::vector::embed_query_text(query);
+    let mut hits = Vec::new();
+    for row in crate::db::query::collect_rows(rows)? {
+        let (memory_id, blob, dimensions) = row;
+        let embedding = crate::retrieval::vector::decode_embedding(&blob, dimensions)?;
+        let distance = crate::retrieval::vector::cosine_distance(&query_embedding, &embedding)?;
+        if distance <= MAX_VECTOR_DISTANCE {
+            hits.push((memory_id, distance));
+        }
+    }
+    hits.sort_by(|a, b| {
+        a.1.partial_cmp(&b.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+    Ok(hits
+        .into_iter()
+        .enumerate()
+        .map(|(rank, (id, distance))| WeightedRankedHit {
+            id,
+            normalized_score: vector_similarity_score(distance).max(rank_normalized_score(rank)),
+        })
+        .collect())
+}
+
+fn query_local_like_channel(
+    conn: &Connection,
+    project: &str,
+    query: &str,
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+    limit: i64,
+) -> Result<Vec<WeightedRankedHit>> {
+    let tokens = crate::retrieval::query_expand::core_tokens(query);
+    if tokens.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut conditions = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+    for token in &tokens {
+        conditions.push(format!("(m.title LIKE ?{idx} OR m.content LIKE ?{idx})"));
+        params.push(Box::new(format!("%{token}%")));
+        idx += 1;
+    }
+    push_context_memory_filters(
+        project,
+        current_branch,
+        excluded_types,
+        "m",
+        &mut idx,
+        &mut conditions,
+        &mut params,
+    );
+    params.push(Box::new(limit));
+
+    let sql = format!(
+        "SELECT m.id
+         FROM memories m
+         WHERE {}
+         ORDER BY m.updated_at_epoch DESC, m.id DESC
+         LIMIT ?{idx}",
+        conditions.join(" AND ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let refs = crate::db::to_sql_refs(&params);
+    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, i64>(0))?;
+    Ok(rank_ordered_hits(crate::db::query::collect_rows(rows)?))
+}
+
+fn push_context_memory_filters(
+    project: &str,
+    current_branch: Option<&str>,
+    excluded_types: &[&str],
+    alias: &str,
+    idx: &mut usize,
+    conditions: &mut Vec<String>,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+) {
+    let status_col = qualify(alias, "status");
+    let expires_col = qualify(alias, "expires_at_epoch");
+    conditions.push(crate::memory::memory_current_filter_sql(
+        &status_col,
+        &expires_col,
+        false,
+    ));
+    conditions.push(crate::memory::memory_state_key_current_filter_sql(alias));
+    push_owner_included_filter(project, idx, conditions, params);
+    if let Some(branch) = current_branch.filter(|branch| !branch.trim().is_empty()) {
+        conditions.push(format!(
+            "({}.branch = ?{idx} OR {}.branch IS NULL)",
+            table_ref(alias),
+            table_ref(alias)
+        ));
+        params.push(Box::new(branch.to_string()));
+        *idx += 1;
+    }
+    push_excluded_type_filter(excluded_types, idx, conditions, params);
+}
+
+fn qualify(alias: &str, column: &str) -> String {
+    if alias.trim().is_empty() {
+        column.to_string()
+    } else {
+        format!("{}.{}", alias.trim(), column)
+    }
+}
+
+fn table_ref(alias: &str) -> &str {
+    if alias.trim().is_empty() {
+        "memories"
+    } else {
+        alias.trim()
+    }
+}
+
+fn local_temporal_sql(
+    field: crate::retrieval::temporal::TemporalField,
+    has_memory_facts: bool,
+) -> (String, String) {
+    match field {
+        crate::retrieval::temporal::TemporalField::UpdatedAt => (
+            "m.updated_at_epoch BETWEEN ?1 AND ?2".to_string(),
+            "m.updated_at_epoch".to_string(),
+        ),
+        crate::retrieval::temporal::TemporalField::EventTime if has_memory_facts => {
+            let fact_event_overlap = "f.source_memory_id = m.id \
+                 AND f.status = 'active' \
+                 AND f.valid_from_epoch IS NOT NULL \
+                 AND f.valid_from_epoch <= ?2 \
+                 AND (f.valid_to_epoch IS NULL OR f.valid_to_epoch > ?1)";
+            let any_fact_event = "f.source_memory_id = m.id \
+                 AND f.status = 'active' \
+                 AND f.valid_from_epoch IS NOT NULL";
+            (
+                format!(
+                    "(EXISTS (
+                         SELECT 1 FROM memory_facts f
+                         WHERE {fact_event_overlap}
+                     )
+                     OR (
+                         NOT EXISTS (
+                             SELECT 1 FROM memory_facts f
+                             WHERE {any_fact_event}
+                         )
+                         AND m.created_at_epoch BETWEEN ?1 AND ?2
+                     ))"
+                ),
+                format!(
+                    "COALESCE((
+                         SELECT MAX(f.valid_from_epoch)
+                         FROM memory_facts f
+                         WHERE {fact_event_overlap}
+                     ), m.created_at_epoch)"
+                ),
+            )
+        }
+        crate::retrieval::temporal::TemporalField::EventTime => (
+            "m.created_at_epoch BETWEEN ?1 AND ?2".to_string(),
+            "m.created_at_epoch".to_string(),
+        ),
+    }
+}
+
+fn sqlite_table_available(conn: &Connection, table: &str) -> Result<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1 LIMIT 1",
+            [table],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+fn fts_ranked_hits(hits: &[(i64, f64)]) -> Vec<WeightedRankedHit> {
+    let best = hits
+        .iter()
+        .map(|(_, score)| *score)
+        .fold(f64::INFINITY, f64::min);
+    let worst = hits
+        .iter()
+        .map(|(_, score)| *score)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let spread = worst - best;
+    hits.iter()
+        .enumerate()
+        .map(|(rank, (id, score))| WeightedRankedHit {
+            id: *id,
+            normalized_score: if spread.abs() < f64::EPSILON {
+                rank_normalized_score(rank)
+            } else {
+                ((worst - *score) / spread).clamp(0.0, 1.0)
+            },
+        })
+        .collect()
+}
+
+fn rank_ordered_hits(ids: Vec<i64>) -> Vec<WeightedRankedHit> {
+    ids.into_iter()
+        .enumerate()
+        .map(|(rank, id)| WeightedRankedHit {
+            id,
+            normalized_score: rank_normalized_score(rank),
+        })
+        .collect()
+}
+
+fn vector_similarity_score(distance: f32) -> f64 {
+    let threshold = f64::from(MAX_VECTOR_DISTANCE);
+    ((threshold - f64::from(distance)) / threshold).clamp(0.0, 1.0)
+}

--- a/src/context/implicit_query.rs
+++ b/src/context/implicit_query.rs
@@ -1,0 +1,129 @@
+use std::collections::HashSet;
+
+use crate::workstream::WorkStream;
+
+use super::types::SessionSummaryBrief;
+
+const MAX_QUERY_CHARS: usize = 512;
+const MAX_BRANCH_SEGMENTS: usize = 4;
+const MAX_COMMIT_SIGNALS: usize = 3;
+const MAX_WORKSTREAM_SIGNALS: usize = 3;
+const MAX_SUMMARY_SIGNALS: usize = 2;
+
+pub(super) fn build_implicit_context_query(
+    project: &str,
+    current_branch: Option<&str>,
+    commit_messages: &[String],
+    summaries: &[SessionSummaryBrief],
+    workstreams: &[WorkStream],
+) -> Option<String> {
+    let mut builder = QueryBuilder::default();
+    builder.push_signal(project.rsplit('/').next().unwrap_or(project));
+    if let Some(branch) = current_branch {
+        builder.push_signal(branch);
+        for segment in branch
+            .split(|ch: char| !ch.is_ascii_alphanumeric())
+            .filter(|segment| segment.len() >= 3)
+            .take(MAX_BRANCH_SEGMENTS)
+        {
+            builder.push_signal(segment);
+        }
+    }
+    for message in commit_messages.iter().take(MAX_COMMIT_SIGNALS) {
+        builder.push_signal(message);
+    }
+    for workstream in workstreams.iter().take(MAX_WORKSTREAM_SIGNALS) {
+        builder.push_signal(&workstream.title);
+        builder.push_signal(workstream.next_action.as_deref().unwrap_or_default());
+        builder.push_signal(workstream.blockers.as_deref().unwrap_or_default());
+    }
+    for summary in summaries.iter().take(MAX_SUMMARY_SIGNALS) {
+        builder.push_signal(&summary.request);
+        builder.push_signal(summary.completed.as_deref().unwrap_or_default());
+    }
+    builder.build()
+}
+
+#[derive(Default)]
+struct QueryBuilder {
+    parts: Vec<String>,
+    seen: HashSet<String>,
+    char_count: usize,
+}
+
+impl QueryBuilder {
+    fn push_signal(&mut self, value: &str) {
+        let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+        let trimmed = normalized.trim();
+        if trimmed.len() < 2 {
+            return;
+        }
+        let key = trimmed.to_ascii_lowercase();
+        if !self.seen.insert(key) {
+            return;
+        }
+        let remaining = MAX_QUERY_CHARS.saturating_sub(self.char_count);
+        if remaining == 0 {
+            return;
+        }
+        let part = truncate_chars(trimmed, remaining);
+        if part.is_empty() {
+            return;
+        }
+        self.char_count += part.chars().count() + 1;
+        self.parts.push(part);
+    }
+
+    fn build(self) -> Option<String> {
+        (!self.parts.is_empty()).then(|| self.parts.join(" "))
+    }
+}
+
+fn truncate_chars(value: &str, limit: usize) -> String {
+    value.chars().take(limit).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::workstream::{WorkStream, WorkStreamStatus};
+
+    use super::*;
+
+    #[test]
+    fn implicit_query_uses_project_branch_workstream_and_summary_signals() {
+        let summaries = vec![SessionSummaryBrief {
+            request: "Investigate SQLCipher context recall".to_string(),
+            completed: Some("Verified retrieval injection path".to_string()),
+            created_at_epoch: 1,
+        }];
+        let workstreams = vec![WorkStream {
+            id: 1,
+            project: "/tmp/remem".to_string(),
+            title: "Context retrieval".to_string(),
+            description: None,
+            status: WorkStreamStatus::Active,
+            progress: None,
+            next_action: Some("Wire hybrid search into SessionStart".to_string()),
+            blockers: None,
+            created_at_epoch: 1,
+            updated_at_epoch: 1,
+            completed_at_epoch: None,
+        }];
+
+        let query = build_implicit_context_query(
+            "/tmp/remem",
+            Some("fix/context-retrieval"),
+            &["Preserve SQLCipher retrieval evidence".to_string()],
+            &summaries,
+            &workstreams,
+        )
+        .expect("query");
+
+        assert!(query.contains("remem"));
+        assert!(query.contains("context"));
+        assert!(query.contains("retrieval"));
+        assert!(query.contains("SessionStart"));
+        assert!(query.contains("SQLCipher"));
+        assert!(query.contains("Preserve"));
+    }
+}

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -5,16 +5,18 @@ use rusqlite::Connection;
 
 use crate::memory::{self, Memory};
 
+use super::commit_signals::query_recent_commit_messages;
 use super::filters::{
     push_context_related_filter, push_excluded_type_filter, push_owner_excluded_filter,
     push_owner_included_filter,
 };
+use super::hybrid_context::query_hybrid_context_memories;
+use super::implicit_query::build_implicit_context_query;
 use super::memory_traits::{is_memory_self_diagnostic, is_self_diagnostic_text};
 use super::ownership::{startup_memory_owner_decision, OwnerCounts, OwnerMetadata, OwnerTrace};
 use super::policy::{ContextPolicy, SectionKind};
 use super::types::{ContextLoadError, HiddenDuplicateGroup, LoadedContext, SessionSummaryBrief};
 
-const BASENAME_SEARCH_LIMIT: i64 = 20;
 const SUMMARY_FETCH_BATCH_SIZE: usize = 25;
 const SUMMARY_MAX_SCAN: usize = 200;
 const STALE_DESIGN_SUMMARY_DAYS: i64 = 7;
@@ -37,8 +39,37 @@ pub(super) fn load_context_data_with_policy(
     collect_diagnostics: bool,
 ) -> LoadedContext {
     let mut errors = Vec::new();
-    let mut memory_selection =
-        load_project_memories(conn, project, current_branch, policy, collect_diagnostics);
+    let summaries = query_recent_summaries(conn, project, policy.limits.session_limit)
+        .unwrap_or_else(|e| {
+            let message = format!("failed to load recent summaries for {project}: {e}");
+            crate::log::error("context", &message);
+            errors.push(ContextLoadError::new("sessions", message));
+            Vec::new()
+        });
+    let workstreams =
+        crate::workstream::query_active_workstreams(conn, project).unwrap_or_else(|e| {
+            let message = format!("failed to load active workstreams for {project}: {e}");
+            crate::log::error("context", &message);
+            errors.push(ContextLoadError::new("workstreams", message));
+            Vec::new()
+        });
+    let commit_messages = query_recent_commit_messages(conn, project, current_branch, 3)
+        .unwrap_or_else(|e| {
+            let message = format!("failed to load recent git commit messages for {project}: {e}");
+            crate::log::error("context", &message);
+            errors.push(ContextLoadError::new("commits", message));
+            Vec::new()
+        });
+    let mut memory_selection = load_project_memories(
+        conn,
+        project,
+        current_branch,
+        policy,
+        collect_diagnostics,
+        &commit_messages,
+        &summaries,
+        &workstreams,
+    );
     errors.append(&mut memory_selection.errors);
     let mut memories = memory_selection.memories;
     sort_memories_by_branch(&mut memories, current_branch);
@@ -54,21 +85,6 @@ pub(super) fn load_context_data_with_policy(
         errors.push(ContextLoadError::new("lessons", message));
         Vec::new()
     });
-
-    let summaries = query_recent_summaries(conn, project, policy.limits.session_limit)
-        .unwrap_or_else(|e| {
-            let message = format!("failed to load recent summaries for {project}: {e}");
-            crate::log::error("context", &message);
-            errors.push(ContextLoadError::new("sessions", message));
-            Vec::new()
-        });
-    let workstreams =
-        crate::workstream::query_active_workstreams(conn, project).unwrap_or_else(|e| {
-            let message = format!("failed to load active workstreams for {project}: {e}");
-            crate::log::error("context", &message);
-            errors.push(ContextLoadError::new("workstreams", message));
-            Vec::new()
-        });
 
     LoadedContext {
         memories,
@@ -101,6 +117,9 @@ fn load_project_memories(
     current_branch: Option<&str>,
     policy: &ContextPolicy,
     collect_diagnostics: bool,
+    commit_messages: &[String],
+    summaries: &[SessionSummaryBrief],
+    workstreams: &[crate::workstream::WorkStream],
 ) -> ContextMemorySelection {
     let mut memories = Vec::new();
     let mut errors = Vec::new();
@@ -111,6 +130,37 @@ fn load_project_memories(
         .section(SectionKind::MemoryIndex)
         .map(|section| section.exclude_types.as_slice())
         .unwrap_or(&[]);
+    if let Some(implicit_query) = build_implicit_context_query(
+        project,
+        current_branch,
+        commit_messages,
+        summaries,
+        workstreams,
+    ) {
+        match query_hybrid_context_memories(
+            conn,
+            project,
+            &implicit_query,
+            current_branch,
+            excluded_types,
+            policy.limits.candidate_fetch_limit as i64,
+        ) {
+            Ok(retrieved) => {
+                for memory in retrieved {
+                    if seen_ids.insert(memory.id) {
+                        memories.push(memory);
+                    }
+                }
+            }
+            Err(e) => {
+                let message =
+                    format!("failed to retrieve hybrid context memories for {project}: {e}");
+                crate::log::error("context", &message);
+                errors.push(ContextLoadError::new("memories", message));
+            }
+        }
+    }
+
     let recent = query_owner_included_memory_rows(
         conn,
         project,
@@ -128,29 +178,6 @@ fn load_project_memories(
     for row in recent {
         if seen_ids.insert(row.memory.id) {
             memories.push(row.memory);
-        }
-    }
-
-    let project_query = project.rsplit('/').next().unwrap_or(project);
-    match query_owner_included_memory_rows(
-        conn,
-        project,
-        Some(project_query),
-        current_branch,
-        excluded_types,
-        BASENAME_SEARCH_LIMIT,
-    ) {
-        Ok(searched) => {
-            for row in searched {
-                if seen_ids.insert(row.memory.id) {
-                    memories.push(row.memory);
-                }
-            }
-        }
-        Err(e) => {
-            let message = format!("failed to search context memories for {project}: {e}");
-            crate::log::error("context", &message);
-            errors.push(ContextLoadError::new("memories", message));
         }
     }
 

--- a/src/context/tests/load.rs
+++ b/src/context/tests/load.rs
@@ -28,9 +28,9 @@ fn load_context_data_records_primary_memory_query_failures() {
     assert!(memory_errors.iter().any(|error| error
         .message
         .contains("failed to load recent context memories")));
-    assert!(memory_errors
-        .iter()
-        .any(|error| error.message.contains("failed to search context memories")));
+    assert!(memory_errors.iter().any(|error| error
+        .message
+        .contains("failed to retrieve hybrid context memories")));
 }
 
 #[test]
@@ -636,7 +636,7 @@ fn load_context_data_excludes_global_non_preferences_from_main_memory_pool() {
 }
 
 #[test]
-fn load_context_data_excludes_global_non_preferences_from_basename_search() {
+fn load_context_data_excludes_global_non_preferences_from_hybrid_retrieval() {
     let conn = Connection::open_in_memory().unwrap();
     setup_context_schema(&conn);
     let project = "/tmp/remem";
@@ -656,7 +656,7 @@ fn load_context_data_excludes_global_non_preferences_from_basename_search() {
         Some("older-local-memory"),
         "decision",
         "Older local remem decision",
-        "A project-local decision should still appear through basename search.",
+        "A project-local decision should still appear through hybrid retrieval.",
         now - 10,
     );
     insert_memory(

--- a/src/context/tests/mod.rs
+++ b/src/context/tests/mod.rs
@@ -6,6 +6,7 @@ mod diagnostics;
 mod load;
 mod ownership;
 mod render;
+mod retrieval;
 mod sessions;
 
 pub(super) fn sample_memory(id: i64, memory_type: &str, title: &str) -> Memory {

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -595,7 +595,7 @@ fn render_context_output_exposes_primary_memory_query_failures() {
         .contains("- memories: failed to load recent context memories for /tmp/remem"));
     assert!(rendered
         .output
-        .contains("- memories: failed to search context memories for /tmp/remem"));
+        .contains("- memories: failed to retrieve hybrid context memories for /tmp/remem"));
     assert!(!rendered.output.contains("No previous sessions found."));
 }
 

--- a/src/context/tests/retrieval.rs
+++ b/src/context/tests/retrieval.rs
@@ -1,0 +1,179 @@
+use rusqlite::{params, Connection};
+
+use super::super::policy::{ContextLimits, ContextPolicy};
+use super::super::query::load_context_data_with_policy;
+use super::{insert_global_memory, insert_memory, setup_context_schema};
+
+#[test]
+fn load_context_data_uses_hybrid_retrieval_from_workstream_signal() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_context_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+    let limits = ContextLimits {
+        candidate_fetch_limit: 3,
+        memory_index_limit: 10,
+        core_item_limit: 4,
+        ..ContextLimits::default()
+    };
+    let policy = ContextPolicy::from_limits(limits);
+
+    for idx in 0..20 {
+        insert_memory(
+            &conn,
+            idx + 1,
+            project,
+            Some(&format!("recent-noise-{idx}")),
+            "discovery",
+            &format!("Recent unrelated note {idx}"),
+            "Recent context entry without the task terms.",
+            now - idx,
+        );
+    }
+    insert_memory(
+        &conn,
+        200,
+        project,
+        Some("sqlcipher-storage-decision"),
+        "decision",
+        "SQLCipher storage decision",
+        "Persist private data with SQLCipher encryption at rest.",
+        now - 10_000,
+    );
+    conn.execute(
+        "INSERT INTO workstreams
+         (id, project, title, status, next_action, created_at_epoch, updated_at_epoch)
+         VALUES (1, ?1, 'Private persistence', 'active',
+                 'Fix SQLCipher recall for private persisted data', ?2, ?2)",
+        params![project, now],
+    )
+    .unwrap();
+
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy, true);
+
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "SQLCipher storage decision"));
+}
+
+#[test]
+fn hybrid_context_retrieval_still_excludes_global_non_preferences() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_context_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+    let limits = ContextLimits {
+        candidate_fetch_limit: 1,
+        memory_index_limit: 10,
+        core_item_limit: 3,
+        ..ContextLimits::default()
+    };
+    let policy = ContextPolicy::from_limits(limits);
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("local-sqlcipher-decision"),
+        "decision",
+        "Local SQLCipher decision",
+        "Repository-local SQLCipher storage decision.",
+        now - 100,
+    );
+    insert_memory(
+        &conn,
+        2,
+        "global",
+        Some("global-sqlcipher-decision"),
+        "bugfix",
+        "Global SQLCipher note",
+        "Global SQLCipher note should not enter project startup context.",
+        now,
+    );
+    conn.execute(
+        "UPDATE memories SET scope = 'global', owner_scope = 'user', owner_key = 'manual'
+         WHERE id = 2",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO workstreams
+         (id, project, title, status, next_action, created_at_epoch, updated_at_epoch)
+         VALUES (1, ?1, 'SQLCipher recall', 'active',
+                 'Find SQLCipher startup context decision', ?2, ?2)",
+        params![project, now],
+    )
+    .unwrap();
+
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy, true);
+
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Local SQLCipher decision"));
+    assert!(!loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Global SQLCipher note"));
+}
+
+#[test]
+fn hybrid_context_vector_recall_is_not_crowded_out_by_global_hits() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_context_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+    let limits = ContextLimits {
+        candidate_fetch_limit: 1,
+        memory_index_limit: 10,
+        core_item_limit: 3,
+        ..ContextLimits::default()
+    };
+    let policy = ContextPolicy::from_limits(limits);
+
+    insert_memory(
+        &conn,
+        1,
+        project,
+        Some("credential-store"),
+        "architecture",
+        "Credential store",
+        "SQLCipher encrypts secrets at rest.",
+        now - 10_000,
+    );
+    crate::retrieval::vector::upsert_memory_embedding_for_row(&conn, 1)?;
+    for idx in 0..30 {
+        let id = idx + 2;
+        insert_global_memory(
+            &conn,
+            id,
+            "global",
+            Some(&format!("global-private-data-{idx}")),
+            "bugfix",
+            &format!("Global private data note {idx}"),
+            "Protect private persisted data with a global-only diagnostic note.",
+            now + idx,
+        );
+        crate::retrieval::vector::upsert_memory_embedding_for_row(&conn, id)?;
+    }
+    conn.execute(
+        "INSERT INTO workstreams
+         (id, project, title, status, next_action, created_at_epoch, updated_at_epoch)
+         VALUES (1, ?1, 'Private persistence', 'active',
+                 'How do we protect private persisted data?', ?2, ?2)",
+        params![project, now],
+    )?;
+
+    let loaded = load_context_data_with_policy(&conn, project, None, &policy, true);
+
+    assert!(loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title == "Credential store"));
+    assert!(!loaded
+        .memories
+        .iter()
+        .any(|memory| memory.title.starts_with("Global private data note")));
+    Ok(())
+}

--- a/src/retrieval/search.rs
+++ b/src/retrieval/search.rs
@@ -1,4 +1,4 @@
-mod common;
+pub(crate) mod common;
 mod memory;
 mod observation;
 

--- a/src/retrieval/search/common.rs
+++ b/src/retrieval/search/common.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::memory::Memory;
 
-pub(super) fn sanitize_fts_query(raw: &str) -> String {
+pub(crate) fn sanitize_fts_query(raw: &str) -> String {
     let tokens: Vec<String> = raw
         .split_whitespace()
         .map(|token| {
@@ -18,18 +18,18 @@ pub(super) fn sanitize_fts_query(raw: &str) -> String {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(super) struct WeightedRankedHit {
+pub(crate) struct WeightedRankedHit {
     pub id: i64,
     pub normalized_score: f64,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(super) struct WeightedRankedChannel<'a> {
+pub(crate) struct WeightedRankedChannel<'a> {
     pub weight: f64,
     pub hits: &'a [WeightedRankedHit],
 }
 
-pub(super) fn weighted_ranked_fuse(
+pub(crate) fn weighted_ranked_fuse(
     channels: &[WeightedRankedChannel<'_>],
     k: f64,
 ) -> Vec<(i64, f64)> {
@@ -52,9 +52,13 @@ pub(super) fn weighted_ranked_fuse(
     results
 }
 
-pub(super) fn weighted_rank_score(weight: f64, k: f64, rank: usize, normalized_score: f64) -> f64 {
+pub(crate) fn weighted_rank_score(weight: f64, k: f64, rank: usize, normalized_score: f64) -> f64 {
     let rank_score = 1.0 / (k + rank as f64 + 1.0);
     weight * rank_score * (1.0 + normalized_score.clamp(0.0, 1.0))
+}
+
+pub(crate) fn rank_normalized_score(rank: usize) -> f64 {
+    1.0 / (rank as f64 + 1.0)
 }
 
 pub(super) fn paginate_memories(memories: Vec<Memory>, limit: i64, offset: i64) -> Vec<Memory> {

--- a/src/retrieval/search/memory/text.rs
+++ b/src/retrieval/search/memory/text.rs
@@ -6,8 +6,8 @@ use rusqlite::Connection;
 use crate::memory::{self, Memory};
 
 use super::super::common::{
-    paginate_memories, sanitize_fts_query, weighted_rank_score, weighted_ranked_fuse,
-    WeightedRankedChannel, WeightedRankedHit,
+    paginate_memories, rank_normalized_score, sanitize_fts_query, weighted_rank_score,
+    weighted_ranked_fuse, WeightedRankedChannel, WeightedRankedHit,
 };
 use super::{
     ChannelContribution, ChannelHit, SearchExplain, SearchExplainChannel, SearchExplainResult,
@@ -461,10 +461,6 @@ fn weighted_channel_inputs(channels: &[NamedChannel]) -> Vec<WeightedRankedChann
             hits: &channel.hits,
         })
         .collect()
-}
-
-fn rank_normalized_score(rank: usize) -> f64 {
-    1.0 / (rank as f64 + 1.0)
 }
 
 fn vector_similarity_score(distance: f32) -> f64 {

--- a/src/retrieval/vector.rs
+++ b/src/retrieval/vector.rs
@@ -365,7 +365,7 @@ fn encode_embedding(embedding: &[f32]) -> Vec<u8> {
     out
 }
 
-fn decode_embedding(blob: &[u8], dimensions: i64) -> Result<Vec<f32>> {
+pub(crate) fn decode_embedding(blob: &[u8], dimensions: i64) -> Result<Vec<f32>> {
     if dimensions != EMBEDDING_DIMENSIONS as i64 {
         anyhow::bail!(
             "embedding dimensions must be {}, got {}",
@@ -386,7 +386,7 @@ fn decode_embedding(blob: &[u8], dimensions: i64) -> Result<Vec<f32>> {
         .collect())
 }
 
-fn cosine_distance(a: &[f32], b: &[f32]) -> Result<f32> {
+pub(crate) fn cosine_distance(a: &[f32], b: &[f32]) -> Result<f32> {
     if a.len() != b.len() {
         anyhow::bail!(
             "embedding dimensions differ: query={} stored={}",


### PR DESCRIPTION
## Summary
- Replaces SessionStart basename LIKE memory lookup with an implicit hybrid retrieval query built from project basename, branch, recent commit messages, active workstreams, and recent summaries.
- Adds SessionStart owner-scoped FTS/entity/temporal/vector/LIKE channels so global non-preference rows cannot enter or crowd out local startup context.
- Keeps recent owner-included memories as fallback, records hybrid retrieval failures explicitly, and bumps package/plugin version to 0.5.48.

## Verification
- cargo check --message-format=short
- cargo test context::tests::retrieval:: -- --nocapture
- cargo test context::tests::load:: -- --nocapture
- cargo test context::tests::render::render_context_output_exposes_primary_memory_query_failures -- --nocapture
- cargo test context::commit_signals::tests:: -- --nocapture
- cargo test context::implicit_query::tests:: -- --nocapture
- cargo fmt --check
- git diff --check
- python3 scripts/ci/check_plugin_version_sync.py
- cargo clippy -- -D warnings
- cargo test
- python3 scripts/ci/check_version_bump.py origin/main HEAD

Closes #356
