### PR TITLE
Replace feature-hash embeddings with configurable semantic provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.48"
+version = "0.5.49"
 dependencies = [
  "anyhow",
  "axum",
@@ -1249,7 +1249,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.48"
+version = "0.5.49"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"
@@ -36,7 +36,7 @@ anyhow = "1"
 fs2 = "0.4"
 tokio = { version = "1", features = ["full"] }
 rmcp = { version = "0.15", features = ["server", "transport-io", "macros"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 axum = { version = "0.8.8", features = ["json"] }
 getrandom = "0.3"
 toml_edit = "0.22"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.48",
+  "version": "0.5.49",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.48",
+  "version": "0.5.49",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.48": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.48",
+    "0.5.49": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.49",
       "assets": {}
     }
   }

--- a/src/cli/actions/query/backfill.rs
+++ b/src/cli/actions/query/backfill.rs
@@ -73,13 +73,5 @@ pub(in crate::cli) fn run_backfill_embeddings(limit: i64) -> Result<()> {
 }
 
 fn count_missing_embeddings(conn: &Connection) -> Result<i64> {
-    Ok(conn.query_row(
-        "SELECT COUNT(*)
-         FROM memories m
-         LEFT JOIN memory_embeddings e ON e.memory_id = m.id
-         WHERE e.memory_id IS NULL
-           AND m.status IN ('active', 'stale', 'archived')",
-        [],
-        |row| row.get(0),
-    )?)
+    crate::retrieval::vector::pending_memory_embedding_count(conn)
 }

--- a/src/context/hybrid_context.rs
+++ b/src/context/hybrid_context.rs
@@ -400,9 +400,14 @@ fn query_local_vector_channel(
         return Ok(vec![]);
     }
 
-    let mut conditions = Vec::new();
-    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-    let mut idx = 1;
+    let query_embedding = crate::retrieval::embedding::embed_query(query)?;
+    let profile = query_embedding.profile();
+    let mut conditions = vec!["e.model = ?1".to_string(), "e.dimensions = ?2".to_string()];
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+        Box::new(profile.model.to_string()),
+        Box::new(profile.dimensions as i64),
+    ];
+    let mut idx = 3;
     push_context_memory_filters(
         project,
         current_branch,
@@ -434,12 +439,12 @@ fn query_local_vector_channel(
             row.get::<_, i64>(2)?,
         ))
     })?;
-    let query_embedding = crate::retrieval::vector::embed_query_text(query);
     let mut hits = Vec::new();
     for row in crate::db::query::collect_rows(rows)? {
         let (memory_id, blob, dimensions) = row;
         let embedding = crate::retrieval::vector::decode_embedding(&blob, dimensions)?;
-        let distance = crate::retrieval::vector::cosine_distance(&query_embedding, &embedding)?;
+        let distance =
+            crate::retrieval::vector::cosine_distance(query_embedding.values(), &embedding)?;
         if distance <= MAX_VECTOR_DISTANCE {
             hits.push((memory_id, distance));
         }

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -1,3 +1,4 @@
+pub mod embedding;
 pub mod entity;
 pub mod memory_search;
 pub mod query_expand;

--- a/src/retrieval/embedding.rs
+++ b/src/retrieval/embedding.rs
@@ -1,0 +1,677 @@
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use toml_edit::{DocumentMut, Item};
+
+pub const LOCAL_EMBEDDING_DIMENSIONS: usize = 768;
+pub const LOCAL_EMBEDDING_MODEL: &str = "remem-local-feature-hash-v1";
+
+const DEFAULT_PROVIDER: EmbeddingProvider = EmbeddingProvider::Auto;
+const OPENAI_DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+const OPENAI_DEFAULT_MODEL: &str = "text-embedding-3-small";
+const DEFAULT_API_KEY_ENV: &str = "OPENAI_API_KEY";
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+const ENV_PROVIDER: &str = "REMEM_EMBEDDINGS_PROVIDER";
+const ENV_PROVIDER_LEGACY: &str = "REMEM_EMBEDDING_PROVIDER";
+const ENV_MODEL: &str = "REMEM_EMBEDDINGS_MODEL";
+const ENV_MODEL_LEGACY: &str = "REMEM_EMBEDDING_MODEL";
+const ENV_BASE_URL: &str = "REMEM_EMBEDDINGS_BASE_URL";
+const ENV_BASE_URL_LEGACY: &str = "REMEM_EMBEDDING_BASE_URL";
+const ENV_DIMENSIONS: &str = "REMEM_EMBEDDINGS_DIMENSIONS";
+const ENV_DIMENSIONS_LEGACY: &str = "REMEM_EMBEDDING_DIMENSIONS";
+const ENV_API_KEY: &str = "REMEM_EMBEDDINGS_API_KEY";
+const ENV_API_KEY_LEGACY: &str = "REMEM_EMBEDDING_API_KEY";
+const ENV_API_KEY_ENV: &str = "REMEM_EMBEDDINGS_API_KEY_ENV";
+const ENV_TIMEOUT_SECS: &str = "REMEM_EMBEDDINGS_TIMEOUT_SECS";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddingProvider {
+    Auto,
+    Local,
+    OpenAi,
+}
+
+impl EmbeddingProvider {
+    fn parse(raw: &str) -> Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "local" | "offline" | "feature-hash" | "feature_hash" => Ok(Self::Local),
+            "openai" | "openai-compatible" | "openai_compatible" => Ok(Self::OpenAi),
+            other => bail!("unknown embeddings.provider: {other}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingConfig {
+    pub provider: EmbeddingProvider,
+    pub model: String,
+    pub base_url: String,
+    pub dimensions: Option<usize>,
+    pub api_key_env: String,
+    pub timeout_secs: u64,
+}
+
+impl Default for EmbeddingConfig {
+    fn default() -> Self {
+        Self {
+            provider: DEFAULT_PROVIDER,
+            model: OPENAI_DEFAULT_MODEL.to_string(),
+            base_url: OPENAI_DEFAULT_BASE_URL.to_string(),
+            dimensions: None,
+            api_key_env: DEFAULT_API_KEY_ENV.to_string(),
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextEmbedding {
+    model: String,
+    values: Vec<f32>,
+}
+
+impl TextEmbedding {
+    pub fn new(model: impl Into<String>, values: Vec<f32>) -> Result<Self> {
+        let model = model.into();
+        if model.trim().is_empty() {
+            bail!("embedding model must not be empty");
+        }
+        validate_embedding_values(&values)?;
+        Ok(Self { model, values })
+    }
+
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub fn values(&self) -> &[f32] {
+        &self.values
+    }
+
+    pub fn dimensions(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn profile(&self) -> EmbeddingProfile<'_> {
+        EmbeddingProfile {
+            model: &self.model,
+            dimensions: self.values.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmbeddingProfile<'a> {
+    pub model: &'a str,
+    pub dimensions: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingBackfillTarget {
+    pub model: String,
+    pub dimensions: usize,
+}
+
+pub fn embed_query(query: &str) -> Result<TextEmbedding> {
+    embed_text(query)
+}
+
+pub fn embed_memory(
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+) -> Result<TextEmbedding> {
+    let text = memory_embedding_text(title, content, memory_type, topic_key);
+    embed_text(&text)
+}
+
+pub fn embed_query_text_local(query: &str) -> Vec<f32> {
+    embed_text_local(query)
+}
+
+pub fn embed_memory_text_local(
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+) -> Vec<f32> {
+    embed_text_local(&memory_embedding_text(
+        title,
+        content,
+        memory_type,
+        topic_key,
+    ))
+}
+
+pub fn embedding_content_hash(
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(memory_type.as_bytes());
+    hasher.update([0]);
+    if let Some(topic_key) = topic_key {
+        hasher.update(topic_key.as_bytes());
+    }
+    hasher.update([0]);
+    hasher.update(title.as_bytes());
+    hasher.update([0]);
+    hasher.update(content.as_bytes());
+    let digest = hasher.finalize();
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+pub(crate) fn configured_backfill_target() -> Result<EmbeddingBackfillTarget> {
+    let probe = embed_text("remem embedding profile probe")?;
+    Ok(EmbeddingBackfillTarget {
+        model: probe.model().to_string(),
+        dimensions: probe.dimensions(),
+    })
+}
+
+fn embed_text(text: &str) -> Result<TextEmbedding> {
+    let config = resolve_embedding_config()?;
+    match active_provider(&config)? {
+        ActiveEmbeddingProvider::Local => {
+            TextEmbedding::new(LOCAL_EMBEDDING_MODEL, embed_text_local(text))
+        }
+        ActiveEmbeddingProvider::OpenAi { api_key } => embed_openai(text, &config, &api_key),
+    }
+}
+
+fn memory_embedding_text(
+    title: &str,
+    content: &str,
+    memory_type: &str,
+    topic_key: Option<&str>,
+) -> String {
+    let mut text = String::new();
+    text.push_str(memory_type);
+    text.push('\n');
+    if let Some(topic_key) = topic_key {
+        text.push_str(topic_key);
+        text.push('\n');
+    }
+    text.push_str(title);
+    text.push('\n');
+    text.push_str(content);
+    text
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ActiveEmbeddingProvider {
+    Local,
+    OpenAi { api_key: String },
+}
+
+fn active_provider(config: &EmbeddingConfig) -> Result<ActiveEmbeddingProvider> {
+    match config.provider {
+        EmbeddingProvider::Local => Ok(ActiveEmbeddingProvider::Local),
+        EmbeddingProvider::OpenAi => Ok(ActiveEmbeddingProvider::OpenAi {
+            api_key: configured_api_key(config)?.with_context(|| {
+                format!(
+                    "embedding provider openai requires {ENV_API_KEY} or {}",
+                    config.api_key_env
+                )
+            })?,
+        }),
+        EmbeddingProvider::Auto => {
+            if let Some(api_key) = auto_api_key(config)? {
+                Ok(ActiveEmbeddingProvider::OpenAi { api_key })
+            } else {
+                Ok(ActiveEmbeddingProvider::Local)
+            }
+        }
+    }
+}
+
+fn auto_api_key(config: &EmbeddingConfig) -> Result<Option<String>> {
+    if let Some(value) = env_value(ENV_API_KEY).or_else(|| env_value(ENV_API_KEY_LEGACY)) {
+        return Ok(Some(value));
+    }
+    if config.api_key_env != DEFAULT_API_KEY_ENV {
+        configured_api_key(config)
+    } else {
+        Ok(None)
+    }
+}
+
+fn configured_api_key(config: &EmbeddingConfig) -> Result<Option<String>> {
+    if let Some(value) = env_value(ENV_API_KEY).or_else(|| env_value(ENV_API_KEY_LEGACY)) {
+        return Ok(Some(value));
+    }
+    Ok(std::env::var(&config.api_key_env)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty()))
+}
+
+fn resolve_embedding_config() -> Result<EmbeddingConfig> {
+    let mut config = config_from_file()?.unwrap_or_default();
+    apply_env_overrides(&mut config)?;
+    validate_config(&config)?;
+    Ok(config)
+}
+
+fn config_from_file() -> Result<Option<EmbeddingConfig>> {
+    let path = crate::runtime_config::config_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content =
+        std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let doc = content
+        .parse::<DocumentMut>()
+        .with_context(|| format!("parse {} as TOML", path.display()))?;
+    let Some(table) = doc.get("embeddings").and_then(Item::as_table) else {
+        return Ok(None);
+    };
+
+    let mut config = EmbeddingConfig::default();
+    if let Some(provider) = optional_str(table, "provider") {
+        config.provider = EmbeddingProvider::parse(&provider)?;
+    }
+    if let Some(model) = optional_str(table, "model") {
+        config.model = model;
+    }
+    if let Some(base_url) = optional_str(table, "base_url") {
+        config.base_url = base_url;
+    }
+    if let Some(dimensions) = optional_usize(table, "dimensions")? {
+        config.dimensions = Some(dimensions);
+    }
+    if let Some(api_key_env) = optional_str(table, "api_key_env") {
+        config.api_key_env = api_key_env;
+    }
+    if let Some(timeout_secs) = optional_u64(table, "timeout_secs")? {
+        config.timeout_secs = timeout_secs;
+    }
+    Ok(Some(config))
+}
+
+fn apply_env_overrides(config: &mut EmbeddingConfig) -> Result<()> {
+    if let Some(provider) = env_value(ENV_PROVIDER).or_else(|| env_value(ENV_PROVIDER_LEGACY)) {
+        config.provider = EmbeddingProvider::parse(&provider)?;
+    }
+    if let Some(model) = env_value(ENV_MODEL).or_else(|| env_value(ENV_MODEL_LEGACY)) {
+        config.model = model;
+    }
+    if let Some(base_url) = env_value(ENV_BASE_URL).or_else(|| env_value(ENV_BASE_URL_LEGACY)) {
+        config.base_url = base_url;
+    }
+    if let Some(dimensions) = env_value(ENV_DIMENSIONS).or_else(|| env_value(ENV_DIMENSIONS_LEGACY))
+    {
+        config.dimensions = Some(parse_positive_usize(&dimensions, ENV_DIMENSIONS)?);
+    }
+    if let Some(api_key_env) = env_value(ENV_API_KEY_ENV) {
+        config.api_key_env = api_key_env;
+    }
+    if let Some(timeout_secs) = env_value(ENV_TIMEOUT_SECS) {
+        config.timeout_secs = parse_positive_u64(&timeout_secs, ENV_TIMEOUT_SECS)?;
+    }
+    Ok(())
+}
+
+fn validate_config(config: &EmbeddingConfig) -> Result<()> {
+    if config.model.trim().is_empty() {
+        bail!("embeddings.model must not be empty");
+    }
+    if config.base_url.trim().is_empty() {
+        bail!("embeddings.base_url must not be empty");
+    }
+    if config.api_key_env.trim().is_empty() {
+        bail!("embeddings.api_key_env must not be empty");
+    }
+    if config.timeout_secs == 0 {
+        bail!("embeddings.timeout_secs must be positive");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiEmbeddingRequest<'a> {
+    input: &'a str,
+    model: &'a str,
+    encoding_format: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dimensions: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingResponse {
+    data: Vec<OpenAiEmbeddingData>,
+    model: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingData {
+    embedding: Vec<f32>,
+}
+
+fn embed_openai(text: &str, config: &EmbeddingConfig, api_key: &str) -> Result<TextEmbedding> {
+    if text.trim().is_empty() {
+        bail!("embedding input must not be empty");
+    }
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(config.timeout_secs))
+        .build()
+        .context("build embedding HTTP client")?;
+    let request = OpenAiEmbeddingRequest {
+        input: text,
+        model: &config.model,
+        encoding_format: "float",
+        dimensions: config.dimensions,
+    };
+    let url = format!("{}/embeddings", config.base_url.trim_end_matches('/'));
+    let response = client
+        .post(&url)
+        .bearer_auth(api_key)
+        .json(&request)
+        .send()
+        .with_context(|| format!("call embedding provider at {url}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .context("read embedding provider response body")?;
+    if !status.is_success() {
+        bail!(
+            "embedding provider returned HTTP {status}: {}",
+            truncate_error_body(&body)
+        );
+    }
+    parse_openai_embedding_response(&body, &config.model)
+}
+
+fn parse_openai_embedding_response(body: &str, fallback_model: &str) -> Result<TextEmbedding> {
+    let response: OpenAiEmbeddingResponse =
+        serde_json::from_str(body).context("parse embedding provider response")?;
+    let mut data = response.data.into_iter();
+    let first = data
+        .next()
+        .context("embedding provider response did not include data[0]")?;
+    if data.next().is_some() {
+        bail!("embedding provider returned multiple embeddings for single input");
+    }
+    TextEmbedding::new(
+        response.model.unwrap_or_else(|| fallback_model.to_string()),
+        first.embedding,
+    )
+}
+
+fn truncate_error_body(body: &str) -> String {
+    const MAX: usize = 500;
+    if body.len() <= MAX {
+        body.to_string()
+    } else {
+        let mut end = MAX;
+        while !body.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &body[..end])
+    }
+}
+
+fn validate_embedding_values(values: &[f32]) -> Result<()> {
+    if values.is_empty() {
+        bail!("embedding vector must not be empty");
+    }
+    if values.iter().any(|value| !value.is_finite()) {
+        bail!("embedding vector contains non-finite values");
+    }
+    Ok(())
+}
+
+fn embed_text_local(text: &str) -> Vec<f32> {
+    let normalized = text.to_lowercase();
+    let mut vector = vec![0.0f32; LOCAL_EMBEDDING_DIMENSIONS];
+    for token in semantic_tokens(&normalized) {
+        add_feature(&mut vector, &format!("token:{token}"), 1.0);
+    }
+    for ngram in char_ngrams(&normalized) {
+        add_feature(&mut vector, &format!("ngram:{ngram}"), 0.35);
+    }
+    for (concept, phrases) in semantic_concepts() {
+        if phrases.iter().any(|phrase| normalized.contains(phrase)) {
+            add_feature(&mut vector, &format!("concept:{concept}"), 4.0);
+        }
+    }
+    normalize(&mut vector);
+    vector
+}
+
+fn semantic_tokens(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if ch.is_alphanumeric() || is_cjk(ch) {
+            current.push(ch);
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn char_ngrams(text: &str) -> Vec<String> {
+    let chars: Vec<char> = text
+        .chars()
+        .filter(|ch| ch.is_alphanumeric() || is_cjk(*ch))
+        .collect();
+    let mut grams = Vec::new();
+    for width in [2usize, 3] {
+        if chars.len() < width {
+            continue;
+        }
+        grams.extend(
+            chars
+                .windows(width)
+                .map(|window| window.iter().collect::<String>()),
+        );
+    }
+    grams
+}
+
+fn add_feature(vector: &mut [f32], feature: &str, weight: f32) {
+    let digest = Sha256::digest(feature.as_bytes());
+    for offset in [0usize, 8, 16] {
+        let raw = u64::from_le_bytes([
+            digest[offset],
+            digest[offset + 1],
+            digest[offset + 2],
+            digest[offset + 3],
+            digest[offset + 4],
+            digest[offset + 5],
+            digest[offset + 6],
+            digest[offset + 7],
+        ]);
+        let idx = raw as usize % vector.len();
+        let sign = if raw & 1 == 0 { 1.0 } else { -1.0 };
+        vector[idx] += weight * sign;
+    }
+}
+
+fn normalize(vector: &mut [f32]) {
+    let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
+    if norm == 0.0 {
+        return;
+    }
+    for value in vector {
+        *value /= norm;
+    }
+}
+
+fn is_cjk(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{4E00}'..='\u{9FFF}' |
+        '\u{3400}'..='\u{4DBF}' |
+        '\u{F900}'..='\u{FAFF}'
+    )
+}
+
+fn semantic_concepts() -> &'static [(&'static str, &'static [&'static str])] {
+    &[
+        (
+            "data-security",
+            &[
+                "sqlcipher",
+                "encrypt",
+                "encrypted",
+                "encryption",
+                "secret",
+                "secrets",
+                "credential",
+                "credentials",
+                "private",
+                "confidential",
+                "protect",
+                "protected",
+                "at rest",
+                "persisted data",
+                "加密",
+                "密钥",
+            ],
+        ),
+        (
+            "transcript-capture",
+            &[
+                "transcript",
+                "raw archive",
+                "raw message",
+                "hook fallback",
+                "assistant message",
+                "conversation capture",
+                "jsonl",
+                "会话",
+                "原始消息",
+            ],
+        ),
+        (
+            "retrieval-quality",
+            &[
+                "semantic",
+                "embedding",
+                "vector",
+                "recall",
+                "search quality",
+                "paraphrase",
+                "检索",
+                "语义",
+                "召回",
+                "向量",
+            ],
+        ),
+        (
+            "current-state",
+            &[
+                "current decision",
+                "current state",
+                "supersede",
+                "supersedes",
+                "stale",
+                "replacement",
+                "现在",
+                "当前",
+                "替代",
+            ],
+        ),
+        (
+            "compression",
+            &[
+                "compress",
+                "compression",
+                "compaction",
+                "summarize",
+                "compressed",
+                "压缩",
+                "摘要",
+                "总结",
+            ],
+        ),
+    ]
+}
+
+fn optional_str(table: &toml_edit::Table, key: &str) -> Option<String> {
+    table
+        .get(key)
+        .and_then(Item::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn optional_usize(table: &toml_edit::Table, key: &str) -> Result<Option<usize>> {
+    table
+        .get(key)
+        .map(|item| match item.as_integer() {
+            Some(value) => usize::try_from(value)
+                .ok()
+                .filter(|value| *value > 0)
+                .with_context(|| format!("embeddings.{key} must be positive")),
+            None => item
+                .as_str()
+                .with_context(|| format!("embeddings.{key} must be an integer"))
+                .and_then(|raw| parse_positive_usize(raw, key)),
+        })
+        .transpose()
+}
+
+fn optional_u64(table: &toml_edit::Table, key: &str) -> Result<Option<u64>> {
+    table
+        .get(key)
+        .map(|item| match item.as_integer() {
+            Some(value) => u64::try_from(value)
+                .ok()
+                .filter(|value| *value > 0)
+                .with_context(|| format!("embeddings.{key} must be positive")),
+            None => item
+                .as_str()
+                .with_context(|| format!("embeddings.{key} must be an integer"))
+                .and_then(|raw| parse_positive_u64(raw, key)),
+        })
+        .transpose()
+}
+
+fn parse_positive_usize(raw: &str, key: &str) -> Result<usize> {
+    raw.trim()
+        .parse::<usize>()
+        .with_context(|| format!("{key} must be a positive integer"))
+        .and_then(|value| {
+            if value == 0 {
+                bail!("{key} must be positive");
+            }
+            Ok(value)
+        })
+}
+
+fn parse_positive_u64(raw: &str, key: &str) -> Result<u64> {
+    raw.trim()
+        .parse::<u64>()
+        .with_context(|| format!("{key} must be a positive integer"))
+        .and_then(|value| {
+            if value == 0 {
+                bail!("{key} must be positive");
+            }
+            Ok(value)
+        })
+}
+
+fn env_value(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/retrieval/embedding/tests.rs
+++ b/src/retrieval/embedding/tests.rs
@@ -1,0 +1,202 @@
+use std::io::{Read, Write};
+use std::sync::Mutex;
+
+use super::*;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+const TEST_API_KEY_ENV: &str = "REMEM_TEST_EMBEDDING_KEY";
+
+const ENV_KEYS: &[&str] = &[
+    "REMEM_CONFIG",
+    ENV_PROVIDER,
+    ENV_PROVIDER_LEGACY,
+    ENV_MODEL,
+    ENV_MODEL_LEGACY,
+    ENV_BASE_URL,
+    ENV_BASE_URL_LEGACY,
+    ENV_DIMENSIONS,
+    ENV_DIMENSIONS_LEGACY,
+    ENV_API_KEY,
+    ENV_API_KEY_LEGACY,
+    ENV_API_KEY_ENV,
+    ENV_TIMEOUT_SECS,
+    DEFAULT_API_KEY_ENV,
+    TEST_API_KEY_ENV,
+];
+
+fn with_clean_env<T>(f: impl FnOnce() -> T) -> T {
+    let _guard = ENV_LOCK.lock().expect("env lock should acquire");
+    let saved = ENV_KEYS
+        .iter()
+        .map(|key| (*key, std::env::var(key).ok()))
+        .collect::<Vec<_>>();
+    for key in ENV_KEYS {
+        unsafe { std::env::remove_var(key) };
+    }
+    let result = f();
+    for (key, value) in saved {
+        match value {
+            Some(value) => unsafe { std::env::set_var(key, value) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+    result
+}
+
+#[test]
+fn auto_provider_uses_local_without_remem_specific_key() -> Result<()> {
+    with_clean_env(|| {
+        let embedding = embed_query("protect persisted data")?;
+
+        assert_eq!(embedding.model(), LOCAL_EMBEDDING_MODEL);
+        assert_eq!(embedding.dimensions(), LOCAL_EMBEDDING_DIMENSIONS);
+        Ok(())
+    })
+}
+
+#[test]
+fn explicit_openai_requires_api_key() {
+    with_clean_env(|| {
+        unsafe { std::env::set_var(ENV_PROVIDER, "openai") };
+
+        let err = embed_query("hello").unwrap_err();
+
+        assert!(err.to_string().contains("requires"));
+    });
+}
+
+#[test]
+fn config_file_selects_openai_without_secret_in_file() -> Result<()> {
+    with_clean_env(|| {
+        let path = std::env::temp_dir().join(format!(
+            "remem-embedding-config-{}-{}.toml",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::write(
+            &path,
+            r#"[embeddings]
+provider = "openai"
+model = "text-embedding-3-large"
+base_url = "https://example.invalid/v1"
+dimensions = 256
+api_key_env = "REMEM_TEST_EMBEDDING_KEY"
+"#,
+        )?;
+        unsafe {
+            std::env::set_var("REMEM_CONFIG", &path);
+            std::env::set_var(TEST_API_KEY_ENV, "test-key");
+        }
+
+        let config = resolve_embedding_config()?;
+        let active = active_provider(&config)?;
+
+        assert_eq!(config.provider, EmbeddingProvider::OpenAi);
+        assert_eq!(config.model, "text-embedding-3-large");
+        assert_eq!(config.dimensions, Some(256));
+        assert!(matches!(active, ActiveEmbeddingProvider::OpenAi { .. }));
+        std::fs::remove_file(path).ok();
+        Ok(())
+    })
+}
+
+#[test]
+fn parses_openai_embedding_response() -> Result<()> {
+    let embedding = parse_openai_embedding_response(
+        r#"{"data":[{"embedding":[0.1,0.2,0.3]}],"model":"text-embedding-3-small"}"#,
+        "fallback",
+    )?;
+
+    assert_eq!(embedding.model(), "text-embedding-3-small");
+    assert_eq!(embedding.values(), &[0.1, 0.2, 0.3]);
+    Ok(())
+}
+
+#[test]
+fn backfill_target_uses_provider_returned_profile() -> Result<()> {
+    with_clean_env(|| {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let addr = listener.local_addr()?;
+        let handle = std::thread::spawn(move || -> Result<String> {
+            let (mut stream, _) = listener.accept()?;
+            let mut buffer = [0u8; 8192];
+            let read = stream.read(&mut buffer)?;
+            let request = String::from_utf8_lossy(&buffer[..read]).to_string();
+            let body = r#"{"data":[{"embedding":[0.1,0.2,0.3,0.4]}],"model":"normalized-model"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes())?;
+            Ok(request)
+        });
+        unsafe {
+            std::env::set_var(ENV_PROVIDER, "openai");
+            std::env::set_var(ENV_API_KEY, "test-key");
+            std::env::set_var(ENV_MODEL, "requested-model");
+            std::env::set_var(ENV_DIMENSIONS, "256");
+            std::env::set_var(ENV_BASE_URL, format!("http://{addr}/v1"));
+        }
+
+        let target = configured_backfill_target()?;
+        let request = handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("embedding test server thread panicked"))??;
+
+        assert_eq!(target.model, "normalized-model");
+        assert_eq!(target.dimensions, 4);
+        assert!(request.contains("\"model\":\"requested-model\""));
+        assert!(request.contains("\"dimensions\":256"));
+        Ok(())
+    })
+}
+
+#[test]
+fn truncates_provider_error_body_on_char_boundary() {
+    let body = format!("{}猫", "x".repeat(499));
+
+    let truncated = truncate_error_body(&body);
+
+    assert!(truncated.ends_with("..."));
+}
+
+#[test]
+fn openai_provider_calls_configured_embeddings_endpoint() -> Result<()> {
+    with_clean_env(|| {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let addr = listener.local_addr()?;
+        let handle = std::thread::spawn(move || -> Result<String> {
+            let (mut stream, _) = listener.accept()?;
+            let mut buffer = [0u8; 8192];
+            let read = stream.read(&mut buffer)?;
+            let request = String::from_utf8_lossy(&buffer[..read]).to_string();
+            let body = r#"{"data":[{"embedding":[0.4,0.5,0.6]}],"model":"test-embedding"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes())?;
+            Ok(request)
+        });
+        unsafe {
+            std::env::set_var(ENV_PROVIDER, "openai");
+            std::env::set_var(ENV_API_KEY, "test-key");
+            std::env::set_var(ENV_MODEL, "test-embedding");
+            std::env::set_var(ENV_BASE_URL, format!("http://{addr}/v1"));
+        }
+
+        let embedding = embed_query("remote semantic text")?;
+        let request = handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("embedding test server thread panicked"))??;
+
+        assert_eq!(embedding.model(), "test-embedding");
+        assert_eq!(embedding.values(), &[0.4, 0.5, 0.6]);
+        assert!(request.starts_with("POST /v1/embeddings "));
+        assert!(request.contains("authorization: Bearer test-key"));
+        assert!(request.contains("\"model\":\"test-embedding\""));
+        Ok(())
+    })
+}

--- a/src/retrieval/search/memory/text.rs
+++ b/src/retrieval/search/memory/text.rs
@@ -283,8 +283,8 @@ fn build_query_search_plan(
         }
     }
 
-    let query_embedding = crate::retrieval::vector::embed_query_text(query_text);
-    let vector_outcome = crate::retrieval::vector::vector_search_filtered(
+    let query_embedding = crate::retrieval::embedding::embed_query(query_text)?;
+    let vector_outcome = crate::retrieval::vector::vector_search_embedding_filtered(
         conn,
         &query_embedding,
         crate::retrieval::vector::VectorSearchFilters {

--- a/src/retrieval/vector.rs
+++ b/src/retrieval/vector.rs
@@ -1,11 +1,13 @@
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
-use sha2::{Digest, Sha256};
 
+use super::embedding::TextEmbedding;
 pub use super::vector_candidates::VECTOR_SEARCH_CANDIDATE_LIMIT;
 
-pub const EMBEDDING_DIMENSIONS: usize = 768;
-pub const DEFAULT_EMBEDDING_MODEL: &str = "remem-local-feature-hash-v1";
+pub use super::embedding::{
+    LOCAL_EMBEDDING_DIMENSIONS as EMBEDDING_DIMENSIONS,
+    LOCAL_EMBEDDING_MODEL as DEFAULT_EMBEDDING_MODEL,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct VectorHit {
@@ -83,14 +85,15 @@ pub fn upsert_memory_embedding(
     memory_type: &str,
     topic_key: Option<&str>,
 ) -> Result<()> {
-    let embedding = embed_memory_text(title, content, memory_type, topic_key);
-    let content_hash = embedding_content_hash(title, content, memory_type, topic_key);
+    let embedding = super::embedding::embed_memory(title, content, memory_type, topic_key)?;
+    let content_hash =
+        super::embedding::embedding_content_hash(title, content, memory_type, topic_key);
     upsert_embedding_with_metadata(
         conn,
         memory_id,
-        DEFAULT_EMBEDDING_MODEL,
+        embedding.model(),
         &content_hash,
-        &embedding,
+        embedding.values(),
         chrono::Utc::now().timestamp(),
     )
     .with_context(|| format!("memory embedding upsert failed for memory id={memory_id}"))
@@ -125,16 +128,22 @@ pub fn backfill_missing_memory_embeddings(conn: &Connection, limit: i64) -> Resu
         return Ok(0);
     }
 
-    let mut stmt = conn.prepare(
-        "SELECT m.id, m.topic_key, m.title, m.content, m.memory_type
+    let target = super::embedding::configured_backfill_target()?;
+    let sql = "SELECT m.id, m.topic_key, m.title, m.content, m.memory_type
          FROM memories m
          LEFT JOIN memory_embeddings e ON e.memory_id = m.id
-         WHERE e.memory_id IS NULL
+         WHERE (e.memory_id IS NULL OR e.model <> ?1 OR e.dimensions <> ?2)
            AND m.status IN ('active', 'stale', 'archived')
          ORDER BY m.updated_at_epoch DESC, m.id DESC
-         LIMIT ?1",
-    )?;
-    let rows = stmt.query_map([limit], |row| {
+         LIMIT ?3";
+    let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+        Box::new(target.model.clone()),
+        Box::new(target.dimensions as i64),
+    ];
+    values.push(Box::new(limit));
+    let refs = crate::db::to_sql_refs(&values);
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
         Ok((
             row.get::<_, i64>(0)?,
             row.get::<_, Option<String>>(1)?,
@@ -158,6 +167,22 @@ pub fn backfill_missing_memory_embeddings(conn: &Connection, limit: i64) -> Resu
     Ok(count)
 }
 
+pub fn pending_memory_embedding_count(conn: &Connection) -> Result<i64> {
+    if !table_exists(conn, "memories")? || !table_exists(conn, "memory_embeddings")? {
+        return Ok(0);
+    }
+    let target = super::embedding::configured_backfill_target()?;
+    let sql = "SELECT COUNT(*)
+               FROM memories m
+               LEFT JOIN memory_embeddings e ON e.memory_id = m.id
+               WHERE (e.memory_id IS NULL OR e.model <> ?1 OR e.dimensions <> ?2)
+                 AND m.status IN ('active', 'stale', 'archived')";
+    let values: Vec<Box<dyn rusqlite::types::ToSql>> =
+        vec![Box::new(target.model), Box::new(target.dimensions as i64)];
+    let refs = crate::db::to_sql_refs(&values);
+    Ok(conn.query_row(sql, refs.as_slice(), |row| row.get(0))?)
+}
+
 pub fn embedding_count(conn: &Connection) -> Result<i64> {
     if !table_exists(conn, "memory_embeddings")? {
         return Ok(0);
@@ -170,7 +195,7 @@ pub fn embedding_count(conn: &Connection) -> Result<i64> {
 }
 
 pub fn embed_query_text(query: &str) -> Vec<f32> {
-    embed_text(query)
+    super::embedding::embed_query_text_local(query)
 }
 
 pub fn embed_memory_text(
@@ -179,17 +204,7 @@ pub fn embed_memory_text(
     memory_type: &str,
     topic_key: Option<&str>,
 ) -> Vec<f32> {
-    let mut text = String::new();
-    text.push_str(memory_type);
-    text.push('\n');
-    if let Some(topic_key) = topic_key {
-        text.push_str(topic_key);
-        text.push('\n');
-    }
-    text.push_str(title);
-    text.push('\n');
-    text.push_str(content);
-    embed_text(&text)
+    super::embedding::embed_memory_text_local(title, content, memory_type, topic_key)
 }
 
 pub fn vector_search(
@@ -219,6 +234,16 @@ pub fn vector_search_filtered(
             query_embedding.len()
         );
     }
+    let embedding = TextEmbedding::new(DEFAULT_EMBEDDING_MODEL, query_embedding.to_vec())?;
+    vector_search_embedding_filtered(conn, &embedding, filters, limit)
+}
+
+pub fn vector_search_embedding_filtered(
+    conn: &Connection,
+    query_embedding: &TextEmbedding,
+    filters: VectorSearchFilters<'_>,
+    limit: usize,
+) -> Result<VectorSearchOutcome> {
     if limit == 0 {
         return Ok(VectorSearchOutcome::ready(vec![]));
     }
@@ -235,7 +260,18 @@ pub fn vector_search_filtered(
         ));
     }
 
-    let candidate_ids = super::vector_candidates::select_candidate_ids(conn, filters, limit)?;
+    let profile = query_embedding.profile();
+    if super::vector_candidates::matching_embedding_count(conn, filters, profile)? == 0
+        && super::vector_candidates::matching_memory_count(conn, filters)? > 0
+    {
+        return Ok(VectorSearchOutcome::disabled(format!(
+            "memory_embeddings has no rows for model={} dimensions={}; run `remem backfill-embeddings --limit 1000`",
+            profile.model, profile.dimensions
+        )));
+    }
+
+    let candidate_ids =
+        super::vector_candidates::select_candidate_ids(conn, filters, profile, limit)?;
     let candidates_scanned = candidate_ids.len();
     if candidate_ids.is_empty() {
         return Ok(VectorSearchOutcome::ready_with_scan_count(vec![], 0));
@@ -246,12 +282,16 @@ pub fn vector_search_filtered(
     let sql = format!(
         "SELECT memory_id, embedding, dimensions
          FROM memory_embeddings
-         WHERE memory_id IN ({placeholders})"
+         WHERE memory_id IN ({placeholders})
+           AND model = ?
+           AND dimensions = ?"
     );
-    let param_values = candidate_ids
+    let mut param_values = candidate_ids
         .iter()
         .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
         .collect::<Vec<_>>();
+    param_values.push(Box::new(profile.model.to_string()));
+    param_values.push(Box::new(profile.dimensions as i64));
     let refs = crate::db::to_sql_refs(&param_values);
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(refs.as_slice(), |row| {
@@ -266,7 +306,7 @@ pub fn vector_search_filtered(
     for (memory_id, blob, dimensions) in candidates {
         let embedding = decode_embedding(&blob, dimensions)
             .with_context(|| format!("invalid embedding blob for memory id={memory_id}"))?;
-        let distance = cosine_distance(query_embedding, &embedding)?;
+        let distance = cosine_distance(query_embedding.values(), &embedding)?;
         hits.push(VectorHit {
             memory_id,
             distance,
@@ -327,14 +367,17 @@ fn upsert_embedding_with_metadata(
     embedding: &[f32],
     updated_at_epoch: i64,
 ) -> Result<()> {
-    if embedding.len() != EMBEDDING_DIMENSIONS {
-        anyhow::bail!(
-            "embedding must be {} dimensions, got {}",
-            EMBEDDING_DIMENSIONS,
-            embedding.len()
-        );
+    if model.trim().is_empty() {
+        anyhow::bail!("embedding model must not be empty");
+    }
+    if embedding.is_empty() {
+        anyhow::bail!("embedding vector must not be empty");
+    }
+    if embedding.iter().any(|value| !value.is_finite()) {
+        anyhow::bail!("embedding vector contains non-finite values");
     }
     let blob = encode_embedding(embedding);
+    let dimensions = embedding.len() as i64;
     conn.execute(
         "INSERT INTO memory_embeddings
          (memory_id, embedding, dimensions, model, content_hash, updated_at_epoch)
@@ -348,7 +391,7 @@ fn upsert_embedding_with_metadata(
         params![
             memory_id,
             blob,
-            EMBEDDING_DIMENSIONS as i64,
+            dimensions,
             model,
             content_hash,
             updated_at_epoch
@@ -366,17 +409,15 @@ fn encode_embedding(embedding: &[f32]) -> Vec<u8> {
 }
 
 pub(crate) fn decode_embedding(blob: &[u8], dimensions: i64) -> Result<Vec<f32>> {
-    if dimensions != EMBEDDING_DIMENSIONS as i64 {
-        anyhow::bail!(
-            "embedding dimensions must be {}, got {}",
-            EMBEDDING_DIMENSIONS,
-            dimensions
-        );
+    if dimensions <= 0 {
+        anyhow::bail!("embedding dimensions must be positive, got {dimensions}");
     }
-    if blob.len() != EMBEDDING_DIMENSIONS * std::mem::size_of::<f32>() {
+    let dimensions = dimensions as usize;
+    let expected_bytes = dimensions * std::mem::size_of::<f32>();
+    if blob.len() != expected_bytes {
         anyhow::bail!(
             "embedding blob must be {} bytes, got {}",
-            EMBEDDING_DIMENSIONS * std::mem::size_of::<f32>(),
+            expected_bytes,
             blob.len()
         );
     }
@@ -408,108 +449,6 @@ pub(crate) fn cosine_distance(a: &[f32], b: &[f32]) -> Result<f32> {
     Ok((1.0 - dot / (a_norm.sqrt() * b_norm.sqrt())).clamp(0.0, 2.0))
 }
 
-fn embed_text(text: &str) -> Vec<f32> {
-    let normalized = text.to_lowercase();
-    let mut vector = vec![0.0f32; EMBEDDING_DIMENSIONS];
-    for token in semantic_tokens(&normalized) {
-        add_feature(&mut vector, &format!("token:{token}"), 1.0);
-    }
-    for ngram in char_ngrams(&normalized) {
-        add_feature(&mut vector, &format!("ngram:{ngram}"), 0.35);
-    }
-    for (concept, phrases) in semantic_concepts() {
-        if phrases.iter().any(|phrase| normalized.contains(phrase)) {
-            add_feature(&mut vector, &format!("concept:{concept}"), 4.0);
-        }
-    }
-    normalize(&mut vector);
-    vector
-}
-
-fn semantic_tokens(text: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    let mut current = String::new();
-    for ch in text.chars() {
-        if ch.is_alphanumeric() || is_cjk(ch) {
-            current.push(ch);
-        } else if !current.is_empty() {
-            tokens.push(std::mem::take(&mut current));
-        }
-    }
-    if !current.is_empty() {
-        tokens.push(current);
-    }
-    tokens
-}
-
-fn char_ngrams(text: &str) -> Vec<String> {
-    let chars: Vec<char> = text
-        .chars()
-        .filter(|ch| ch.is_alphanumeric() || is_cjk(*ch))
-        .collect();
-    let mut grams = Vec::new();
-    for width in [2usize, 3] {
-        if chars.len() < width {
-            continue;
-        }
-        grams.extend(
-            chars
-                .windows(width)
-                .map(|window| window.iter().collect::<String>()),
-        );
-    }
-    grams
-}
-
-fn add_feature(vector: &mut [f32], feature: &str, weight: f32) {
-    let digest = Sha256::digest(feature.as_bytes());
-    for offset in [0usize, 8, 16] {
-        let raw = u64::from_le_bytes([
-            digest[offset],
-            digest[offset + 1],
-            digest[offset + 2],
-            digest[offset + 3],
-            digest[offset + 4],
-            digest[offset + 5],
-            digest[offset + 6],
-            digest[offset + 7],
-        ]);
-        let idx = raw as usize % vector.len();
-        let sign = if raw & 1 == 0 { 1.0 } else { -1.0 };
-        vector[idx] += weight * sign;
-    }
-}
-
-fn normalize(vector: &mut [f32]) {
-    let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
-    if norm == 0.0 {
-        return;
-    }
-    for value in vector {
-        *value /= norm;
-    }
-}
-
-fn embedding_content_hash(
-    title: &str,
-    content: &str,
-    memory_type: &str,
-    topic_key: Option<&str>,
-) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(memory_type.as_bytes());
-    hasher.update([0]);
-    if let Some(topic_key) = topic_key {
-        hasher.update(topic_key.as_bytes());
-    }
-    hasher.update([0]);
-    hasher.update(title.as_bytes());
-    hasher.update([0]);
-    hasher.update(content.as_bytes());
-    let digest = hasher.finalize();
-    digest.iter().map(|byte| format!("{byte:02x}")).collect()
-}
-
 fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
     Ok(conn
         .query_row(
@@ -519,97 +458,6 @@ fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
         )
         .optional()?
         .is_some())
-}
-
-fn is_cjk(ch: char) -> bool {
-    matches!(
-        ch,
-        '\u{4E00}'..='\u{9FFF}' |
-        '\u{3400}'..='\u{4DBF}' |
-        '\u{F900}'..='\u{FAFF}'
-    )
-}
-
-fn semantic_concepts() -> &'static [(&'static str, &'static [&'static str])] {
-    &[
-        (
-            "data-security",
-            &[
-                "sqlcipher",
-                "encrypt",
-                "encrypted",
-                "encryption",
-                "secret",
-                "secrets",
-                "credential",
-                "credentials",
-                "private",
-                "confidential",
-                "protect",
-                "protected",
-                "at rest",
-                "persisted data",
-                "加密",
-                "密钥",
-            ],
-        ),
-        (
-            "transcript-capture",
-            &[
-                "transcript",
-                "raw archive",
-                "raw message",
-                "hook fallback",
-                "assistant message",
-                "conversation capture",
-                "jsonl",
-                "会话",
-                "原始消息",
-            ],
-        ),
-        (
-            "retrieval-quality",
-            &[
-                "semantic",
-                "embedding",
-                "vector",
-                "recall",
-                "search quality",
-                "paraphrase",
-                "检索",
-                "语义",
-                "召回",
-                "向量",
-            ],
-        ),
-        (
-            "current-state",
-            &[
-                "current decision",
-                "current state",
-                "supersede",
-                "supersedes",
-                "stale",
-                "replacement",
-                "现在",
-                "当前",
-                "替代",
-            ],
-        ),
-        (
-            "compression",
-            &[
-                "compress",
-                "compression",
-                "compaction",
-                "summarize",
-                "compressed",
-                "压缩",
-                "摘要",
-                "总结",
-            ],
-        ),
-    ]
 }
 
 #[cfg(test)]
@@ -623,6 +471,16 @@ mod tests {
         let conn = Connection::open_in_memory()?;
         crate::migrate::run_migrations(&conn)?;
         Ok(conn)
+    }
+
+    fn insert_test_memory(conn: &Connection, id: i64) -> Result<()> {
+        conn.execute(
+            "INSERT INTO memories
+             (id, project, title, content, memory_type, created_at_epoch, updated_at_epoch, status)
+             VALUES (?1, '/repo', 'Credential store', 'SQLCipher encrypts secrets at rest.', 'architecture', 1, 1, 'active')",
+            params![id],
+        )?;
+        Ok(())
     }
 
     #[test]
@@ -749,6 +607,65 @@ mod tests {
             )?;
             assert_eq!(status_count, 1);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn vector_search_ignores_embeddings_from_other_models() -> Result<()> {
+        let conn = setup_conn()?;
+        insert_test_memory(&conn, 1)?;
+        upsert_memory_embedding(
+            &conn,
+            1,
+            "Credential store",
+            "SQLCipher encrypts secrets at rest.",
+            "architecture",
+            None,
+        )?;
+
+        let query = TextEmbedding::new("remote-test-model", vec![0.1, 0.2, 0.3])?;
+        let outcome = vector_search_embedding_filtered(
+            &conn,
+            &query,
+            VectorSearchFilters {
+                project: Some("/repo"),
+                ..VectorSearchFilters::default()
+            },
+            5,
+        )?;
+
+        assert!(outcome.hits.is_empty());
+        assert!(outcome
+            .disabled_reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("remote-test-model"));
+        Ok(())
+    }
+
+    #[test]
+    fn backfill_rebuilds_embeddings_from_stale_model() -> Result<()> {
+        let conn = setup_conn()?;
+        insert_test_memory(&conn, 1)?;
+        let stale_blob = vec![0u8; 3 * std::mem::size_of::<f32>()];
+        conn.execute(
+            "INSERT INTO memory_embeddings
+             (memory_id, embedding, dimensions, model, content_hash, updated_at_epoch)
+             VALUES (1, ?1, 3, 'old-model', 'old-hash', 1)",
+            params![stale_blob],
+        )?;
+
+        assert_eq!(pending_memory_embedding_count(&conn)?, 1);
+        assert_eq!(backfill_missing_memory_embeddings(&conn, 100)?, 1);
+
+        let row: (String, i64) = conn.query_row(
+            "SELECT model, dimensions FROM memory_embeddings WHERE memory_id = 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(row.0, DEFAULT_EMBEDDING_MODEL);
+        assert_eq!(row.1, EMBEDDING_DIMENSIONS as i64);
+        assert_eq!(pending_memory_embedding_count(&conn)?, 0);
         Ok(())
     }
 

--- a/src/retrieval/vector_candidates.rs
+++ b/src/retrieval/vector_candidates.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
+use super::embedding::EmbeddingProfile;
 use super::vector::VectorSearchFilters;
 
 pub const VECTOR_SEARCH_CANDIDATE_LIMIT: usize = 4_096;
@@ -27,10 +28,11 @@ pub(crate) fn matching_memory_count(
 pub(crate) fn select_candidate_ids(
     conn: &Connection,
     filters: VectorSearchFilters<'_>,
+    profile: EmbeddingProfile<'_>,
     limit: usize,
 ) -> Result<Vec<i64>> {
     let limit = vector_candidate_limit(limit);
-    let Some((min_id, max_id)) = embedding_id_bounds(conn)? else {
+    let Some((min_id, max_id)) = embedding_id_bounds(conn, profile)? else {
         return Ok(Vec::new());
     };
 
@@ -51,6 +53,7 @@ pub(crate) fn select_candidate_ids(
         append_bucket_ids(
             conn,
             filters,
+            profile,
             start,
             end.max(start),
             per_bucket,
@@ -60,17 +63,47 @@ pub(crate) fn select_candidate_ids(
     }
 
     if ids.len() < limit {
-        append_recent_ids(conn, filters, limit, &mut ids)?;
+        append_recent_ids(conn, filters, profile, limit, &mut ids)?;
     }
 
     ids.truncate(limit);
     Ok(ids)
 }
 
-fn embedding_id_bounds(conn: &Connection) -> Result<Option<(i64, i64)>> {
+pub(crate) fn matching_embedding_count(
+    conn: &Connection,
+    filters: VectorSearchFilters<'_>,
+    profile: EmbeddingProfile<'_>,
+) -> Result<i64> {
+    let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+        Box::new(profile.model.to_string()),
+        Box::new(profile.dimensions as i64),
+    ];
+    let (conditions, mut filter_values) = memory_filter_conditions(filters, 3);
+    values.append(&mut filter_values);
+    let sql = format!(
+        "SELECT COUNT(*)
+         FROM memory_embeddings e
+         JOIN memories m ON m.id = e.memory_id
+         WHERE e.model = ?1
+           AND e.dimensions = ?2
+           AND {}",
+        conditions.join(" AND ")
+    );
+    let refs = crate::db::to_sql_refs(&values);
+    Ok(conn.query_row(&sql, refs.as_slice(), |row| row.get(0))?)
+}
+
+fn embedding_id_bounds(
+    conn: &Connection,
+    profile: EmbeddingProfile<'_>,
+) -> Result<Option<(i64, i64)>> {
     let (min_id, max_id): (Option<i64>, Option<i64>) = conn.query_row(
-        "SELECT MIN(memory_id), MAX(memory_id) FROM memory_embeddings",
-        [],
+        "SELECT MIN(memory_id), MAX(memory_id)
+         FROM memory_embeddings
+         WHERE model = ?1
+           AND dimensions = ?2",
+        (&profile.model, profile.dimensions as i64),
         |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
     Ok(min_id.zip(max_id))
@@ -79,18 +112,26 @@ fn embedding_id_bounds(conn: &Connection) -> Result<Option<(i64, i64)>> {
 fn append_bucket_ids(
     conn: &Connection,
     filters: VectorSearchFilters<'_>,
+    profile: EmbeddingProfile<'_>,
     start: i64,
     end: i64,
     per_bucket: usize,
     total_limit: usize,
     ids: &mut Vec<i64>,
 ) -> Result<()> {
-    let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(start), Box::new(end)];
-    let (mut conditions, mut filter_values) = memory_filter_conditions(filters, 3);
+    let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+        Box::new(start),
+        Box::new(end),
+        Box::new(profile.model.to_string()),
+        Box::new(profile.dimensions as i64),
+    ];
+    let (mut conditions, mut filter_values) = memory_filter_conditions(filters, 5);
     values.append(&mut filter_values);
     let limit_idx = values.len() + 1;
     values.push(Box::new(per_bucket as i64));
     conditions.insert(0, "e.memory_id BETWEEN ?1 AND ?2".to_string());
+    conditions.insert(1, "e.model = ?3".to_string());
+    conditions.insert(2, "e.dimensions = ?4".to_string());
     let sql = format!(
         "SELECT e.memory_id
          FROM memory_embeddings e
@@ -106,12 +147,20 @@ fn append_bucket_ids(
 fn append_recent_ids(
     conn: &Connection,
     filters: VectorSearchFilters<'_>,
+    profile: EmbeddingProfile<'_>,
     total_limit: usize,
     ids: &mut Vec<i64>,
 ) -> Result<()> {
-    let (conditions, mut values) = memory_filter_conditions(filters, 1);
+    let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+        Box::new(profile.model.to_string()),
+        Box::new(profile.dimensions as i64),
+    ];
+    let (mut conditions, mut filter_values) = memory_filter_conditions(filters, 3);
+    values.append(&mut filter_values);
     let limit_idx = values.len() + 1;
     values.push(Box::new(total_limit as i64));
+    conditions.insert(0, "e.model = ?1".to_string());
+    conditions.insert(1, "e.dimensions = ?2".to_string());
     let sql = format!(
         "SELECT e.memory_id
          FROM memory_embeddings e


### PR DESCRIPTION
## Summary
- add configurable text embedding providers with OpenAI-compatible embeddings support and explicit local feature-hash fallback
- store and query vector rows by the actual returned model and dimensions, including stale-profile backfill detection
- route memory search and hybrid context vector channels through the configured embedding provider
- bump runtime/package version to 0.5.49

Fixes #358

## Verification
- cargo fmt --check
- git diff --check
- python3 scripts/ci/check_plugin_version_sync.py
- cargo check --message-format=short
- cargo clippy -- -D warnings
- cargo test retrieval::embedding -- --nocapture
- cargo test retrieval::vector -- --nocapture
- cargo test retrieval::search::memory::tests::semantic_vector_channel_recalls_paraphrase_without_lexical_overlap -- --nocapture
- cargo test context::tests::retrieval::hybrid_context_vector_recall_is_not_crowded_out_by_global_hits -- --nocapture
- cargo test
- node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js
- python3 scripts/ci/check_version_bump.py origin/main HEAD