### PR TITLE
Add semantic dedup for curated memories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.49"
+version = "0.5.50"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.49"
+version = "0.5.50"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.49",
+  "version": "0.5.50",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.49",
+  "version": "0.5.50",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.49": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.49",
+    "0.5.50": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.50",
       "assets": {}
     }
   }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -18,6 +18,7 @@ pub mod raw_archive;
 pub(crate) mod raw_transcript;
 pub mod scope_cleanup;
 pub mod search_context;
+pub(crate) mod semantic_dedup;
 pub mod service;
 pub mod state_key;
 pub mod store;

--- a/src/memory/lesson.rs
+++ b/src/memory/lesson.rs
@@ -62,7 +62,8 @@ pub fn save_lesson(conn: &Connection, req: &SaveLessonRequest<'_>) -> Result<i64
         scope,
         req.created_at_epoch,
     )?;
-    upsert_lesson_metadata(conn, id, req, existing_id.is_some())?;
+    let metadata_exists = get_lesson_metadata(conn, id)?.is_some();
+    upsert_lesson_metadata(conn, id, req, existing_id.is_some() || metadata_exists)?;
     Ok(id)
 }
 

--- a/src/memory/lesson/tests.rs
+++ b/src/memory/lesson/tests.rs
@@ -77,6 +77,110 @@ fn save_lesson_reinforces_duplicate_topic() {
 }
 
 #[test]
+fn save_lesson_reinforces_semantic_near_duplicate() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+
+    let first_id = save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("s1"),
+            project: "/repo",
+            topic_key: Some("lesson-build-loop-a"),
+            title: "Avoid build failure loops",
+            content: "Lesson: after repeated build failures, stop and challenge the hypothesis before editing again.",
+            confidence: 0.6,
+            source_evidence: Some("first run"),
+            files: None,
+            branch: None,
+            scope: "project",
+            created_at_epoch: None,
+            stale_after_epoch: None,
+        },
+    )
+    ?;
+    let second_id = save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("s2"),
+            project: "/repo",
+            topic_key: Some("lesson-build-loop-b"),
+            title: "Break repeated build failures",
+            content: "Lesson: when build failures repeat, pause and challenge the hypothesis before more edits.",
+            confidence: 0.9,
+            source_evidence: Some("second run"),
+            files: None,
+            branch: None,
+            scope: "project",
+            created_at_epoch: None,
+            stale_after_epoch: None,
+        },
+    )
+    ?;
+
+    assert_eq!(second_id, first_id);
+    let metadata =
+        get_lesson_metadata(&conn, first_id)?.ok_or_else(|| anyhow::anyhow!("metadata missing"))?;
+    assert_eq!(metadata.reinforcement_count, 2);
+    assert_eq!(metadata.confidence, 0.9);
+    assert_eq!(metadata.source_evidence.as_deref(), Some("second run"));
+    Ok(())
+}
+
+#[test]
+fn semantic_lesson_dedup_keeps_branch_scope_isolated() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+
+    let first_id = save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("s1"),
+            project: "/repo",
+            topic_key: Some("lesson-build-loop-main"),
+            title: "Avoid build failure loops",
+            content: "Lesson: after repeated build failures, stop and challenge the hypothesis before editing again.",
+            confidence: 0.6,
+            source_evidence: Some("main branch"),
+            files: None,
+            branch: Some("main"),
+            scope: "project",
+            created_at_epoch: None,
+            stale_after_epoch: None,
+        },
+    )?;
+    let second_id = save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("s2"),
+            project: "/repo",
+            topic_key: Some("lesson-build-loop-feature"),
+            title: "Break repeated build failures",
+            content: "Lesson: when build failures repeat, pause and challenge the hypothesis before more edits.",
+            confidence: 0.9,
+            source_evidence: Some("feature branch"),
+            files: None,
+            branch: Some("feature"),
+            scope: "project",
+            created_at_epoch: None,
+            stale_after_epoch: None,
+        },
+    )?;
+
+    assert_ne!(second_id, first_id);
+    let active_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories
+         WHERE project = '/repo'
+           AND memory_type = 'lesson'
+           AND status = 'active'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(active_count, 2);
+    Ok(())
+}
+
+#[test]
 fn save_lesson_reinforcement_clears_stale_deadline() {
     let conn = Connection::open_in_memory().unwrap();
     setup_memory_schema(&conn);
@@ -126,9 +230,26 @@ fn list_lessons_for_context_filters_low_confidence_and_stale() {
     setup_memory_schema(&conn);
     let now = chrono::Utc::now().timestamp();
 
-    for (idx, confidence, stale_after_epoch) in
-        [(1, 0.9, None), (2, 0.2, None), (3, 0.8, Some(now - 1))]
-    {
+    for (idx, confidence, stale_after_epoch, content) in [
+        (
+            1,
+            0.9,
+            None,
+            "Lesson: active evidence-backed fixes need fresh verification output.",
+        ),
+        (
+            2,
+            0.2,
+            None,
+            "Lesson: low confidence notes should stay below the context threshold.",
+        ),
+        (
+            3,
+            0.8,
+            Some(now - 1),
+            "Lesson: stale remediation notes expire after their review window.",
+        ),
+    ] {
         save_lesson(
             &conn,
             &SaveLessonRequest {
@@ -136,7 +257,7 @@ fn list_lessons_for_context_filters_low_confidence_and_stale() {
                 project: "/repo",
                 topic_key: Some(&format!("lesson-{idx}")),
                 title: &format!("Lesson {idx}"),
-                content: "Lesson: use evidence-backed fixes for recurring failures.",
+                content,
                 confidence,
                 source_evidence: None,
                 files: None,
@@ -311,6 +432,7 @@ fn is_lesson_candidate_requires_actionable_signal() {
 }
 
 fn save_ranked_lesson(conn: &Connection, title: &str, confidence: f64) -> anyhow::Result<i64> {
+    let content = format!("Lesson: {title} has a distinct ranking signal for context ordering.");
     save_lesson(
         conn,
         &SaveLessonRequest {
@@ -318,7 +440,7 @@ fn save_ranked_lesson(conn: &Connection, title: &str, confidence: f64) -> anyhow
             project: "/repo",
             topic_key: Some(title),
             title,
-            content: "Lesson: keep deterministic ranking when many lessons compete for context.",
+            content: &content,
             confidence,
             source_evidence: None,
             files: None,

--- a/src/memory/operation.rs
+++ b/src/memory/operation.rs
@@ -101,13 +101,16 @@ pub fn plan_direct_save(
     let state_key =
         crate::memory::state_key::derive_state_key(memory_type, topic_key, title, content)
             .map(|decision| decision.state_key);
-    let existing = existing_memory_for_direct_save(
+    let existing_match = existing_memory_for_direct_save(
         conn,
         project,
         scope,
         memory_type,
         topic_key,
         state_key.as_deref(),
+        title,
+        content,
+        branch,
         now,
     )?;
     let input = MemoryOperationInput {
@@ -122,22 +125,34 @@ pub fn plan_direct_save(
         source_candidate_id,
         confidence,
     };
-    let plan = match existing {
-        Some(existing) if existing.matches_noop_write(title, content, files, branch, now) => {
+    let plan = match existing_match {
+        Some(existing_match)
+            if existing_match
+                .memory
+                .matches_noop_write(title, content, files, branch, now) =>
+        {
             MemoryOperationPlan::new(
                 MemoryLifecycleOp::Noop,
                 state_key,
                 "existing active memory already represents this fact",
             )
-            .with_target_memory_id(Some(existing.id))
+            .with_target_memory_id(Some(existing_match.memory.id))
             .with_noop_reason("already represented by active memory")
         }
-        Some(existing) => MemoryOperationPlan::new(
-            MemoryLifecycleOp::Update,
-            state_key,
-            "existing state/topic memory will be updated",
-        )
-        .with_target_memory_id(Some(existing.id)),
+        Some(existing_match) => {
+            let reason = match existing_match.source {
+                ExistingMemoryMatchSource::TopicKey | ExistingMemoryMatchSource::StateKey => {
+                    "existing state/topic memory will be updated".to_string()
+                }
+                ExistingMemoryMatchSource::Semantic { similarity } => {
+                    format!(
+                        "semantic duplicate memory will be updated (similarity {similarity:.3})"
+                    )
+                }
+            };
+            MemoryOperationPlan::new(MemoryLifecycleOp::Update, state_key, reason)
+                .with_target_memory_id(Some(existing_match.memory.id))
+        }
         None => MemoryOperationPlan::new(
             MemoryLifecycleOp::Add,
             state_key,
@@ -241,6 +256,19 @@ struct ExistingMemory {
     expires_at_epoch: Option<i64>,
 }
 
+#[derive(Debug)]
+struct ExistingMemoryMatch {
+    memory: ExistingMemory,
+    source: ExistingMemoryMatchSource,
+}
+
+#[derive(Debug)]
+enum ExistingMemoryMatchSource {
+    TopicKey,
+    StateKey,
+    Semantic { similarity: f32 },
+}
+
 impl ExistingMemory {
     fn matches_noop_write(
         &self,
@@ -273,10 +301,13 @@ fn existing_memory_for_direct_save(
     memory_type: &str,
     topic_key: Option<&str>,
     state_key: Option<&str>,
+    title: &str,
+    content: &str,
+    branch: Option<&str>,
     now_epoch: i64,
-) -> Result<Option<ExistingMemory>> {
+) -> Result<Option<ExistingMemoryMatch>> {
     if let Some(topic_key) = topic_key.filter(|topic_key| !topic_key.is_empty()) {
-        let existing_id = conn
+        let existing = conn
             .query_row(
                 "SELECT id, title, content, status, files, branch, expires_at_epoch FROM memories
                  WHERE project = ?1 AND topic_key = ?2 AND scope = ?3
@@ -289,26 +320,58 @@ fn existing_memory_for_direct_save(
             )
             .optional()
             .context("check existing durable memory for topic_key upsert")?;
-        if existing_id.is_some() {
-            return Ok(existing_id);
+        if let Some(memory) = existing {
+            return Ok(Some(ExistingMemoryMatch {
+                memory,
+                source: ExistingMemoryMatchSource::TopicKey,
+            }));
         }
     }
 
-    let Some(state_key) = state_key else {
-        return Ok(None);
-    };
-    let (owner_scope, owner_key) = owner_for_scope(project, scope);
-    let Some(id) = crate::memory::state_key::current_memory_id(
+    if let Some(state_key) = state_key {
+        let (owner_scope, owner_key) = owner_for_scope(project, scope);
+        if let Some(id) = crate::memory::state_key::current_memory_id(
+            conn,
+            owner_scope,
+            &owner_key,
+            memory_type,
+            state_key,
+            now_epoch,
+        )? {
+            if let Some(memory) = load_existing_memory(conn, id)? {
+                return Ok(Some(ExistingMemoryMatch {
+                    memory,
+                    source: ExistingMemoryMatchSource::StateKey,
+                }));
+            }
+        }
+    }
+
+    if let Some(duplicate) = crate::memory::semantic_dedup::find_curated_duplicate(
         conn,
-        owner_scope,
-        &owner_key,
+        project,
+        scope,
         memory_type,
-        state_key,
+        title,
+        content,
+        topic_key,
+        branch,
         now_epoch,
-    )?
-    else {
-        return Ok(None);
-    };
+    )? {
+        if let Some(memory) = load_existing_memory(conn, duplicate.memory_id)? {
+            return Ok(Some(ExistingMemoryMatch {
+                memory,
+                source: ExistingMemoryMatchSource::Semantic {
+                    similarity: duplicate.similarity,
+                },
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+fn load_existing_memory(conn: &Connection, id: i64) -> Result<Option<ExistingMemory>> {
     conn.query_row(
         "SELECT id, title, content, status, files, branch, expires_at_epoch
          FROM memories WHERE id = ?1",

--- a/src/memory/preference/tests.rs
+++ b/src/memory/preference/tests.rs
@@ -199,6 +199,95 @@ fn test_global_preferences_keep_same_topic_across_owner_groups() -> Result<()> {
 }
 
 #[test]
+fn add_preference_reuses_semantic_near_duplicate() -> Result<()> {
+    let conn = setup_test_db();
+
+    let first_id = add_preference(
+        &conn,
+        "test/proj",
+        "Prefer small reversible changes and include verification output for every fix.",
+        false,
+    )?;
+    let second_id = add_preference(
+        &conn,
+        "test/proj",
+        "Prefer small reversible code changes with verification output for each fix.",
+        false,
+    )?;
+
+    assert_eq!(second_id, first_id);
+    let active_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories
+         WHERE project = 'test/proj'
+           AND memory_type = 'preference'
+           AND status = 'active'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(active_count, 1);
+    Ok(())
+}
+
+#[test]
+fn semantic_preference_dedup_keeps_project_scope_isolated() -> Result<()> {
+    let conn = setup_test_db();
+
+    let first_id = add_preference(
+        &conn,
+        "first/proj",
+        "Prefer small reversible changes and include verification output for every fix.",
+        false,
+    )?;
+    let second_id = add_preference(
+        &conn,
+        "second/proj",
+        "Prefer small reversible code changes with verification output for each fix.",
+        false,
+    )?;
+
+    assert_ne!(second_id, first_id);
+    let active_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories
+         WHERE memory_type = 'preference'
+           AND status = 'active'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(active_count, 2);
+    Ok(())
+}
+
+#[test]
+fn semantic_preference_dedup_keeps_opposite_preferences_separate() -> Result<()> {
+    let conn = setup_test_db();
+
+    let first_id = add_preference(
+        &conn,
+        "test/proj",
+        "Never force push branches; require explicit approval before rewriting history.",
+        false,
+    )?;
+    let second_id = add_preference(
+        &conn,
+        "test/proj",
+        "Always force push branches when they are behind; do not ask for approval.",
+        false,
+    )?;
+
+    assert_ne!(second_id, first_id);
+    let active_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories
+         WHERE project = 'test/proj'
+           AND memory_type = 'preference'
+           AND status = 'active'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(active_count, 2);
+    Ok(())
+}
+
+#[test]
 fn test_preferences_use_state_key_current_view_per_owner() -> Result<()> {
     let conn = setup_test_db();
     insert_preference_row(

--- a/src/memory/semantic_dedup.rs
+++ b/src/memory/semantic_dedup.rs
@@ -1,0 +1,146 @@
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+
+const REAL_EMBEDDING_SIMILARITY_THRESHOLD: f32 = 0.95;
+const LOCAL_FEATURE_HASH_SIMILARITY_THRESHOLD: f32 = 0.875;
+const CANDIDATE_LIMIT: i64 = 200;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SemanticDuplicate {
+    pub memory_id: i64,
+    pub similarity: f32,
+}
+
+pub(crate) fn find_curated_duplicate_id(
+    conn: &Connection,
+    project: &str,
+    scope: &str,
+    memory_type: &str,
+    title: &str,
+    content: &str,
+    topic_key: Option<&str>,
+    branch: Option<&str>,
+    now_epoch: i64,
+) -> Result<Option<i64>> {
+    Ok(find_curated_duplicate(
+        conn,
+        project,
+        scope,
+        memory_type,
+        title,
+        content,
+        topic_key,
+        branch,
+        now_epoch,
+    )?
+    .map(|duplicate| duplicate.memory_id))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn find_curated_duplicate(
+    conn: &Connection,
+    project: &str,
+    scope: &str,
+    memory_type: &str,
+    title: &str,
+    content: &str,
+    topic_key: Option<&str>,
+    branch: Option<&str>,
+    now_epoch: i64,
+) -> Result<Option<SemanticDuplicate>> {
+    if !is_curated_dedup_type(memory_type) || crate::retrieval::vector::embedding_count(conn)? == 0
+    {
+        return Ok(None);
+    }
+
+    let scope = if scope.trim().is_empty() {
+        "project"
+    } else {
+        scope
+    };
+    let (owner_scope, owner_key) = crate::memory::operation::owner_for_scope(project, scope);
+    let branch_key = branch.unwrap_or_default();
+    let query_embedding =
+        crate::retrieval::embedding::embed_memory(title, content, memory_type, topic_key)?;
+    let threshold = similarity_threshold(query_embedding.model());
+    let max_distance = 1.0 - threshold;
+    let current_filter = crate::memory::memory_state_key_current_filter_sql("m");
+    let sql = format!(
+        "SELECT m.id, e.embedding, e.dimensions
+         FROM memories m
+         JOIN memory_embeddings e ON e.memory_id = m.id
+         WHERE m.memory_type = ?1
+           AND m.status = 'active'
+           AND (m.expires_at_epoch IS NULL OR m.expires_at_epoch > ?2)
+           AND {current_filter}
+           AND COALESCE(m.scope, 'project') = ?3
+           AND COALESCE(m.owner_scope, ?4) = ?4
+           AND COALESCE(
+                 m.owner_key,
+                 CASE
+                   WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user:default'
+                   ELSE m.project
+                 END
+               ) = ?5
+           AND COALESCE(m.branch, '') = ?6
+           AND e.model = ?7
+           AND e.dimensions = ?8
+         ORDER BY m.updated_at_epoch DESC, m.id DESC
+         LIMIT ?9"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(
+        params![
+            memory_type,
+            now_epoch,
+            scope,
+            owner_scope,
+            owner_key,
+            branch_key,
+            query_embedding.model(),
+            query_embedding.dimensions() as i64,
+            CANDIDATE_LIMIT
+        ],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        },
+    )?;
+    let candidates = crate::db::query::collect_rows(rows)?;
+    let mut best: Option<SemanticDuplicate> = None;
+    for (memory_id, blob, dimensions) in candidates {
+        let stored = crate::retrieval::vector::decode_embedding(&blob, dimensions)
+            .with_context(|| format!("invalid embedding blob for memory id={memory_id}"))?;
+        let distance = crate::retrieval::vector::cosine_distance(query_embedding.values(), &stored)
+            .with_context(|| format!("compare semantic duplicate candidate id={memory_id}"))?;
+        if distance > max_distance {
+            continue;
+        }
+        let similarity = 1.0 - distance;
+        match &best {
+            Some(current) if current.similarity >= similarity => {}
+            _ => {
+                best = Some(SemanticDuplicate {
+                    memory_id,
+                    similarity,
+                });
+            }
+        }
+    }
+    Ok(best)
+}
+
+fn is_curated_dedup_type(memory_type: &str) -> bool {
+    matches!(memory_type, "preference" | "lesson")
+}
+
+fn similarity_threshold(model: &str) -> f32 {
+    if model == crate::retrieval::embedding::LOCAL_EMBEDDING_MODEL {
+        LOCAL_FEATURE_HASH_SIMILARITY_THRESHOLD
+    } else {
+        REAL_EMBEDDING_SIMILARITY_THRESHOLD
+    }
+}

--- a/src/memory/service/save_tests.rs
+++ b/src/memory/service/save_tests.rs
@@ -35,6 +35,61 @@ fn repeated_lesson_save_reinforces_metadata_and_logs_update() -> anyhow::Result<
 }
 
 #[test]
+fn semantic_preference_duplicate_logs_update() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("semantic-preference-duplicate-update");
+    let conn = db::open_db()?;
+    let first = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: "Prefer small reversible changes and include verification output for every fix."
+                .to_string(),
+            title: Some("Small reversible changes".to_string()),
+            project: Some("proj".to_string()),
+            topic_key: Some("preference-a1b2c3d4".to_string()),
+            memory_type: Some("preference".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    let second = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: "Prefer small reversible code changes with verification output for each fix."
+                .to_string(),
+            title: Some("Reversible verified changes".to_string()),
+            project: Some("proj".to_string()),
+            topic_key: Some("preference-deadbeef".to_string()),
+            memory_type: Some("preference".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+
+    assert_eq!(second.id, first.id);
+    assert_eq!(second.operation, "update");
+    let logs = conn
+        .prepare("SELECT operation, reason FROM memory_operation_log ORDER BY id ASC")?
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    assert_eq!(
+        logs.iter()
+            .map(|(operation, _)| operation.as_str())
+            .collect::<Vec<_>>(),
+        vec!["add", "update"]
+    );
+    assert!(
+        logs[1]
+            .1
+            .contains("semantic duplicate memory will be updated"),
+        "semantic update should be auditable, got: {}",
+        logs[1].1
+    );
+    Ok(())
+}
+
+#[test]
 fn direct_save_refreshes_expired_same_text_current_fact() -> anyhow::Result<()> {
     let _dir = ScopedTestDataDir::new("save-expired-current-fact-refresh");
     let conn = db::open_db()?;

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -111,6 +111,19 @@ pub fn insert_memory_full(
             )?;
         }
     }
+    if existing_id.is_none() {
+        existing_id = crate::memory::semantic_dedup::find_curated_duplicate_id(
+            conn,
+            project,
+            scope,
+            memory_type,
+            title,
+            content,
+            topic_key,
+            branch,
+            now,
+        )?;
+    }
 
     if let Some(id) = existing_id {
         return with_memory_savepoint(conn, || {


### PR DESCRIPTION
Fixes #355.

## Summary
- add semantic duplicate detection for curated `preference` and `lesson` writes using current embeddings
- reuse matching active memories within the same owner/scope/branch instead of accumulating near-duplicates
- reinforce semantic lesson matches and log direct-save semantic updates with similarity
- add regression coverage for near-duplicates, branch/project isolation, and opposite preferences that must remain separate
- bump package/plugin runtime version to 0.5.50

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `cargo check --message-format=short`
- `cargo clippy -- -D warnings`
- `cargo test memory::preference -- --nocapture`
- `cargo test memory::lesson -- --nocapture`
- `cargo test memory::service::save_tests -- --nocapture`
- `cargo test`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js`