### PR TITLE
Add deterministic extraction-quality eval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
+      - run: cargo run -- eval-extraction --json --check-baseline > /tmp/remem-extraction-eval.json
       - run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.50"
+version = "0.5.51"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.50"
+version = "0.5.51"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/eval/README.md
+++ b/eval/README.md
@@ -84,3 +84,26 @@ Example:
   ]
 }
 ```
+
+## Extraction Quality Eval
+
+`remem eval-extraction` runs a deterministic extraction-quality check against a
+labeled transcript corpus and committed parser/model-output baseline.
+
+```bash
+remem eval-extraction --json --check-baseline
+```
+
+The corpus lives in `eval/extraction/corpus.json`; the committed baseline report
+lives in `eval/extraction/baseline.json`. CI runs the command above, so prompt,
+parser, replay fixture, and label changes that affect extraction metrics or
+request fingerprints must update the baseline intentionally.
+
+The JSON report includes:
+
+- observation precision and recall
+- memory-candidate precision and recall
+- forbidden-label exclusion rates
+- over-saved prediction count and over-save penalty
+- observation and candidate replay request SHA-256 fingerprints
+- per-case missing, unexpected, and forbidden predictions

--- a/eval/extraction/baseline.json
+++ b/eval/extraction/baseline.json
@@ -1,0 +1,112 @@
+{
+  "metadata": {
+    "corpus": "eval/extraction/corpus.json",
+    "corpus_version": "2026-06-12",
+    "description": "Deterministic extraction-quality corpus for observation and memory-candidate parser outputs.",
+    "cases": 2,
+    "transcript_events": 5
+  },
+  "metrics": {
+    "observation_precision": {
+      "passed": 2,
+      "total": 2,
+      "rate": 1.0
+    },
+    "observation_recall": {
+      "passed": 2,
+      "total": 2,
+      "rate": 1.0
+    },
+    "candidate_precision": {
+      "passed": 2,
+      "total": 2,
+      "rate": 1.0
+    },
+    "candidate_recall": {
+      "passed": 2,
+      "total": 2,
+      "rate": 1.0
+    },
+    "forbidden_observation_exclusion": {
+      "passed": 2,
+      "total": 2,
+      "rate": 1.0
+    },
+    "forbidden_candidate_exclusion": {
+      "passed": 2,
+      "total": 2,
+      "rate": 1.0
+    },
+    "over_saved_predictions": 0,
+    "total_predictions": 4,
+    "over_save_penalty": 0.0,
+    "all_checks_passed": true
+  },
+  "cases": [
+    {
+      "id": "build-fix-loop-guard",
+      "transcript_events": 3,
+      "observation_request_sha256": "437263a2511ff81146c931822fa2e367a1d906f0c4f83627607440a8bffc687a",
+      "candidate_request_sha256": "a21e45990a9f9a11b49107714b0e2b0f644e6709eb617ddbca7837a503c76f3d",
+      "predicted_observations": [
+        {
+          "index": 0,
+          "observation_type": "decision",
+          "text": "After three consecutive failed build fixes on the same problem, stop and challenge the hypothesis before editing again.",
+          "confidence": 0.91
+        }
+      ],
+      "predicted_candidates": [
+        {
+          "index": 0,
+          "scope": "project",
+          "memory_type": "lesson",
+          "topic_key": "build-fix-loop-guard",
+          "risk_class": "medium",
+          "text": "After three consecutive failed build fixes on the same problem, stop and challenge the hypothesis before editing again."
+        }
+      ],
+      "missing_expected_observations": [],
+      "unexpected_observations": [],
+      "forbidden_observations": [],
+      "missing_expected_candidates": [],
+      "unexpected_candidates": [],
+      "forbidden_candidates": [],
+      "over_saved_predictions": 0,
+      "pass": true
+    },
+    {
+      "id": "automatic-capture-primary",
+      "transcript_events": 2,
+      "observation_request_sha256": "e5f68e4b40772ab93175f682f2382c4e4ee9cd0dbaae3a97c18ae6c346a4d648",
+      "candidate_request_sha256": "c885dc5134cd6e9cf944bcb6cc341432b925c2a1a3a6101b36d2fe78721e28ee",
+      "predicted_observations": [
+        {
+          "index": 0,
+          "observation_type": "decision",
+          "text": "Memory capture must not depend on Codex voluntarily calling save_memory; automatic extraction is the primary channel and manual saves are only supplemental.",
+          "confidence": 0.95
+        }
+      ],
+      "predicted_candidates": [
+        {
+          "index": 0,
+          "scope": "project",
+          "memory_type": "architecture",
+          "topic_key": "automatic-capture-primary",
+          "risk_class": "medium",
+          "text": "Memory capture must not depend on Codex voluntarily calling save_memory; automatic extraction is the primary channel and manual saves are supplemental."
+        }
+      ],
+      "missing_expected_observations": [],
+      "unexpected_observations": [],
+      "forbidden_observations": [],
+      "missing_expected_candidates": [],
+      "unexpected_candidates": [],
+      "forbidden_candidates": [],
+      "over_saved_predictions": 0,
+      "pass": true
+    }
+  ],
+  "failing_examples": []
+}

--- a/eval/extraction/corpus.json
+++ b/eval/extraction/corpus.json
@@ -1,0 +1,124 @@
+{
+  "version": "2026-06-12",
+  "description": "Deterministic extraction-quality corpus for observation and memory-candidate parser outputs.",
+  "cases": [
+    {
+      "id": "build-fix-loop-guard",
+      "transcript": [
+        {
+          "id": "evt-1",
+          "role": "assistant",
+          "tool_name": "cargo check",
+          "content": "cargo check failed after the third attempted fix for the same compiler error."
+        },
+        {
+          "id": "evt-2",
+          "role": "user",
+          "content": "Stop and challenge the hypothesis after three consecutive failed fixes."
+        },
+        {
+          "id": "evt-3",
+          "role": "assistant",
+          "content": "I will pause further edits and reassess the root cause before changing more code."
+        }
+      ],
+      "observation_output": "<observation>\n<type>decision</type>\n<title>Build-fix loop guard</title>\n<narrative>After three consecutive failed build fixes on the same problem, stop and challenge the hypothesis before editing again.</narrative>\n<confidence>0.91</confidence>\n</observation>",
+      "candidate_output": "<memory_candidate>\n<scope>project</scope>\n<type>lesson</type>\n<topic_key>build-fix-loop-guard</topic_key>\n<risk_class>medium</risk_class>\n<confidence>0.87</confidence>\n<text>After three consecutive failed build fixes on the same problem, stop and challenge the hypothesis before editing again.</text>\n</memory_candidate>",
+      "expected_observations": [
+        {
+          "id": "obs-build-loop",
+          "observation_type": "decision",
+          "text_contains": [
+            "three consecutive failed build fixes",
+            "challenge the hypothesis"
+          ]
+        }
+      ],
+      "forbidden_observations": [
+        {
+          "id": "obs-zero-llm-cost",
+          "text_contains": [
+            "zero-llm"
+          ]
+        }
+      ],
+      "expected_candidates": [
+        {
+          "id": "cand-build-loop",
+          "scope": "project",
+          "memory_type": "lesson",
+          "topic_key": "build-fix-loop-guard",
+          "risk_class": "medium",
+          "text_contains": [
+            "three consecutive failed build fixes",
+            "challenge the hypothesis"
+          ]
+        }
+      ],
+      "forbidden_candidates": [
+        {
+          "id": "cand-zero-llm-cost",
+          "text_contains": [
+            "zero-llm"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "automatic-capture-primary",
+      "transcript": [
+        {
+          "id": "evt-4",
+          "role": "user",
+          "content": "Do not rely on Codex voluntarily calling save_memory. Automatic capture is the primary path."
+        },
+        {
+          "id": "evt-5",
+          "role": "assistant",
+          "content": "The design keeps automatic extraction as the main memory capture channel and treats manual saves as supplemental."
+        }
+      ],
+      "observation_output": "<observation>\n<type>decision</type>\n<title>Automatic capture is primary</title>\n<narrative>Memory capture must not depend on Codex voluntarily calling save_memory; automatic extraction is the primary channel and manual saves are only supplemental.</narrative>\n<confidence>0.95</confidence>\n</observation>",
+      "candidate_output": "<memory_candidate>\n<scope>project</scope>\n<type>architecture</type>\n<topic_key>automatic-capture-primary</topic_key>\n<risk_class>medium</risk_class>\n<confidence>0.9</confidence>\n<text>Memory capture must not depend on Codex voluntarily calling save_memory; automatic extraction is the primary channel and manual saves are supplemental.</text>\n</memory_candidate>",
+      "expected_observations": [
+        {
+          "id": "obs-auto-capture-primary",
+          "observation_type": "decision",
+          "text_contains": [
+            "must not depend on codex voluntarily calling save_memory",
+            "automatic extraction is the primary channel"
+          ]
+        }
+      ],
+      "forbidden_observations": [
+        {
+          "id": "obs-manual-save-enough",
+          "text_contains": [
+            "manual saves are sufficient"
+          ]
+        }
+      ],
+      "expected_candidates": [
+        {
+          "id": "cand-auto-capture-primary",
+          "scope": "project",
+          "memory_type": "architecture",
+          "topic_key": "automatic-capture-primary",
+          "risk_class": "medium",
+          "text_contains": [
+            "must not depend on codex voluntarily calling save_memory",
+            "automatic extraction is the primary channel"
+          ]
+        }
+      ],
+      "forbidden_candidates": [
+        {
+          "id": "cand-manual-save-enough",
+          "text_contains": [
+            "manual saves are sufficient"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.50",
+  "version": "0.5.51",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.50",
+  "version": "0.5.51",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.50": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.50",
+    "0.5.51": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.51",
       "assets": {}
     }
   }

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -14,7 +14,9 @@ mod usage;
 
 pub(super) use admin::run_admin;
 pub(super) use config_command::run_config;
-pub(super) use eval::{run_eval, run_eval_e2e, run_eval_governance, run_eval_local};
+pub(super) use eval::{
+    run_eval, run_eval_e2e, run_eval_extraction, run_eval_governance, run_eval_local,
+};
 pub(super) use import::run_import;
 pub(super) use maintenance::{
     run_cleanup, run_dream, run_encrypt, run_governance, GovernanceCliRequest,

--- a/src/cli/actions/eval.rs
+++ b/src/cli/actions/eval.rs
@@ -1,4 +1,6 @@
-use anyhow::{bail, Result};
+use std::fs;
+
+use anyhow::{bail, Context, Result};
 
 use crate::db;
 
@@ -48,6 +50,37 @@ pub(in crate::cli) fn run_eval_governance(k: usize, json: bool) -> Result<()> {
     }
     if !report.metrics.all_checks_passed {
         bail!("eval-governance checks failed");
+    }
+    Ok(())
+}
+
+pub(in crate::cli) fn run_eval_extraction(
+    corpus_path: &str,
+    baseline_path: &str,
+    json: bool,
+    check_baseline: bool,
+) -> Result<()> {
+    let report =
+        crate::eval::extraction::run_corpus_path(crate::eval::extraction::ExtractionEvalOptions {
+            corpus_path: corpus_path.to_string(),
+        })?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", report);
+    }
+    if check_baseline {
+        let actual = serde_json::to_value(&report)?;
+        let baseline_content = fs::read_to_string(baseline_path)
+            .with_context(|| format!("read extraction eval baseline {baseline_path}"))?;
+        let expected: serde_json::Value = serde_json::from_str(&baseline_content)
+            .with_context(|| format!("parse extraction eval baseline {baseline_path}"))?;
+        if actual != expected {
+            bail!("extraction eval baseline changed; regenerate {baseline_path} intentionally");
+        }
+    }
+    if !report.metrics.all_checks_passed {
+        bail!("eval-extraction checks failed");
     }
     Ok(())
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -5,10 +5,11 @@ use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 use super::actions::{
     run_admin, run_archive, run_audit_scope, run_backfill_embeddings, run_backfill_entities,
     run_cleanup, run_commit, run_config, run_current_state, run_dream, run_encrypt, run_eval,
-    run_eval_e2e, run_eval_governance, run_eval_local, run_governance, run_graph_review,
-    run_import, run_memory_cleanup, run_merge_preferences, run_model, run_pending, run_preferences,
-    run_raw, run_reroute, run_review, run_search, run_show, run_status, run_timeline, run_usage,
-    run_why, run_workstreams, GovernanceCliRequest, RerouteCliRequest,
+    run_eval_e2e, run_eval_extraction, run_eval_governance, run_eval_local, run_governance,
+    run_graph_review, run_import, run_memory_cleanup, run_merge_preferences, run_model,
+    run_pending, run_preferences, run_raw, run_reroute, run_review, run_search, run_show,
+    run_status, run_timeline, run_usage, run_why, run_workstreams, GovernanceCliRequest,
+    RerouteCliRequest,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands, ContextGateAction, MemoryAction};
@@ -252,6 +253,9 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
             keep_data_dir,
         } => run_eval_e2e(k, json, keep_data_dir).await?,
         Commands::EvalGovernance { k, json } => run_eval_governance(k, json)?,
+        Commands::EvalExtraction(args) => {
+            run_eval_extraction(&args.corpus, &args.baseline, args.json, args.check_baseline)?
+        }
         Commands::EvalLocal => run_eval_local()?,
         Commands::BackfillEntities => run_backfill_entities()?,
         Commands::BackfillEmbeddings { limit } => run_backfill_embeddings(limit)?,

--- a/src/cli/eval_types.rs
+++ b/src/cli/eval_types.rs
@@ -1,0 +1,13 @@
+use clap::Args;
+
+#[derive(Args)]
+pub(in crate::cli) struct EvalExtractionArgs {
+    #[arg(long, default_value = crate::eval::extraction::DEFAULT_CORPUS_PATH)]
+    pub(in crate::cli) corpus: String,
+    #[arg(long, default_value = crate::eval::extraction::DEFAULT_BASELINE_PATH)]
+    pub(in crate::cli) baseline: String,
+    #[arg(long)]
+    pub(in crate::cli) json: bool,
+    #[arg(long)]
+    pub(in crate::cli) check_baseline: bool,
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ mod actions;
 mod config_types;
 mod cwd;
 mod dispatch;
+mod eval_types;
 mod query_types;
 #[cfg(test)]
 mod tests;

--- a/src/cli/tests_eval.rs
+++ b/src/cli/tests_eval.rs
@@ -22,3 +22,27 @@ fn cli_parses_eval_json_options() {
         _ => panic!("expected eval command"),
     }
 }
+
+#[test]
+fn cli_parses_eval_extraction_options() {
+    let cli = Cli::parse_from([
+        "remem",
+        "eval-extraction",
+        "--corpus",
+        "fixtures/extraction.json",
+        "--baseline",
+        "fixtures/baseline.json",
+        "--json",
+        "--check-baseline",
+    ]);
+
+    match cli.command {
+        Commands::EvalExtraction(args) => {
+            assert_eq!(args.corpus, "fixtures/extraction.json");
+            assert_eq!(args.baseline, "fixtures/baseline.json");
+            assert!(args.json);
+            assert!(args.check_baseline);
+        }
+        _ => panic!("expected eval-extraction command"),
+    }
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -448,6 +448,8 @@ pub(super) enum Commands {
         #[arg(long)]
         json: bool,
     },
+    #[command(name = "eval-extraction")]
+    EvalExtraction(super::eval_types::EvalExtractionArgs),
     /// Run local retrieval diagnostics.
     EvalLocal,
     /// Backfill entity records for existing memories.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,4 +1,5 @@
 pub mod e2e;
+pub mod extraction;
 pub mod golden;
 pub mod governance;
 pub mod injection;

--- a/src/eval/extraction.rs
+++ b/src/eval/extraction.rs
@@ -1,0 +1,10 @@
+mod run;
+#[cfg(test)]
+mod tests;
+mod types;
+
+pub use run::run_corpus_path;
+pub use types::{
+    ExtractionCaseReport, ExtractionEvalMetadata, ExtractionEvalOptions, ExtractionEvalReport,
+    ExtractionMetricSummary, ExtractionRateMetric, DEFAULT_BASELINE_PATH, DEFAULT_CORPUS_PATH,
+};

--- a/src/eval/extraction/run.rs
+++ b/src/eval/extraction/run.rs
@@ -1,0 +1,585 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{ensure, Context, Result};
+use sha2::{Digest, Sha256};
+
+use super::types::{
+    CandidateExpectation, CandidatePrediction, ExtractionCase, ExtractionCaseReport,
+    ExtractionCorpus, ExtractionEvalMetadata, ExtractionEvalOptions, ExtractionEvalReport,
+    ExtractionMetricSummary, ExtractionRateMetric, ObservationExpectation, ObservationPrediction,
+};
+
+const EVAL_PROJECT: &str = "/tmp/remem/extraction-eval";
+const EVAL_HOST: &str = "codex-cli";
+const EVAL_SESSION_ID: &str = "extraction-eval-session";
+const DEFAULT_OBSERVATION_CONFIDENCE: f64 = 0.75;
+
+pub(crate) fn load_corpus(path: &str) -> Result<ExtractionCorpus> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("read extraction eval corpus {}", Path::new(path).display()))?;
+    let corpus: ExtractionCorpus = serde_json::from_str(&content)
+        .with_context(|| format!("parse extraction eval corpus {}", Path::new(path).display()))?;
+    validate_corpus(&corpus)?;
+    Ok(corpus)
+}
+
+pub fn run_corpus_path(options: ExtractionEvalOptions) -> Result<ExtractionEvalReport> {
+    let corpus = load_corpus(&options.corpus_path)?;
+    evaluate_corpus(options.corpus_path.as_str(), &corpus)
+}
+
+pub(crate) fn evaluate_corpus(
+    corpus_path: &str,
+    corpus: &ExtractionCorpus,
+) -> Result<ExtractionEvalReport> {
+    let cases: Vec<ExtractionCaseReport> = corpus
+        .cases
+        .iter()
+        .map(evaluate_case)
+        .collect::<Result<Vec<_>>>()?;
+    let metrics = summarize_metrics(corpus, &cases);
+    let failing_examples = collect_failures(&cases);
+    let transcript_events = corpus
+        .cases
+        .iter()
+        .map(|case| case.transcript.len())
+        .sum::<usize>();
+    Ok(ExtractionEvalReport {
+        metadata: ExtractionEvalMetadata {
+            corpus: stable_corpus_path(corpus_path),
+            corpus_version: corpus.version.clone(),
+            description: corpus.description.clone(),
+            cases: cases.len(),
+            transcript_events,
+        },
+        metrics: ExtractionMetricSummary {
+            all_checks_passed: failing_examples.is_empty(),
+            ..metrics
+        },
+        cases,
+        failing_examples,
+    })
+}
+
+fn validate_corpus(corpus: &ExtractionCorpus) -> Result<()> {
+    ensure!(
+        !corpus.version.trim().is_empty(),
+        "extraction eval corpus version is required"
+    );
+    ensure!(
+        !corpus.cases.is_empty(),
+        "extraction eval corpus must contain at least one case"
+    );
+    for case in &corpus.cases {
+        ensure!(
+            !case.id.trim().is_empty(),
+            "extraction eval case id is required"
+        );
+        ensure!(
+            !case.transcript.is_empty(),
+            "extraction eval case {} must include transcript events",
+            case.id
+        );
+        ensure!(
+            !case.expected_observations.is_empty() || !case.expected_candidates.is_empty(),
+            "extraction eval case {} must include at least one expected label",
+            case.id
+        );
+        for event in &case.transcript {
+            ensure!(
+                !event.id.trim().is_empty()
+                    && !event.role.trim().is_empty()
+                    && !event.content.trim().is_empty(),
+                "extraction eval case {} has an incomplete transcript event",
+                case.id
+            );
+            if let Some(tool_name) = event.tool_name.as_deref() {
+                ensure!(
+                    !tool_name.trim().is_empty(),
+                    "extraction eval case {} has an empty tool_name",
+                    case.id
+                );
+            }
+        }
+        for expected in &case.expected_observations {
+            validate_observation_ref(&case.id, "expected_observations", expected)?;
+        }
+        for forbidden in &case.forbidden_observations {
+            validate_observation_ref(&case.id, "forbidden_observations", forbidden)?;
+        }
+        for expected in &case.expected_candidates {
+            validate_candidate_ref(&case.id, "expected_candidates", expected)?;
+        }
+        for forbidden in &case.forbidden_candidates {
+            validate_candidate_ref(&case.id, "forbidden_candidates", forbidden)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_observation_ref(
+    case_id: &str,
+    field: &str,
+    reference: &ObservationExpectation,
+) -> Result<()> {
+    ensure!(
+        !reference.id.trim().is_empty(),
+        "extraction eval case {case_id} {field} id is required"
+    );
+    ensure!(
+        reference.observation_type.is_some() || !reference.text_contains.is_empty(),
+        "extraction eval case {case_id} {field} {} needs a matcher",
+        reference.id
+    );
+    Ok(())
+}
+
+fn validate_candidate_ref(
+    case_id: &str,
+    field: &str,
+    reference: &CandidateExpectation,
+) -> Result<()> {
+    ensure!(
+        !reference.id.trim().is_empty(),
+        "extraction eval case {case_id} {field} id is required"
+    );
+    ensure!(
+        reference.scope.is_some()
+            || reference.memory_type.is_some()
+            || reference.topic_key.is_some()
+            || reference.risk_class.is_some()
+            || !reference.text_contains.is_empty(),
+        "extraction eval case {case_id} {field} {} needs a matcher",
+        reference.id
+    );
+    Ok(())
+}
+
+fn evaluate_case(case: &ExtractionCase) -> Result<ExtractionCaseReport> {
+    let predicted_observations = parse_observation_predictions(&case.observation_output);
+    let predicted_candidates = parse_candidate_predictions(&case.candidate_output)?;
+    let observation_request_sha256 = sha256_hex(&build_observation_request(case));
+    let candidate_request_sha256 =
+        sha256_hex(&build_candidate_request(case, &predicted_observations));
+
+    let observation_match =
+        match_observations(&predicted_observations, &case.expected_observations);
+    let candidate_match = match_candidates(&predicted_candidates, &case.expected_candidates);
+    let forbidden_observations =
+        forbidden_observation_hits(&predicted_observations, &case.forbidden_observations);
+    let forbidden_candidates =
+        forbidden_candidate_hits(&predicted_candidates, &case.forbidden_candidates);
+    let over_saved_predictions =
+        observation_match.unexpected.len() + candidate_match.unexpected.len();
+    let pass = observation_match.missing.is_empty()
+        && observation_match.unexpected.is_empty()
+        && forbidden_observations.is_empty()
+        && candidate_match.missing.is_empty()
+        && candidate_match.unexpected.is_empty()
+        && forbidden_candidates.is_empty();
+
+    Ok(ExtractionCaseReport {
+        id: case.id.clone(),
+        transcript_events: case.transcript.len(),
+        observation_request_sha256,
+        candidate_request_sha256,
+        predicted_observations,
+        predicted_candidates,
+        missing_expected_observations: observation_match.missing,
+        unexpected_observations: observation_match.unexpected,
+        forbidden_observations,
+        missing_expected_candidates: candidate_match.missing,
+        unexpected_candidates: candidate_match.unexpected,
+        forbidden_candidates,
+        over_saved_predictions,
+        pass,
+    })
+}
+
+fn parse_observation_predictions(output: &str) -> Vec<ObservationPrediction> {
+    crate::memory::format::parse_observations(output)
+        .into_iter()
+        .enumerate()
+        .map(|(index, observation)| ObservationPrediction {
+            index,
+            observation_type: observation.obs_type.clone(),
+            text: crate::observation_extract::observation_text(&observation),
+            confidence: observation.confidence,
+        })
+        .collect()
+}
+
+fn parse_candidate_predictions(output: &str) -> Result<Vec<CandidatePrediction>> {
+    Ok(crate::memory_candidate::parse_candidate_output(output)?
+        .into_iter()
+        .enumerate()
+        .map(|(index, candidate)| CandidatePrediction {
+            index,
+            scope: candidate.scope,
+            memory_type: candidate.memory_type,
+            topic_key: candidate.topic_key,
+            risk_class: candidate.risk_class,
+            text: candidate.text,
+        })
+        .collect())
+}
+
+struct MatchOutcome {
+    missing: Vec<String>,
+    unexpected: Vec<usize>,
+}
+
+fn match_observations(
+    predictions: &[ObservationPrediction],
+    expected: &[ObservationExpectation],
+) -> MatchOutcome {
+    let mut used_predictions = vec![false; predictions.len()];
+    let mut missing = Vec::new();
+    for reference in expected {
+        if let Some(index) = predictions
+            .iter()
+            .enumerate()
+            .position(|(index, prediction)| {
+                !used_predictions[index] && observation_matches(prediction, reference)
+            })
+        {
+            used_predictions[index] = true;
+        } else {
+            missing.push(reference.id.clone());
+        }
+    }
+    let unexpected = used_predictions
+        .iter()
+        .enumerate()
+        .filter_map(|(index, used)| (!*used).then_some(index))
+        .collect::<Vec<_>>();
+    MatchOutcome {
+        missing,
+        unexpected,
+    }
+}
+
+fn match_candidates(
+    predictions: &[CandidatePrediction],
+    expected: &[CandidateExpectation],
+) -> MatchOutcome {
+    let mut used_predictions = vec![false; predictions.len()];
+    let mut missing = Vec::new();
+    for reference in expected {
+        if let Some(index) = predictions
+            .iter()
+            .enumerate()
+            .position(|(index, prediction)| {
+                !used_predictions[index] && candidate_matches(prediction, reference)
+            })
+        {
+            used_predictions[index] = true;
+        } else {
+            missing.push(reference.id.clone());
+        }
+    }
+    let unexpected = used_predictions
+        .iter()
+        .enumerate()
+        .filter_map(|(index, used)| (!*used).then_some(index))
+        .collect::<Vec<_>>();
+    MatchOutcome {
+        missing,
+        unexpected,
+    }
+}
+
+fn forbidden_observation_hits(
+    predictions: &[ObservationPrediction],
+    forbidden: &[ObservationExpectation],
+) -> Vec<String> {
+    forbidden
+        .iter()
+        .filter(|reference| {
+            predictions
+                .iter()
+                .any(|prediction| observation_matches(prediction, reference))
+        })
+        .map(|reference| reference.id.clone())
+        .collect()
+}
+
+fn forbidden_candidate_hits(
+    predictions: &[CandidatePrediction],
+    forbidden: &[CandidateExpectation],
+) -> Vec<String> {
+    forbidden
+        .iter()
+        .filter(|reference| {
+            predictions
+                .iter()
+                .any(|prediction| candidate_matches(prediction, reference))
+        })
+        .map(|reference| reference.id.clone())
+        .collect()
+}
+
+fn observation_matches(
+    prediction: &ObservationPrediction,
+    reference: &ObservationExpectation,
+) -> bool {
+    if let Some(expected_type) = reference.observation_type.as_deref() {
+        if !prediction
+            .observation_type
+            .eq_ignore_ascii_case(expected_type.trim())
+        {
+            return false;
+        }
+    }
+    contains_all(&prediction.text, &reference.text_contains)
+}
+
+fn candidate_matches(prediction: &CandidatePrediction, reference: &CandidateExpectation) -> bool {
+    field_matches(reference.scope.as_deref(), &prediction.scope)
+        && field_matches(reference.memory_type.as_deref(), &prediction.memory_type)
+        && field_matches(reference.topic_key.as_deref(), &prediction.topic_key)
+        && field_matches(reference.risk_class.as_deref(), &prediction.risk_class)
+        && contains_all(&prediction.text, &reference.text_contains)
+}
+
+fn field_matches(expected: Option<&str>, actual: &str) -> bool {
+    expected
+        .map(|value| actual.eq_ignore_ascii_case(value.trim()))
+        .unwrap_or(true)
+}
+
+fn contains_all(text: &str, needles: &[String]) -> bool {
+    let haystack = text.to_ascii_lowercase();
+    needles
+        .iter()
+        .all(|needle| haystack.contains(&needle.to_ascii_lowercase()))
+}
+
+fn summarize_metrics(
+    corpus: &ExtractionCorpus,
+    cases: &[ExtractionCaseReport],
+) -> ExtractionMetricSummary {
+    let observation_predictions = cases
+        .iter()
+        .map(|case| case.predicted_observations.len())
+        .sum::<usize>();
+    let candidate_predictions = cases
+        .iter()
+        .map(|case| case.predicted_candidates.len())
+        .sum::<usize>();
+    let over_saved_predictions = cases
+        .iter()
+        .map(|case| case.over_saved_predictions)
+        .sum::<usize>();
+    let total_predictions = observation_predictions + candidate_predictions;
+    let observation_expected = corpus
+        .cases
+        .iter()
+        .map(|case| case.expected_observations.len())
+        .sum::<usize>();
+    let candidate_expected = corpus
+        .cases
+        .iter()
+        .map(|case| case.expected_candidates.len())
+        .sum::<usize>();
+    let observation_matched = observation_predictions
+        - cases
+            .iter()
+            .map(|case| case.unexpected_observations.len())
+            .sum::<usize>();
+    let candidate_matched = candidate_predictions
+        - cases
+            .iter()
+            .map(|case| case.unexpected_candidates.len())
+            .sum::<usize>();
+    let forbidden_observation_hits = cases
+        .iter()
+        .map(|case| case.forbidden_observations.len())
+        .sum::<usize>();
+    let forbidden_candidate_hits = cases
+        .iter()
+        .map(|case| case.forbidden_candidates.len())
+        .sum::<usize>();
+    let forbidden_observation_total = corpus
+        .cases
+        .iter()
+        .map(|case| case.forbidden_observations.len())
+        .sum::<usize>();
+    let forbidden_candidate_total = corpus
+        .cases
+        .iter()
+        .map(|case| case.forbidden_candidates.len())
+        .sum::<usize>();
+
+    ExtractionMetricSummary {
+        observation_precision: ExtractionRateMetric::new(
+            observation_matched,
+            observation_predictions,
+        ),
+        observation_recall: ExtractionRateMetric::new(
+            observation_expected - missing_observations(cases),
+            observation_expected,
+        ),
+        candidate_precision: ExtractionRateMetric::new(candidate_matched, candidate_predictions),
+        candidate_recall: ExtractionRateMetric::new(
+            candidate_expected - missing_candidates(cases),
+            candidate_expected,
+        ),
+        forbidden_observation_exclusion: ExtractionRateMetric::new(
+            forbidden_observation_total - forbidden_observation_hits,
+            forbidden_observation_total,
+        ),
+        forbidden_candidate_exclusion: ExtractionRateMetric::new(
+            forbidden_candidate_total - forbidden_candidate_hits,
+            forbidden_candidate_total,
+        ),
+        over_saved_predictions,
+        total_predictions,
+        over_save_penalty: if total_predictions == 0 {
+            0.0
+        } else {
+            over_saved_predictions as f64 / total_predictions as f64
+        },
+        all_checks_passed: false,
+    }
+}
+
+fn missing_observations(cases: &[ExtractionCaseReport]) -> usize {
+    cases
+        .iter()
+        .map(|case| case.missing_expected_observations.len())
+        .sum()
+}
+
+fn missing_candidates(cases: &[ExtractionCaseReport]) -> usize {
+    cases
+        .iter()
+        .map(|case| case.missing_expected_candidates.len())
+        .sum()
+}
+
+fn collect_failures(cases: &[ExtractionCaseReport]) -> Vec<String> {
+    let mut failures = Vec::new();
+    for case in cases {
+        for missing in &case.missing_expected_observations {
+            failures.push(format!(
+                "{} missing expected observation {}",
+                case.id, missing
+            ));
+        }
+        for unexpected in &case.unexpected_observations {
+            failures.push(format!(
+                "{} unexpected observation prediction {}",
+                case.id, unexpected
+            ));
+        }
+        for forbidden in &case.forbidden_observations {
+            failures.push(format!(
+                "{} saved forbidden observation {}",
+                case.id, forbidden
+            ));
+        }
+        for missing in &case.missing_expected_candidates {
+            failures.push(format!(
+                "{} missing expected candidate {}",
+                case.id, missing
+            ));
+        }
+        for unexpected in &case.unexpected_candidates {
+            failures.push(format!(
+                "{} unexpected candidate prediction {}",
+                case.id, unexpected
+            ));
+        }
+        for forbidden in &case.forbidden_candidates {
+            failures.push(format!(
+                "{} saved forbidden candidate {}",
+                case.id, forbidden
+            ));
+        }
+    }
+    failures
+}
+
+fn build_observation_request(case: &ExtractionCase) -> String {
+    let events = case
+        .transcript
+        .iter()
+        .enumerate()
+        .map(
+            |(index, event)| crate::observation_extract::ObservationPromptEvent {
+                id: (index + 1) as i64,
+                event_type: event.event_type.as_deref().unwrap_or_else(|| {
+                    if event.tool_name.is_some() {
+                        "tool_result"
+                    } else {
+                        "message"
+                    }
+                }),
+                role: Some(event.role.as_str()),
+                tool_name: event.tool_name.as_deref(),
+                content: event.content.as_str(),
+                token_estimate: event
+                    .token_estimate
+                    .unwrap_or_else(|| estimate_tokens(&event.content)),
+                created_at_epoch: event.created_at_epoch.unwrap_or((index + 1) as i64),
+            },
+        )
+        .collect::<Vec<_>>();
+    crate::observation_extract::build_eval_extract_request(
+        EVAL_PROJECT,
+        EVAL_HOST,
+        Some(EVAL_SESSION_ID),
+        &events,
+    )
+}
+
+fn build_candidate_request(
+    case: &ExtractionCase,
+    observations: &[ObservationPrediction],
+) -> String {
+    let event_ids = (1..=case.transcript.len() as i64).collect::<Vec<_>>();
+    let prompt_observations = observations
+        .iter()
+        .map(
+            |observation| crate::memory_candidate::CandidatePromptObservation {
+                id: (observation.index + 1) as i64,
+                observation_type: observation.observation_type.as_str(),
+                text: observation.text.as_str(),
+                evidence_event_ids: event_ids.clone(),
+                confidence: observation
+                    .confidence
+                    .unwrap_or(DEFAULT_OBSERVATION_CONFIDENCE),
+            },
+        )
+        .collect::<Vec<_>>();
+    crate::memory_candidate::build_eval_candidate_request(
+        EVAL_PROJECT,
+        EVAL_HOST,
+        Some(EVAL_SESSION_ID),
+        &prompt_observations,
+    )
+}
+
+fn estimate_tokens(content: &str) -> i64 {
+    ((content.len() as i64) + 3) / 4
+}
+
+fn stable_corpus_path(path: &str) -> String {
+    let mut normalized = path.replace('\\', "/");
+    while let Some(stripped) = normalized.strip_prefix("./") {
+        normalized = stripped.to_string();
+    }
+    normalized
+}
+
+fn sha256_hex(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}

--- a/src/eval/extraction/tests.rs
+++ b/src/eval/extraction/tests.rs
@@ -1,0 +1,88 @@
+use super::run::{evaluate_corpus, run_corpus_path};
+use super::types::{
+    CandidateExpectation, ExtractionCase, ExtractionCorpus, ExtractionEvalOptions,
+    ExtractionRateMetric, ObservationExpectation, TranscriptEvent,
+};
+
+#[test]
+fn committed_corpus_scores_current_baseline() {
+    let report = run_corpus_path(ExtractionEvalOptions::default()).unwrap();
+
+    assert!(report.metrics.all_checks_passed);
+    assert_eq!(report.metadata.cases, 2);
+    assert_eq!(
+        report.metrics.observation_precision,
+        ExtractionRateMetric::new(2, 2)
+    );
+    assert_eq!(
+        report.metrics.observation_recall,
+        ExtractionRateMetric::new(2, 2)
+    );
+    assert_eq!(
+        report.metrics.candidate_precision,
+        ExtractionRateMetric::new(2, 2)
+    );
+    assert_eq!(
+        report.metrics.candidate_recall,
+        ExtractionRateMetric::new(2, 2)
+    );
+    assert_eq!(report.metrics.over_saved_predictions, 0);
+    assert!(report
+        .cases
+        .iter()
+        .all(|case| case.observation_request_sha256.len() == 64
+            && case.candidate_request_sha256.len() == 64));
+    assert!(report.failing_examples.is_empty());
+}
+
+#[test]
+fn detects_over_saved_observations_and_candidates() {
+    let corpus = ExtractionCorpus {
+        version: "test".to_string(),
+        description: "inline over-save fixture".to_string(),
+        cases: vec![ExtractionCase {
+            id: "over-save".to_string(),
+            transcript: vec![TranscriptEvent {
+                id: "evt-1".to_string(),
+                role: "user".to_string(),
+                content: "Remember the verified build loop rule only.".to_string(),
+                tool_name: None,
+                event_type: None,
+                token_estimate: None,
+                created_at_epoch: None,
+            }],
+            observation_output: "<observation>\n<type>decision</type>\n<narrative>Keep the verified build loop rule.</narrative>\n<confidence>0.9</confidence>\n</observation>\n<observation>\n<type>discovery</type>\n<narrative>Invent an unsupported preference.</narrative>\n<confidence>0.7</confidence>\n</observation>".to_string(),
+            candidate_output: "<memory_candidate>\n<scope>project</scope>\n<type>lesson</type>\n<topic_key>verified-build-loop-rule</topic_key>\n<risk_class>medium</risk_class>\n<confidence>0.85</confidence>\n<text>Keep the verified build loop rule.</text>\n</memory_candidate>\n<memory_candidate>\n<scope>project</scope>\n<type>preference</type>\n<topic_key>unsupported-preference</topic_key>\n<risk_class>high</risk_class>\n<confidence>0.8</confidence>\n<text>Invent an unsupported preference.</text>\n</memory_candidate>".to_string(),
+            expected_observations: vec![ObservationExpectation {
+                id: "obs-rule".to_string(),
+                observation_type: Some("decision".to_string()),
+                text_contains: vec!["verified build loop rule".to_string()],
+            }],
+            forbidden_observations: vec![],
+            expected_candidates: vec![CandidateExpectation {
+                id: "cand-rule".to_string(),
+                scope: Some("project".to_string()),
+                memory_type: Some("lesson".to_string()),
+                topic_key: Some("verified-build-loop-rule".to_string()),
+                risk_class: Some("medium".to_string()),
+                text_contains: vec!["verified build loop rule".to_string()],
+            }],
+            forbidden_candidates: vec![],
+        }],
+    };
+
+    let report = evaluate_corpus("inline", &corpus).unwrap();
+
+    assert!(!report.metrics.all_checks_passed);
+    assert_eq!(
+        report.metrics.observation_precision,
+        ExtractionRateMetric::new(1, 2)
+    );
+    assert_eq!(
+        report.metrics.candidate_precision,
+        ExtractionRateMetric::new(1, 2)
+    );
+    assert_eq!(report.metrics.over_saved_predictions, 2);
+    assert_eq!(report.metrics.total_predictions, 4);
+    assert_eq!(report.metrics.over_save_penalty, 0.5);
+}

--- a/src/eval/extraction/types.rs
+++ b/src/eval/extraction/types.rs
@@ -1,0 +1,195 @@
+use std::fmt::{self, Display};
+
+use serde::{Deserialize, Serialize};
+
+pub type ExtractionRateMetric = crate::eval::governance::RateMetric;
+
+pub const DEFAULT_CORPUS_PATH: &str = "eval/extraction/corpus.json";
+pub const DEFAULT_BASELINE_PATH: &str = "eval/extraction/baseline.json";
+
+#[derive(Debug, Clone)]
+pub struct ExtractionEvalOptions {
+    pub corpus_path: String,
+}
+
+impl Default for ExtractionEvalOptions {
+    fn default() -> Self {
+        Self {
+            corpus_path: DEFAULT_CORPUS_PATH.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ExtractionCorpus {
+    pub version: String,
+    #[serde(default)]
+    pub description: String,
+    pub cases: Vec<ExtractionCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ExtractionCase {
+    pub id: String,
+    #[serde(default)]
+    pub transcript: Vec<TranscriptEvent>,
+    pub observation_output: String,
+    pub candidate_output: String,
+    #[serde(default)]
+    pub expected_observations: Vec<ObservationExpectation>,
+    #[serde(default)]
+    pub forbidden_observations: Vec<ObservationExpectation>,
+    #[serde(default)]
+    pub expected_candidates: Vec<CandidateExpectation>,
+    #[serde(default)]
+    pub forbidden_candidates: Vec<CandidateExpectation>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TranscriptEvent {
+    pub id: String,
+    pub role: String,
+    pub content: String,
+    #[serde(default)]
+    pub tool_name: Option<String>,
+    #[serde(default)]
+    pub event_type: Option<String>,
+    #[serde(default)]
+    pub token_estimate: Option<i64>,
+    #[serde(default)]
+    pub created_at_epoch: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ObservationExpectation {
+    pub id: String,
+    #[serde(default)]
+    pub observation_type: Option<String>,
+    #[serde(default)]
+    pub text_contains: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct CandidateExpectation {
+    pub id: String,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub memory_type: Option<String>,
+    #[serde(default)]
+    pub topic_key: Option<String>,
+    #[serde(default)]
+    pub risk_class: Option<String>,
+    #[serde(default)]
+    pub text_contains: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ExtractionEvalReport {
+    pub metadata: ExtractionEvalMetadata,
+    pub metrics: ExtractionMetricSummary,
+    pub cases: Vec<ExtractionCaseReport>,
+    pub failing_examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ExtractionEvalMetadata {
+    pub corpus: String,
+    pub corpus_version: String,
+    pub description: String,
+    pub cases: usize,
+    pub transcript_events: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ExtractionMetricSummary {
+    pub observation_precision: ExtractionRateMetric,
+    pub observation_recall: ExtractionRateMetric,
+    pub candidate_precision: ExtractionRateMetric,
+    pub candidate_recall: ExtractionRateMetric,
+    pub forbidden_observation_exclusion: ExtractionRateMetric,
+    pub forbidden_candidate_exclusion: ExtractionRateMetric,
+    pub over_saved_predictions: usize,
+    pub total_predictions: usize,
+    pub over_save_penalty: f64,
+    pub all_checks_passed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ExtractionCaseReport {
+    pub id: String,
+    pub transcript_events: usize,
+    pub observation_request_sha256: String,
+    pub candidate_request_sha256: String,
+    pub predicted_observations: Vec<ObservationPrediction>,
+    pub predicted_candidates: Vec<CandidatePrediction>,
+    pub missing_expected_observations: Vec<String>,
+    pub unexpected_observations: Vec<usize>,
+    pub forbidden_observations: Vec<String>,
+    pub missing_expected_candidates: Vec<String>,
+    pub unexpected_candidates: Vec<usize>,
+    pub forbidden_candidates: Vec<String>,
+    pub over_saved_predictions: usize,
+    pub pass: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ObservationPrediction {
+    pub index: usize,
+    pub observation_type: String,
+    pub text: String,
+    pub confidence: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CandidatePrediction {
+    pub index: usize,
+    pub scope: String,
+    pub memory_type: String,
+    pub topic_key: String,
+    pub risk_class: String,
+    pub text: String,
+}
+
+impl Display for ExtractionEvalReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "Extraction eval: {} cases from {}",
+            self.metadata.cases, self.metadata.corpus
+        )?;
+        writeln!(
+            f,
+            "Observations: precision {} recall {} forbidden exclusion {}",
+            format_rate(&self.metrics.observation_precision),
+            format_rate(&self.metrics.observation_recall),
+            format_rate(&self.metrics.forbidden_observation_exclusion)
+        )?;
+        writeln!(
+            f,
+            "Candidates: precision {} recall {} forbidden exclusion {}",
+            format_rate(&self.metrics.candidate_precision),
+            format_rate(&self.metrics.candidate_recall),
+            format_rate(&self.metrics.forbidden_candidate_exclusion)
+        )?;
+        writeln!(
+            f,
+            "Over-save penalty: {:.4} ({}/{})",
+            self.metrics.over_save_penalty,
+            self.metrics.over_saved_predictions,
+            self.metrics.total_predictions
+        )?;
+        writeln!(f, "All checks passed: {}", self.metrics.all_checks_passed)?;
+        if !self.failing_examples.is_empty() {
+            writeln!(f, "Failures:")?;
+            for failure in &self.failing_examples {
+                writeln!(f, "- {failure}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn format_rate(metric: &ExtractionRateMetric) -> String {
+    format!("{}/{} ({:.4})", metric.passed, metric.total, metric.rate)
+}

--- a/src/memory_candidate.rs
+++ b/src/memory_candidate.rs
@@ -79,6 +79,14 @@ struct ObservationBatch {
     observations: Vec<SourceObservation>,
 }
 
+pub(crate) struct CandidatePromptObservation<'a> {
+    pub(crate) id: i64,
+    pub(crate) observation_type: &'a str,
+    pub(crate) text: &'a str,
+    pub(crate) evidence_event_ids: Vec<i64>,
+    pub(crate) confidence: f64,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ParsedMemoryCandidate {
     pub(crate) scope: String,
@@ -87,6 +95,52 @@ pub(crate) struct ParsedMemoryCandidate {
     pub(crate) text: String,
     pub(crate) confidence: f64,
     pub(crate) risk_class: String,
+}
+
+pub(crate) fn parse_candidate_output(text: &str) -> Result<Vec<ParsedMemoryCandidate>> {
+    parse_memory_candidates(text)
+}
+
+pub(crate) fn build_eval_candidate_request(
+    project: &str,
+    host: &str,
+    session_id: Option<&str>,
+    observations: &[CandidatePromptObservation<'_>],
+) -> String {
+    let mut evidence_set = BTreeSet::new();
+    for observation in observations {
+        for event_id in &observation.evidence_event_ids {
+            evidence_set.insert(*event_id);
+        }
+    }
+    let from_event_id = evidence_set.iter().copied().min().unwrap_or(0);
+    let to_event_id = evidence_set.iter().copied().max().unwrap_or(0);
+    let batch = ObservationBatch {
+        from_event_id,
+        to_event_id,
+        evidence_event_ids: evidence_set.into_iter().collect(),
+        observations: observations
+            .iter()
+            .map(|observation| SourceObservation {
+                id: observation.id,
+                observation_type: observation.observation_type.to_string(),
+                text: observation.text.to_string(),
+                evidence_event_ids: observation.evidence_event_ids.clone(),
+                confidence: observation.confidence,
+            })
+            .collect(),
+    };
+    let task = eval_task(
+        project,
+        host,
+        session_id,
+        db::ExtractionTaskKind::MemoryCandidate,
+    );
+    format!(
+        "{}\n\n<user_prompt>\n{}\n</user_prompt>",
+        MEMORY_CANDIDATE_SYSTEM,
+        build_candidate_prompt(&task, &batch)
+    )
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -642,6 +696,31 @@ fn build_candidate_prompt(task: &db::ExtractionTask, batch: &ObservationBatch) -
         prompt.push_str("\n</observation>\n\n");
     }
     prompt
+}
+
+fn eval_task(
+    project: &str,
+    host: &str,
+    session_id: Option<&str>,
+    task_kind: db::ExtractionTaskKind,
+) -> db::ExtractionTask {
+    db::ExtractionTask {
+        id: 0,
+        task_kind,
+        host_id: 0,
+        workspace_id: 0,
+        project_id: 0,
+        session_row_id: None,
+        host: host.to_string(),
+        project: project.to_string(),
+        session_id: session_id.map(str::to_string),
+        ai_profile: None,
+        priority: 0,
+        cursor_event_id: None,
+        high_watermark_event_id: None,
+        attempts: 0,
+        replay_range_id: None,
+    }
 }
 
 #[cfg(test)]

--- a/src/observation_extract.rs
+++ b/src/observation_extract.rs
@@ -41,6 +41,55 @@ struct EvidenceRange {
     events: Vec<EvidenceEvent>,
 }
 
+pub(crate) struct ObservationPromptEvent<'a> {
+    pub(crate) id: i64,
+    pub(crate) event_type: &'a str,
+    pub(crate) role: Option<&'a str>,
+    pub(crate) tool_name: Option<&'a str>,
+    pub(crate) content: &'a str,
+    pub(crate) token_estimate: i64,
+    pub(crate) created_at_epoch: i64,
+}
+
+pub(crate) fn build_eval_extract_request(
+    project: &str,
+    host: &str,
+    session_id: Option<&str>,
+    events: &[ObservationPromptEvent<'_>],
+) -> String {
+    let event_ids = events.iter().map(|event| event.id).collect::<Vec<_>>();
+    let from_event_id = event_ids.iter().copied().min().unwrap_or(0);
+    let to_event_id = event_ids.iter().copied().max().unwrap_or(0);
+    let range = EvidenceRange {
+        from_event_id,
+        to_event_id,
+        event_ids,
+        events: events
+            .iter()
+            .map(|event| EvidenceEvent {
+                id: event.id,
+                event_type: event.event_type.to_string(),
+                role: event.role.map(str::to_string),
+                tool_name: event.tool_name.map(str::to_string),
+                content: event.content.to_string(),
+                token_estimate: event.token_estimate,
+                created_at_epoch: event.created_at_epoch,
+            })
+            .collect(),
+    };
+    let task = eval_task(
+        project,
+        host,
+        session_id,
+        db::ExtractionTaskKind::ObservationExtract,
+    );
+    format!(
+        "{}\n\n<user_prompt>\n{}\n</user_prompt>",
+        OBSERVATION_EXTRACT_SYSTEM,
+        build_extract_prompt(&task, &range)
+    )
+}
+
 pub(crate) async fn process(task: &db::ExtractionTask) -> Result<ObservationExtractResult> {
     let mut conn = db::open_db()?;
     let project = task.project.clone();
@@ -301,7 +350,7 @@ fn observation_exists(
     Ok(existing.is_some())
 }
 
-fn observation_text(observation: &ParsedObservation) -> String {
+pub(crate) fn observation_text(observation: &ParsedObservation) -> String {
     observation
         .narrative
         .clone()
@@ -339,6 +388,31 @@ fn build_extract_prompt(task: &db::ExtractionTask, range: &EvidenceRange) -> Str
         prompt.push_str("\n</event>\n\n");
     }
     prompt
+}
+
+fn eval_task(
+    project: &str,
+    host: &str,
+    session_id: Option<&str>,
+    task_kind: db::ExtractionTaskKind,
+) -> db::ExtractionTask {
+    db::ExtractionTask {
+        id: 0,
+        task_kind,
+        host_id: 0,
+        workspace_id: 0,
+        project_id: 0,
+        session_row_id: None,
+        host: host.to_string(),
+        project: project.to_string(),
+        session_id: session_id.map(str::to_string),
+        ai_profile: None,
+        priority: 0,
+        cursor_event_id: None,
+        high_watermark_event_id: None,
+        attempts: 0,
+        replay_range_id: None,
+    }
 }
 
 fn xml_attr(value: &str) -> String {


### PR DESCRIPTION
Closes #372.

## Summary
- add `remem eval-extraction` for deterministic extraction-quality scoring
- add labeled transcript corpus plus committed baseline JSON with precision, recall, forbidden-label exclusion, and over-save penalty
- run the baseline check in CI and document the eval workflow

## Validation
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `cargo test eval::extraction -- --nocapture`
- `cargo run --quiet -- eval-extraction --json --check-baseline > /tmp/remem-extraction-eval.json`
- `cargo clippy -- -D warnings`
- `cargo test`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js`