### PR TITLE
Add context injection item audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.52"
+version = "0.5.53"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.52"
+version = "0.5.53"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/eval/gates/baseline.json
+++ b/eval/gates/baseline.json
@@ -42,6 +42,7 @@
     "golden.slice.temporal.precision_at_k": 0.25,
     "golden.slice.temporal.recall_at_k": 1.0,
     "golden.total_queries": 50.0,
+    "injection.abstention_false_positive_bound": 1.0,
     "injection.all_checks": 1.0,
     "injection.expected_memory_recall": 1.0,
     "injection.forbidden_memory_exclusion": 1.0

--- a/eval/gates/thresholds.json
+++ b/eval/gates/thresholds.json
@@ -2,6 +2,9 @@
   "version": "2026-06-12",
   "default_max_drop": 0.0,
   "metrics": {
+    "injection.abstention_false_positive_bound": {
+      "max_drop": 0.0
+    },
     "golden.slice.abstention.abstention_pass_rate": {
       "max_drop": 0.0
     },

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.52",
+  "version": "0.5.53",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.52",
+  "version": "0.5.53",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.52": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.52",
+    "0.5.53": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.53",
       "assets": {}
     }
   }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,5 @@
+mod abstention;
+mod audit;
 pub mod claude_memory;
 mod commit_signals;
 mod debug;

--- a/src/context/abstention.rs
+++ b/src/context/abstention.rs
@@ -1,0 +1,94 @@
+use anyhow::Result;
+use rusqlite::Connection;
+
+use super::query::ContextMemoryRow;
+
+const MAX_ABSTENTION_RESCUE_VECTOR_DISTANCE: f32 = 0.72;
+
+pub(super) fn filter_recent_rows_by_task_embedding(
+    conn: &Connection,
+    task_query: &str,
+    recent: Vec<ContextMemoryRow>,
+    limit: usize,
+) -> Result<Vec<ContextMemoryRow>> {
+    let candidate_ids = recent.iter().map(|row| row.memory.id).collect::<Vec<_>>();
+    let matched_ids = rank_stored_embedding_matches(conn, task_query, &candidate_ids, limit)?;
+    let ranks = matched_ids
+        .into_iter()
+        .enumerate()
+        .map(|(rank, id)| (id, rank))
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut matched_rows = recent
+        .into_iter()
+        .filter(|row| ranks.contains_key(&row.memory.id))
+        .collect::<Vec<_>>();
+    matched_rows.sort_by_key(|row| ranks.get(&row.memory.id).copied().unwrap_or(usize::MAX));
+    Ok(matched_rows)
+}
+
+pub(super) fn rank_stored_embedding_matches(
+    conn: &Connection,
+    query: &str,
+    candidate_ids: &[i64],
+    limit: usize,
+) -> Result<Vec<i64>> {
+    if limit == 0 || query.trim().is_empty() || candidate_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let query_embedding = crate::retrieval::embedding::embed_query(query)?;
+    let profile = query_embedding.profile();
+    let mut ids = candidate_ids.to_vec();
+    ids.sort_unstable();
+    ids.dedup();
+    let placeholders = (0..ids.len())
+        .map(|idx| format!("?{}", idx + 3))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+        Box::new(profile.model.to_string()),
+        Box::new(profile.dimensions as i64),
+    ];
+    params.extend(
+        ids.iter()
+            .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>),
+    );
+    let sql = format!(
+        "SELECT memory_id, embedding, dimensions
+         FROM memory_embeddings
+         WHERE model = ?1
+           AND dimensions = ?2
+           AND memory_id IN ({placeholders})"
+    );
+    let refs = crate::db::to_sql_refs(&params);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, Vec<u8>>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+
+    let mut matches = Vec::new();
+    for row in crate::db::query::collect_rows(rows)? {
+        let (memory_id, blob, dimensions) = row;
+        let embedding = crate::retrieval::vector::decode_embedding(&blob, dimensions)?;
+        let distance =
+            crate::retrieval::vector::cosine_distance(query_embedding.values(), &embedding)?;
+        if distance <= MAX_ABSTENTION_RESCUE_VECTOR_DISTANCE {
+            matches.push((memory_id, distance));
+        }
+    }
+    matches.sort_by(|left, right| {
+        left.1
+            .partial_cmp(&right.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    Ok(matches
+        .into_iter()
+        .take(limit)
+        .map(|(memory_id, _)| memory_id)
+        .collect())
+}

--- a/src/context/audit.rs
+++ b/src/context/audit.rs
@@ -1,0 +1,328 @@
+use anyhow::Result;
+use rusqlite::params;
+use std::collections::HashSet;
+
+use crate::memory::Memory;
+
+use super::injection_gate::{ContextGateAction, ContextGateDecision};
+use super::invocation::ContextInvocation;
+use super::types::LoadedContext;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(in crate::context) struct ContextAuditItem {
+    pub item_kind: &'static str,
+    pub item_id: Option<i64>,
+    pub memory_id: Option<i64>,
+    pub channel: &'static str,
+    pub score: Option<f64>,
+    pub render_order: Option<i64>,
+    pub status: &'static str,
+    pub drop_reason: Option<&'static str>,
+    pub title: String,
+    pub provenance: String,
+    pub staleness: String,
+}
+
+impl ContextAuditItem {
+    pub fn injected_memory(memory: &Memory, channel: &'static str, render_order: i64) -> Self {
+        Self::memory_item(memory, channel, Some(render_order), "injected", None)
+    }
+
+    pub fn dropped_memory(memory: &Memory, channel: &'static str, reason: &'static str) -> Self {
+        Self::memory_item(memory, channel, None, "dropped", Some(reason))
+    }
+
+    pub fn abstained_memory(reason: &'static str) -> Self {
+        Self {
+            item_kind: "memory",
+            item_id: None,
+            memory_id: None,
+            channel: "memory",
+            score: None,
+            render_order: None,
+            status: "abstained",
+            drop_reason: Some(reason),
+            title: "memory context abstained".to_string(),
+            provenance: "src=memory".to_string(),
+            staleness: "staleness=none".to_string(),
+        }
+    }
+
+    pub fn injected_workstream(
+        id: i64,
+        title: &str,
+        render_order: i64,
+        updated_at_epoch: i64,
+    ) -> Self {
+        Self {
+            item_kind: "workstream",
+            item_id: Some(id),
+            memory_id: None,
+            channel: "workstreams",
+            score: None,
+            render_order: Some(render_order),
+            status: "injected",
+            drop_reason: None,
+            title: title.to_string(),
+            provenance: format!("src=workstream:#{id}"),
+            staleness: age_staleness_label(updated_at_epoch, chrono::Utc::now().timestamp()),
+        }
+    }
+
+    pub fn dropped_workstream(
+        id: i64,
+        title: &str,
+        updated_at_epoch: i64,
+        reason: &'static str,
+    ) -> Self {
+        Self {
+            item_kind: "workstream",
+            item_id: Some(id),
+            memory_id: None,
+            channel: "workstreams",
+            score: None,
+            render_order: None,
+            status: "dropped",
+            drop_reason: Some(reason),
+            title: title.to_string(),
+            provenance: format!("src=workstream:#{id}"),
+            staleness: age_staleness_label(updated_at_epoch, chrono::Utc::now().timestamp()),
+        }
+    }
+
+    fn memory_item(
+        memory: &Memory,
+        channel: &'static str,
+        render_order: Option<i64>,
+        status: &'static str,
+        drop_reason: Option<&'static str>,
+    ) -> Self {
+        Self {
+            item_kind: "memory",
+            item_id: Some(memory.id),
+            memory_id: Some(memory.id),
+            channel,
+            score: None,
+            render_order,
+            status,
+            drop_reason,
+            title: memory.title.clone(),
+            provenance: memory_provenance(memory),
+            staleness: memory_staleness(memory, chrono::Utc::now().timestamp()),
+        }
+    }
+}
+
+pub(in crate::context) fn memory_render_metadata(memory: &Memory, now_epoch: i64) -> String {
+    format!(
+        "src=memory:#{}; {}",
+        memory.id,
+        memory_staleness(memory, now_epoch)
+    )
+}
+
+pub(in crate::context) fn memory_provenance(memory: &Memory) -> String {
+    let mut parts = vec![format!("src=memory:#{}", memory.id)];
+    if let Some(session_id) = memory
+        .session_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        parts.push(format!("session={session_id}"));
+    }
+    parts.push(format!("scope={}", memory.scope));
+    parts.join("; ")
+}
+
+pub(in crate::context) fn memory_staleness(memory: &Memory, now_epoch: i64) -> String {
+    let age = age_staleness(memory.updated_at_epoch, now_epoch);
+    format!("status={}; staleness={age}", memory.status)
+}
+
+fn age_staleness_label(updated_at_epoch: i64, now_epoch: i64) -> String {
+    format!("staleness={}", age_staleness(updated_at_epoch, now_epoch))
+}
+
+fn age_staleness(updated_at_epoch: i64, now_epoch: i64) -> &'static str {
+    let age_days = now_epoch.saturating_sub(updated_at_epoch) / 86_400;
+    if age_days <= 30 {
+        "fresh"
+    } else if age_days <= 90 {
+        "aging"
+    } else {
+        "old"
+    }
+}
+
+pub(in crate::context) fn record_context_injection_items(
+    conn: &rusqlite::Connection,
+    invocation: &ContextInvocation,
+    decision: &ContextGateDecision,
+    rendered_items: &[ContextAuditItem],
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let key = decision
+        .key
+        .clone()
+        .unwrap_or_else(|| super::injection_gate::injection_key_for_audit(invocation));
+    let context_hash = decision.context_hash.as_deref();
+    let output_mode = decision.output_mode.unwrap_or(match decision.action {
+        ContextGateAction::Suppressed => "suppressed",
+        ContextGateAction::Bypassed => "bypassed",
+        ContextGateAction::FailOpen => "fail_open",
+        ContextGateAction::EmittedFull => "full",
+        ContextGateAction::EmittedDelta => "delta",
+    });
+    let run_id = format!(
+        "{}:{}:{}",
+        key,
+        now,
+        context_hash.unwrap_or(decision.reason)
+    );
+
+    let mut statement = conn.prepare(
+        "INSERT INTO context_injection_items
+         (injection_run_id, host, project, session_id, injection_key, hook_source,
+          context_hash, output_mode, decision, item_kind, item_id, memory_id, channel,
+          score, render_order, status, drop_reason, title, provenance, staleness,
+          injected_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                 ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
+    )?;
+    for item in finalize_items_for_decision(decision, rendered_items) {
+        statement.execute(params![
+            run_id,
+            invocation.host.as_env_value(),
+            invocation.project,
+            invocation.session_id,
+            key,
+            invocation.source,
+            context_hash,
+            output_mode,
+            decision.reason,
+            item.item_kind,
+            item.item_id,
+            item.memory_id,
+            item.channel,
+            item.score,
+            item.render_order,
+            item.status,
+            item.drop_reason,
+            item.title,
+            item.provenance,
+            item.staleness,
+            now,
+        ])?;
+    }
+    Ok(())
+}
+
+pub(in crate::context) fn build_context_audit_items(
+    loaded: &LoadedContext,
+    core_ids: &[i64],
+    index_ids: &[i64],
+    lesson_ids: &[i64],
+    workstream_ids: &[i64],
+) -> Vec<ContextAuditItem> {
+    let mut items = Vec::new();
+    let mut render_order = 1_i64;
+    if loaded.memory_abstained {
+        items.push(ContextAuditItem::abstained_memory("no_relevant_context"));
+    }
+    let core = core_ids.iter().copied().collect::<HashSet<_>>();
+    let index = index_ids.iter().copied().collect::<HashSet<_>>();
+    for id in core_ids {
+        if let Some(memory) = loaded.memories.iter().find(|memory| memory.id == *id) {
+            items.push(ContextAuditItem::injected_memory(
+                memory,
+                "core",
+                render_order,
+            ));
+            render_order += 1;
+        }
+    }
+    for id in index_ids {
+        if let Some(memory) = loaded.memories.iter().find(|memory| memory.id == *id) {
+            items.push(ContextAuditItem::injected_memory(
+                memory,
+                "index",
+                render_order,
+            ));
+            render_order += 1;
+        }
+    }
+    for memory in &loaded.memories {
+        if !core.contains(&memory.id) && !index.contains(&memory.id) {
+            items.push(ContextAuditItem::dropped_memory(
+                memory,
+                "memory",
+                "section_budget",
+            ));
+        }
+    }
+    let lesson = lesson_ids.iter().copied().collect::<HashSet<_>>();
+    for id in lesson_ids {
+        if let Some(lesson_memory) = loaded.lessons.iter().find(|lesson| lesson.memory.id == *id) {
+            items.push(ContextAuditItem::injected_memory(
+                &lesson_memory.memory,
+                "lessons",
+                render_order,
+            ));
+            render_order += 1;
+        }
+    }
+    for lesson_memory in &loaded.lessons {
+        if !lesson.contains(&lesson_memory.memory.id) {
+            items.push(ContextAuditItem::dropped_memory(
+                &lesson_memory.memory,
+                "lessons",
+                "section_budget",
+            ));
+        }
+    }
+    let workstream = workstream_ids.iter().copied().collect::<HashSet<_>>();
+    for id in workstream_ids {
+        if let Some(item) = loaded.workstreams.iter().find(|item| item.id == *id) {
+            items.push(ContextAuditItem::injected_workstream(
+                item.id,
+                &item.title,
+                render_order,
+                item.updated_at_epoch,
+            ));
+            render_order += 1;
+        }
+    }
+    for item in &loaded.workstreams {
+        if !workstream.contains(&item.id) {
+            items.push(ContextAuditItem::dropped_workstream(
+                item.id,
+                &item.title,
+                item.updated_at_epoch,
+                "section_budget",
+            ));
+        }
+    }
+    items
+}
+
+fn finalize_items_for_decision(
+    decision: &ContextGateDecision,
+    rendered_items: &[ContextAuditItem],
+) -> Vec<ContextAuditItem> {
+    rendered_items
+        .iter()
+        .cloned()
+        .map(|mut item| {
+            if item.status == "injected" && !decision.output.contains(&item.title) {
+                item.status = "dropped";
+                item.render_order = None;
+                item.drop_reason = Some(match decision.action {
+                    ContextGateAction::Suppressed => "gate_suppressed",
+                    ContextGateAction::EmittedDelta => "delta_preview",
+                    _ => "total_char_limit",
+                });
+            }
+            item
+        })
+        .collect()
+}

--- a/src/context/injection_gate.rs
+++ b/src/context/injection_gate.rs
@@ -441,6 +441,10 @@ fn injection_key(invocation: &ContextInvocation) -> String {
     format!("fallback:{}:{}", invocation.project, cwd)
 }
 
+pub(in crate::context) fn injection_key_for_audit(invocation: &ContextInvocation) -> String {
+    injection_key(invocation)
+}
+
 fn fallback_cwd_key(cwd: &str) -> String {
     let path = Path::new(cwd);
     std::fs::canonicalize(path)

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -5,6 +5,7 @@ use rusqlite::Connection;
 
 use crate::memory::{self, Memory};
 
+use super::abstention::filter_recent_rows_by_task_embedding;
 use super::commit_signals::query_recent_commit_messages;
 use super::filters::{
     push_context_related_filter, push_excluded_type_filter, push_owner_excluded_filter,
@@ -91,6 +92,7 @@ pub(super) fn load_context_data_with_policy(
         lessons,
         summaries,
         workstreams,
+        memory_abstained: memory_selection.abstained,
         errors,
         owner_traces: memory_selection.owner_traces,
         owner_counts: memory_selection.owner_counts,
@@ -100,14 +102,15 @@ pub(super) fn load_context_data_with_policy(
 
 struct ContextMemorySelection {
     memories: Vec<Memory>,
+    abstained: bool,
     errors: Vec<ContextLoadError>,
     owner_traces: Vec<OwnerTrace>,
     owner_counts: OwnerCounts,
     diagnostics: super::types::ContextDiagnostics,
 }
 
-struct ContextMemoryRow {
-    memory: Memory,
+pub(super) struct ContextMemoryRow {
+    pub(super) memory: Memory,
     owner: OwnerMetadata,
 }
 
@@ -125,11 +128,15 @@ fn load_project_memories(
     let mut errors = Vec::new();
     let mut traces = Vec::new();
     let mut seen_ids = HashSet::new();
+    let mut abstained = false;
+    let mut task_abstention_query = None;
 
     let excluded_types = policy
         .section(SectionKind::MemoryIndex)
         .map(|section| section.exclude_types.as_slice())
         .unwrap_or(&[]);
+    let has_task_signals =
+        !commit_messages.is_empty() || !summaries.is_empty() || !workstreams.is_empty();
     if let Some(implicit_query) = build_implicit_context_query(
         project,
         current_branch,
@@ -146,9 +153,13 @@ fn load_project_memories(
             policy.limits.candidate_fetch_limit as i64,
         ) {
             Ok(retrieved) => {
-                for memory in retrieved {
-                    if seen_ids.insert(memory.id) {
-                        memories.push(memory);
+                if retrieved.is_empty() && has_task_signals {
+                    task_abstention_query = Some(implicit_query);
+                } else {
+                    for memory in retrieved {
+                        if seen_ids.insert(memory.id) {
+                            memories.push(memory);
+                        }
                     }
                 }
             }
@@ -161,23 +172,54 @@ fn load_project_memories(
         }
     }
 
-    let recent = query_owner_included_memory_rows(
-        conn,
-        project,
-        None,
-        current_branch,
-        excluded_types,
-        policy.limits.candidate_fetch_limit as i64,
-    )
-    .unwrap_or_else(|e| {
-        let message = format!("failed to load recent context memories for {project}: {e}");
-        crate::log::error("context", &message);
-        errors.push(ContextLoadError::new("memories", message));
-        Vec::new()
-    });
-    for row in recent {
-        if seen_ids.insert(row.memory.id) {
-            memories.push(row.memory);
+    if !abstained {
+        let recent_limit = if task_abstention_query.is_some() {
+            policy
+                .limits
+                .candidate_fetch_limit
+                .saturating_mul(20)
+                .max(30) as i64
+        } else {
+            policy.limits.candidate_fetch_limit as i64
+        };
+        let recent = query_owner_included_memory_rows(
+            conn,
+            project,
+            None,
+            current_branch,
+            excluded_types,
+            recent_limit,
+        )
+        .unwrap_or_else(|e| {
+            let message = format!("failed to load recent context memories for {project}: {e}");
+            crate::log::error("context", &message);
+            errors.push(ContextLoadError::new("memories", message));
+            Vec::new()
+        });
+        let recent = match task_abstention_query.as_deref() {
+            Some(task_query) => filter_recent_rows_by_task_embedding(
+                conn,
+                task_query,
+                recent,
+                policy.limits.candidate_fetch_limit,
+            )
+            .unwrap_or_else(|e| {
+                let message =
+                    format!("failed to evaluate abstention rescue memories for {project}: {e}");
+                crate::log::error("context", &message);
+                errors.push(ContextLoadError::new("memories", message));
+                abstained = true;
+                Vec::new()
+            }),
+            None => recent,
+        };
+        if task_abstention_query.is_some() && recent.is_empty() {
+            abstained = true;
+        }
+        for row in recent {
+            if seen_ids.insert(row.memory.id) {
+                memories.push(row.memory);
+            }
         }
     }
 
@@ -229,6 +271,7 @@ fn load_project_memories(
 
     ContextMemorySelection {
         memories: selected,
+        abstained,
         errors,
         owner_traces: traces,
         owner_counts,

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 
 use crate::db;
 
+use super::audit::{build_context_audit_items, record_context_injection_items, ContextAuditItem};
 use super::format::{char_len, truncate_chars_with_ellipsis};
 use super::host::resolve_profile;
 use super::injection_gate::{
@@ -13,16 +14,18 @@ use super::injection_gate::{
 use super::invocation::{
     direct_context_invocation, resolve_context_invocation, ContextCliOptions, ContextInvocation,
 };
-use super::ownership::OwnerCounts;
 use super::policy::{ContextLimits, ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
     empty_state_output, render_core_memory_with_limits, render_lessons_with_limit,
-    render_memory_index_with_limits_excluding, render_recent_sessions_with_limit,
-    render_workstreams_with_limits,
+    render_lessons_with_summary, render_memory_index_with_limits_excluding,
+    render_memory_index_with_summary, render_recent_sessions_with_limit,
+    render_workstreams_with_limits, render_workstreams_with_summary,
 };
 use super::types::{ContextLoadError, ContextRequest};
+mod stats;
 mod timer;
+pub(in crate::context) use stats::{ContextRenderStats, SectionRenderStats};
 use timer::log_context_timer;
 
 pub(in crate::context) use super::debug::build_context_debug_trace;
@@ -30,6 +33,7 @@ pub(in crate::context) use super::debug::build_context_debug_trace;
 pub(in crate::context) struct RenderedContext {
     pub(in crate::context) output: String,
     pub(in crate::context) stats: ContextRenderStats,
+    pub(in crate::context) audit_items: Vec<ContextAuditItem>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -272,11 +276,16 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
             return Ok(());
         }
     };
-    let (mut decision, stats, precheck) = if use_gate {
+    let (mut decision, stats, precheck, audit_items) = if use_gate {
         let precheck =
             pre_render_context_gate(&conn, &invocation, &request, &policy, debug_enabled);
         if let Some(decision) = precheck.decision {
-            (decision, ContextRenderStats::default(), precheck.precheck)
+            (
+                decision,
+                ContextRenderStats::default(),
+                precheck.precheck,
+                Vec::new(),
+            )
         } else {
             let rendered =
                 render_context_output_with_policy(&conn, &request, debug_enabled, policy)?;
@@ -286,7 +295,12 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
                 rendered.output,
                 precheck.data_version.as_deref(),
             );
-            (decision, rendered.stats, precheck.precheck)
+            (
+                decision,
+                rendered.stats,
+                precheck.precheck,
+                rendered.audit_items,
+            )
         }
     } else {
         let rendered = render_context_output_with_policy(&conn, &request, debug_enabled, policy)?;
@@ -301,11 +315,22 @@ fn generate_context_for_invocation(invocation: ContextInvocation, use_gate: bool
             },
             rendered.stats,
             ContextGatePrecheck::Off,
+            rendered.audit_items,
         )
     };
     if debug_enabled {
         let decision_for_debug = decision.clone();
         append_context_gate_debug_trace(&mut decision.output, &request, &decision_for_debug);
+    }
+    if !audit_items.is_empty() {
+        if let Err(error) =
+            record_context_injection_items(&conn, &invocation, &decision, &audit_items)
+        {
+            crate::log::warn(
+                "context-audit",
+                &format!("failed to write audit rows: {error}"),
+            );
+        }
     }
     print!("{}", decision.output);
     log_context_timer(timer, &request, &decision, &stats, precheck);
@@ -409,10 +434,12 @@ fn render_context_output_with_policy(
         return Ok(RenderedContext {
             output: empty_context_output(request),
             stats: empty_stats(request),
+            audit_items: Vec::new(),
         });
     }
 
     let mut output = String::new();
+    let (mut lesson_ids, mut index_ids, mut workstream_ids) = (Vec::new(), Vec::new(), Vec::new());
     output.push_str(&build_context_header_with_style(
         &request.project,
         request.current_branch.as_deref(),
@@ -456,14 +483,15 @@ fn render_context_output_with_policy(
 
     if !loaded.lessons.is_empty() {
         let before = char_len(&output);
-        let lesson_count = render_lessons_with_limit(
+        let lesson_summary = render_lessons_with_summary(
             &mut output,
             &loaded.lessons,
             policy.section_item_limit(SectionKind::Lessons, policy.limits.lesson_limit),
             policy.section_char_limit(SectionKind::Lessons, policy.limits.lesson_char_limit),
         );
+        lesson_ids = lesson_summary.ids;
         stats.lessons = SectionRenderStats {
-            count: lesson_count,
+            count: lesson_summary.count,
             chars: char_len(&output).saturating_sub(before),
         };
     }
@@ -480,27 +508,29 @@ fn render_context_output_with_policy(
         };
         let before = char_len(&output);
         let core_ids = core_summary.ids.into_iter().collect();
-        let index_count = render_memory_index_with_limits_excluding(
+        let index_summary = render_memory_index_with_summary(
             &mut output,
             &loaded.memories,
             &render_limits,
             &core_ids,
         );
+        index_ids = index_summary.ids;
         stats.index = SectionRenderStats {
-            count: index_count,
+            count: index_summary.count,
             chars: char_len(&output).saturating_sub(before),
         };
     }
     if !loaded.workstreams.is_empty() {
         let before = char_len(&output);
-        let workstream_count = render_workstreams_with_limits(
+        let workstream_summary = render_workstreams_with_summary(
             &mut output,
             &loaded.workstreams,
             policy.section_item_limit(SectionKind::Workstreams, 5),
             policy.section_char_limit(SectionKind::Workstreams, 1_200),
         );
+        workstream_ids = workstream_summary.ids;
         stats.workstreams = SectionRenderStats {
-            count: workstream_count,
+            count: workstream_summary.count,
             chars: char_len(&output).saturating_sub(before),
         };
     }
@@ -541,7 +571,18 @@ fn render_context_output_with_policy(
         policy.limits.total_char_limit,
         &stats_footer,
     );
-    Ok(RenderedContext { output, stats })
+    let audit_items = build_context_audit_items(
+        &loaded,
+        &stats.core_ids,
+        &index_ids,
+        &lesson_ids,
+        &workstream_ids,
+    );
+    Ok(RenderedContext {
+        output,
+        stats,
+        audit_items,
+    })
 }
 
 fn open_context_connection_or_error(
@@ -576,7 +617,11 @@ fn render_context_open_error(
     stats.total_char_limit = policy.limits.total_char_limit;
     stats.output_chars = char_len(&output);
     enforce_total_char_limit_preserving_footer(&mut output, policy.limits.total_char_limit, "");
-    RenderedContext { output, stats }
+    RenderedContext {
+        output,
+        stats,
+        audit_items: Vec::new(),
+    }
 }
 
 fn context_error_output(request: &ContextRequest, errors: &[ContextLoadError]) -> String {
@@ -667,33 +712,6 @@ fn render_preferences_to_buffer(
     Ok((output, details))
 }
 
-#[derive(Debug, Clone, Default)]
-pub(in crate::context) struct SectionRenderStats {
-    pub count: usize,
-    pub chars: usize,
-}
-
-#[derive(Debug, Clone, Default)]
-pub(in crate::context) struct ContextRenderStats {
-    pub host: String,
-    pub branch: Option<String>,
-    pub hook_source: Option<String>,
-    pub total_char_limit: usize,
-    pub memories_loaded: usize,
-    pub core: SectionRenderStats,
-    pub lessons: SectionRenderStats,
-    pub index: SectionRenderStats,
-    pub preferences: SectionRenderStats,
-    pub project_preferences: usize,
-    pub global_preferences: usize,
-    pub sessions: SectionRenderStats,
-    pub workstreams: SectionRenderStats,
-    pub owner_counts: OwnerCounts,
-    pub core_ids: Vec<i64>,
-    pub output_chars: usize,
-    pub truncated: bool,
-}
-
 #[cfg(test)]
 pub(in crate::context) fn build_context_stats_footer(stats: &ContextRenderStats) -> String {
     build_context_stats_footer_with_style(stats, false)
@@ -754,21 +772,6 @@ pub(in crate::context) fn enforce_total_char_limit_preserving_footer(
     let mut truncated: String = output.chars().take(keep_chars).collect();
     truncated.push_str(marker);
     *output = truncated;
-}
-
-#[cfg(test)]
-pub(in crate::context) fn build_context_header(
-    project: &str,
-    current_branch: Option<&str>,
-    hook_source: Option<&str>,
-) -> String {
-    build_context_header_with_style(
-        project,
-        current_branch,
-        hook_source,
-        super::host::HostKind::Unknown,
-        false,
-    )
 }
 
 fn build_context_header_with_style(

--- a/src/context/render/stats.rs
+++ b/src/context/render/stats.rs
@@ -1,0 +1,28 @@
+use super::super::ownership::OwnerCounts;
+
+#[derive(Debug, Clone, Default)]
+pub(in crate::context) struct SectionRenderStats {
+    pub count: usize,
+    pub chars: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(in crate::context) struct ContextRenderStats {
+    pub host: String,
+    pub branch: Option<String>,
+    pub hook_source: Option<String>,
+    pub total_char_limit: usize,
+    pub memories_loaded: usize,
+    pub core: SectionRenderStats,
+    pub lessons: SectionRenderStats,
+    pub index: SectionRenderStats,
+    pub preferences: SectionRenderStats,
+    pub project_preferences: usize,
+    pub global_preferences: usize,
+    pub sessions: SectionRenderStats,
+    pub workstreams: SectionRenderStats,
+    pub owner_counts: OwnerCounts,
+    pub core_ids: Vec<i64>,
+    pub output_chars: usize,
+    pub truncated: bool,
+}

--- a/src/context/sections.rs
+++ b/src/context/sections.rs
@@ -14,10 +14,13 @@ pub(super) use index::render_memory_index;
 #[cfg(test)]
 pub(super) use index::render_memory_index_with_limits;
 pub(super) use index::render_memory_index_with_limits_excluding;
+pub(super) use index::render_memory_index_with_summary;
 pub(super) use lessons::render_lessons_with_limit;
+pub(super) use lessons::render_lessons_with_summary;
 #[cfg(test)]
 pub(super) use sessions::render_recent_sessions;
 pub(super) use sessions::render_recent_sessions_with_limit;
 #[cfg(test)]
 pub(super) use workstreams::render_workstreams;
 pub(super) use workstreams::render_workstreams_with_limits;
+pub(super) use workstreams::render_workstreams_with_summary;

--- a/src/context/sections/core.rs
+++ b/src/context/sections/core.rs
@@ -1,6 +1,7 @@
 use crate::memory::{Memory, MemoryType};
 use std::collections::HashMap;
 
+use super::super::audit::memory_render_metadata;
 use super::super::format::{char_len, format_epoch_short, truncate_chars_with_ellipsis};
 use super::super::memory_traits::is_memory_self_diagnostic;
 use super::super::policy::ContextLimits;
@@ -76,6 +77,7 @@ pub(in crate::context) fn render_core_memory_with_limits(
             &mut total_chars,
             memory,
             limits.core_char_limit,
+            now,
         ) {
             selected_ids.insert(memory.id);
             *type_counts.entry(memory.memory_type.as_str()).or_default() += 1;
@@ -97,6 +99,7 @@ pub(in crate::context) fn render_core_memory_with_limits(
             &mut total_chars,
             memory,
             limits.core_char_limit,
+            now,
         );
     }
 
@@ -113,8 +116,12 @@ pub(in crate::context) fn render_core_memory_with_limits(
     for (memory, preview) in selected {
         let date = format_epoch_short(memory.updated_at_epoch);
         output.push_str(&format!(
-            "**#{} {}** ({}, {})\n",
-            memory.id, memory.title, memory.memory_type, date
+            "**#{} {}** ({}, {}; {})\n",
+            memory.id,
+            memory.title,
+            memory.memory_type,
+            date,
+            memory_render_metadata(memory, now)
         ));
         output.push_str(&preview);
         output.push('\n');
@@ -131,13 +138,15 @@ fn push_selected_memory<'a>(
     total_chars: &mut usize,
     memory: &'a Memory,
     max_chars: usize,
+    now_epoch: i64,
 ) -> bool {
     let header = format!(
-        "**#{} {}** ({}, {})\n",
+        "**#{} {}** ({}, {}; {})\n",
         memory.id,
         memory.title,
         memory.memory_type,
-        format_epoch_short(memory.updated_at_epoch)
+        format_epoch_short(memory.updated_at_epoch),
+        memory_render_metadata(memory, now_epoch)
     );
     let fixed_chars = char_len(&header) + 1;
     if *total_chars + fixed_chars >= max_chars {

--- a/src/context/sections/index.rs
+++ b/src/context/sections/index.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::memory::{Memory, MemoryType};
 
+use super::super::audit::memory_render_metadata;
 use super::super::format::{
     char_len, format_epoch_short, truncate_chars_with_ellipsis, type_label,
 };
@@ -28,8 +29,23 @@ pub(in crate::context) fn render_memory_index_with_limits_excluding(
     limits: &ContextLimits,
     excluded_ids: &HashSet<i64>,
 ) -> usize {
+    render_memory_index_with_summary(output, memories, limits, excluded_ids).count
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(in crate::context) struct IndexRenderSummary {
+    pub count: usize,
+    pub ids: Vec<i64>,
+}
+
+pub(in crate::context) fn render_memory_index_with_summary(
+    output: &mut String,
+    memories: &[Memory],
+    limits: &ContextLimits,
+    excluded_ids: &HashSet<i64>,
+) -> IndexRenderSummary {
     if limits.memory_index_limit == 0 || limits.memory_index_char_limit == 0 {
-        return 0;
+        return IndexRenderSummary::default();
     }
 
     let mut by_type: HashMap<&str, Vec<&Memory>> = HashMap::new();
@@ -45,9 +61,10 @@ pub(in crate::context) fn render_memory_index_with_limits_excluding(
             .push(memory);
     }
     if by_type.is_empty() {
-        return 0;
+        return IndexRenderSummary::default();
     }
 
+    let now = chrono::Utc::now().timestamp();
     let mut display_order = MemoryType::ALL
         .iter()
         .copied()
@@ -58,6 +75,7 @@ pub(in crate::context) fn render_memory_index_with_limits_excluding(
     let mut body = String::new();
     let mut total_chars = 0usize;
     let mut rendered_count = 0usize;
+    let mut rendered_ids = Vec::new();
     let mut ordered_types = HashSet::new();
     for memory_type in display_order {
         let memory_type_key = memory_type.as_str();
@@ -73,6 +91,8 @@ pub(in crate::context) fn render_memory_index_with_limits_excluding(
                 memories_for_type,
                 limits.memory_index_char_limit,
                 &mut total_chars,
+                &mut rendered_ids,
+                now,
             );
         }
     }
@@ -93,17 +113,22 @@ pub(in crate::context) fn render_memory_index_with_limits_excluding(
                     memories_for_type,
                     limits.memory_index_char_limit,
                     &mut total_chars,
+                    &mut rendered_ids,
+                    now,
                 );
             }
         }
     }
     if rendered_count == 0 {
-        return 0;
+        return IndexRenderSummary::default();
     }
     output.push_str("## Index\n");
     output.push_str(&body);
     output.push('\n');
-    rendered_count
+    IndexRenderSummary {
+        count: rendered_count,
+        ids: rendered_ids,
+    }
 }
 
 fn push_memory_index_line(
@@ -113,6 +138,8 @@ fn push_memory_index_line(
     memories: &[&Memory],
     max_chars: usize,
     total_chars: &mut usize,
+    rendered_ids: &mut Vec<i64>,
+    now_epoch: i64,
 ) -> usize {
     let section_label = if label == memory_type {
         memory_type.to_string()
@@ -131,7 +158,13 @@ fn push_memory_index_line(
     let mut first = true;
     for memory in memories.iter().take(10) {
         let date = format_epoch_short(memory.updated_at_epoch);
-        let item = format!("#{} {} ({})", memory.id, memory.title, date);
+        let item = format!(
+            "#{} {} ({}; {})",
+            memory.id,
+            memory.title,
+            date,
+            memory_render_metadata(memory, now_epoch)
+        );
         let separator = if first { "" } else { " | " };
         let next_len = char_len(separator) + char_len(&item);
         if *total_chars + line_chars + next_len > max_chars {
@@ -150,12 +183,14 @@ fn push_memory_index_line(
             line.push_str(separator);
             line.push_str(&truncated);
             line_chars += char_len(separator) + char_len(&truncated);
+            rendered_ids.push(memory.id);
             rendered += 1;
             break;
         }
         line.push_str(separator);
         line.push_str(&item);
         line_chars += next_len;
+        rendered_ids.push(memory.id);
         rendered += 1;
         first = false;
     }

--- a/src/context/sections/lessons.rs
+++ b/src/context/sections/lessons.rs
@@ -1,8 +1,15 @@
 use crate::memory::lesson::LessonMemory;
 
+use super::super::audit::memory_render_metadata;
 use super::super::format::{char_len, format_epoch_short, truncate_chars_with_ellipsis};
 
 const PREVIEW_LEN: usize = 180;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(in crate::context) struct LessonRenderSummary {
+    pub count: usize,
+    pub ids: Vec<i64>,
+}
 
 pub(in crate::context) fn render_lessons_with_limit(
     output: &mut String,
@@ -10,28 +17,40 @@ pub(in crate::context) fn render_lessons_with_limit(
     item_limit: usize,
     char_limit: usize,
 ) -> usize {
+    render_lessons_with_summary(output, lessons, item_limit, char_limit).count
+}
+
+pub(in crate::context) fn render_lessons_with_summary(
+    output: &mut String,
+    lessons: &[LessonMemory],
+    item_limit: usize,
+    char_limit: usize,
+) -> LessonRenderSummary {
     if lessons.is_empty() || item_limit == 0 || char_limit == 0 {
-        return 0;
+        return LessonRenderSummary::default();
     }
     let header = "## Lessons\n";
     let trailer_chars = 1;
     let mut total_chars = char_len(header) + trailer_chars;
     if total_chars >= char_limit {
-        return 0;
+        return LessonRenderSummary::default();
     }
 
+    let now = chrono::Utc::now().timestamp();
     let mut body = String::new();
     let mut rendered = 0usize;
+    let mut ids = Vec::new();
     for lesson in lessons.iter().take(item_limit) {
         let memory = &lesson.memory;
         let metadata = &lesson.metadata;
         let title = format!(
-            "**#{} {}** (confidence {:.2}, reinforced {}, {})\n",
+            "**#{} {}** (confidence {:.2}, reinforced {}, {}; {})\n",
             memory.id,
             memory.title,
             metadata.confidence,
             metadata.reinforcement_count,
-            format_epoch_short(metadata.last_reinforced_at_epoch)
+            format_epoch_short(metadata.last_reinforced_at_epoch),
+            memory_render_metadata(memory, now)
         );
         let fixed_chars = char_len(&title) + 1;
         if total_chars + fixed_chars >= char_limit {
@@ -50,13 +69,17 @@ pub(in crate::context) fn render_lessons_with_limit(
         body.push_str(&preview);
         body.push('\n');
         total_chars += item_chars;
+        ids.push(memory.id);
         rendered += 1;
     }
     if rendered == 0 {
-        return 0;
+        return LessonRenderSummary::default();
     }
     output.push_str(header);
     output.push_str(&body);
     output.push('\n');
-    rendered
+    LessonRenderSummary {
+        count: rendered,
+        ids,
+    }
 }

--- a/src/context/sections/workstreams.rs
+++ b/src/context/sections/workstreams.rs
@@ -2,6 +2,12 @@ use crate::workstream::WorkStream;
 
 use super::super::format::char_len;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(in crate::context) struct WorkstreamRenderSummary {
+    pub count: usize,
+    pub ids: Vec<i64>,
+}
+
 #[cfg(test)]
 pub(in crate::context) fn render_workstreams(output: &mut String, workstreams: &[WorkStream]) {
     render_workstreams_with_limits(output, workstreams, usize::MAX, usize::MAX);
@@ -13,20 +19,30 @@ pub(in crate::context) fn render_workstreams_with_limits(
     item_limit: usize,
     char_limit: usize,
 ) -> usize {
+    render_workstreams_with_summary(output, workstreams, item_limit, char_limit).count
+}
+
+pub(in crate::context) fn render_workstreams_with_summary(
+    output: &mut String,
+    workstreams: &[WorkStream],
+    item_limit: usize,
+    char_limit: usize,
+) -> WorkstreamRenderSummary {
     if item_limit == 0 || char_limit == 0 {
-        return 0;
+        return WorkstreamRenderSummary::default();
     }
 
     let header = "## WorkStreams\n";
     let header_chars = char_len(header);
     let trailer_chars = 1;
     if header_chars + trailer_chars >= char_limit {
-        return 0;
+        return WorkstreamRenderSummary::default();
     }
 
     let mut section = String::from(header);
     let mut total_chars = header_chars + trailer_chars;
     let mut rendered = 0usize;
+    let mut ids = Vec::new();
 
     for workstream in workstreams.iter().take(item_limit) {
         let line = format_workstream_line(workstream);
@@ -36,16 +52,20 @@ pub(in crate::context) fn render_workstreams_with_limits(
         }
         section.push_str(&line);
         total_chars += line_chars;
+        ids.push(workstream.id);
         rendered += 1;
     }
 
     if rendered == 0 {
-        return 0;
+        return WorkstreamRenderSummary::default();
     }
 
     section.push('\n');
     output.push_str(&section);
-    rendered
+    WorkstreamRenderSummary {
+        count: rendered,
+        ids,
+    }
 }
 
 fn format_workstream_line(workstream: &WorkStream) -> String {
@@ -55,11 +75,18 @@ fn format_workstream_line(workstream: &WorkStream) -> String {
     } else {
         format!(" -> {}", next)
     };
+    let blockers = workstream.blockers.as_deref().unwrap_or("");
+    let blockers_part = if blockers.is_empty() {
+        String::new()
+    } else {
+        format!(" | blockers: {}", blockers.replace('\n', " "))
+    };
     format!(
-        "- #{} [{}] {}{}\n",
+        "- #{} [{}] {}{}{}\n",
         workstream.id,
         workstream.status.as_str(),
         workstream.title,
-        next_part
+        next_part,
+        blockers_part
     )
 }

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -6,9 +6,8 @@ use super::super::injection_gate::{ContextGateAction, ContextGateDecision};
 use super::super::invocation::ContextInvocation;
 use super::super::policy::ContextLimits;
 use super::super::render::{
-    append_context_gate_debug_trace, build_context_header, build_context_stats_footer,
-    empty_context_output, generate_context_for_test, render_context_output, ContextRenderStats,
-    SectionRenderStats,
+    append_context_gate_debug_trace, build_context_stats_footer, empty_context_output,
+    generate_context_for_test, render_context_output, ContextRenderStats, SectionRenderStats,
 };
 use super::super::sections::{
     render_core_memory, render_core_memory_with_limits, render_lessons_with_limit,
@@ -17,7 +16,7 @@ use super::super::sections::{
     render_recent_sessions_with_limit, render_workstreams, render_workstreams_with_limits,
 };
 use super::super::types::{ContextRequest, SessionSummaryBrief};
-use super::{sample_memory, sample_memory_with_epoch, sample_workstream};
+use super::{insert_memory, sample_memory, sample_memory_with_epoch, sample_workstream};
 
 #[test]
 fn render_recent_sessions_truncates_completed_line() {
@@ -173,6 +172,24 @@ fn render_memory_index_excludes_lessons() {
 }
 
 #[test]
+fn render_core_memory_includes_provenance_and_staleness_labels() {
+    let mut output = String::new();
+    let now = chrono::Utc::now().timestamp();
+    let memories = vec![sample_memory_with_epoch(
+        42,
+        "decision",
+        "Labeled decision",
+        now,
+    )];
+
+    render_core_memory(&mut output, &memories);
+
+    assert!(output.contains("src=memory:#42"));
+    assert!(output.contains("status=active"));
+    assert!(output.contains("staleness=fresh"));
+}
+
+#[test]
 fn render_lessons_respects_item_and_char_limits() {
     let mut output = String::new();
     let lessons = vec![
@@ -280,6 +297,17 @@ fn render_workstreams_includes_next_action_when_present() {
     render_workstreams(&mut output, &workstreams);
 
     assert!(output.contains("#7 [active] Refactor context -> split renderers"));
+}
+
+#[test]
+fn render_workstreams_includes_blockers_when_present() {
+    let mut output = String::new();
+    let mut workstream = sample_workstream(7, "Refactor context", Some("split renderers"));
+    workstream.blockers = Some("waiting for review".to_string());
+
+    render_workstreams(&mut output, &[workstream]);
+
+    assert!(output.contains("blockers: waiting for review"));
 }
 
 #[test]
@@ -455,7 +483,13 @@ fn context_stats_footer_reports_budget_scope_and_truncation() {
 
 #[test]
 fn context_header_marks_compact_reload_visibly() {
-    let header = build_context_header("/tmp/remem", Some("main"), Some("compact"));
+    let header = super::super::style::context_header(
+        "/tmp/remem",
+        Some("main"),
+        Some("compact"),
+        HostKind::Unknown,
+        false,
+    );
 
     assert!(header.starts_with("remem context"));
     assert!(header.contains("├─ project: /tmp/remem"));
@@ -624,6 +658,119 @@ fn strict_context_pipeline_opens_one_database_connection() -> anyhow::Result<()>
     generate_context_for_test(invocation, true)?;
 
     assert_eq!(crate::db::test_support::runtime_connection_open_count(), 1);
+    Ok(())
+}
+
+#[test]
+fn context_audit_rows_reconstruct_injected_memories_for_session() -> anyhow::Result<()> {
+    let data_dir = crate::db::test_support::ScopedTestDataDir::new("context-audit-injected");
+    let conn = crate::db::test_support::runtime_connection()?;
+    insert_memory(
+        &conn,
+        1,
+        data_dir.path.to_string_lossy().as_ref(),
+        Some("audit-memory"),
+        "decision",
+        "Audit decision",
+        "Audit body",
+        chrono::Utc::now().timestamp(),
+    );
+    drop(conn);
+
+    generate_context_for_test(
+        ContextInvocation {
+            cwd: data_dir.path.to_string_lossy().to_string(),
+            project: data_dir.path.to_string_lossy().to_string(),
+            session_id: Some("sess-audit-injected".to_string()),
+            transcript_path: None,
+            source: Some("session_start".to_string()),
+            host: HostKind::CodexCli,
+            use_colors: false,
+            debug: false,
+            force: true,
+            gate_mode: None,
+        },
+        true,
+    )?;
+
+    let conn = crate::db::test_support::runtime_connection()?;
+    let row: (i64, String, String, String) = conn.query_row(
+        "SELECT memory_id, status, channel, provenance
+         FROM context_injection_items
+         WHERE session_id = 'sess-audit-injected' AND status = 'injected'
+         ORDER BY render_order LIMIT 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+
+    assert_eq!(row.0, 1);
+    assert_eq!(row.1, "injected");
+    assert!(matches!(row.2.as_str(), "core" | "index"));
+    assert!(row.3.contains("src=memory:#1"));
+    Ok(())
+}
+
+#[test]
+fn context_audit_records_abstention_for_unmatched_task_signal() -> anyhow::Result<()> {
+    let data_dir = crate::db::test_support::ScopedTestDataDir::new("context-audit-abstain");
+    let project = data_dir.path.to_string_lossy().to_string();
+    let conn = crate::db::test_support::runtime_connection()?;
+    insert_memory(
+        &conn,
+        1,
+        &project,
+        Some("unrelated-recent"),
+        "decision",
+        "Unrelated recent deployment note",
+        "Legacy release checklist for cache warmup.",
+        chrono::Utc::now().timestamp(),
+    );
+    conn.execute(
+        "INSERT INTO workstreams
+         (project, title, description, status, progress, next_action, blockers,
+          created_at_epoch, updated_at_epoch, completed_at_epoch)
+         VALUES (?1, 'Prompt-aware task with no match', NULL, 'active', NULL,
+                 'Investigate quantum telemetry routing', NULL, 1, 1, NULL)",
+        [project.as_str()],
+    )?;
+    drop(conn);
+
+    generate_context_for_test(
+        ContextInvocation {
+            cwd: project.clone(),
+            project,
+            session_id: Some("sess-audit-abstain".to_string()),
+            transcript_path: None,
+            source: Some("session_start".to_string()),
+            host: HostKind::CodexCli,
+            use_colors: false,
+            debug: false,
+            force: true,
+            gate_mode: None,
+        },
+        true,
+    )?;
+
+    let conn = crate::db::test_support::runtime_connection()?;
+    let abstained: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM context_injection_items
+         WHERE session_id = 'sess-audit-abstain'
+           AND status = 'abstained'
+           AND drop_reason = 'no_relevant_context'",
+        [],
+        |row| row.get(0),
+    )?;
+    let unrelated_injected: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM context_injection_items
+         WHERE session_id = 'sess-audit-abstain'
+           AND status = 'injected'
+           AND title = 'Unrelated recent deployment note'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(abstained, 1);
+    assert_eq!(unrelated_injected, 0);
     Ok(())
 }
 

--- a/src/context/types.rs
+++ b/src/context/types.rs
@@ -30,6 +30,7 @@ pub(super) struct LoadedContext {
     pub lessons: Vec<LessonMemory>,
     pub summaries: Vec<SessionSummaryBrief>,
     pub workstreams: Vec<WorkStream>,
+    pub memory_abstained: bool,
     pub errors: Vec<ContextLoadError>,
     pub owner_traces: Vec<OwnerTrace>,
     pub owner_counts: OwnerCounts,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -189,6 +189,10 @@ pub mod gates {
             injection.metrics.forbidden_memory_exclusion.rate,
         );
         metrics.insert(
+            "injection.abstention_false_positive_bound".to_string(),
+            injection.metrics.abstention_false_positive_bound.rate,
+        );
+        metrics.insert(
             "injection.all_checks".to_string(),
             bool_metric(injection.metrics.all_checks_passed),
         );

--- a/src/eval/injection/run.rs
+++ b/src/eval/injection/run.rs
@@ -11,8 +11,10 @@ use super::types::{
 
 const PROJECT: &str = "/tmp/remem-injection-eval/repo";
 const OTHER_PROJECT: &str = "/tmp/remem-injection-eval/other";
+const ABSTENTION_PROJECT: &str = "/tmp/remem-injection-eval/abstain";
 const HOST: &str = "codex-cli";
 const CURRENT_BRANCH: &str = "main";
+const ABSTENTION_FORBIDDEN_TITLE: &str = "Unrelated recent deployment note";
 
 #[derive(Clone, Copy)]
 struct FixtureMemory {
@@ -108,6 +110,18 @@ const FIXTURE_MEMORIES: &[FixtureMemory] = &[
         updated_offset: -2,
         expected: InjectionExpectation::Filler,
     },
+    FixtureMemory {
+        id: 7,
+        project: ABSTENTION_PROJECT,
+        topic_key: "inject-abstention-unrelated",
+        title: ABSTENTION_FORBIDDEN_TITLE,
+        content: "Legacy release checklist for cache warmup.",
+        memory_type: "decision",
+        branch: None,
+        status: "active",
+        updated_offset: 40,
+        expected: InjectionExpectation::Filler,
+    },
 ];
 
 pub fn run_sandbox_eval(options: InjectionEvalOptions) -> Result<InjectionEvalReport> {
@@ -130,6 +144,13 @@ fn run_sandbox_eval_inner(
     let snapshot =
         crate::context::session_start_eval_snapshot(PROJECT, PROJECT, Some(CURRENT_BRANCH), HOST)
             .context("render SessionStart injection context")?;
+    let abstention_snapshot = crate::context::session_start_eval_snapshot(
+        ABSTENTION_PROJECT,
+        ABSTENTION_PROJECT,
+        Some(CURRENT_BRANCH),
+        HOST,
+    )
+    .context("render abstention SessionStart injection context")?;
 
     let expected_cases = evaluate_cases(&snapshot.rendered_output, InjectionExpectation::Expected);
     let forbidden_cases =
@@ -142,14 +163,25 @@ fn run_sandbox_eval_inner(
         forbidden_cases.iter().filter(|case| case.matched).count(),
         forbidden_cases.len(),
     );
-    let all_checks_passed =
-        expected_memory_recall.is_perfect() && forbidden_memory_exclusion.is_perfect();
+    let abstention_passed = !abstention_snapshot
+        .rendered_output
+        .contains(ABSTENTION_FORBIDDEN_TITLE);
+    let abstention_false_positive_bound =
+        InjectionRateMetric::new(usize::from(abstention_passed), 1);
+    let all_checks_passed = expected_memory_recall.is_perfect()
+        && forbidden_memory_exclusion.is_perfect()
+        && abstention_false_positive_bound.is_perfect();
     let mut failing_examples = Vec::new();
     for case in expected_cases.iter().filter(|case| !case.matched) {
         failing_examples.push(format!("missing expected memory: {}", case.title));
     }
     for case in forbidden_cases.iter().filter(|case| !case.matched) {
         failing_examples.push(format!("rendered forbidden memory: {}", case.title));
+    }
+    if !abstention_passed {
+        failing_examples.push(format!(
+            "abstention rendered unrelated memory: {ABSTENTION_FORBIDDEN_TITLE}"
+        ));
     }
 
     let mut cases = expected_cases;
@@ -178,6 +210,7 @@ fn run_sandbox_eval_inner(
         metrics: InjectionMetricSummary {
             expected_memory_recall,
             forbidden_memory_exclusion,
+            abstention_false_positive_bound,
             all_checks_passed,
         },
         cases,
@@ -239,6 +272,14 @@ fn seed_fixture(conn: &mut Connection) -> Result<()> {
             ],
         )?;
     }
+    tx.execute(
+        "INSERT INTO workstreams
+         (id, project, title, description, status, progress, next_action, blockers,
+          created_at_epoch, updated_at_epoch, completed_at_epoch)
+         VALUES (1, ?1, 'Prompt-aware task with no memory match', NULL, 'active',
+                 NULL, 'Investigate quantum telemetry routing', NULL, ?2, ?2, NULL)",
+        params![ABSTENTION_PROJECT, now],
+    )?;
     tx.commit()?;
     Ok(())
 }

--- a/src/eval/injection/tests.rs
+++ b/src/eval/injection/tests.rs
@@ -24,6 +24,11 @@ fn injection_eval_exercises_session_start_render_path() -> Result<()> {
         "{:#?}",
         report
     );
+    assert!(
+        report.metrics.abstention_false_positive_bound.is_perfect(),
+        "{:#?}",
+        report
+    );
     assert!(report.metrics.all_checks_passed, "{:#?}", report);
     assert!(report.metadata.memories_loaded > 0);
     assert!(report.metadata.core_count > 0 || report.metadata.index_count > 0);
@@ -58,6 +63,7 @@ fn injection_eval_display_includes_metrics() {
         metrics: InjectionMetricSummary {
             expected_memory_recall: InjectionRateMetric::new(2, 2),
             forbidden_memory_exclusion: InjectionRateMetric::new(3, 3),
+            abstention_false_positive_bound: InjectionRateMetric::new(1, 1),
             all_checks_passed: true,
         },
         cases: vec![],
@@ -69,5 +75,6 @@ fn injection_eval_display_includes_metrics() {
     assert!(rendered.contains("=== remem eval-injection"));
     assert!(rendered.contains("expected_memory_recall: 2/2"));
     assert!(rendered.contains("forbidden_memory_exclusion: 3/3"));
+    assert!(rendered.contains("abstention_false_positive_bound: 1/1"));
     assert!(rendered.contains("all_checks_passed: true"));
 }

--- a/src/eval/injection/types.rs
+++ b/src/eval/injection/types.rs
@@ -45,6 +45,7 @@ pub struct InjectionEvalMetadata {
 pub struct InjectionMetricSummary {
     pub expected_memory_recall: InjectionRateMetric,
     pub forbidden_memory_exclusion: InjectionRateMetric,
+    pub abstention_false_positive_bound: InjectionRateMetric,
     pub all_checks_passed: bool,
 }
 
@@ -79,6 +80,13 @@ impl Display for InjectionEvalReport {
             self.metrics.forbidden_memory_exclusion.passed,
             self.metrics.forbidden_memory_exclusion.total,
             self.metrics.forbidden_memory_exclusion.rate * 100.0
+        )?;
+        writeln!(
+            f,
+            "abstention_false_positive_bound: {}/{} ({:.1}%)",
+            self.metrics.abstention_false_positive_bound.passed,
+            self.metrics.abstention_false_positive_bound.total,
+            self.metrics.abstention_false_positive_bound.rate * 100.0
         )?;
         writeln!(
             f,

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -195,6 +195,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "extraction_replay_ranges",
         sql: include_str!("../migrations/v038_extraction_replay_ranges.sql"),
     },
+    Migration {
+        version: 39,
+        name: "context_injection_items",
+        sql: include_str!("../migrations/v039_context_injection_items.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v039_context_injection_items.sql
+++ b/src/migrations/v039_context_injection_items.sql
@@ -1,0 +1,38 @@
+-- v039_context_injection_items: append-only per-item audit rows for context
+-- injection accountability. `context_injections` remains the output-level
+-- de-dup gate; this table records which memory-like items were injected,
+-- dropped, or abstained for each emission.
+
+CREATE TABLE IF NOT EXISTS context_injection_items (
+    id INTEGER PRIMARY KEY,
+    injection_run_id TEXT NOT NULL,
+    host TEXT NOT NULL,
+    project TEXT NOT NULL,
+    session_id TEXT,
+    injection_key TEXT NOT NULL,
+    hook_source TEXT,
+    context_hash TEXT,
+    output_mode TEXT NOT NULL,
+    decision TEXT NOT NULL,
+    item_kind TEXT NOT NULL,
+    item_id INTEGER,
+    memory_id INTEGER,
+    channel TEXT NOT NULL,
+    score REAL,
+    render_order INTEGER,
+    status TEXT NOT NULL CHECK (status IN ('injected', 'dropped', 'abstained')),
+    drop_reason TEXT,
+    title TEXT,
+    provenance TEXT,
+    staleness TEXT,
+    injected_at_epoch INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_context_injection_items_session
+    ON context_injection_items(host, session_id, injected_at_epoch, render_order);
+
+CREATE INDEX IF NOT EXISTS idx_context_injection_items_memory
+    ON context_injection_items(memory_id, injected_at_epoch DESC);
+
+CREATE INDEX IF NOT EXISTS idx_context_injection_items_project
+    ON context_injection_items(project, injected_at_epoch DESC);


### PR DESCRIPTION
## Summary

- add schema v39 `context_injection_items` as append-only per-item audit rows while keeping `context_injections` as the output-level gate
- render memory provenance/staleness labels and record injected, dropped, suppressed, delta-previewed, and abstained items
- add a task-signal abstention path with stored-embedding rescue so unrelated recent memories do not leak into prompt-aware contexts
- extend injection eval gates with `injection.abstention_false_positive_bound`

Closes #377.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check --message-format=short`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `cargo test migrate::tests::full_migration_on_empty_db -- --nocapture`
- `cargo test context::tests::retrieval::hybrid_context_vector_recall_is_not_crowded_out_by_global_hits -- --nocapture`
- `cargo test context::tests::render -- --nocapture`
- `cargo test eval::injection -- --nocapture`
- `cargo run --quiet -- eval-gates --json-out /tmp/remem-issue377-eval-gates.json`
- `cargo clippy -- -D warnings`
- `cargo test`
- `REMEM_NPM_BINARY=/private/tmp/remem-issue377-injection-accountability/target/debug/remem npm test --prefix npm/remem`

Note: plain `npm test --prefix npm/remem` fails in this worktree because the packaged vendor binary is not present; the wrapper passes when pointed at the freshly built local binary.
