### PR TITLE
Add prompt-aware UserPromptSubmit context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.53"
+version = "0.5.54"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.53"
+version = "0.5.54"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/eval/gates/baseline.json
+++ b/eval/gates/baseline.json
@@ -45,6 +45,8 @@
     "injection.abstention_false_positive_bound": 1.0,
     "injection.all_checks": 1.0,
     "injection.expected_memory_recall": 1.0,
-    "injection.forbidden_memory_exclusion": 1.0
+    "injection.forbidden_memory_exclusion": 1.0,
+    "injection.user_prompt_submit_abstention_false_positive_bound": 1.0,
+    "injection.user_prompt_submit_memory_recall": 1.0
   }
 }

--- a/eval/gates/thresholds.json
+++ b/eval/gates/thresholds.json
@@ -5,6 +5,12 @@
     "injection.abstention_false_positive_bound": {
       "max_drop": 0.0
     },
+    "injection.user_prompt_submit_abstention_false_positive_bound": {
+      "max_drop": 0.0
+    },
+    "injection.user_prompt_submit_memory_recall": {
+      "max_drop": 0.0
+    },
     "golden.slice.abstention.abstention_pass_rate": {
       "max_drop": 0.0
     },

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.53",
+  "version": "0.5.54",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.53",
+  "version": "0.5.54",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.53": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.53",
+    "0.5.54": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.54",
       "assets": {}
     }
   }

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,6 +14,7 @@ mod invocation;
 mod memory_traits;
 mod ownership;
 mod policy;
+mod prompt_submit;
 mod query;
 mod render;
 mod sections;
@@ -23,6 +24,7 @@ mod style;
 mod tests;
 mod types;
 
+pub(crate) use prompt_submit::prompt_submit_additional_context;
 pub(crate) use render::governance_eval_snapshot;
 pub(crate) use render::session_start_eval_snapshot;
 pub use render::{generate_context, generate_context_from_cli};

--- a/src/context/prompt_submit.rs
+++ b/src/context/prompt_submit.rs
@@ -1,0 +1,499 @@
+use std::collections::HashSet;
+
+use anyhow::Result;
+use rusqlite::params;
+
+use crate::memory::Memory;
+
+use super::audit::{memory_render_metadata, record_context_injection_items, ContextAuditItem};
+use super::format::{char_len, format_epoch_short, truncate_chars_with_ellipsis};
+use super::host::resolve_host_kind;
+use super::hybrid_context::query_hybrid_context_memories;
+use super::injection_gate::{injection_key_for_audit, ContextGateAction, ContextGateDecision};
+use super::invocation::ContextInvocation;
+use super::policy::{ContextLimits, ContextPolicy, SectionKind};
+
+const PROMPT_SUBMIT_MEMORY_LIMIT: i64 = 3;
+const PROMPT_SUBMIT_CHAR_LIMIT: usize = 1_800;
+const PROMPT_SUBMIT_PREVIEW_CHARS: usize = 240;
+#[cfg(test)]
+const PROMPT_SUBMIT_LATENCY_BUDGET_MS: u128 = 250;
+
+pub(crate) fn prompt_submit_additional_context(
+    conn: &rusqlite::Connection,
+    cwd: &str,
+    project: &str,
+    session_id: &str,
+    prompt: &str,
+    host_arg: Option<&str>,
+) -> Result<Option<String>> {
+    let prompt = prompt.trim();
+    if prompt.is_empty() {
+        return Ok(None);
+    }
+
+    let host = resolve_host_kind(host_arg);
+    let invocation = ContextInvocation {
+        cwd: cwd.to_string(),
+        project: project.to_string(),
+        session_id: Some(session_id.to_string()),
+        transcript_path: None,
+        source: Some("UserPromptSubmit".to_string()),
+        host,
+        use_colors: false,
+        debug: false,
+        force: false,
+        gate_mode: None,
+    };
+    let policy = ContextPolicy::from_limits(ContextLimits::default());
+    let excluded_types = policy
+        .section(SectionKind::MemoryIndex)
+        .map(|section| section.exclude_types.as_slice())
+        .unwrap_or(&[]);
+    let current_branch = crate::db::detect_git_branch(cwd);
+    let retrieved = query_hybrid_context_memories(
+        conn,
+        project,
+        prompt,
+        current_branch.as_deref(),
+        excluded_types,
+        PROMPT_SUBMIT_MEMORY_LIMIT,
+    )?;
+    let already_injected = query_previously_injected_memory_ids(conn, &invocation)?;
+    let mut rendered = Vec::new();
+    let mut audit_items = Vec::new();
+    for memory in retrieved {
+        if already_injected.contains(&memory.id) {
+            audit_items.push(ContextAuditItem::dropped_memory(
+                &memory,
+                "prompt_submit",
+                "already_injected",
+            ));
+        } else if !prompt_relevance_passes(prompt, &memory) {
+            audit_items.push(ContextAuditItem::dropped_memory(
+                &memory,
+                "prompt_submit",
+                "below_prompt_relevance_threshold",
+            ));
+        } else {
+            rendered.push(memory);
+        }
+    }
+
+    if rendered.is_empty() {
+        if audit_items.is_empty() {
+            audit_items.push(prompt_submit_abstained_item(
+                "prompt_submit_no_relevant_context",
+            ));
+        }
+        let decision = empty_prompt_submit_decision();
+        record_context_injection_items(conn, &invocation, &decision, &audit_items)?;
+        return Ok(None);
+    }
+
+    audit_items.extend(rendered.iter().enumerate().map(|(index, memory)| {
+        ContextAuditItem::injected_memory(memory, "prompt_submit", index as i64 + 1)
+    }));
+    let output = render_prompt_submit_context(&rendered);
+    let decision = prompt_submit_decision(output);
+    record_context_injection_items(conn, &invocation, &decision, &audit_items)?;
+    Ok(Some(decision.output))
+}
+
+fn query_previously_injected_memory_ids(
+    conn: &rusqlite::Connection,
+    invocation: &ContextInvocation,
+) -> Result<HashSet<i64>> {
+    let key = injection_key_for_audit(invocation);
+    let Some(session_id) = invocation.session_id.as_deref() else {
+        return Ok(HashSet::new());
+    };
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT memory_id
+         FROM context_injection_items
+         WHERE host = ?1
+           AND project = ?2
+           AND session_id = ?3
+           AND injection_key = ?4
+           AND status = 'injected'
+           AND memory_id IS NOT NULL",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            invocation.host.as_env_value(),
+            invocation.project,
+            session_id,
+            key
+        ],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(crate::db::query::collect_rows(rows)?.into_iter().collect())
+}
+
+fn prompt_relevance_passes(prompt: &str, memory: &Memory) -> bool {
+    let prompt_tokens = significant_prompt_tokens(prompt);
+    if prompt_tokens.is_empty() {
+        return false;
+    }
+    let memory_text = format!("{} {}", memory.title, memory.text).to_lowercase();
+    prompt_tokens
+        .iter()
+        .any(|token| memory_text.contains(token))
+}
+
+fn render_prompt_submit_context(memories: &[Memory]) -> String {
+    let mut output = String::from("# remem prompt context\n\n## Relevant Memories\n");
+    let now = chrono::Utc::now().timestamp();
+    for memory in memories {
+        let header = format!(
+            "**#{} {}** ({}, {}; {})\n",
+            memory.id,
+            memory.title,
+            memory.memory_type,
+            format_epoch_short(memory.updated_at_epoch),
+            memory_render_metadata(memory, now)
+        );
+        if char_len(&output) + char_len(&header) >= PROMPT_SUBMIT_CHAR_LIMIT {
+            break;
+        }
+        output.push_str(&header);
+        let remaining = PROMPT_SUBMIT_CHAR_LIMIT.saturating_sub(char_len(&output) + 1);
+        let preview =
+            truncate_chars_with_ellipsis(&memory.text, remaining.min(PROMPT_SUBMIT_PREVIEW_CHARS));
+        if !preview.is_empty() {
+            output.push_str(&preview);
+            output.push('\n');
+        }
+    }
+    output
+}
+
+fn empty_prompt_submit_decision() -> ContextGateDecision {
+    ContextGateDecision {
+        output: String::new(),
+        action: ContextGateAction::Bypassed,
+        reason: "prompt_submit_empty",
+        key: None,
+        context_hash: None,
+        output_mode: Some("prompt_submit"),
+    }
+}
+
+fn prompt_submit_decision(output: String) -> ContextGateDecision {
+    ContextGateDecision {
+        output,
+        action: ContextGateAction::Bypassed,
+        reason: "prompt_submit",
+        key: None,
+        context_hash: None,
+        output_mode: Some("prompt_submit"),
+    }
+}
+
+fn significant_prompt_tokens(text: &str) -> HashSet<String> {
+    text.split_whitespace()
+        .map(|token| {
+            token
+                .trim_matches(|ch: char| ch.is_ascii_punctuation())
+                .to_lowercase()
+        })
+        .filter(|token| token.chars().count() >= 3 || !token.is_ascii())
+        .filter(|token| !is_prompt_stop_token(token))
+        .collect()
+}
+
+fn is_prompt_stop_token(token: &str) -> bool {
+    matches!(
+        token,
+        "the"
+            | "and"
+            | "for"
+            | "with"
+            | "from"
+            | "that"
+            | "this"
+            | "should"
+            | "when"
+            | "where"
+            | "what"
+            | "why"
+            | "how"
+            | "into"
+            | "was"
+            | "were"
+            | "does"
+            | "need"
+            | "about"
+    )
+}
+
+fn prompt_submit_abstained_item(reason: &'static str) -> ContextAuditItem {
+    ContextAuditItem {
+        item_kind: "memory",
+        item_id: None,
+        memory_id: None,
+        channel: "prompt_submit",
+        score: None,
+        render_order: None,
+        status: "abstained",
+        drop_reason: Some(reason),
+        title: "prompt context abstained".to_string(),
+        provenance: "src=memory".to_string(),
+        staleness: "staleness=none".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::context::host::HostKind;
+    use crate::context::injection_gate::apply_context_gate_with_data_version;
+    use crate::context::invocation::ContextInvocation;
+
+    fn setup_prompt_submit_conn() -> Result<Connection> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        Ok(conn)
+    }
+
+    fn insert_prompt_submit_memory(
+        conn: &Connection,
+        project: &str,
+        title: &str,
+        content: &str,
+    ) -> Result<i64> {
+        crate::memory::insert_memory(
+            conn,
+            Some("seed-session"),
+            project,
+            None,
+            title,
+            content,
+            "decision",
+            None,
+        )
+    }
+
+    #[test]
+    fn prompt_submit_injects_relevant_memory() -> Result<()> {
+        let conn = setup_prompt_submit_conn()?;
+        let project = "/tmp/remem-prompt-submit";
+        insert_prompt_submit_memory(
+            &conn,
+            project,
+            "SQLCipher storage decision",
+            "Persist private data with SQLCipher encryption at rest.",
+        )?;
+
+        let output = prompt_submit_additional_context(
+            &conn,
+            project,
+            project,
+            "sess-prompt-hit",
+            "How should we protect private persisted data with SQLCipher?",
+            Some("claude-code"),
+        )?
+        .expect("matching prompt should inject context");
+
+        assert!(output.contains("SQLCipher storage decision"));
+        assert!(output.contains("src=memory:#"));
+        Ok(())
+    }
+
+    #[test]
+    fn prompt_submit_abstains_for_unrelated_prompt() -> Result<()> {
+        let conn = setup_prompt_submit_conn()?;
+        let project = "/tmp/remem-prompt-submit-abstain";
+        insert_prompt_submit_memory(
+            &conn,
+            project,
+            "Legacy release checklist",
+            "Legacy release checklist for cache warmup.",
+        )?;
+
+        let output = prompt_submit_additional_context(
+            &conn,
+            project,
+            project,
+            "sess-prompt-abstain",
+            "Investigate quantum telemetry routing",
+            Some("claude-code"),
+        )?;
+
+        assert!(output.is_none());
+        let (channel, status): (String, String) = conn.query_row(
+            "SELECT channel, status
+             FROM context_injection_items
+             WHERE session_id = 'sess-prompt-abstain'
+             ORDER BY id DESC
+             LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(channel, "prompt_submit");
+        assert_eq!(status, "abstained");
+        Ok(())
+    }
+
+    #[test]
+    fn prompt_submit_does_not_resend_already_injected_memory() -> Result<()> {
+        let conn = setup_prompt_submit_conn()?;
+        let project = "/tmp/remem-prompt-submit-dedup";
+        insert_prompt_submit_memory(
+            &conn,
+            project,
+            "Migration locking fix",
+            "Serialize startup migrations to prevent races.",
+        )?;
+
+        let first = prompt_submit_additional_context(
+            &conn,
+            project,
+            project,
+            "sess-prompt-dedup",
+            "How do we fix startup migration races?",
+            Some("claude-code"),
+        )?;
+        let second = prompt_submit_additional_context(
+            &conn,
+            project,
+            project,
+            "sess-prompt-dedup",
+            "How do we fix startup migration races?",
+            Some("claude-code"),
+        )?;
+
+        assert!(first.is_some());
+        assert!(second.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn prompt_submit_does_not_resend_session_start_injected_memory() -> Result<()> {
+        let conn = setup_prompt_submit_conn()?;
+        let project = "/tmp/remem-prompt-submit-session-start-dedup";
+        let memory_id = insert_prompt_submit_memory(
+            &conn,
+            project,
+            "Migration locking fix",
+            "Serialize startup migrations to prevent races.",
+        )?;
+        let memory = crate::memory::get_memories_by_ids(&conn, &[memory_id], Some(project))?
+            .pop()
+            .ok_or_else(|| anyhow::anyhow!("inserted memory should load"))?;
+        let invocation = prompt_submit_test_invocation(project, "sess-session-start-dedup");
+        let decision = ContextGateDecision {
+            output: "# remem context\nMigration locking fix\n".into(),
+            action: ContextGateAction::EmittedFull,
+            reason: "first_or_forced",
+            key: Some(injection_key_for_audit(&invocation)),
+            context_hash: Some("seed-session-start-context".to_string()),
+            output_mode: Some("full"),
+        };
+        record_context_injection_items(
+            &conn,
+            &invocation,
+            &decision,
+            &[ContextAuditItem::injected_memory(&memory, "core", 1)],
+        )?;
+
+        let output = prompt_submit_additional_context(
+            &conn,
+            project,
+            project,
+            "sess-session-start-dedup",
+            "How do we fix startup migration races?",
+            Some("claude-code"),
+        )?;
+
+        assert!(output.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn prompt_submit_ignores_output_level_context_gate_rows() -> Result<()> {
+        let conn = setup_prompt_submit_conn()?;
+        let project = "/tmp/remem-prompt-submit-gate-row";
+        insert_prompt_submit_memory(
+            &conn,
+            project,
+            "Migration locking fix",
+            "Serialize startup migrations to prevent races.",
+        )?;
+        let invocation = prompt_submit_test_invocation(project, "sess-gate-row");
+        let first = apply_context_gate_with_data_version(
+            &conn,
+            &invocation,
+            "# remem context\nExisting SessionStart body\n".to_string(),
+            None,
+        );
+        assert_eq!(first.action, ContextGateAction::EmittedFull);
+
+        let output = prompt_submit_additional_context(
+            &conn,
+            project,
+            project,
+            "sess-gate-row",
+            "How do we fix startup migration races?",
+            Some("claude-code"),
+        )?
+        .ok_or_else(|| anyhow::anyhow!("prompt output should not be suppressed"))?;
+
+        assert!(output.starts_with("# remem prompt context"));
+        assert!(output.contains("Migration locking fix"));
+        assert!(!output.contains("# remem context delta"));
+        Ok(())
+    }
+
+    #[test]
+    fn prompt_submit_p95_latency_stays_under_budget() -> Result<()> {
+        let conn = setup_prompt_submit_conn()?;
+        let project = "/tmp/remem-prompt-submit-latency";
+        insert_prompt_submit_memory(
+            &conn,
+            project,
+            "SQLCipher storage decision",
+            "Persist private data with SQLCipher encryption at rest.",
+        )?;
+        let mut durations = Vec::new();
+        for idx in 0..20 {
+            let start = Instant::now();
+            let output = prompt_submit_additional_context(
+                &conn,
+                project,
+                project,
+                &format!("sess-prompt-latency-{idx}"),
+                "How should SQLCipher protect private persisted data?",
+                Some("claude-code"),
+            )?;
+            assert!(output.is_some());
+            durations.push(start.elapsed().as_millis());
+        }
+        durations.sort_unstable();
+        let p95 = durations[(durations.len() * 95).div_ceil(100) - 1];
+        assert!(
+            p95 <= PROMPT_SUBMIT_LATENCY_BUDGET_MS,
+            "p95 {p95}ms exceeded {PROMPT_SUBMIT_LATENCY_BUDGET_MS}ms"
+        );
+        Ok(())
+    }
+
+    fn prompt_submit_test_invocation(project: &str, session_id: &str) -> ContextInvocation {
+        ContextInvocation {
+            cwd: project.to_string(),
+            project: project.to_string(),
+            session_id: Some(session_id.to_string()),
+            transcript_path: None,
+            source: Some("SessionStart".to_string()),
+            host: HostKind::ClaudeCode,
+            use_colors: false,
+            debug: false,
+            force: false,
+            gate_mode: None,
+        }
+    }
+}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -193,6 +193,17 @@ pub mod gates {
             injection.metrics.abstention_false_positive_bound.rate,
         );
         metrics.insert(
+            "injection.user_prompt_submit_memory_recall".to_string(),
+            injection.metrics.user_prompt_submit_memory_recall.rate,
+        );
+        metrics.insert(
+            "injection.user_prompt_submit_abstention_false_positive_bound".to_string(),
+            injection
+                .metrics
+                .user_prompt_submit_abstention_false_positive_bound
+                .rate,
+        );
+        metrics.insert(
             "injection.all_checks".to_string(),
             bool_metric(injection.metrics.all_checks_passed),
         );

--- a/src/eval/injection/run.rs
+++ b/src/eval/injection/run.rs
@@ -13,8 +13,10 @@ const PROJECT: &str = "/tmp/remem-injection-eval/repo";
 const OTHER_PROJECT: &str = "/tmp/remem-injection-eval/other";
 const ABSTENTION_PROJECT: &str = "/tmp/remem-injection-eval/abstain";
 const HOST: &str = "codex-cli";
+const USER_PROMPT_HOST: &str = "claude-code";
 const CURRENT_BRANCH: &str = "main";
 const ABSTENTION_FORBIDDEN_TITLE: &str = "Unrelated recent deployment note";
+const USER_PROMPT_SESSION: &str = "eval-user-prompt-submit";
 
 #[derive(Clone, Copy)]
 struct FixtureMemory {
@@ -139,6 +141,24 @@ fn run_sandbox_eval_inner(
 ) -> Result<InjectionEvalReport> {
     let mut conn = crate::db::open_db().context("open sandbox injection eval DB")?;
     seed_fixture(&mut conn).context("seed injection eval fixture")?;
+    let user_prompt_context = crate::context::prompt_submit_additional_context(
+        &conn,
+        PROJECT,
+        PROJECT,
+        USER_PROMPT_SESSION,
+        "How do we fix startup migration races?",
+        Some(USER_PROMPT_HOST),
+    )
+    .context("render UserPromptSubmit matching additionalContext")?;
+    let user_prompt_abstention_context = crate::context::prompt_submit_additional_context(
+        &conn,
+        ABSTENTION_PROJECT,
+        ABSTENTION_PROJECT,
+        USER_PROMPT_SESSION,
+        "Investigate quantum telemetry routing",
+        Some(USER_PROMPT_HOST),
+    )
+    .context("render UserPromptSubmit abstention additionalContext")?;
     drop(conn);
 
     let snapshot =
@@ -168,9 +188,21 @@ fn run_sandbox_eval_inner(
         .contains(ABSTENTION_FORBIDDEN_TITLE);
     let abstention_false_positive_bound =
         InjectionRateMetric::new(usize::from(abstention_passed), 1);
+    let user_prompt_submit_passed = user_prompt_context
+        .as_deref()
+        .is_some_and(|output| output.contains("Migration locking fix"));
+    let user_prompt_submit_memory_recall =
+        InjectionRateMetric::new(usize::from(user_prompt_submit_passed), 1);
+    let user_prompt_submit_abstention_passed = user_prompt_abstention_context
+        .as_deref()
+        .is_none_or(|output| !output.contains(ABSTENTION_FORBIDDEN_TITLE));
+    let user_prompt_submit_abstention_false_positive_bound =
+        InjectionRateMetric::new(usize::from(user_prompt_submit_abstention_passed), 1);
     let all_checks_passed = expected_memory_recall.is_perfect()
         && forbidden_memory_exclusion.is_perfect()
-        && abstention_false_positive_bound.is_perfect();
+        && abstention_false_positive_bound.is_perfect()
+        && user_prompt_submit_memory_recall.is_perfect()
+        && user_prompt_submit_abstention_false_positive_bound.is_perfect();
     let mut failing_examples = Vec::new();
     for case in expected_cases.iter().filter(|case| !case.matched) {
         failing_examples.push(format!("missing expected memory: {}", case.title));
@@ -181,6 +213,15 @@ fn run_sandbox_eval_inner(
     if !abstention_passed {
         failing_examples.push(format!(
             "abstention rendered unrelated memory: {ABSTENTION_FORBIDDEN_TITLE}"
+        ));
+    }
+    if !user_prompt_submit_passed {
+        failing_examples
+            .push("UserPromptSubmit missing expected memory: Migration locking fix".to_string());
+    }
+    if !user_prompt_submit_abstention_passed {
+        failing_examples.push(format!(
+            "UserPromptSubmit rendered unrelated memory: {ABSTENTION_FORBIDDEN_TITLE}"
         ));
     }
 
@@ -211,6 +252,8 @@ fn run_sandbox_eval_inner(
             expected_memory_recall,
             forbidden_memory_exclusion,
             abstention_false_positive_bound,
+            user_prompt_submit_memory_recall,
+            user_prompt_submit_abstention_false_positive_bound,
             all_checks_passed,
         },
         cases,

--- a/src/eval/injection/run.rs
+++ b/src/eval/injection/run.rs
@@ -193,9 +193,7 @@ fn run_sandbox_eval_inner(
         .is_some_and(|output| output.contains("Migration locking fix"));
     let user_prompt_submit_memory_recall =
         InjectionRateMetric::new(usize::from(user_prompt_submit_passed), 1);
-    let user_prompt_submit_abstention_passed = user_prompt_abstention_context
-        .as_deref()
-        .is_none_or(|output| !output.contains(ABSTENTION_FORBIDDEN_TITLE));
+    let user_prompt_submit_abstention_passed = user_prompt_abstention_context.is_none();
     let user_prompt_submit_abstention_false_positive_bound =
         InjectionRateMetric::new(usize::from(user_prompt_submit_abstention_passed), 1);
     let all_checks_passed = expected_memory_recall.is_perfect()
@@ -220,9 +218,7 @@ fn run_sandbox_eval_inner(
             .push("UserPromptSubmit missing expected memory: Migration locking fix".to_string());
     }
     if !user_prompt_submit_abstention_passed {
-        failing_examples.push(format!(
-            "UserPromptSubmit rendered unrelated memory: {ABSTENTION_FORBIDDEN_TITLE}"
-        ));
+        failing_examples.push("UserPromptSubmit rendered unexpected additionalContext".to_string());
     }
 
     let mut cases = expected_cases;

--- a/src/eval/injection/tests.rs
+++ b/src/eval/injection/tests.rs
@@ -29,6 +29,19 @@ fn injection_eval_exercises_session_start_render_path() -> Result<()> {
         "{:#?}",
         report
     );
+    assert!(
+        report.metrics.user_prompt_submit_memory_recall.is_perfect(),
+        "{:#?}",
+        report
+    );
+    assert!(
+        report
+            .metrics
+            .user_prompt_submit_abstention_false_positive_bound
+            .is_perfect(),
+        "{:#?}",
+        report
+    );
     assert!(report.metrics.all_checks_passed, "{:#?}", report);
     assert!(report.metadata.memories_loaded > 0);
     assert!(report.metadata.core_count > 0 || report.metadata.index_count > 0);
@@ -64,6 +77,8 @@ fn injection_eval_display_includes_metrics() {
             expected_memory_recall: InjectionRateMetric::new(2, 2),
             forbidden_memory_exclusion: InjectionRateMetric::new(3, 3),
             abstention_false_positive_bound: InjectionRateMetric::new(1, 1),
+            user_prompt_submit_memory_recall: InjectionRateMetric::new(1, 1),
+            user_prompt_submit_abstention_false_positive_bound: InjectionRateMetric::new(1, 1),
             all_checks_passed: true,
         },
         cases: vec![],
@@ -76,5 +91,7 @@ fn injection_eval_display_includes_metrics() {
     assert!(rendered.contains("expected_memory_recall: 2/2"));
     assert!(rendered.contains("forbidden_memory_exclusion: 3/3"));
     assert!(rendered.contains("abstention_false_positive_bound: 1/1"));
+    assert!(rendered.contains("user_prompt_submit_memory_recall: 1/1"));
+    assert!(rendered.contains("user_prompt_submit_abstention_false_positive_bound: 1/1"));
     assert!(rendered.contains("all_checks_passed: true"));
 }

--- a/src/eval/injection/types.rs
+++ b/src/eval/injection/types.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 pub use crate::eval::governance::RateMetric as InjectionRateMetric;
 
-pub(super) const CORPUS_NAME: &str = "builtin-session-start-injection-v1";
+pub(super) const CORPUS_NAME: &str = "builtin-context-injection-v2";
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InjectionEvalOptions {
@@ -46,6 +46,8 @@ pub struct InjectionMetricSummary {
     pub expected_memory_recall: InjectionRateMetric,
     pub forbidden_memory_exclusion: InjectionRateMetric,
     pub abstention_false_positive_bound: InjectionRateMetric,
+    pub user_prompt_submit_memory_recall: InjectionRateMetric,
+    pub user_prompt_submit_abstention_false_positive_bound: InjectionRateMetric,
     pub all_checks_passed: bool,
 }
 
@@ -87,6 +89,27 @@ impl Display for InjectionEvalReport {
             self.metrics.abstention_false_positive_bound.passed,
             self.metrics.abstention_false_positive_bound.total,
             self.metrics.abstention_false_positive_bound.rate * 100.0
+        )?;
+        writeln!(
+            f,
+            "user_prompt_submit_memory_recall: {}/{} ({:.1}%)",
+            self.metrics.user_prompt_submit_memory_recall.passed,
+            self.metrics.user_prompt_submit_memory_recall.total,
+            self.metrics.user_prompt_submit_memory_recall.rate * 100.0
+        )?;
+        writeln!(
+            f,
+            "user_prompt_submit_abstention_false_positive_bound: {}/{} ({:.1}%)",
+            self.metrics
+                .user_prompt_submit_abstention_false_positive_bound
+                .passed,
+            self.metrics
+                .user_prompt_submit_abstention_false_positive_bound
+                .total,
+            self.metrics
+                .user_prompt_submit_abstention_false_positive_bound
+                .rate
+                * 100.0
         )?;
         writeln!(
             f,

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -2,9 +2,11 @@ mod hook;
 mod native;
 mod parse;
 mod path;
+mod session_init;
 mod spill;
 #[cfg(test)]
 mod tests;
 
-pub use hook::{observe, session_init};
+pub use hook::observe;
 pub use path::short_path;
+pub use session_init::session_init;

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -1,46 +1,12 @@
 use anyhow::Result;
 
-use crate::db;
-
 use super::native::sync_native_memory;
 use super::spill::{
     record_capture_drop_lossy, replay_spilled_capture_events, spill_capture_event,
     SPILL_REASON_CAPTURE_PERSISTENCE_FAILED, SPILL_REASON_DB_OPEN_FAILED,
 };
 
-pub async fn session_init(host: Option<&str>) -> Result<()> {
-    let timer = crate::log::Timer::start("session-init", "");
-    let input = std::io::read_to_string(std::io::stdin())?;
-    crate::log::debug(
-        "session-init",
-        &format!("raw input: {}", crate::db::truncate_str(&input, 500)),
-    );
-
-    let Some(event) = session_init_event(&input, host) else {
-        timer.done("skipped");
-        return Ok(());
-    };
-
-    let project = event.project.clone();
-    let conn = db::open_db()?;
-    db::upsert_session(&conn, &event.session_id, &event.project, None)?;
-
-    timer.done(&format!("project={}", project));
-    Ok(())
-}
-
-fn session_init_event(input: &str, host: Option<&str>) -> Option<crate::adapter::ParsedHookEvent> {
-    let Some((_adapter, event)) = detect_adapter_for_host(input, host) else {
-        crate::log::warn("session-init", "SKIP no adapter matched hook input");
-        return None;
-    };
-
-    crate::log::info(
-        "session-init",
-        &format!("project={} session={}", event.project, event.session_id),
-    );
-    Some(event)
-}
+use crate::db;
 
 pub async fn observe(host: Option<&str>) -> Result<()> {
     let input = std::io::read_to_string(std::io::stdin())?;
@@ -215,7 +181,7 @@ fn record_observed_event(
     Ok(capture_event_id)
 }
 
-fn detect_adapter_for_host(
+pub(super) fn detect_adapter_for_host(
     input: &str,
     host: Option<&str>,
 ) -> Option<(
@@ -345,7 +311,7 @@ mod tests {
 
     use super::super::spill::spill_capture_event;
     use super::{
-        event_skip_reason, observe_input, record_capture_event, session_init_event,
+        event_skip_reason, observe_input, record_capture_event,
         SPILL_REASON_CAPTURE_PERSISTENCE_FAILED,
     };
 
@@ -409,32 +375,6 @@ mod tests {
         unsafe { std::env::remove_var("REMEM_ENABLE_CODEX_BASH_OBSERVE") };
 
         assert_eq!(skipped, None);
-    }
-
-    #[test]
-    fn session_init_skips_empty_hook_input() {
-        let _test_dir = ScopedTestDataDir::new("session-init-empty");
-
-        assert!(session_init_event("", Some("claude-code")).is_none());
-    }
-
-    #[test]
-    fn session_init_accepts_claude_user_prompt_submit_shape() {
-        let _test_dir = ScopedTestDataDir::new("session-init-user-prompt");
-        let input = serde_json::json!({
-            "session_id": "sess-user-prompt",
-            "cwd": "/tmp/remem",
-            "hook_event_name": "UserPromptSubmit",
-            "prompt": "hello"
-        })
-        .to_string();
-
-        let Some(event) = session_init_event(&input, Some("claude-code")) else {
-            panic!("event should parse");
-        };
-
-        assert_eq!(event.session_id, "sess-user-prompt");
-        assert_eq!(event.project, "/tmp/remem");
     }
 
     #[test]

--- a/src/observe/session_init.rs
+++ b/src/observe/session_init.rs
@@ -1,0 +1,137 @@
+use anyhow::Result;
+use serde::Deserialize;
+
+use crate::db;
+
+#[derive(Debug, Deserialize)]
+struct UserPromptSubmitInput {
+    hook_event_name: Option<String>,
+    prompt: Option<String>,
+}
+
+pub async fn session_init(host: Option<&str>) -> Result<()> {
+    let input = std::io::read_to_string(std::io::stdin())?;
+    if let Some(output) = session_init_input(&input, host).await? {
+        print!("{output}");
+    }
+    Ok(())
+}
+
+async fn session_init_input(input: &str, host: Option<&str>) -> Result<Option<String>> {
+    let timer = crate::log::Timer::start("session-init", "");
+    crate::log::debug(
+        "session-init",
+        &format!("raw input: {}", crate::db::truncate_str(input, 500)),
+    );
+
+    let Some(event) = session_init_event(input, host) else {
+        timer.done("skipped");
+        return Ok(None);
+    };
+
+    let project = event.project.clone();
+    let conn = db::open_db()?;
+    db::upsert_session(&conn, &event.session_id, &event.project, None)?;
+    let output = if let Some(prompt) = user_prompt_submit_prompt(input) {
+        let cwd = event.cwd.as_deref().unwrap_or(&event.project);
+        crate::context::prompt_submit_additional_context(
+            &conn,
+            cwd,
+            &event.project,
+            &event.session_id,
+            &prompt,
+            host,
+        )?
+        .map(|context| user_prompt_submit_output(&context))
+        .transpose()?
+    } else {
+        None
+    };
+
+    timer.done(&format!("project={project}"));
+    Ok(output)
+}
+
+fn session_init_event(input: &str, host: Option<&str>) -> Option<crate::adapter::ParsedHookEvent> {
+    let Some((_adapter, event)) = super::hook::detect_adapter_for_host(input, host) else {
+        crate::log::warn("session-init", "SKIP no adapter matched hook input");
+        return None;
+    };
+
+    crate::log::info(
+        "session-init",
+        &format!("project={} session={}", event.project, event.session_id),
+    );
+    Some(event)
+}
+
+fn user_prompt_submit_prompt(input: &str) -> Option<String> {
+    let hook: UserPromptSubmitInput = serde_json::from_str(input).ok()?;
+    let event_name = hook.hook_event_name.as_deref()?.trim();
+    if !event_name.eq_ignore_ascii_case("UserPromptSubmit") {
+        return None;
+    }
+    hook.prompt
+        .map(|prompt| prompt.trim().to_string())
+        .filter(|prompt| !prompt.is_empty())
+}
+
+fn user_prompt_submit_output(additional_context: &str) -> Result<String> {
+    let output = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": additional_context
+        }
+    });
+    Ok(serde_json::to_string(&output)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::test_support::ScopedTestDataDir;
+
+    use super::{session_init_event, user_prompt_submit_output, user_prompt_submit_prompt};
+
+    #[test]
+    fn session_init_skips_empty_hook_input() {
+        let _test_dir = ScopedTestDataDir::new("session-init-empty");
+
+        assert!(session_init_event("", Some("claude-code")).is_none());
+    }
+
+    #[test]
+    fn session_init_accepts_claude_user_prompt_submit_shape() {
+        let _test_dir = ScopedTestDataDir::new("session-init-user-prompt");
+        let input = serde_json::json!({
+            "session_id": "sess-user-prompt",
+            "cwd": "/tmp/remem",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "hello"
+        })
+        .to_string();
+
+        let Some(event) = session_init_event(&input, Some("claude-code")) else {
+            panic!("event should parse");
+        };
+
+        assert_eq!(event.session_id, "sess-user-prompt");
+        assert_eq!(event.project, "/tmp/remem");
+        assert_eq!(user_prompt_submit_prompt(&input).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn user_prompt_submit_output_uses_hook_specific_additional_context() -> anyhow::Result<()> {
+        let output = user_prompt_submit_output("Remember SQLCipher")?;
+        let parsed: serde_json::Value = serde_json::from_str(&output)?;
+
+        assert_eq!(
+            parsed["hookSpecificOutput"]["hookEventName"],
+            "UserPromptSubmit"
+        );
+        assert_eq!(
+            parsed["hookSpecificOutput"]["additionalContext"],
+            "Remember SQLCipher"
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- Handle Claude UserPromptSubmit in session-init by retrieving prompt-relevant memories and emitting hookSpecificOutput.additionalContext.
- Add prompt-submit item audit/dedup so memories already injected in the same session are not resent, without using output-level context gate suppression/delta.
- Extend injection eval gates with UserPromptSubmit recall and abstention metrics, and bump package/plugin versions to 0.5.54.

Fixes #376

## Verification
- cargo fmt --check && git diff --check
- cargo check --message-format=short
- cargo test context::prompt_submit -- --nocapture
- cargo test observe::session_init -- --nocapture
- cargo test eval::injection -- --nocapture
- cargo run --quiet -- eval-gates --json-out /tmp/remem-issue376-eval-gates.json
- cargo clippy -- -D warnings
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js
- REMEM_NPM_BINARY=/private/tmp/remem-issue376-prompt-submit-context/target/debug/remem npm test --prefix npm/remem
- cargo test