### PR TITLE
Add graph retrieval decision gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.54"
+version = "0.5.55"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.54"
+version = "0.5.55"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/docs/adr/2026-06-12-graph-decision-gate.md
+++ b/docs/adr/2026-06-12-graph-decision-gate.md
@@ -1,4 +1,4 @@
-# ADR: Freeze `graph_edges` as a Retrieval Channel Until It Clears the Graph Decision Gate
+# ADR: Keep `graph_edges` Retrieval Frozen Pending a Literal Graph Eval
 
 Date: 2026-06-12
 
@@ -8,11 +8,18 @@ Accepted.
 
 ## Decision
 
-Do not wire first-class `graph_edges` traversal into the default retrieval stack yet.
+Do not wire first-class `graph_edges` traversal into the default retrieval
+stack yet.
 
 Keep the existing explicit `--multi-hop` entity expansion path available, but treat
 `graph_edges` as a provenance/candidate contract until a future pre-registered
 A/B eval shows a material retrieval gain.
+
+This ADR deliberately separates the two channels:
+
+- evaluated channel: the existing entity-BFS proxy path through
+  `memory_entities` plus FTS mention fallback
+- unevaluated channel: literal traversal over the `graph_edges` table
 
 ## Drivers
 
@@ -22,6 +29,9 @@ A/B eval shows a material retrieval gain.
   including 10 `multi_hop` cases.
 - The current `multi_hop` slice is saturated under standard retrieval:
   `recall_at_k = 1.0` and `evidence_recall_at_k = 1.0`.
+- The current entity-BFS proxy run does not exercise two-hop expansion on the
+  committed `multi_hop` fixture, so it is not evidence that literal
+  `graph_edges` traversal has been evaluated.
 - Adding graph traversal to retrieval creates privacy/filtering and ranking risk,
   so it needs evidence before becoming a search channel.
 
@@ -37,22 +47,28 @@ remem eval-graph-decision --json-out eval/graph-decision/report.json
 
 Summary from the committed report:
 
-- Decision: `freeze_graph_edges_retrieval_channel`
+- Decision: `keep_graph_edges_frozen_pending_literal_eval`
+- Evaluated channel: `entity_bfs_proxy`
+- `graph_edges` evaluated: `false`
+- `graph_edges` retrieval decision:
+  `remain_frozen_pending_literal_eval`
 - Benefit threshold: `0.05`
 - Multi-hop evidence recall delta: `0.0`
 - Multi-hop recall delta: `0.0`
 - Multi-hop nDCG@10 delta: `0.0`
 - Non-multi-hop evidence recall delta: `0.2666666666666667`
-- Entity-BFS p95 latency: `13.938834ms`
+- Entity-BFS p95 latency: see the committed JSON artifact for the exact run
 - Checks: `non_multi_hop_zero_regression = true`,
-  `p95_latency_within_budget = true`, `all_checks_passed = true`
+  `p95_latency_within_budget = true`, `safe_to_wire_entity_bfs = false`,
+  `all_checks_passed = true`
 
 ## Consequences
 
 - `graph_edges` remains a typed graph/provenance contract, not a retrieval
   channel.
-- #332, #334, and #335 should remain frozen unless a future eval expands the
-  graph fixture with harder cases and shows a pre-registered gain.
+- #332, #334, and #335 should remain frozen unless a future eval implements
+  literal `graph_edges` traversal, expands the graph fixture with harder cases,
+  and shows a pre-registered gain.
 - Future graph retrieval work must come with an A/B artifact, filter-leakage
   tests, and explainable path output before it can change defaults.
 
@@ -60,6 +76,8 @@ Summary from the committed report:
 
 - Expand the multi-hop fixture with cases where standard retrieval does not
   already saturate recall.
+- Implement a literal `graph_edges` traversal eval arm before claiming
+  `graph_edges` has retrieval evidence.
 - If a future graph channel is attempted, gate it behind explicit configuration
   first and preserve project, branch, owner, memory type, and stale filters.
 - Re-run `remem eval-graph-decision` after fixture expansion or ranking changes

--- a/docs/adr/2026-06-12-graph-decision-gate.md
+++ b/docs/adr/2026-06-12-graph-decision-gate.md
@@ -1,0 +1,66 @@
+# ADR: Freeze `graph_edges` as a Retrieval Channel Until It Clears the Graph Decision Gate
+
+Date: 2026-06-12
+
+## Status
+
+Accepted.
+
+## Decision
+
+Do not wire first-class `graph_edges` traversal into the default retrieval stack yet.
+
+Keep the existing explicit `--multi-hop` entity expansion path available, but treat
+`graph_edges` as a provenance/candidate contract until a future pre-registered
+A/B eval shows a material retrieval gain.
+
+## Drivers
+
+- Issue #382 requires a wire-or-freeze decision for graph retrieval before
+  unblocking the older graph roadmap issues.
+- The current deterministic golden corpus already has 50 fixture-backed queries,
+  including 10 `multi_hop` cases.
+- The current `multi_hop` slice is saturated under standard retrieval:
+  `recall_at_k = 1.0` and `evidence_recall_at_k = 1.0`.
+- Adding graph traversal to retrieval creates privacy/filtering and ranking risk,
+  so it needs evidence before becoming a search channel.
+
+## Evidence
+
+Committed artifact: `eval/graph-decision/report.json`.
+
+Command:
+
+```bash
+remem eval-graph-decision --json-out eval/graph-decision/report.json
+```
+
+Summary from the committed report:
+
+- Decision: `freeze_graph_edges_retrieval_channel`
+- Benefit threshold: `0.05`
+- Multi-hop evidence recall delta: `0.0`
+- Multi-hop recall delta: `0.0`
+- Multi-hop nDCG@10 delta: `0.0`
+- Non-multi-hop evidence recall delta: `0.2666666666666667`
+- Entity-BFS p95 latency: `13.938834ms`
+- Checks: `non_multi_hop_zero_regression = true`,
+  `p95_latency_within_budget = true`, `all_checks_passed = true`
+
+## Consequences
+
+- `graph_edges` remains a typed graph/provenance contract, not a retrieval
+  channel.
+- #332, #334, and #335 should remain frozen unless a future eval expands the
+  graph fixture with harder cases and shows a pre-registered gain.
+- Future graph retrieval work must come with an A/B artifact, filter-leakage
+  tests, and explainable path output before it can change defaults.
+
+## Follow-ups
+
+- Expand the multi-hop fixture with cases where standard retrieval does not
+  already saturate recall.
+- If a future graph channel is attempted, gate it behind explicit configuration
+  first and preserve project, branch, owner, memory type, and stale filters.
+- Re-run `remem eval-graph-decision` after fixture expansion or ranking changes
+  before reopening graph retrieval implementation work.

--- a/eval/README.md
+++ b/eval/README.md
@@ -129,3 +129,19 @@ changes cannot pass on aggregate rates alone.
 The hidden `--simulate-golden-regression` flag is exercised in CI to prove the
 gate fails on a constructed per-slice retrieval regression before changing
 defaults.
+
+## Graph Decision Gate
+
+`remem eval-graph-decision` runs the issue #382 wire-or-freeze gate. It compares
+standard golden retrieval against the explicit entity-BFS multi-hop path and
+writes the A/B artifact used by the graph retrieval ADR:
+
+```bash
+remem eval-graph-decision --json-out eval/graph-decision/report.json
+```
+
+The gate records the pre-registered 5% multi-hop evidence-recall threshold,
+non-`multi_hop` zero-regression checks, and a 1000ms p95 latency budget. A
+failure to clear the benefit threshold is not a process failure by itself; it
+means the correct decision is to freeze `graph_edges` as a retrieval channel
+until a future fixture and A/B report prove material value.

--- a/eval/README.md
+++ b/eval/README.md
@@ -133,15 +133,17 @@ defaults.
 ## Graph Decision Gate
 
 `remem eval-graph-decision` runs the issue #382 wire-or-freeze gate. It compares
-standard golden retrieval against the explicit entity-BFS multi-hop path and
-writes the A/B artifact used by the graph retrieval ADR:
+standard golden retrieval against the explicit entity-BFS multi-hop proxy path
+and writes the artifact used by the graph retrieval ADR:
 
 ```bash
 remem eval-graph-decision --json-out eval/graph-decision/report.json
 ```
 
 The gate records the pre-registered 5% multi-hop evidence-recall threshold,
-non-`multi_hop` zero-regression checks, and a 1000ms p95 latency budget. A
-failure to clear the benefit threshold is not a process failure by itself; it
-means the correct decision is to freeze `graph_edges` as a retrieval channel
-until a future fixture and A/B report prove material value.
+non-`multi_hop` zero-regression checks, a 1000ms p95 latency budget, whether the
+entity-BFS proxy exercised two-hop expansion, and whether literal `graph_edges`
+traversal was evaluated. A failure to clear the entity-BFS wire requirements is
+not a process failure by itself; it means the correct decision is to keep
+`graph_edges` frozen as a retrieval channel until a future literal graph-edge
+fixture and A/B report prove material value.

--- a/eval/graph-decision/report.json
+++ b/eval/graph-decision/report.json
@@ -4,8 +4,11 @@
   "k": 5,
   "benefit_threshold": 0.05,
   "latency_budget_p95_ms": 1000.0,
-  "decision": "freeze_graph_edges_retrieval_channel",
-  "decision_reason": "Entity BFS did not clear the pre-registered 5% multi-hop evidence-recall gain threshold; do not wire graph_edges into retrieval by default.",
+  "evaluated_channel": "entity_bfs_proxy",
+  "graph_edges_evaluated": false,
+  "graph_edges_retrieval_decision": "remain_frozen_pending_literal_eval",
+  "decision": "keep_graph_edges_frozen_pending_literal_eval",
+  "decision_reason": "This gate evaluated the entity-BFS proxy path, not literal graph_edges traversal. The proxy did not satisfy all wire requirements: >= 5% multi-hop evidence-recall gain, non-multi-hop zero regression, p95 latency <= 1000ms, and observed two-hop expansion. Keep graph_edges retrieval frozen pending a dedicated graph_edges A/B eval.",
   "standard": {
     "mode": "standard",
     "overall": {
@@ -14,8 +17,8 @@
       "abstention_queries": 10,
       "abstention_passed": 0,
       "query_tokens_per_query": 12.88,
-      "retrieval_latency_p50_ms": 9.129916999999999,
-      "retrieval_latency_p95_ms": 10.02725,
+      "retrieval_latency_p50_ms": 8.972666,
+      "retrieval_latency_p95_ms": 9.558834000000001,
       "metrics": {
         "count": 40,
         "hit_at_k": 0.75,
@@ -32,8 +35,8 @@
       "abstention_queries": 0,
       "abstention_passed": 0,
       "query_tokens_per_query": 19.6,
-      "retrieval_latency_p50_ms": 9.362957999999999,
-      "retrieval_latency_p95_ms": 9.441167,
+      "retrieval_latency_p50_ms": 9.535042,
+      "retrieval_latency_p95_ms": 9.654334,
       "metrics": {
         "count": 10,
         "hit_at_k": 1.0,
@@ -50,8 +53,8 @@
       "abstention_queries": 10,
       "abstention_passed": 0,
       "query_tokens_per_query": 11.2,
-      "retrieval_latency_p50_ms": 8.979583,
-      "retrieval_latency_p95_ms": 10.072833999999999,
+      "retrieval_latency_p50_ms": 8.862541,
+      "retrieval_latency_p95_ms": 9.487874999999999,
       "metrics": {
         "count": 30,
         "hit_at_k": 0.6666666666666666,
@@ -62,6 +65,7 @@
         "evidence_recall_at_k": 0.6666666666666666
       }
     },
+    "multi_hop_queries_with_two_or_more_hops": 0,
     "query_summaries": [
       {
         "id": "paraphrase-01",
@@ -73,7 +77,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.86475,
+        "retrieval_latency_ms": 9.490874999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -89,7 +93,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.912167,
+        "retrieval_latency_ms": 8.675458,
         "hops": null,
         "entities_discovered": []
       },
@@ -101,7 +105,7 @@
         "retrieved_ids": [],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.811917000000001,
+        "retrieval_latency_ms": 8.660499999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -115,7 +119,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.575416,
+        "retrieval_latency_ms": 8.446957999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -127,7 +131,7 @@
         "retrieved_ids": [],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.856083,
+        "retrieval_latency_ms": 8.6325,
         "hops": null,
         "entities_discovered": []
       },
@@ -141,7 +145,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.994208,
+        "retrieval_latency_ms": 8.560584,
         "hops": null,
         "entities_discovered": []
       },
@@ -157,7 +161,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.84875,
+        "retrieval_latency_ms": 9.017624999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -172,7 +176,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.680334,
+        "retrieval_latency_ms": 8.97775,
         "hops": null,
         "entities_discovered": []
       },
@@ -188,7 +192,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.63475,
+        "retrieval_latency_ms": 8.686416000000001,
         "hops": null,
         "entities_discovered": []
       },
@@ -204,7 +208,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.747625,
+        "retrieval_latency_ms": 8.6245,
         "hops": null,
         "entities_discovered": []
       },
@@ -221,7 +225,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.176791,
+        "retrieval_latency_ms": 9.036584,
         "hops": null,
         "entities_discovered": []
       },
@@ -238,7 +242,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.998000000000001,
+        "retrieval_latency_ms": 8.862541,
         "hops": null,
         "entities_discovered": []
       },
@@ -255,7 +259,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.050958,
+        "retrieval_latency_ms": 8.969083,
         "hops": null,
         "entities_discovered": []
       },
@@ -272,7 +276,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.161875,
+        "retrieval_latency_ms": 9.060209,
         "hops": null,
         "entities_discovered": []
       },
@@ -289,7 +293,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.202292,
+        "retrieval_latency_ms": 9.051416,
         "hops": null,
         "entities_discovered": []
       },
@@ -306,7 +310,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.264415999999999,
+        "retrieval_latency_ms": 8.8455,
         "hops": null,
         "entities_discovered": []
       },
@@ -323,7 +327,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.927916,
+        "retrieval_latency_ms": 9.354958,
         "hops": null,
         "entities_discovered": []
       },
@@ -340,7 +344,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.562291,
+        "retrieval_latency_ms": 9.487874999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -357,7 +361,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.397417,
+        "retrieval_latency_ms": 8.833499999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -374,7 +378,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 10.02725,
+        "retrieval_latency_ms": 9.008208999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -391,7 +395,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 10.072833999999999,
+        "retrieval_latency_ms": 9.016417,
         "hops": null,
         "entities_discovered": []
       },
@@ -408,7 +412,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 10.477416,
+        "retrieval_latency_ms": 8.803916000000001,
         "hops": null,
         "entities_discovered": []
       },
@@ -425,7 +429,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.951375,
+        "retrieval_latency_ms": 8.90525,
         "hops": null,
         "entities_discovered": []
       },
@@ -442,7 +446,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.462,
+        "retrieval_latency_ms": 8.985417,
         "hops": null,
         "entities_discovered": []
       },
@@ -459,7 +463,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.129916999999999,
+        "retrieval_latency_ms": 8.972666,
         "hops": null,
         "entities_discovered": []
       },
@@ -476,7 +480,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.829959,
+        "retrieval_latency_ms": 8.890041,
         "hops": null,
         "entities_discovered": []
       },
@@ -493,7 +497,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.956000000000001,
+        "retrieval_latency_ms": 8.9965,
         "hops": null,
         "entities_discovered": []
       },
@@ -510,7 +514,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.001083,
+        "retrieval_latency_ms": 9.005,
         "hops": null,
         "entities_discovered": []
       },
@@ -527,7 +531,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.814,
+        "retrieval_latency_ms": 8.874,
         "hops": null,
         "entities_discovered": []
       },
@@ -544,7 +548,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.979583,
+        "retrieval_latency_ms": 8.731833,
         "hops": null,
         "entities_discovered": []
       },
@@ -561,7 +565,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 9.648875,
+        "retrieval_latency_ms": 9.072125,
         "hops": null,
         "entities_discovered": []
       },
@@ -577,7 +581,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 8.746291,
+        "retrieval_latency_ms": 8.403542,
         "hops": null,
         "entities_discovered": []
       },
@@ -594,7 +598,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 8.586583,
+        "retrieval_latency_ms": 8.550624999999998,
         "hops": null,
         "entities_discovered": []
       },
@@ -610,7 +614,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 8.271208,
+        "retrieval_latency_ms": 8.262291999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -626,7 +630,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 8.455833,
+        "retrieval_latency_ms": 8.444375,
         "hops": null,
         "entities_discovered": []
       },
@@ -642,7 +646,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 8.097874999999998,
+        "retrieval_latency_ms": 8.081,
         "hops": null,
         "entities_discovered": []
       },
@@ -658,7 +662,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 8.33075,
+        "retrieval_latency_ms": 8.376584,
         "hops": null,
         "entities_discovered": []
       },
@@ -674,7 +678,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 8.269416999999999,
+        "retrieval_latency_ms": 8.287374999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -690,7 +694,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 8.283333,
+        "retrieval_latency_ms": 8.283459,
         "hops": null,
         "entities_discovered": []
       },
@@ -708,7 +712,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 8.576084,
+        "retrieval_latency_ms": 8.576375,
         "hops": null,
         "entities_discovered": []
       },
@@ -726,7 +730,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.441167,
+        "retrieval_latency_ms": 9.421667,
         "hops": null,
         "entities_discovered": []
       },
@@ -744,7 +748,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.338166,
+        "retrieval_latency_ms": 9.333375,
         "hops": null,
         "entities_discovered": []
       },
@@ -762,7 +766,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.409832999999999,
+        "retrieval_latency_ms": 9.547292,
         "hops": null,
         "entities_discovered": []
       },
@@ -780,7 +784,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.379375000000001,
+        "retrieval_latency_ms": 9.654334,
         "hops": null,
         "entities_discovered": []
       },
@@ -798,7 +802,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.376542,
+        "retrieval_latency_ms": 9.56725,
         "hops": null,
         "entities_discovered": []
       },
@@ -816,7 +820,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.292666,
+        "retrieval_latency_ms": 9.558834000000001,
         "hops": null,
         "entities_discovered": []
       },
@@ -834,7 +838,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.362957999999999,
+        "retrieval_latency_ms": 9.535042,
         "hops": null,
         "entities_discovered": []
       },
@@ -852,7 +856,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.261833000000001,
+        "retrieval_latency_ms": 9.480208000000001,
         "hops": null,
         "entities_discovered": []
       },
@@ -870,7 +874,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.287500000000001,
+        "retrieval_latency_ms": 9.310291999999999,
         "hops": null,
         "entities_discovered": []
       },
@@ -888,7 +892,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 9.322416,
+        "retrieval_latency_ms": 9.388458,
         "hops": null,
         "entities_discovered": []
       }
@@ -902,8 +906,8 @@
       "abstention_queries": 10,
       "abstention_passed": 0,
       "query_tokens_per_query": 12.88,
-      "retrieval_latency_p50_ms": 12.179499999999999,
-      "retrieval_latency_p95_ms": 13.938834,
+      "retrieval_latency_p50_ms": 12.216958,
+      "retrieval_latency_p95_ms": 13.660874999999999,
       "metrics": {
         "count": 40,
         "hit_at_k": 0.95,
@@ -920,8 +924,8 @@
       "abstention_queries": 0,
       "abstention_passed": 0,
       "query_tokens_per_query": 19.6,
-      "retrieval_latency_p50_ms": 13.644708,
-      "retrieval_latency_p95_ms": 14.207709000000001,
+      "retrieval_latency_p50_ms": 13.35075,
+      "retrieval_latency_p95_ms": 13.737875,
       "metrics": {
         "count": 10,
         "hit_at_k": 1.0,
@@ -938,8 +942,8 @@
       "abstention_queries": 10,
       "abstention_passed": 0,
       "query_tokens_per_query": 11.2,
-      "retrieval_latency_p50_ms": 12.069792,
-      "retrieval_latency_p95_ms": 12.866958,
+      "retrieval_latency_p50_ms": 11.977666999999999,
+      "retrieval_latency_p95_ms": 12.814709,
       "metrics": {
         "count": 30,
         "hit_at_k": 0.9333333333333333,
@@ -950,6 +954,7 @@
         "evidence_recall_at_k": 0.9333333333333333
       }
     },
+    "multi_hop_queries_with_two_or_more_hops": 0,
     "query_summaries": [
       {
         "id": "paraphrase-01",
@@ -965,7 +970,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 10.734541,
+        "retrieval_latency_ms": 10.57325,
         "hops": 2,
         "entities_discovered": [
           "Kestrelnook",
@@ -989,7 +994,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 11.707334,
+        "retrieval_latency_ms": 11.643749999999999,
         "hops": 2,
         "entities_discovered": [
           "Lumenquay",
@@ -1013,7 +1018,7 @@
         "retrieved_ids": [],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 8.635541,
+        "retrieval_latency_ms": 8.602791999999999,
         "hops": 1,
         "entities_discovered": []
       },
@@ -1030,7 +1035,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 10.057291,
+        "retrieval_latency_ms": 9.966249999999999,
         "hops": 2,
         "entities_discovered": [
           "Brindleforge",
@@ -1047,7 +1052,7 @@
         "retrieved_ids": [],
         "matched_refs": 0,
         "expected_refs": 1,
-        "retrieval_latency_ms": 9.155875,
+        "retrieval_latency_ms": 8.595084,
         "hops": 1,
         "entities_discovered": []
       },
@@ -1064,7 +1069,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 10.736208000000001,
+        "retrieval_latency_ms": 10.006499999999999,
         "hops": 2,
         "entities_discovered": [
           "Hollowspan",
@@ -1087,7 +1092,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 11.834667,
+        "retrieval_latency_ms": 11.804291,
         "hops": 2,
         "entities_discovered": [
           "Paleravine",
@@ -1117,7 +1122,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 10.967541,
+        "retrieval_latency_ms": 10.795083,
         "hops": 2,
         "entities_discovered": [
           "Copperoven",
@@ -1143,7 +1148,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 11.261917,
+        "retrieval_latency_ms": 11.3715,
         "hops": 2,
         "entities_discovered": [
           "Cyanward",
@@ -1171,7 +1176,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 11.806875,
+        "retrieval_latency_ms": 12.033083,
         "hops": 2,
         "entities_discovered": [
           "Violetdome",
@@ -1201,7 +1206,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.535041999999999,
+        "retrieval_latency_ms": 12.729709,
         "hops": 2,
         "entities_discovered": [
           "Kestrelnook",
@@ -1233,7 +1238,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 11.990708,
+        "retrieval_latency_ms": 12.08125,
         "hops": 2,
         "entities_discovered": [
           "Lumenquay",
@@ -1264,7 +1269,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.179499999999999,
+        "retrieval_latency_ms": 11.977666999999999,
         "hops": 2,
         "entities_discovered": [
           "Cinderbloom",
@@ -1295,7 +1300,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.6455,
+        "retrieval_latency_ms": 12.535459000000001,
         "hops": 2,
         "entities_discovered": [
           "Brindleforge",
@@ -1327,7 +1332,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.839,
+        "retrieval_latency_ms": 12.556875,
         "hops": 2,
         "entities_discovered": [
           "Vellumspire",
@@ -1359,7 +1364,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 11.85075,
+        "retrieval_latency_ms": 11.737167,
         "hops": 2,
         "entities_discovered": [
           "Hollowspan",
@@ -1389,7 +1394,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.069792,
+        "retrieval_latency_ms": 12.040291999999999,
         "hops": 2,
         "entities_discovered": [
           "Paleravine",
@@ -1420,7 +1425,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 11.936542,
+        "retrieval_latency_ms": 11.92175,
         "hops": 2,
         "entities_discovered": [
           "Copperoven",
@@ -1451,7 +1456,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.090958,
+        "retrieval_latency_ms": 11.9245,
         "hops": 2,
         "entities_discovered": [
           "Cyanward",
@@ -1482,7 +1487,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.622625,
+        "retrieval_latency_ms": 12.536125,
         "hops": 2,
         "entities_discovered": [
           "Violetdome",
@@ -1513,7 +1518,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.743625,
+        "retrieval_latency_ms": 12.697040999999999,
         "hops": 2,
         "entities_discovered": [
           "Kestrelnook",
@@ -1546,7 +1551,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.096166,
+        "retrieval_latency_ms": 12.188416,
         "hops": 2,
         "entities_discovered": [
           "Lumenquay",
@@ -1578,7 +1583,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.175625,
+        "retrieval_latency_ms": 12.216958,
         "hops": 2,
         "entities_discovered": [
           "Cinderbloom",
@@ -1610,7 +1615,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.866958,
+        "retrieval_latency_ms": 12.613958,
         "hops": 2,
         "entities_discovered": [
           "Brindleforge",
@@ -1643,7 +1648,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.840834000000001,
+        "retrieval_latency_ms": 12.714875000000001,
         "hops": 2,
         "entities_discovered": [
           "Vellumspire",
@@ -1676,7 +1681,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.142125,
+        "retrieval_latency_ms": 11.971875,
         "hops": 2,
         "entities_discovered": [
           "Hollowspan",
@@ -1707,7 +1712,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.482334,
+        "retrieval_latency_ms": 12.268457999999999,
         "hops": 2,
         "entities_discovered": [
           "Paleravine",
@@ -1739,7 +1744,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.472083,
+        "retrieval_latency_ms": 12.533125,
         "hops": 2,
         "entities_discovered": [
           "Copperoven",
@@ -1771,7 +1776,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.346792,
+        "retrieval_latency_ms": 12.357333,
         "hops": 2,
         "entities_discovered": [
           "Cyanward",
@@ -1803,7 +1808,7 @@
         ],
         "matched_refs": 1,
         "expected_refs": 1,
-        "retrieval_latency_ms": 12.787583,
+        "retrieval_latency_ms": 12.814709,
         "hops": 2,
         "entities_discovered": [
           "Violetdome",
@@ -1835,7 +1840,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 12.7,
+        "retrieval_latency_ms": 12.733583,
         "hops": 2,
         "entities_discovered": [
           "Quorum",
@@ -1867,7 +1872,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 11.525916,
+        "retrieval_latency_ms": 11.306833000000001,
         "hops": 2,
         "entities_discovered": [
           "Lumenquay",
@@ -1896,7 +1901,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 12.542124999999999,
+        "retrieval_latency_ms": 12.441333,
         "hops": 2,
         "entities_discovered": [
           "Cinderbloom",
@@ -1929,7 +1934,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 11.070875000000001,
+        "retrieval_latency_ms": 11.091916,
         "hops": 2,
         "entities_discovered": [
           "Brindleforge",
@@ -1957,7 +1962,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 11.467292,
+        "retrieval_latency_ms": 11.199583,
         "hops": 2,
         "entities_discovered": [
           "Vellumspire",
@@ -1985,7 +1990,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 11.031541,
+        "retrieval_latency_ms": 10.743,
         "hops": 2,
         "entities_discovered": [
           "Hollowspan",
@@ -2013,7 +2018,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 11.134666999999999,
+        "retrieval_latency_ms": 11.272,
         "hops": 2,
         "entities_discovered": [
           "Paleravine",
@@ -2042,7 +2047,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 10.612417,
+        "retrieval_latency_ms": 10.819542,
         "hops": 2,
         "entities_discovered": [
           "Copperoven",
@@ -2069,7 +2074,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 10.605125,
+        "retrieval_latency_ms": 10.770166,
         "hops": 2,
         "entities_discovered": [
           "Cyanward",
@@ -2096,7 +2101,7 @@
         ],
         "matched_refs": 0,
         "expected_refs": 0,
-        "retrieval_latency_ms": 12.9835,
+        "retrieval_latency_ms": 13.276542000000001,
         "hops": 1,
         "entities_discovered": [
           "Violetdome",
@@ -2130,7 +2135,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 13.496875000000001,
+        "retrieval_latency_ms": 13.660874999999999,
         "hops": 1,
         "entities_discovered": [
           "Kestrelnook",
@@ -2164,7 +2169,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 13.177417,
+        "retrieval_latency_ms": 13.230917,
         "hops": 1,
         "entities_discovered": [
           "Lumenquay",
@@ -2197,7 +2202,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 13.649,
+        "retrieval_latency_ms": 13.247458,
         "hops": 1,
         "entities_discovered": [
           "Cinderbloom",
@@ -2230,7 +2235,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 14.207709000000001,
+        "retrieval_latency_ms": 13.737875,
         "hops": 1,
         "entities_discovered": [
           "Brindleforge",
@@ -2264,7 +2269,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 13.938834,
+        "retrieval_latency_ms": 13.735000000000001,
         "hops": 1,
         "entities_discovered": [
           "Vellumspire",
@@ -2298,7 +2303,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 13.231084000000001,
+        "retrieval_latency_ms": 13.027209,
         "hops": 1,
         "entities_discovered": [
           "Hollowspan",
@@ -2330,7 +2335,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 13.644708,
+        "retrieval_latency_ms": 13.35075,
         "hops": 1,
         "entities_discovered": [
           "Paleravine",
@@ -2363,7 +2368,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 13.631375,
+        "retrieval_latency_ms": 13.130083,
         "hops": 1,
         "entities_discovered": [
           "Copperoven",
@@ -2396,7 +2401,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 13.524750000000001,
+        "retrieval_latency_ms": 12.948833,
         "hops": 1,
         "entities_discovered": [
           "Cyanward",
@@ -2429,7 +2434,7 @@
         ],
         "matched_refs": 2,
         "expected_refs": 2,
-        "retrieval_latency_ms": 14.119833,
+        "retrieval_latency_ms": 13.591583,
         "hops": 1,
         "entities_discovered": [
           "Violetdome",
@@ -2457,16 +2462,19 @@
     "non_multi_hop_recall_at_k": 0.2666666666666667,
     "non_multi_hop_evidence_recall_at_k": 0.2666666666666667,
     "non_multi_hop_ndcg_at_10": 0.11484708215290484,
-    "p95_latency_ms": 3.9115839999999995
+    "p95_latency_ms": 4.102040999999998
   },
   "checks": {
+    "multi_hop_slice_present": true,
+    "entity_bfs_two_hop_observed": false,
     "benefit_threshold_met": false,
     "non_multi_hop_zero_regression": true,
     "p95_latency_within_budget": true,
+    "safe_to_wire_entity_bfs": false,
     "all_checks_passed": true
   },
   "notes": [
-    "Entity BFS is the existing explicit multi-hop expansion through memory_entities plus FTS mention fallback; this report does not wire first-class graph_edges traversal.",
-    "A freeze decision keeps graph_edges available for provenance/candidates but blocks retrieval-channel rollout until a future pre-registered eval shows a material gain."
+    "Entity BFS is the existing explicit multi-hop expansion through memory_entities plus FTS mention fallback; this report does not evaluate first-class graph_edges traversal.",
+    "The graph_edges retrieval decision is therefore a conservative freeze: graph_edges remains available for provenance/candidates but cannot become a retrieval channel until a future pre-registered literal graph_edges eval shows a material gain."
   ]
 }

--- a/eval/graph-decision/report.json
+++ b/eval/graph-decision/report.json
@@ -1,0 +1,2472 @@
+{
+  "version": "2026-06-12",
+  "dataset_path": "eval/golden.json",
+  "k": 5,
+  "benefit_threshold": 0.05,
+  "latency_budget_p95_ms": 1000.0,
+  "decision": "freeze_graph_edges_retrieval_channel",
+  "decision_reason": "Entity BFS did not clear the pre-registered 5% multi-hop evidence-recall gain threshold; do not wire graph_edges into retrieval by default.",
+  "standard": {
+    "mode": "standard",
+    "overall": {
+      "total_queries": 50,
+      "scored_queries": 40,
+      "abstention_queries": 10,
+      "abstention_passed": 0,
+      "query_tokens_per_query": 12.88,
+      "retrieval_latency_p50_ms": 9.129916999999999,
+      "retrieval_latency_p95_ms": 10.02725,
+      "metrics": {
+        "count": 40,
+        "hit_at_k": 0.75,
+        "mrr_at_10": 0.6708333333333333,
+        "precision_at_k": 0.2250000000000001,
+        "recall_at_k": 0.75,
+        "ndcg_at_10": 0.6569288667454157,
+        "evidence_recall_at_k": 0.75
+      }
+    },
+    "multi_hop_slice": {
+      "total_queries": 10,
+      "scored_queries": 10,
+      "abstention_queries": 0,
+      "abstention_passed": 0,
+      "query_tokens_per_query": 19.6,
+      "retrieval_latency_p50_ms": 9.362957999999999,
+      "retrieval_latency_p95_ms": 9.441167,
+      "metrics": {
+        "count": 10,
+        "hit_at_k": 1.0,
+        "mrr_at_10": 0.95,
+        "precision_at_k": 0.39999999999999997,
+        "recall_at_k": 1.0,
+        "ndcg_at_10": 0.827715466981663,
+        "evidence_recall_at_k": 1.0
+      }
+    },
+    "non_multi_hop_slices": {
+      "total_queries": 40,
+      "scored_queries": 30,
+      "abstention_queries": 10,
+      "abstention_passed": 0,
+      "query_tokens_per_query": 11.2,
+      "retrieval_latency_p50_ms": 8.979583,
+      "retrieval_latency_p95_ms": 10.072833999999999,
+      "metrics": {
+        "count": 30,
+        "hit_at_k": 0.6666666666666666,
+        "mrr_at_10": 0.5777777777777777,
+        "precision_at_k": 0.16666666666666666,
+        "recall_at_k": 0.6666666666666666,
+        "ndcg_at_10": 0.6,
+        "evidence_recall_at_k": 0.6666666666666666
+      }
+    },
+    "query_summaries": [
+      {
+        "id": "paraphrase-01",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 1,
+        "retrieved_ids": [
+          31
+        ],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.86475,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-02",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 3,
+        "retrieved_ids": [
+          12,
+          33,
+          22
+        ],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.912167,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-03",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 0,
+        "retrieved_ids": [],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.811917000000001,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-04",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 1,
+        "retrieved_ids": [
+          24
+        ],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.575416,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-05",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 0,
+        "retrieved_ids": [],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.856083,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-06",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 1,
+        "retrieved_ids": [
+          26
+        ],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.994208,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-07",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 3,
+        "retrieved_ids": [
+          17,
+          43,
+          27
+        ],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.84875,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-08",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 2,
+        "retrieved_ids": [
+          28,
+          45
+        ],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.680334,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-09",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 3,
+        "retrieved_ids": [
+          19,
+          47,
+          29
+        ],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.63475,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-10",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 3,
+        "retrieved_ids": [
+          20,
+          49,
+          30
+        ],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.747625,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-01",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          11,
+          31,
+          1,
+          21
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.176791,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-02",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          12,
+          33,
+          22,
+          2
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.998000000000001,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-03",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          13,
+          35,
+          3,
+          23
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.050958,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-04",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          14,
+          37,
+          24,
+          4
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.161875,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-05",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          15,
+          39,
+          5,
+          25
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.202292,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-06",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          16,
+          41,
+          26,
+          6
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.264415999999999,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-07",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          17,
+          43,
+          7,
+          27
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.927916,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-08",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          18,
+          45,
+          28,
+          8
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.562291,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-09",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          19,
+          47,
+          29,
+          9
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.397417,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "knowledge-update-10",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          20,
+          49,
+          30,
+          10
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 10.02725,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-01",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          21,
+          1,
+          11,
+          31
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 10.072833999999999,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-02",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          22,
+          12,
+          33,
+          2
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 10.477416,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-03",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          13,
+          35,
+          23,
+          3
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.951375,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-04",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          24,
+          37,
+          14,
+          4
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.462,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-05",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          15,
+          39,
+          25,
+          5
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.129916999999999,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-06",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          26,
+          16,
+          41,
+          6
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.829959,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-07",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          17,
+          43,
+          27,
+          7
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.956000000000001,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-08",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          28,
+          18,
+          45,
+          8
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.001083,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-09",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          19,
+          47,
+          29,
+          9
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.814,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "temporal-10",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          30,
+          20,
+          49,
+          10
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.979583,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-01",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 4,
+        "retrieved_ids": [
+          11,
+          31,
+          1,
+          21
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 9.648875,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-02",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 3,
+        "retrieved_ids": [
+          12,
+          33,
+          22
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 8.746291,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-03",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 4,
+        "retrieved_ids": [
+          13,
+          35,
+          23,
+          3
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 8.586583,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-04",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 3,
+        "retrieved_ids": [
+          14,
+          37,
+          24
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 8.271208,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-05",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 3,
+        "retrieved_ids": [
+          15,
+          39,
+          25
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 8.455833,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-06",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 3,
+        "retrieved_ids": [
+          41,
+          16,
+          26
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 8.097874999999998,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-07",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 3,
+        "retrieved_ids": [
+          43,
+          17,
+          27
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 8.33075,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-08",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 3,
+        "retrieved_ids": [
+          18,
+          45,
+          28
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 8.269416999999999,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-09",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 3,
+        "retrieved_ids": [
+          47,
+          19,
+          29
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 8.283333,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "abstention-10",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          49,
+          20,
+          30,
+          50,
+          10
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 8.576084,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-01",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          31,
+          11,
+          1,
+          21,
+          32
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.441167,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-02",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          33,
+          12,
+          22,
+          2,
+          34
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.338166,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-03",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          35,
+          13,
+          23,
+          3,
+          36
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.409832999999999,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-04",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          37,
+          14,
+          24,
+          4,
+          38
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.379375000000001,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-05",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          39,
+          15,
+          25,
+          5,
+          40
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.376542,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-06",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          41,
+          16,
+          26,
+          6,
+          42
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.292666,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-07",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          43,
+          17,
+          27,
+          7,
+          44
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.362957999999999,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-08",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          18,
+          45,
+          28,
+          8,
+          46
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.261833000000001,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-09",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          47,
+          19,
+          29,
+          9,
+          48
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.287500000000001,
+        "hops": null,
+        "entities_discovered": []
+      },
+      {
+        "id": "multi-hop-10",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          49,
+          20,
+          30,
+          10,
+          50
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 9.322416,
+        "hops": null,
+        "entities_discovered": []
+      }
+    ]
+  },
+  "entity_bfs": {
+    "mode": "entity_bfs",
+    "overall": {
+      "total_queries": 50,
+      "scored_queries": 40,
+      "abstention_queries": 10,
+      "abstention_passed": 0,
+      "query_tokens_per_query": 12.88,
+      "retrieval_latency_p50_ms": 12.179499999999999,
+      "retrieval_latency_p95_ms": 13.938834,
+      "metrics": {
+        "count": 40,
+        "hit_at_k": 0.95,
+        "mrr_at_10": 0.7208333333333333,
+        "precision_at_k": 0.24250000000000016,
+        "recall_at_k": 0.95,
+        "ndcg_at_10": 0.7430641783600943,
+        "evidence_recall_at_k": 0.95
+      }
+    },
+    "multi_hop_slice": {
+      "total_queries": 10,
+      "scored_queries": 10,
+      "abstention_queries": 0,
+      "abstention_passed": 0,
+      "query_tokens_per_query": 19.6,
+      "retrieval_latency_p50_ms": 13.644708,
+      "retrieval_latency_p95_ms": 14.207709000000001,
+      "metrics": {
+        "count": 10,
+        "hit_at_k": 1.0,
+        "mrr_at_10": 0.95,
+        "precision_at_k": 0.39999999999999997,
+        "recall_at_k": 1.0,
+        "ndcg_at_10": 0.827715466981663,
+        "evidence_recall_at_k": 1.0
+      }
+    },
+    "non_multi_hop_slices": {
+      "total_queries": 40,
+      "scored_queries": 30,
+      "abstention_queries": 10,
+      "abstention_passed": 0,
+      "query_tokens_per_query": 11.2,
+      "retrieval_latency_p50_ms": 12.069792,
+      "retrieval_latency_p95_ms": 12.866958,
+      "metrics": {
+        "count": 30,
+        "hit_at_k": 0.9333333333333333,
+        "mrr_at_10": 0.6444444444444444,
+        "precision_at_k": 0.19000000000000009,
+        "recall_at_k": 0.9333333333333333,
+        "ndcg_at_10": 0.7148470821529048,
+        "evidence_recall_at_k": 0.9333333333333333
+      }
+    },
+    "query_summaries": [
+      {
+        "id": "paraphrase-01",
+        "slice": "paraphrase",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          31,
+          21,
+          11,
+          1,
+          32
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 10.734541,
+        "hops": 2,
+        "entities_discovered": [
+          "Kestrelnook",
+          "Nebulalatch",
+          "Owner",
+          "Team",
+          "Mica"
+        ]
+      },
+      {
+        "id": "paraphrase-02",
+        "slice": "paraphrase",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          12,
+          33,
+          22,
+          2,
+          34
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 11.707334,
+        "hops": 2,
+        "entities_discovered": [
+          "Lumenquay",
+          "Harbormint",
+          "Signer",
+          "Current",
+          "Toma",
+          "Reed",
+          "Owner",
+          "Team",
+          "Brine",
+          "Temporal",
+          "02"
+        ]
+      },
+      {
+        "id": "paraphrase-03",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 0,
+        "retrieved_ids": [],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 8.635541,
+        "hops": 1,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-04",
+        "slice": "paraphrase",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          24,
+          37,
+          14,
+          4
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 10.057291,
+        "hops": 2,
+        "entities_discovered": [
+          "Brindleforge",
+          "Temporal",
+          "04",
+          "KilnGuard"
+        ]
+      },
+      {
+        "id": "paraphrase-05",
+        "slice": "paraphrase",
+        "status": "MISS",
+        "result_count": 0,
+        "retrieved_ids": [],
+        "matched_refs": 0,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 9.155875,
+        "hops": 1,
+        "entities_discovered": []
+      },
+      {
+        "id": "paraphrase-06",
+        "slice": "paraphrase",
+        "status": "HIT",
+        "result_count": 4,
+        "retrieved_ids": [
+          26,
+          41,
+          16,
+          6
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 10.736208000000001,
+        "hops": 2,
+        "entities_discovered": [
+          "Hollowspan",
+          "Temporal",
+          "06",
+          "SpanDrift"
+        ]
+      },
+      {
+        "id": "paraphrase-07",
+        "slice": "paraphrase",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          17,
+          43,
+          27,
+          7,
+          44
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 11.834667,
+        "hops": 2,
+        "entities_discovered": [
+          "Paleravine",
+          "Ravinerelay",
+          "Region",
+          "Current",
+          "Owner",
+          "Team",
+          "Mesa",
+          "Temporal",
+          "07",
+          "Pax",
+          "Rune"
+        ]
+      },
+      {
+        "id": "paraphrase-08",
+        "slice": "paraphrase",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          28,
+          45,
+          18,
+          8,
+          46
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 10.967541,
+        "hops": 2,
+        "entities_discovered": [
+          "Copperoven",
+          "Temporal",
+          "08",
+          "OvenBell",
+          "Owner",
+          "Team",
+          "Hearth"
+        ]
+      },
+      {
+        "id": "paraphrase-09",
+        "slice": "paraphrase",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          19,
+          47,
+          29,
+          9,
+          48
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 11.261917,
+        "hops": 2,
+        "entities_discovered": [
+          "Cyanward",
+          "Wardroster",
+          "Source",
+          "Current",
+          "Owner",
+          "Team",
+          "Aster",
+          "Temporal",
+          "09"
+        ]
+      },
+      {
+        "id": "paraphrase-10",
+        "slice": "paraphrase",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          20,
+          49,
+          30,
+          10,
+          50
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 11.806875,
+        "hops": 2,
+        "entities_discovered": [
+          "Violetdome",
+          "Domepermit",
+          "Approver",
+          "Current",
+          "Vera",
+          "Knox",
+          "Owner",
+          "Team",
+          "Zenith",
+          "Temporal",
+          "10"
+        ]
+      },
+      {
+        "id": "knowledge-update-01",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          11,
+          31,
+          1,
+          21,
+          32
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.535041999999999,
+        "hops": 2,
+        "entities_discovered": [
+          "Kestrelnook",
+          "Quorum",
+          "Owner",
+          "Team",
+          "Mica",
+          "Violet",
+          "Rail",
+          "Allowance",
+          "Mira",
+          "Vale",
+          "Temporal",
+          "01",
+          "NightJar"
+        ]
+      },
+      {
+        "id": "knowledge-update-02",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          12,
+          33,
+          22,
+          2,
+          34
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 11.990708,
+        "hops": 2,
+        "entities_discovered": [
+          "Lumenquay",
+          "Signer",
+          "Toma",
+          "Reed",
+          "Owner",
+          "Team",
+          "Brine",
+          "Temporal",
+          "02",
+          "Orange",
+          "Dock",
+          "Window"
+        ]
+      },
+      {
+        "id": "knowledge-update-03",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          13,
+          35,
+          3,
+          23,
+          36
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.179499999999999,
+        "hops": 2,
+        "entities_discovered": [
+          "Cinderbloom",
+          "Shard",
+          "Owner",
+          "Team",
+          "Fern",
+          "Gray",
+          "Grove",
+          "Pruning",
+          "Nia",
+          "Sol",
+          "Temporal",
+          "03"
+        ]
+      },
+      {
+        "id": "knowledge-update-04",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          14,
+          37,
+          24,
+          4,
+          38
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.6455,
+        "hops": 2,
+        "entities_discovered": [
+          "Brindleforge",
+          "Threshold",
+          "83C",
+          "Owner",
+          "Team",
+          "Ember",
+          "Temporal",
+          "04",
+          "Blue",
+          "Kiln",
+          "Inspection",
+          "Oren",
+          "Pike"
+        ]
+      },
+      {
+        "id": "knowledge-update-05",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          15,
+          39,
+          5,
+          25,
+          40
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.839,
+        "hops": 2,
+        "entities_discovered": [
+          "Vellumspire",
+          "Retention",
+          "112",
+          "Owner",
+          "Team",
+          "Quill",
+          "Red",
+          "Archive",
+          "Allowance",
+          "Ivo",
+          "Lane",
+          "Temporal",
+          "05"
+        ]
+      },
+      {
+        "id": "knowledge-update-06",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          16,
+          41,
+          26,
+          6,
+          42
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 11.85075,
+        "hops": 2,
+        "entities_discovered": [
+          "Hollowspan",
+          "Owner",
+          "Sana",
+          "Holt",
+          "Team",
+          "Arch",
+          "Temporal",
+          "06",
+          "Green",
+          "Span",
+          "Revert"
+        ]
+      },
+      {
+        "id": "knowledge-update-07",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          17,
+          43,
+          7,
+          27,
+          44
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.069792,
+        "hops": 2,
+        "entities_discovered": [
+          "Paleravine",
+          "Region",
+          "Owner",
+          "Team",
+          "Mesa",
+          "White",
+          "Ravine",
+          "Handoff",
+          "Pax",
+          "Rune",
+          "Temporal",
+          "07"
+        ]
+      },
+      {
+        "id": "knowledge-update-08",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          18,
+          45,
+          28,
+          8,
+          46
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 11.936542,
+        "hops": 2,
+        "entities_discovered": [
+          "Copperoven",
+          "Route",
+          "Owner",
+          "Team",
+          "Hearth",
+          "Temporal",
+          "08",
+          "Copper",
+          "Oven",
+          "Alert",
+          "Lina",
+          "Moss"
+        ]
+      },
+      {
+        "id": "knowledge-update-09",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          19,
+          47,
+          29,
+          9,
+          48
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.090958,
+        "hops": 2,
+        "entities_discovered": [
+          "Cyanward",
+          "Source",
+          "Owner",
+          "Team",
+          "Aster",
+          "Temporal",
+          "09",
+          "Cyan",
+          "Ward",
+          "Schedule",
+          "Miko",
+          "Ash"
+        ]
+      },
+      {
+        "id": "knowledge-update-10",
+        "slice": "knowledge_update",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          20,
+          49,
+          30,
+          10,
+          50
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.622625,
+        "hops": 2,
+        "entities_discovered": [
+          "Violetdome",
+          "Approver",
+          "Vera",
+          "Knox",
+          "Owner",
+          "Team",
+          "Zenith",
+          "Temporal",
+          "10",
+          "Purple",
+          "Observatory",
+          "Authorization"
+        ]
+      },
+      {
+        "id": "temporal-01",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          21,
+          1,
+          11,
+          31,
+          32
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.743625,
+        "hops": 2,
+        "entities_discovered": [
+          "Kestrelnook",
+          "Temporal",
+          "01",
+          "Violet",
+          "Rail",
+          "Allowance",
+          "Mira",
+          "Vale",
+          "Nebulalatch",
+          "Quorum",
+          "Current",
+          "Owner",
+          "Team",
+          "Mica"
+        ]
+      },
+      {
+        "id": "temporal-02",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          22,
+          12,
+          33,
+          2,
+          34
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.096166,
+        "hops": 2,
+        "entities_discovered": [
+          "Lumenquay",
+          "Temporal",
+          "02",
+          "Signer",
+          "Current",
+          "Toma",
+          "Reed",
+          "Owner",
+          "Team",
+          "Brine",
+          "Orange",
+          "Dock",
+          "Window"
+        ]
+      },
+      {
+        "id": "temporal-03",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          13,
+          35,
+          23,
+          3,
+          36
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.175625,
+        "hops": 2,
+        "entities_discovered": [
+          "Cinderbloom",
+          "Shard",
+          "Current",
+          "Owner",
+          "Team",
+          "Fern",
+          "Temporal",
+          "03",
+          "Gray",
+          "Grove",
+          "Pruning",
+          "Nia",
+          "Sol"
+        ]
+      },
+      {
+        "id": "temporal-04",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          24,
+          37,
+          14,
+          4,
+          38
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.866958,
+        "hops": 2,
+        "entities_discovered": [
+          "Brindleforge",
+          "Temporal",
+          "04",
+          "Owner",
+          "Team",
+          "Ember",
+          "Threshold",
+          "Current",
+          "83C",
+          "Blue",
+          "Kiln",
+          "Inspection",
+          "Oren",
+          "Pike"
+        ]
+      },
+      {
+        "id": "temporal-05",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          15,
+          39,
+          25,
+          5,
+          40
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.840834000000001,
+        "hops": 2,
+        "entities_discovered": [
+          "Vellumspire",
+          "Retention",
+          "Current",
+          "112",
+          "Owner",
+          "Team",
+          "Quill",
+          "Temporal",
+          "05",
+          "Red",
+          "Archive",
+          "Allowance",
+          "Ivo",
+          "Lane"
+        ]
+      },
+      {
+        "id": "temporal-06",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          26,
+          16,
+          41,
+          6,
+          42
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.142125,
+        "hops": 2,
+        "entities_discovered": [
+          "Hollowspan",
+          "Temporal",
+          "06",
+          "Owner",
+          "Current",
+          "Sana",
+          "Holt",
+          "Team",
+          "Arch",
+          "Green",
+          "Span",
+          "Revert"
+        ]
+      },
+      {
+        "id": "temporal-07",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          17,
+          43,
+          27,
+          7,
+          44
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.482334,
+        "hops": 2,
+        "entities_discovered": [
+          "Paleravine",
+          "Region",
+          "Current",
+          "Owner",
+          "Team",
+          "Mesa",
+          "Temporal",
+          "07",
+          "Pax",
+          "Rune",
+          "White",
+          "Ravine",
+          "Handoff"
+        ]
+      },
+      {
+        "id": "temporal-08",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          28,
+          18,
+          45,
+          8,
+          46
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.472083,
+        "hops": 2,
+        "entities_discovered": [
+          "Copperoven",
+          "Temporal",
+          "08",
+          "Route",
+          "Current",
+          "Owner",
+          "Team",
+          "Hearth",
+          "Copper",
+          "Oven",
+          "Alert",
+          "Lina",
+          "Moss"
+        ]
+      },
+      {
+        "id": "temporal-09",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          19,
+          47,
+          29,
+          9,
+          48
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.346792,
+        "hops": 2,
+        "entities_discovered": [
+          "Cyanward",
+          "Source",
+          "Current",
+          "Owner",
+          "Team",
+          "Aster",
+          "Temporal",
+          "09",
+          "Cyan",
+          "Ward",
+          "Schedule",
+          "Miko",
+          "Ash"
+        ]
+      },
+      {
+        "id": "temporal-10",
+        "slice": "temporal",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          30,
+          20,
+          49,
+          10,
+          50
+        ],
+        "matched_refs": 1,
+        "expected_refs": 1,
+        "retrieval_latency_ms": 12.787583,
+        "hops": 2,
+        "entities_discovered": [
+          "Violetdome",
+          "Temporal",
+          "10",
+          "Approver",
+          "Current",
+          "Vera",
+          "Knox",
+          "Owner",
+          "Team",
+          "Zenith",
+          "Purple",
+          "Observatory",
+          "Authorization"
+        ]
+      },
+      {
+        "id": "abstention-01",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          11,
+          31,
+          1,
+          21,
+          32
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 12.7,
+        "hops": 2,
+        "entities_discovered": [
+          "Quorum",
+          "Current",
+          "Owner",
+          "Team",
+          "Mica",
+          "Violet",
+          "Rail",
+          "Allowance",
+          "Mira",
+          "Vale",
+          "Temporal",
+          "01",
+          "NightJar"
+        ]
+      },
+      {
+        "id": "abstention-02",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          12,
+          33,
+          22,
+          2,
+          34
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 11.525916,
+        "hops": 2,
+        "entities_discovered": [
+          "Lumenquay",
+          "Signer",
+          "Current",
+          "Toma",
+          "Reed",
+          "Owner",
+          "Team",
+          "Brine",
+          "Temporal",
+          "02"
+        ]
+      },
+      {
+        "id": "abstention-03",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          13,
+          35,
+          23,
+          3,
+          36
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 12.542124999999999,
+        "hops": 2,
+        "entities_discovered": [
+          "Cinderbloom",
+          "Shard",
+          "Current",
+          "Owner",
+          "Team",
+          "Fern",
+          "Temporal",
+          "03",
+          "Gray",
+          "Grove",
+          "Pruning",
+          "Nia",
+          "Sol",
+          "Project"
+        ]
+      },
+      {
+        "id": "abstention-04",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          14,
+          37,
+          24,
+          4,
+          38
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 11.070875000000001,
+        "hops": 2,
+        "entities_discovered": [
+          "Brindleforge",
+          "Threshold",
+          "Current",
+          "83C",
+          "Owner",
+          "Team",
+          "Ember",
+          "Temporal",
+          "04"
+        ]
+      },
+      {
+        "id": "abstention-05",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          15,
+          39,
+          25,
+          5,
+          40
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 11.467292,
+        "hops": 2,
+        "entities_discovered": [
+          "Vellumspire",
+          "Retention",
+          "Current",
+          "112",
+          "Owner",
+          "Team",
+          "Quill",
+          "Temporal",
+          "05"
+        ]
+      },
+      {
+        "id": "abstention-06",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          41,
+          16,
+          26,
+          6,
+          42
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 11.031541,
+        "hops": 2,
+        "entities_discovered": [
+          "Hollowspan",
+          "Owner",
+          "Team",
+          "Arch",
+          "Current",
+          "Sana",
+          "Holt",
+          "Temporal",
+          "06"
+        ]
+      },
+      {
+        "id": "abstention-07",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          43,
+          17,
+          27,
+          7,
+          44
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 11.134666999999999,
+        "hops": 2,
+        "entities_discovered": [
+          "Paleravine",
+          "Owner",
+          "Team",
+          "Mesa",
+          "Region",
+          "Current",
+          "Temporal",
+          "07",
+          "Pax",
+          "Rune"
+        ]
+      },
+      {
+        "id": "abstention-08",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          18,
+          45,
+          28,
+          8,
+          46
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 10.612417,
+        "hops": 2,
+        "entities_discovered": [
+          "Copperoven",
+          "Route",
+          "Current",
+          "Owner",
+          "Team",
+          "Hearth",
+          "Temporal",
+          "08"
+        ]
+      },
+      {
+        "id": "abstention-09",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          47,
+          19,
+          29,
+          9,
+          48
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 10.605125,
+        "hops": 2,
+        "entities_discovered": [
+          "Cyanward",
+          "Owner",
+          "Team",
+          "Aster",
+          "Source",
+          "Current",
+          "Temporal",
+          "09"
+        ]
+      },
+      {
+        "id": "abstention-10",
+        "slice": "abstention",
+        "status": "FAIL",
+        "result_count": 5,
+        "retrieved_ids": [
+          49,
+          20,
+          30,
+          50,
+          10
+        ],
+        "matched_refs": 0,
+        "expected_refs": 0,
+        "retrieval_latency_ms": 12.9835,
+        "hops": 1,
+        "entities_discovered": [
+          "Violetdome",
+          "Owner",
+          "Team",
+          "Zenith",
+          "Approver",
+          "Current",
+          "Vera",
+          "Knox",
+          "Temporal",
+          "10",
+          "Pager",
+          "Purple",
+          "Observatory",
+          "Authorization",
+          "Project"
+        ]
+      },
+      {
+        "id": "multi-hop-01",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          31,
+          11,
+          1,
+          21,
+          32
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 13.496875000000001,
+        "hops": 1,
+        "entities_discovered": [
+          "Kestrelnook",
+          "Owner",
+          "Team",
+          "Mica",
+          "Quorum",
+          "Current",
+          "Violet",
+          "Rail",
+          "Allowance",
+          "Mira",
+          "Vale",
+          "Temporal",
+          "01",
+          "NightJar",
+          "Pager"
+        ]
+      },
+      {
+        "id": "multi-hop-02",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          33,
+          12,
+          22,
+          2,
+          34
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 13.177417,
+        "hops": 1,
+        "entities_discovered": [
+          "Lumenquay",
+          "Owner",
+          "Team",
+          "Brine",
+          "Signer",
+          "Current",
+          "Toma",
+          "Reed",
+          "Temporal",
+          "02",
+          "Orange",
+          "Dock",
+          "Window",
+          "Pager"
+        ]
+      },
+      {
+        "id": "multi-hop-03",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          35,
+          13,
+          23,
+          3,
+          36
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 13.649,
+        "hops": 1,
+        "entities_discovered": [
+          "Cinderbloom",
+          "Owner",
+          "Team",
+          "Fern",
+          "Shard",
+          "Current",
+          "Temporal",
+          "03",
+          "Gray",
+          "Grove",
+          "Pruning",
+          "Nia",
+          "Sol",
+          "Pager"
+        ]
+      },
+      {
+        "id": "multi-hop-04",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          37,
+          14,
+          24,
+          4,
+          38
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 14.207709000000001,
+        "hops": 1,
+        "entities_discovered": [
+          "Brindleforge",
+          "Owner",
+          "Team",
+          "Ember",
+          "Threshold",
+          "Current",
+          "83C",
+          "Temporal",
+          "04",
+          "Blue",
+          "Kiln",
+          "Inspection",
+          "Oren",
+          "Pike",
+          "Pager"
+        ]
+      },
+      {
+        "id": "multi-hop-05",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          39,
+          15,
+          25,
+          5,
+          40
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 13.938834,
+        "hops": 1,
+        "entities_discovered": [
+          "Vellumspire",
+          "Owner",
+          "Team",
+          "Quill",
+          "Retention",
+          "Current",
+          "112",
+          "Temporal",
+          "05",
+          "Red",
+          "Archive",
+          "Allowance",
+          "Ivo",
+          "Lane",
+          "Pager"
+        ]
+      },
+      {
+        "id": "multi-hop-06",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          41,
+          16,
+          26,
+          6,
+          42
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 13.231084000000001,
+        "hops": 1,
+        "entities_discovered": [
+          "Hollowspan",
+          "Owner",
+          "Team",
+          "Arch",
+          "Current",
+          "Sana",
+          "Holt",
+          "Temporal",
+          "06",
+          "Green",
+          "Span",
+          "Revert",
+          "Pager"
+        ]
+      },
+      {
+        "id": "multi-hop-07",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          43,
+          17,
+          27,
+          7,
+          44
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 13.644708,
+        "hops": 1,
+        "entities_discovered": [
+          "Paleravine",
+          "Owner",
+          "Team",
+          "Mesa",
+          "Region",
+          "Current",
+          "Temporal",
+          "07",
+          "Pax",
+          "Rune",
+          "White",
+          "Ravine",
+          "Handoff",
+          "Pager"
+        ]
+      },
+      {
+        "id": "multi-hop-08",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          18,
+          45,
+          28,
+          8,
+          46
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 13.631375,
+        "hops": 1,
+        "entities_discovered": [
+          "Copperoven",
+          "Route",
+          "Current",
+          "Owner",
+          "Team",
+          "Hearth",
+          "Temporal",
+          "08",
+          "Copper",
+          "Oven",
+          "Alert",
+          "Lina",
+          "Moss",
+          "Pager"
+        ]
+      },
+      {
+        "id": "multi-hop-09",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          47,
+          19,
+          29,
+          9,
+          48
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 13.524750000000001,
+        "hops": 1,
+        "entities_discovered": [
+          "Cyanward",
+          "Owner",
+          "Team",
+          "Aster",
+          "Source",
+          "Current",
+          "Temporal",
+          "09",
+          "Cyan",
+          "Ward",
+          "Schedule",
+          "Miko",
+          "Ash",
+          "Pager"
+        ]
+      },
+      {
+        "id": "multi-hop-10",
+        "slice": "multi_hop",
+        "status": "HIT",
+        "result_count": 5,
+        "retrieved_ids": [
+          49,
+          20,
+          30,
+          10,
+          50
+        ],
+        "matched_refs": 2,
+        "expected_refs": 2,
+        "retrieval_latency_ms": 14.119833,
+        "hops": 1,
+        "entities_discovered": [
+          "Violetdome",
+          "Owner",
+          "Team",
+          "Zenith",
+          "Approver",
+          "Current",
+          "Vera",
+          "Knox",
+          "Temporal",
+          "10",
+          "Purple",
+          "Observatory",
+          "Authorization",
+          "Pager"
+        ]
+      }
+    ]
+  },
+  "deltas": {
+    "multi_hop_recall_at_k": 0.0,
+    "multi_hop_evidence_recall_at_k": 0.0,
+    "multi_hop_ndcg_at_10": 0.0,
+    "non_multi_hop_recall_at_k": 0.2666666666666667,
+    "non_multi_hop_evidence_recall_at_k": 0.2666666666666667,
+    "non_multi_hop_ndcg_at_10": 0.11484708215290484,
+    "p95_latency_ms": 3.9115839999999995
+  },
+  "checks": {
+    "benefit_threshold_met": false,
+    "non_multi_hop_zero_regression": true,
+    "p95_latency_within_budget": true,
+    "all_checks_passed": true
+  },
+  "notes": [
+    "Entity BFS is the existing explicit multi-hop expansion through memory_entities plus FTS mention fallback; this report does not wire first-class graph_edges traversal.",
+    "A freeze decision keeps graph_edges available for provenance/candidates but blocks retrieval-channel rollout until a future pre-registered eval shows a material gain."
+  ]
+}

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.54",
+  "version": "0.5.55",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.54",
+  "version": "0.5.55",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.54": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.54",
+    "0.5.55": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.55",
       "assets": {}
     }
   }

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -16,7 +16,7 @@ pub(super) use admin::run_admin;
 pub(super) use config_command::run_config;
 pub(super) use eval::{
     run_eval, run_eval_e2e, run_eval_extraction, run_eval_gates, run_eval_governance,
-    run_eval_local,
+    run_eval_graph_decision, run_eval_local,
 };
 pub(super) use import::run_import;
 pub(super) use maintenance::{

--- a/src/cli/actions/eval.rs
+++ b/src/cli/actions/eval.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 
@@ -111,5 +112,36 @@ pub(in crate::cli) fn run_eval_gates(
     if !report.summary.passed {
         bail!("eval-gates checks failed");
     }
+    Ok(())
+}
+
+pub(in crate::cli) fn run_eval_graph_decision(
+    dataset_path: &str,
+    k: usize,
+    json_out: &str,
+    json: bool,
+) -> Result<()> {
+    let report = crate::eval::graph_decision::run_graph_decision_eval(
+        crate::eval::graph_decision::GraphDecisionEvalOptions {
+            dataset_path: dataset_path.to_string(),
+            k,
+        },
+    )?;
+    let report_json = serde_json::to_string_pretty(&report)?;
+    if let Some(parent) = Path::new(json_out).parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("create graph decision eval directory {}", parent.display())
+            })?;
+        }
+    }
+    fs::write(json_out, &report_json)
+        .with_context(|| format!("write graph decision eval JSON {json_out}"))?;
+    if json {
+        println!("{report_json}");
+    } else {
+        print!("{report}");
+    }
+    crate::eval::graph_decision::ensure_graph_decision_gate(&report)?;
     Ok(())
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -5,11 +5,11 @@ use crate::{api, context, db, doctor, install, mcp, observe, summarize, worker};
 use super::actions::{
     run_admin, run_archive, run_audit_scope, run_backfill_embeddings, run_backfill_entities,
     run_cleanup, run_commit, run_config, run_current_state, run_dream, run_encrypt, run_eval,
-    run_eval_e2e, run_eval_extraction, run_eval_gates, run_eval_governance, run_eval_local,
-    run_governance, run_graph_review, run_import, run_memory_cleanup, run_merge_preferences,
-    run_model, run_pending, run_preferences, run_raw, run_reroute, run_review, run_search,
-    run_show, run_status, run_timeline, run_usage, run_why, run_workstreams, GovernanceCliRequest,
-    RerouteCliRequest,
+    run_eval_e2e, run_eval_extraction, run_eval_gates, run_eval_governance,
+    run_eval_graph_decision, run_eval_local, run_governance, run_graph_review, run_import,
+    run_memory_cleanup, run_merge_preferences, run_model, run_pending, run_preferences, run_raw,
+    run_reroute, run_review, run_search, run_show, run_status, run_timeline, run_usage, run_why,
+    run_workstreams, GovernanceCliRequest, RerouteCliRequest,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands, ContextGateAction, MemoryAction};
@@ -255,6 +255,9 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         Commands::EvalGovernance { k, json } => run_eval_governance(k, json)?,
         Commands::EvalExtraction(args) => {
             run_eval_extraction(&args.corpus, &args.baseline, args.json, args.check_baseline)?
+        }
+        Commands::EvalGraphDecision(args) => {
+            run_eval_graph_decision(&args.dataset, args.k, &args.json_out, args.json)?
         }
         Commands::EvalGates(args) => run_eval_gates(
             &args.baseline,

--- a/src/cli/eval_types.rs
+++ b/src/cli/eval_types.rs
@@ -27,3 +27,15 @@ pub(in crate::cli) struct EvalGatesArgs {
     #[arg(long, hide = true)]
     pub(in crate::cli) simulate_golden_regression: bool,
 }
+
+#[derive(Args)]
+pub(in crate::cli) struct EvalGraphDecisionArgs {
+    #[arg(long, default_value = crate::eval::graph_decision::DEFAULT_DATASET_PATH)]
+    pub(in crate::cli) dataset: String,
+    #[arg(long, short = 'k', default_value = "5")]
+    pub(in crate::cli) k: usize,
+    #[arg(long, default_value = crate::eval::graph_decision::DEFAULT_REPORT_PATH)]
+    pub(in crate::cli) json_out: String,
+    #[arg(long)]
+    pub(in crate::cli) json: bool,
+}

--- a/src/cli/tests_eval.rs
+++ b/src/cli/tests_eval.rs
@@ -72,3 +72,28 @@ fn cli_parses_eval_gates_options() {
         _ => panic!("expected eval-gates command"),
     }
 }
+
+#[test]
+fn cli_parses_eval_graph_decision_options() {
+    let cli = Cli::parse_from([
+        "remem",
+        "eval-graph-decision",
+        "--dataset",
+        "fixtures/golden.json",
+        "--json-out",
+        "/tmp/graph-decision.json",
+        "--json",
+        "-k",
+        "7",
+    ]);
+
+    match cli.command {
+        Commands::EvalGraphDecision(args) => {
+            assert_eq!(args.dataset, "fixtures/golden.json");
+            assert_eq!(args.json_out, "/tmp/graph-decision.json");
+            assert_eq!(args.k, 7);
+            assert!(args.json);
+        }
+        _ => panic!("expected eval-graph-decision command"),
+    }
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -450,6 +450,8 @@ pub(super) enum Commands {
     },
     #[command(name = "eval-extraction")]
     EvalExtraction(super::eval_types::EvalExtractionArgs),
+    #[command(name = "eval-graph-decision")]
+    EvalGraphDecision(super::eval_types::EvalGraphDecisionArgs),
     #[command(name = "eval-gates")]
     EvalGates(super::eval_types::EvalGatesArgs),
     /// Run local retrieval diagnostics.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -419,6 +419,7 @@ pub mod gates {
 }
 pub mod golden;
 pub mod governance;
+pub mod graph_decision;
 pub mod injection;
 pub mod local;
 pub mod metrics;

--- a/src/eval/golden.rs
+++ b/src/eval/golden.rs
@@ -1,5 +1,5 @@
 mod display;
-mod run;
+pub(in crate::eval) mod run;
 #[cfg(test)]
 mod tests;
 mod types;
@@ -9,6 +9,6 @@ pub use run::{
     run_dataset_path,
 };
 pub use types::{
-    EvidenceRef, GoldenDataset, GoldenEvalReport, GoldenMemory, GoldenQuery, MetricAverages,
-    QueryEvaluation, QueryMetrics, QueryStatus,
+    CategoryEvaluation, EvidenceRef, GoldenDataset, GoldenEvalReport, GoldenMemory, GoldenQuery,
+    MetricAverages, QueryEvaluation, QueryMetrics, QueryStatus,
 };

--- a/src/eval/golden/run.rs
+++ b/src/eval/golden/run.rs
@@ -12,7 +12,7 @@ use super::types::{
 const RANK_K: usize = 10;
 
 #[derive(Default)]
-struct CategoryAccumulator {
+pub(in crate::eval) struct CategoryAccumulator {
     total_queries: usize,
     abstention_queries: usize,
     abstention_passed: usize,
@@ -136,7 +136,7 @@ pub fn evaluate_dataset(
     })
 }
 
-fn record_bucket(
+pub(in crate::eval) fn record_bucket(
     bucket: &mut CategoryAccumulator,
     query: &GoldenQuery,
     evaluation: &QueryEvaluation,
@@ -156,7 +156,7 @@ fn record_bucket(
     }
 }
 
-fn bucket_evaluation(bucket: CategoryAccumulator) -> CategoryEvaluation {
+pub(in crate::eval) fn bucket_evaluation(bucket: CategoryAccumulator) -> CategoryEvaluation {
     let query_tokens_per_query = if bucket.total_queries == 0 {
         0.0
     } else {
@@ -373,7 +373,10 @@ fn corpus_memory_matches_query_filter(memory: &crate::memory::Memory, query: &Go
     true
 }
 
-fn seed_fixture_corpus(conn: &Connection, corpus: &[GoldenMemory]) -> Result<()> {
+pub(in crate::eval) fn seed_fixture_corpus(
+    conn: &Connection,
+    corpus: &[GoldenMemory],
+) -> Result<()> {
     for (index, memory) in corpus.iter().enumerate() {
         let id = crate::memory::insert_memory_full(
             conn,
@@ -418,7 +421,7 @@ fn corpus_memory_label(index: usize, memory: &GoldenMemory) -> String {
         .unwrap_or_else(|| format!("#{}", index + 1))
 }
 
-fn evaluate_query(
+pub(in crate::eval) fn evaluate_query(
     query: &GoldenQuery,
     results: &[crate::memory::Memory],
     k: usize,
@@ -499,11 +502,11 @@ fn evaluate_query(
     }
 }
 
-fn estimate_query_tokens(query: &str) -> usize {
+pub(in crate::eval) fn estimate_query_tokens(query: &str) -> usize {
     query.len().div_ceil(4).max(1)
 }
 
-fn percentile(mut values: Vec<f64>, percentile: f64) -> f64 {
+pub(in crate::eval) fn percentile(mut values: Vec<f64>, percentile: f64) -> f64 {
     if values.is_empty() {
         return 0.0;
     }

--- a/src/eval/graph_decision.rs
+++ b/src/eval/graph_decision.rs
@@ -1,0 +1,375 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::time::Instant;
+
+use anyhow::{bail, Context, Result};
+use rusqlite::Connection;
+use serde::Serialize;
+
+use super::golden::{self, CategoryEvaluation, GoldenDataset, MetricAverages};
+
+pub const DEFAULT_DATASET_PATH: &str = "eval/golden.json";
+pub const DEFAULT_REPORT_PATH: &str = "eval/graph-decision/report.json";
+const BENEFIT_THRESHOLD: f64 = 0.05;
+const LATENCY_BUDGET_P95_MS: f64 = 1000.0;
+const EPSILON: f64 = 0.000_001;
+
+#[derive(Debug, Clone)]
+pub struct GraphDecisionEvalOptions {
+    pub dataset_path: String,
+    pub k: usize,
+}
+
+impl Default for GraphDecisionEvalOptions {
+    fn default() -> Self {
+        Self {
+            dataset_path: DEFAULT_DATASET_PATH.to_string(),
+            k: 5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphDecisionReport {
+    pub version: String,
+    pub dataset_path: String,
+    pub k: usize,
+    pub benefit_threshold: f64,
+    pub latency_budget_p95_ms: f64,
+    pub decision: GraphDecision,
+    pub decision_reason: String,
+    pub standard: GraphDecisionArmReport,
+    pub entity_bfs: GraphDecisionArmReport,
+    pub deltas: GraphDecisionDeltas,
+    pub checks: GraphDecisionChecks,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphDecision {
+    WireEntityBfsExperiment,
+    FreezeGraphEdgesRetrievalChannel,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphDecisionArmReport {
+    pub mode: GraphDecisionMode,
+    pub overall: CategoryEvaluation,
+    pub multi_hop_slice: CategoryEvaluation,
+    pub non_multi_hop_slices: CategoryEvaluation,
+    pub query_summaries: Vec<GraphDecisionQuerySummary>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphDecisionMode {
+    Standard,
+    EntityBfs,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphDecisionQuerySummary {
+    pub id: String,
+    pub slice: String,
+    pub status: String,
+    pub result_count: usize,
+    pub retrieved_ids: Vec<i64>,
+    pub matched_refs: usize,
+    pub expected_refs: usize,
+    pub retrieval_latency_ms: f64,
+    pub hops: Option<u8>,
+    pub entities_discovered: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphDecisionDeltas {
+    pub multi_hop_recall_at_k: f64,
+    pub multi_hop_evidence_recall_at_k: f64,
+    pub multi_hop_ndcg_at_10: f64,
+    pub non_multi_hop_recall_at_k: f64,
+    pub non_multi_hop_evidence_recall_at_k: f64,
+    pub non_multi_hop_ndcg_at_10: f64,
+    pub p95_latency_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphDecisionChecks {
+    pub benefit_threshold_met: bool,
+    pub non_multi_hop_zero_regression: bool,
+    pub p95_latency_within_budget: bool,
+    pub all_checks_passed: bool,
+}
+
+pub fn run_graph_decision_eval(options: GraphDecisionEvalOptions) -> Result<GraphDecisionReport> {
+    let dataset = golden::load_dataset(&options.dataset_path)?;
+    if !dataset.has_fixture_corpus() {
+        bail!("graph decision eval requires a fixture-backed golden dataset");
+    }
+
+    let k = options.k.max(1);
+    let standard = evaluate_arm(&dataset, k, GraphDecisionMode::Standard)?;
+    let entity_bfs = evaluate_arm(&dataset, k, GraphDecisionMode::EntityBfs)?;
+    let deltas = build_deltas(&standard, &entity_bfs);
+    let checks = build_checks(&standard, &entity_bfs, &deltas);
+    let decision = if checks.benefit_threshold_met {
+        GraphDecision::WireEntityBfsExperiment
+    } else {
+        GraphDecision::FreezeGraphEdgesRetrievalChannel
+    };
+    let decision_reason = match decision {
+        GraphDecision::WireEntityBfsExperiment => format!(
+            "Entity BFS improves multi-hop evidence recall by at least {:.0}%.",
+            BENEFIT_THRESHOLD * 100.0
+        ),
+        GraphDecision::FreezeGraphEdgesRetrievalChannel => format!(
+            "Entity BFS did not clear the pre-registered {:.0}% multi-hop evidence-recall gain threshold; do not wire graph_edges into retrieval by default.",
+            BENEFIT_THRESHOLD * 100.0
+        ),
+    };
+
+    Ok(GraphDecisionReport {
+        version: "2026-06-12".to_string(),
+        dataset_path: options.dataset_path,
+        k,
+        benefit_threshold: BENEFIT_THRESHOLD,
+        latency_budget_p95_ms: LATENCY_BUDGET_P95_MS,
+        decision,
+        decision_reason,
+        standard,
+        entity_bfs,
+        deltas,
+        checks,
+        notes: vec![
+            "Entity BFS is the existing explicit multi-hop expansion through memory_entities plus FTS mention fallback; this report does not wire first-class graph_edges traversal.".to_string(),
+            "A freeze decision keeps graph_edges available for provenance/candidates but blocks retrieval-channel rollout until a future pre-registered eval shows a material gain.".to_string(),
+        ],
+    })
+}
+
+pub fn ensure_graph_decision_gate(report: &GraphDecisionReport) -> Result<()> {
+    if report.checks.all_checks_passed {
+        return Ok(());
+    }
+    bail!(
+        "graph decision eval failed: non_multi_hop_zero_regression={} p95_latency_within_budget={}",
+        report.checks.non_multi_hop_zero_regression,
+        report.checks.p95_latency_within_budget
+    )
+}
+
+fn evaluate_arm(
+    dataset: &GoldenDataset,
+    k: usize,
+    mode: GraphDecisionMode,
+) -> Result<GraphDecisionArmReport> {
+    let conn = Connection::open_in_memory().context("open in-memory graph decision eval DB")?;
+    crate::migrate::run_migrations(&conn).context("migrate graph decision eval DB")?;
+    golden::run::seed_fixture_corpus(&conn, &dataset.corpus)?;
+
+    let mut overall = golden::run::CategoryAccumulator::default();
+    let mut multi_hop_slice = golden::run::CategoryAccumulator::default();
+    let mut non_multi_hop_slices = golden::run::CategoryAccumulator::default();
+    let mut query_summaries = Vec::with_capacity(dataset.queries.len());
+
+    for query in &dataset.queries {
+        let started = Instant::now();
+        let (results, hops, entities_discovered) = match mode {
+            GraphDecisionMode::Standard => (
+                crate::retrieval::search::search_with_branch(
+                    &conn,
+                    Some(&query.query),
+                    query.project.as_deref(),
+                    query.memory_type.as_deref(),
+                    k.max(10) as i64,
+                    0,
+                    false,
+                    query.branch.as_deref(),
+                )?,
+                None,
+                Vec::new(),
+            ),
+            GraphDecisionMode::EntityBfs => {
+                let multi_hop = crate::retrieval::search_multihop::search_multi_hop(
+                    &conn,
+                    &query.query,
+                    query.project.as_deref(),
+                    k.max(10) as i64,
+                    0,
+                    query.memory_type.as_deref(),
+                    query.branch.as_deref(),
+                    false,
+                )?;
+                (
+                    multi_hop.memories,
+                    Some(multi_hop.hops),
+                    multi_hop.entities_discovered,
+                )
+            }
+        };
+        let retrieval_latency_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let query_tokens = golden::run::estimate_query_tokens(&query.query);
+        let evaluation =
+            golden::run::evaluate_query(query, &results, k, query_tokens, retrieval_latency_ms);
+
+        golden::run::record_bucket(&mut overall, query, &evaluation);
+        if query.slice_label() == "multi_hop" {
+            golden::run::record_bucket(&mut multi_hop_slice, query, &evaluation);
+        } else {
+            golden::run::record_bucket(&mut non_multi_hop_slices, query, &evaluation);
+        }
+        query_summaries.push(GraphDecisionQuerySummary {
+            id: evaluation.id.clone(),
+            slice: evaluation.slice.clone(),
+            status: evaluation.status.label().to_string(),
+            result_count: evaluation.result_count,
+            retrieved_ids: evaluation.retrieved_ids.clone(),
+            matched_refs: evaluation.matched_refs,
+            expected_refs: evaluation.expected_refs,
+            retrieval_latency_ms,
+            hops,
+            entities_discovered,
+        });
+    }
+
+    Ok(GraphDecisionArmReport {
+        mode,
+        overall: golden::run::bucket_evaluation(overall),
+        multi_hop_slice: golden::run::bucket_evaluation(multi_hop_slice),
+        non_multi_hop_slices: golden::run::bucket_evaluation(non_multi_hop_slices),
+        query_summaries,
+    })
+}
+
+fn build_deltas(
+    standard: &GraphDecisionArmReport,
+    entity_bfs: &GraphDecisionArmReport,
+) -> GraphDecisionDeltas {
+    GraphDecisionDeltas {
+        multi_hop_recall_at_k: metric_delta(
+            standard.multi_hop_slice.metrics.as_ref(),
+            entity_bfs.multi_hop_slice.metrics.as_ref(),
+            |m| m.recall_at_k,
+        ),
+        multi_hop_evidence_recall_at_k: metric_delta(
+            standard.multi_hop_slice.metrics.as_ref(),
+            entity_bfs.multi_hop_slice.metrics.as_ref(),
+            |m| m.evidence_recall_at_k,
+        ),
+        multi_hop_ndcg_at_10: metric_delta(
+            standard.multi_hop_slice.metrics.as_ref(),
+            entity_bfs.multi_hop_slice.metrics.as_ref(),
+            |m| m.ndcg_at_10,
+        ),
+        non_multi_hop_recall_at_k: metric_delta(
+            standard.non_multi_hop_slices.metrics.as_ref(),
+            entity_bfs.non_multi_hop_slices.metrics.as_ref(),
+            |m| m.recall_at_k,
+        ),
+        non_multi_hop_evidence_recall_at_k: metric_delta(
+            standard.non_multi_hop_slices.metrics.as_ref(),
+            entity_bfs.non_multi_hop_slices.metrics.as_ref(),
+            |m| m.evidence_recall_at_k,
+        ),
+        non_multi_hop_ndcg_at_10: metric_delta(
+            standard.non_multi_hop_slices.metrics.as_ref(),
+            entity_bfs.non_multi_hop_slices.metrics.as_ref(),
+            |m| m.ndcg_at_10,
+        ),
+        p95_latency_ms: entity_bfs.overall.retrieval_latency_p95_ms
+            - standard.overall.retrieval_latency_p95_ms,
+    }
+}
+
+fn metric_delta(
+    standard: Option<&MetricAverages>,
+    entity_bfs: Option<&MetricAverages>,
+    value: impl Fn(&MetricAverages) -> f64,
+) -> f64 {
+    match (standard, entity_bfs) {
+        (Some(standard), Some(entity_bfs)) => value(entity_bfs) - value(standard),
+        _ => 0.0,
+    }
+}
+
+fn build_checks(
+    standard: &GraphDecisionArmReport,
+    entity_bfs: &GraphDecisionArmReport,
+    deltas: &GraphDecisionDeltas,
+) -> GraphDecisionChecks {
+    let benefit_threshold_met = deltas.multi_hop_evidence_recall_at_k >= BENEFIT_THRESHOLD;
+    let non_multi_hop_zero_regression = metrics_not_lower(
+        standard.non_multi_hop_slices.metrics.as_ref(),
+        entity_bfs.non_multi_hop_slices.metrics.as_ref(),
+    ) && entity_bfs.non_multi_hop_slices.abstention_passed
+        >= standard.non_multi_hop_slices.abstention_passed;
+    let p95_latency_within_budget =
+        entity_bfs.overall.retrieval_latency_p95_ms <= LATENCY_BUDGET_P95_MS;
+
+    GraphDecisionChecks {
+        benefit_threshold_met,
+        non_multi_hop_zero_regression,
+        p95_latency_within_budget,
+        all_checks_passed: non_multi_hop_zero_regression && p95_latency_within_budget,
+    }
+}
+
+fn metrics_not_lower(
+    standard: Option<&MetricAverages>,
+    entity_bfs: Option<&MetricAverages>,
+) -> bool {
+    match (standard, entity_bfs) {
+        (Some(standard), Some(entity_bfs)) => {
+            entity_bfs.hit_at_k + EPSILON >= standard.hit_at_k
+                && entity_bfs.mrr_at_10 + EPSILON >= standard.mrr_at_10
+                && entity_bfs.precision_at_k + EPSILON >= standard.precision_at_k
+                && entity_bfs.recall_at_k + EPSILON >= standard.recall_at_k
+                && entity_bfs.ndcg_at_10 + EPSILON >= standard.ndcg_at_10
+                && entity_bfs.evidence_recall_at_k + EPSILON >= standard.evidence_recall_at_k
+        }
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+impl Display for GraphDecisionReport {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        writeln!(
+            f,
+            "remem graph decision eval — {:?}, k={}, threshold={:.2}",
+            self.decision, self.k, self.benefit_threshold
+        )?;
+        writeln!(f, "reason: {}", self.decision_reason)?;
+        writeln!(
+            f,
+            "multi-hop evidence delta={:.3}, non-multi-hop evidence delta={:.3}, entity-bfs p95={:.2}ms",
+            self.deltas.multi_hop_evidence_recall_at_k,
+            self.deltas.non_multi_hop_evidence_recall_at_k,
+            self.entity_bfs.overall.retrieval_latency_p95_ms
+        )?;
+        writeln!(
+            f,
+            "checks: benefit_threshold_met={} non_multi_hop_zero_regression={} p95_latency_within_budget={} all_checks_passed={}",
+            self.checks.benefit_threshold_met,
+            self.checks.non_multi_hop_zero_regression,
+            self.checks.p95_latency_within_budget,
+            self.checks.all_checks_passed
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graph_decision_eval_freezes_without_material_gain() -> Result<()> {
+        let report = run_graph_decision_eval(GraphDecisionEvalOptions::default())?;
+        assert_eq!(
+            report.decision,
+            GraphDecision::FreezeGraphEdgesRetrievalChannel
+        );
+        assert!(report.checks.all_checks_passed);
+        assert!(report.deltas.multi_hop_evidence_recall_at_k < BENEFIT_THRESHOLD);
+        Ok(())
+    }
+}

--- a/src/eval/graph_decision.rs
+++ b/src/eval/graph_decision.rs
@@ -35,6 +35,9 @@ pub struct GraphDecisionReport {
     pub k: usize,
     pub benefit_threshold: f64,
     pub latency_budget_p95_ms: f64,
+    pub evaluated_channel: EvaluatedGraphChannel,
+    pub graph_edges_evaluated: bool,
+    pub graph_edges_retrieval_decision: GraphEdgesRetrievalDecision,
     pub decision: GraphDecision,
     pub decision_reason: String,
     pub standard: GraphDecisionArmReport,
@@ -48,7 +51,19 @@ pub struct GraphDecisionReport {
 #[serde(rename_all = "snake_case")]
 pub enum GraphDecision {
     WireEntityBfsExperiment,
-    FreezeGraphEdgesRetrievalChannel,
+    KeepGraphEdgesFrozenPendingLiteralEval,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvaluatedGraphChannel {
+    EntityBfsProxy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphEdgesRetrievalDecision {
+    RemainFrozenPendingLiteralEval,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -57,6 +72,7 @@ pub struct GraphDecisionArmReport {
     pub overall: CategoryEvaluation,
     pub multi_hop_slice: CategoryEvaluation,
     pub non_multi_hop_slices: CategoryEvaluation,
+    pub multi_hop_queries_with_two_or_more_hops: usize,
     pub query_summaries: Vec<GraphDecisionQuerySummary>,
 }
 
@@ -94,45 +110,62 @@ pub struct GraphDecisionDeltas {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphDecisionChecks {
+    pub multi_hop_slice_present: bool,
+    pub entity_bfs_two_hop_observed: bool,
     pub benefit_threshold_met: bool,
     pub non_multi_hop_zero_regression: bool,
     pub p95_latency_within_budget: bool,
+    pub safe_to_wire_entity_bfs: bool,
     pub all_checks_passed: bool,
 }
 
 pub fn run_graph_decision_eval(options: GraphDecisionEvalOptions) -> Result<GraphDecisionReport> {
     let dataset = golden::load_dataset(&options.dataset_path)?;
+    run_graph_decision_dataset(dataset, options.dataset_path, options.k)
+}
+
+fn run_graph_decision_dataset(
+    dataset: GoldenDataset,
+    dataset_path: String,
+    requested_k: usize,
+) -> Result<GraphDecisionReport> {
     if !dataset.has_fixture_corpus() {
         bail!("graph decision eval requires a fixture-backed golden dataset");
     }
 
-    let k = options.k.max(1);
+    let k = requested_k.max(1);
     let standard = evaluate_arm(&dataset, k, GraphDecisionMode::Standard)?;
     let entity_bfs = evaluate_arm(&dataset, k, GraphDecisionMode::EntityBfs)?;
+    ensure_required_slices(&standard, &entity_bfs)?;
     let deltas = build_deltas(&standard, &entity_bfs);
     let checks = build_checks(&standard, &entity_bfs, &deltas);
-    let decision = if checks.benefit_threshold_met {
+    let decision = if checks.safe_to_wire_entity_bfs {
         GraphDecision::WireEntityBfsExperiment
     } else {
-        GraphDecision::FreezeGraphEdgesRetrievalChannel
+        GraphDecision::KeepGraphEdgesFrozenPendingLiteralEval
     };
     let decision_reason = match decision {
         GraphDecision::WireEntityBfsExperiment => format!(
-            "Entity BFS improves multi-hop evidence recall by at least {:.0}%.",
+            "Entity BFS is safe to wire as an experiment: it improved multi-hop evidence recall by at least {:.0}%, preserved non-multi-hop quality, stayed within the p95 latency budget, and exercised two-hop expansion.",
             BENEFIT_THRESHOLD * 100.0
         ),
-        GraphDecision::FreezeGraphEdgesRetrievalChannel => format!(
-            "Entity BFS did not clear the pre-registered {:.0}% multi-hop evidence-recall gain threshold; do not wire graph_edges into retrieval by default.",
-            BENEFIT_THRESHOLD * 100.0
+        GraphDecision::KeepGraphEdgesFrozenPendingLiteralEval => format!(
+            "This gate evaluated the entity-BFS proxy path, not literal graph_edges traversal. The proxy did not satisfy all wire requirements: >= {:.0}% multi-hop evidence-recall gain, non-multi-hop zero regression, p95 latency <= {:.0}ms, and observed two-hop expansion. Keep graph_edges retrieval frozen pending a dedicated graph_edges A/B eval.",
+            BENEFIT_THRESHOLD * 100.0,
+            LATENCY_BUDGET_P95_MS
         ),
     };
 
     Ok(GraphDecisionReport {
         version: "2026-06-12".to_string(),
-        dataset_path: options.dataset_path,
+        dataset_path,
         k,
         benefit_threshold: BENEFIT_THRESHOLD,
         latency_budget_p95_ms: LATENCY_BUDGET_P95_MS,
+        evaluated_channel: EvaluatedGraphChannel::EntityBfsProxy,
+        graph_edges_evaluated: false,
+        graph_edges_retrieval_decision:
+            GraphEdgesRetrievalDecision::RemainFrozenPendingLiteralEval,
         decision,
         decision_reason,
         standard,
@@ -140,8 +173,8 @@ pub fn run_graph_decision_eval(options: GraphDecisionEvalOptions) -> Result<Grap
         deltas,
         checks,
         notes: vec![
-            "Entity BFS is the existing explicit multi-hop expansion through memory_entities plus FTS mention fallback; this report does not wire first-class graph_edges traversal.".to_string(),
-            "A freeze decision keeps graph_edges available for provenance/candidates but blocks retrieval-channel rollout until a future pre-registered eval shows a material gain.".to_string(),
+            "Entity BFS is the existing explicit multi-hop expansion through memory_entities plus FTS mention fallback; this report does not evaluate first-class graph_edges traversal.".to_string(),
+            "The graph_edges retrieval decision is therefore a conservative freeze: graph_edges remains available for provenance/candidates but cannot become a retrieval channel until a future pre-registered literal graph_edges eval shows a material gain.".to_string(),
         ],
     })
 }
@@ -151,7 +184,8 @@ pub fn ensure_graph_decision_gate(report: &GraphDecisionReport) -> Result<()> {
         return Ok(());
     }
     bail!(
-        "graph decision eval failed: non_multi_hop_zero_regression={} p95_latency_within_budget={}",
+        "graph decision eval failed: multi_hop_slice_present={} non_multi_hop_zero_regression={} p95_latency_within_budget={}",
+        report.checks.multi_hop_slice_present,
         report.checks.non_multi_hop_zero_regression,
         report.checks.p95_latency_within_budget
     )
@@ -231,13 +265,33 @@ fn evaluate_arm(
         });
     }
 
+    let multi_hop_queries_with_two_or_more_hops = query_summaries
+        .iter()
+        .filter(|summary| {
+            summary.slice == "multi_hop" && summary.hops.is_some_and(|hops| hops >= 2)
+        })
+        .count();
+
     Ok(GraphDecisionArmReport {
         mode,
         overall: golden::run::bucket_evaluation(overall),
         multi_hop_slice: golden::run::bucket_evaluation(multi_hop_slice),
         non_multi_hop_slices: golden::run::bucket_evaluation(non_multi_hop_slices),
+        multi_hop_queries_with_two_or_more_hops,
         query_summaries,
     })
+}
+
+fn ensure_required_slices(
+    standard: &GraphDecisionArmReport,
+    entity_bfs: &GraphDecisionArmReport,
+) -> Result<()> {
+    if standard.multi_hop_slice.scored_queries == 0
+        || entity_bfs.multi_hop_slice.scored_queries == 0
+    {
+        bail!("graph decision eval requires at least one scored multi_hop query in both arms");
+    }
+    Ok(())
 }
 
 fn build_deltas(
@@ -296,6 +350,9 @@ fn build_checks(
     entity_bfs: &GraphDecisionArmReport,
     deltas: &GraphDecisionDeltas,
 ) -> GraphDecisionChecks {
+    let multi_hop_slice_present = standard.multi_hop_slice.scored_queries > 0
+        && entity_bfs.multi_hop_slice.scored_queries > 0;
+    let entity_bfs_two_hop_observed = entity_bfs.multi_hop_queries_with_two_or_more_hops > 0;
     let benefit_threshold_met = deltas.multi_hop_evidence_recall_at_k >= BENEFIT_THRESHOLD;
     let non_multi_hop_zero_regression = metrics_not_lower(
         standard.non_multi_hop_slices.metrics.as_ref(),
@@ -304,12 +361,21 @@ fn build_checks(
         >= standard.non_multi_hop_slices.abstention_passed;
     let p95_latency_within_budget =
         entity_bfs.overall.retrieval_latency_p95_ms <= LATENCY_BUDGET_P95_MS;
+    let safe_to_wire_entity_bfs = benefit_threshold_met
+        && non_multi_hop_zero_regression
+        && p95_latency_within_budget
+        && entity_bfs_two_hop_observed;
 
     GraphDecisionChecks {
+        multi_hop_slice_present,
+        entity_bfs_two_hop_observed,
         benefit_threshold_met,
         non_multi_hop_zero_regression,
         p95_latency_within_budget,
-        all_checks_passed: non_multi_hop_zero_regression && p95_latency_within_budget,
+        safe_to_wire_entity_bfs,
+        all_checks_passed: multi_hop_slice_present
+            && non_multi_hop_zero_regression
+            && p95_latency_within_budget,
     }
 }
 
@@ -348,10 +414,13 @@ impl Display for GraphDecisionReport {
         )?;
         writeln!(
             f,
-            "checks: benefit_threshold_met={} non_multi_hop_zero_regression={} p95_latency_within_budget={} all_checks_passed={}",
+            "checks: multi_hop_slice_present={} entity_bfs_two_hop_observed={} benefit_threshold_met={} non_multi_hop_zero_regression={} p95_latency_within_budget={} safe_to_wire_entity_bfs={} all_checks_passed={}",
+            self.checks.multi_hop_slice_present,
+            self.checks.entity_bfs_two_hop_observed,
             self.checks.benefit_threshold_met,
             self.checks.non_multi_hop_zero_regression,
             self.checks.p95_latency_within_budget,
+            self.checks.safe_to_wire_entity_bfs,
             self.checks.all_checks_passed
         )
     }
@@ -366,10 +435,42 @@ mod tests {
         let report = run_graph_decision_eval(GraphDecisionEvalOptions::default())?;
         assert_eq!(
             report.decision,
-            GraphDecision::FreezeGraphEdgesRetrievalChannel
+            GraphDecision::KeepGraphEdgesFrozenPendingLiteralEval
+        );
+        assert_eq!(
+            report.evaluated_channel,
+            EvaluatedGraphChannel::EntityBfsProxy
+        );
+        assert!(!report.graph_edges_evaluated);
+        assert_eq!(
+            report.graph_edges_retrieval_decision,
+            GraphEdgesRetrievalDecision::RemainFrozenPendingLiteralEval
         );
         assert!(report.checks.all_checks_passed);
+        assert!(!report.checks.safe_to_wire_entity_bfs);
         assert!(report.deltas.multi_hop_evidence_recall_at_k < BENEFIT_THRESHOLD);
+        Ok(())
+    }
+
+    #[test]
+    fn graph_decision_eval_rejects_dataset_without_multi_hop_slice() -> Result<()> {
+        let mut dataset = golden::load_dataset(DEFAULT_DATASET_PATH)?;
+        for query in &mut dataset.queries {
+            if query.slice_label() == "multi_hop" {
+                query.slice = Some("paraphrase".to_string());
+            }
+        }
+
+        let error = run_graph_decision_dataset(
+            dataset,
+            DEFAULT_DATASET_PATH.to_string(),
+            GraphDecisionEvalOptions::default().k,
+        )
+        .expect_err("dataset without multi_hop slice must fail the graph decision gate");
+
+        assert!(error
+            .to_string()
+            .contains("requires at least one scored multi_hop query"));
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Add `remem eval-graph-decision` to compare standard golden retrieval against the explicit entity-BFS multi-hop path.
- Commit the issue #382 A/B artifact at `eval/graph-decision/report.json` and record the freeze decision in `docs/adr/2026-06-12-graph-decision-gate.md`.
- Document the graph decision gate and bump package/plugin versions to 0.5.55.

Decision from the committed report: `freeze_graph_edges_retrieval_channel`. Entity BFS did not clear the pre-registered 5% multi-hop evidence-recall gain threshold; non-multi-hop zero-regression and p95 latency gates passed.

Fixes #382

## Verification
- cargo fmt --check && git diff --check
- cargo check --message-format=short
- cargo test graph_decision -- --nocapture
- cargo test cli_parses_eval_graph_decision_options -- --nocapture
- cargo run --quiet -- eval-graph-decision --json-out /tmp/remem-issue382-graph-decision.json --json
- cargo run --quiet -- eval-gates --json-out /tmp/remem-issue382-eval-gates.json
- cargo clippy -- -D warnings
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main HEAD
- cargo test