### PR TITLE
Expose staleness labels in search explain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.55"
+version = "0.5.56"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.55": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.55",
+    "0.5.56": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.56",
       "assets": {}
     }
   }

--- a/src/api/handlers/search.rs
+++ b/src/api/handlers/search.rs
@@ -184,6 +184,12 @@ mod tests {
         let default_body = to_bytes(default_response.into_body(), usize::MAX).await?;
         let default_json: Value = serde_json::from_slice(&default_body)?;
         assert!(default_json.get("explain").is_none());
+        assert_eq!(default_json["data"][0]["id"], memory_id);
+        assert_eq!(default_json["data"][0]["staleness"]["status"], "active");
+        assert_eq!(
+            default_json["data"][0]["staleness"]["source_anchor"],
+            "untracked"
+        );
 
         let explain_response = handle_search(State(DbState), Query(base_search_params(Some(true))))
             .await

--- a/src/api/handlers/search.rs
+++ b/src/api/handlers/search.rs
@@ -192,10 +192,19 @@ mod tests {
         let explain_json: Value = serde_json::from_slice(&explain_body)?;
 
         assert_eq!(explain_json["data"][0]["id"], memory_id);
+        assert_eq!(explain_json["data"][0]["staleness"]["status"], "active");
+        assert_eq!(
+            explain_json["data"][0]["staleness"]["source_anchor"],
+            "untracked"
+        );
         assert_eq!(explain_json["explain"]["query"], "aurora");
         assert_eq!(
             explain_json["explain"]["results"][0]["memory_id"],
             memory_id
+        );
+        assert_eq!(
+            explain_json["explain"]["results"][0]["staleness"]["status"],
+            "active"
         );
         Ok(())
     }

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -17,6 +17,7 @@ pub(super) fn memory_to_item(memory: &memory::Memory) -> MemoryItem {
         project: memory.project.clone(),
         scope: memory.scope.clone(),
         status: memory.status.clone(),
+        staleness: memory::memory_staleness_label(memory, chrono::Utc::now().timestamp()),
         topic_key: memory.topic_key.clone(),
         branch: memory.branch.clone(),
         created_at_epoch: memory.created_at_epoch,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -59,6 +59,7 @@ pub(super) struct MemoryItem {
     pub project: String,
     pub scope: String,
     pub status: String,
+    pub staleness: crate::memory::MemoryStalenessLabel,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topic_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/cli/actions/query/tests.rs
+++ b/src/cli/actions/query/tests.rs
@@ -89,6 +89,12 @@ fn sample_explain() -> SearchExplain {
             project: "proj".to_string(),
             scope: "project".to_string(),
             visibility: "project-local".to_string(),
+            staleness: crate::memory::MemoryStalenessLabel {
+                status: "active".to_string(),
+                age: "fresh",
+                source_anchor: "untracked",
+                label: "status=active; staleness=fresh; source_anchor=untracked".to_string(),
+            },
             contributions: vec![ChannelContribution {
                 channel: "fts".to_string(),
                 rank: 1,

--- a/src/context/audit.rs
+++ b/src/context/audit.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rusqlite::params;
 use std::collections::HashSet;
 
-use crate::memory::Memory;
+use crate::memory::{age_staleness_label, memory_staleness as shared_memory_staleness, Memory};
 
 use super::injection_gate::{ContextGateAction, ContextGateDecision};
 use super::invocation::ContextInvocation;
@@ -135,23 +135,7 @@ pub(in crate::context) fn memory_provenance(memory: &Memory) -> String {
 }
 
 pub(in crate::context) fn memory_staleness(memory: &Memory, now_epoch: i64) -> String {
-    let age = age_staleness(memory.updated_at_epoch, now_epoch);
-    format!("status={}; staleness={age}", memory.status)
-}
-
-fn age_staleness_label(updated_at_epoch: i64, now_epoch: i64) -> String {
-    format!("staleness={}", age_staleness(updated_at_epoch, now_epoch))
-}
-
-fn age_staleness(updated_at_epoch: i64, now_epoch: i64) -> &'static str {
-    let age_days = now_epoch.saturating_sub(updated_at_epoch) / 86_400;
-    if age_days <= 30 {
-        "fresh"
-    } else if age_days <= 90 {
-        "aging"
-    } else {
-        "old"
-    }
+    shared_memory_staleness(memory, now_epoch)
 }
 
 pub(in crate::context) fn record_context_injection_items(

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -111,6 +111,12 @@ impl MemoryServer {
             let search_results: Vec<SearchResult> = memories
                 .into_iter()
                 .map(|memory| {
+                    let staleness = requested_explain.then(|| {
+                        crate::memory::memory_staleness_label(
+                            &memory,
+                            chrono::Utc::now().timestamp(),
+                        )
+                    });
                     let updated = chrono::DateTime::from_timestamp(memory.updated_at_epoch, 0)
                         .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
                         .unwrap_or_default();
@@ -126,6 +132,7 @@ impl MemoryServer {
                         updated_at: updated,
                         project: memory.project,
                         status: memory.status,
+                        staleness,
                     }
                 })
                 .collect();
@@ -273,6 +280,7 @@ mod tests {
             .map_err(anyhow::Error::msg)?;
         let default_json: Value = serde_json::from_str(&default_response)?;
         assert!(default_json.get("explain").is_none());
+        assert!(default_json["results"][0].get("staleness").is_none());
 
         let explain_response = server
             .search(Parameters(base_search_params(Some(true))))
@@ -280,10 +288,19 @@ mod tests {
         let explain_json: Value = serde_json::from_str(&explain_response)?;
 
         assert_eq!(explain_json["results"][0]["id"], memory_id);
+        assert_eq!(explain_json["results"][0]["staleness"]["status"], "active");
+        assert_eq!(
+            explain_json["results"][0]["staleness"]["source_anchor"],
+            "untracked"
+        );
         assert_eq!(explain_json["explain"]["query"], "aurora");
         assert_eq!(
             explain_json["explain"]["results"][0]["memory_id"],
             memory_id
+        );
+        assert_eq!(
+            explain_json["explain"]["results"][0]["staleness"]["status"],
+            "active"
         );
         Ok(())
     }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -205,6 +205,8 @@ pub(super) struct SearchResult {
     pub updated_at: String,
     pub project: String,
     pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub staleness: Option<crate::memory::MemoryStalenessLabel>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -20,6 +20,7 @@ pub mod scope_cleanup;
 pub mod search_context;
 pub(crate) mod semantic_dedup;
 pub mod service;
+pub mod staleness;
 pub mod state_key;
 pub mod store;
 pub mod types;
@@ -31,5 +32,6 @@ pub use crate::retrieval::memory_search::{
 pub use promote::{promote_summary_to_memory_candidates, slugify_for_topic};
 
 pub use events::*;
+pub use staleness::*;
 pub use store::*;
 pub use types::*;

--- a/src/memory/staleness.rs
+++ b/src/memory/staleness.rs
@@ -1,0 +1,97 @@
+use serde::Serialize;
+
+use super::Memory;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MemoryStalenessLabel {
+    pub status: String,
+    pub age: &'static str,
+    pub source_anchor: &'static str,
+    pub label: String,
+}
+
+pub fn memory_staleness_label(memory: &Memory, now_epoch: i64) -> MemoryStalenessLabel {
+    let age = age_staleness(memory.updated_at_epoch, now_epoch);
+    let source_anchor = "untracked";
+    MemoryStalenessLabel {
+        status: memory.status.clone(),
+        age,
+        source_anchor,
+        label: format!(
+            "status={}; staleness={age}; source_anchor={source_anchor}",
+            memory.status
+        ),
+    }
+}
+
+pub fn memory_staleness(memory: &Memory, now_epoch: i64) -> String {
+    format!(
+        "status={}; staleness={}",
+        memory.status,
+        age_staleness(memory.updated_at_epoch, now_epoch)
+    )
+}
+
+pub fn age_staleness_label(updated_at_epoch: i64, now_epoch: i64) -> String {
+    format!("staleness={}", age_staleness(updated_at_epoch, now_epoch))
+}
+
+pub fn age_staleness(updated_at_epoch: i64, now_epoch: i64) -> &'static str {
+    let age_days = now_epoch.saturating_sub(updated_at_epoch) / 86_400;
+    if age_days <= 30 {
+        "fresh"
+    } else if age_days <= 90 {
+        "aging"
+    } else {
+        "old"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn memory(updated_at_epoch: i64, status: &str) -> Memory {
+        Memory {
+            id: 1,
+            session_id: None,
+            project: "/repo".to_string(),
+            topic_key: None,
+            title: "Staleness fixture".to_string(),
+            text: "body".to_string(),
+            memory_type: "decision".to_string(),
+            files: None,
+            created_at_epoch: updated_at_epoch,
+            updated_at_epoch,
+            status: status.to_string(),
+            branch: None,
+            scope: "project".to_string(),
+        }
+    }
+
+    #[test]
+    fn labels_memory_status_age_and_untracked_source_anchor() {
+        let label = memory_staleness_label(&memory(1_700_000_000, "active"), 1_700_000_000);
+
+        assert_eq!(label.status, "active");
+        assert_eq!(label.age, "fresh");
+        assert_eq!(label.source_anchor, "untracked");
+        assert_eq!(
+            label.label,
+            "status=active; staleness=fresh; source_anchor=untracked"
+        );
+        assert_eq!(
+            memory_staleness(&memory(1_700_000_000, "active"), 1_700_000_000),
+            "status=active; staleness=fresh"
+        );
+    }
+
+    #[test]
+    fn classifies_age_buckets() {
+        let now = 1_700_000_000;
+
+        assert_eq!(age_staleness(now - 30 * 86_400, now), "fresh");
+        assert_eq!(age_staleness(now - 31 * 86_400, now), "aging");
+        assert_eq!(age_staleness(now - 91 * 86_400, now), "old");
+    }
+}

--- a/src/retrieval/search/memory/explain.rs
+++ b/src/retrieval/search/memory/explain.rs
@@ -61,6 +61,7 @@ pub struct SearchExplainResult {
     pub project: String,
     pub scope: String,
     pub visibility: String,
+    pub staleness: crate::memory::MemoryStalenessLabel,
     pub contributions: Vec<ChannelContribution>,
 }
 

--- a/src/retrieval/search/memory/tests.rs
+++ b/src/retrieval/search/memory/tests.rs
@@ -111,6 +111,12 @@ fn search_explain_reports_channels_scores_and_visibility() -> Result<()> {
         .results
         .iter()
         .any(|result| result.visibility == "global-overlay"));
+    assert!(explain.results.iter().all(|result| {
+        result.staleness.status == "active"
+            && result.staleness.age == "fresh"
+            && result.staleness.source_anchor == "untracked"
+            && result.staleness.label.contains("source_anchor=untracked")
+    }));
     let like = explain
         .channels
         .iter()

--- a/src/retrieval/search/memory/text.rs
+++ b/src/retrieval/search/memory/text.rs
@@ -395,6 +395,7 @@ fn build_explain(
         })
         .collect();
     let id_to_score: HashMap<i64, f64> = fused.iter().copied().collect();
+    let now_epoch = chrono::Utc::now().timestamp();
     let results = paged
         .iter()
         .enumerate()
@@ -405,6 +406,7 @@ fn build_explain(
             project: memory.project.clone(),
             scope: memory.scope.clone(),
             visibility: visibility_label(memory, project).to_string(),
+            staleness: memory::memory_staleness_label(memory, now_epoch),
             contributions: contributions_for(memory.id, &plan.channels),
         })
         .collect();


### PR DESCRIPTION
## Summary

Part of #380.

This PR completes the first agent-visible explain slice for M3 search:
- adds a shared `MemoryStalenessLabel` with memory status, age bucket, source-anchor liveness, and a compact label string
- includes staleness labels in standard search explain results, HTTP search memory items, and MCP search when `explain=true`
- keeps MCP default compact search output stable by omitting `results[].staleness` unless explain is explicitly requested
- reuses the shared staleness age helper for context audit/render metadata without adding source-anchor text to normal context lines
- bumps runtime/plugin/npm metadata to `0.5.56`

This does not close #380; calibrated abstention, synonym retirement, grid search artifacts, reindexing, and extraction prompt upgrades remain separate slices.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check --message-format=short`
- `cargo test mcp::server::search_tools -- --nocapture`
- `cargo test api::handlers::search -- --nocapture`
- `cargo test retrieval::search::memory -- --nocapture`
- `cargo test cli::actions::query -- --nocapture`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `cargo clippy -- -D warnings`
- `cargo run -- eval-extraction --json --check-baseline > /tmp/remem-issue380-extraction-eval.json`
- `cargo run -- eval-gates --json-out /tmp/remem-issue380-eval-gates.json`
- `cargo run -- eval-gates --simulate-golden-regression --json-out /tmp/remem-issue380-eval-gates-regression.json` exits non-zero and logs `golden.slice.temporal.hit_at_k regressed`
- `cargo test`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
