### PR TITLE
Add retrieval weight grid eval artifact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.57"
+version = "0.5.58"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.57"
+version = "0.5.58"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/eval/weight-grid/report.json
+++ b/eval/weight-grid/report.json
@@ -1,0 +1,20407 @@
+{
+  "version": "2026-06-12",
+  "dataset_path": "eval/golden.json",
+  "k": 5,
+  "scoring": {
+    "evidence_recall_weight": 4.0,
+    "hit_weight": 3.0,
+    "ndcg_weight": 2.0,
+    "mrr_weight": 1.0,
+    "abstention_weight": 1.0
+  },
+  "default_weights": {
+    "fts": 2.5,
+    "vector": 3.0,
+    "entity": 1.25,
+    "temporal": 1.0,
+    "like_fallback": 0.25,
+    "max_vector_distance": 0.51,
+    "rrf_k": 60.0
+  },
+  "default_rank": 79,
+  "default_score": 7.234691066824165,
+  "best": {
+    "rank": 1,
+    "weights": {
+      "fts": 2.5,
+      "vector": 2.5,
+      "entity": 1.5,
+      "temporal": 1.0,
+      "like_fallback": 0.25,
+      "max_vector_distance": 0.51,
+      "rrf_k": 60.0
+    },
+    "score": 7.259849306590875,
+    "distance_from_defaults": 0.75,
+    "deltas_vs_default": {
+      "hit_at_k": 0.0,
+      "mrr_at_10": 0.012500000000000067,
+      "precision_at_k": 0.0,
+      "recall_at_k": 0.0,
+      "ndcg_at_10": 0.006329119883355272,
+      "evidence_recall_at_k": 0.0,
+      "abstention_pass_rate": 0.0
+    },
+    "overall": {
+      "total_queries": 50,
+      "scored_queries": 40,
+      "abstention_queries": 10,
+      "abstention_passed": 0,
+      "query_tokens_per_query": 12.88,
+      "retrieval_latency_p50_ms": 0.0,
+      "retrieval_latency_p95_ms": 0.0,
+      "metrics": {
+        "count": 40,
+        "hit_at_k": 0.75,
+        "mrr_at_10": 0.6833333333333333,
+        "precision_at_k": 0.2250000000000001,
+        "recall_at_k": 0.75,
+        "ndcg_at_10": 0.663257986628771,
+        "evidence_recall_at_k": 0.75
+      }
+    },
+    "by_slice": {
+      "abstention": {
+        "total_queries": 10,
+        "scored_queries": 0,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.0,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": null
+      },
+      "knowledge_update": {
+        "total_queries": 10,
+        "scored_queries": 10,
+        "abstention_queries": 0,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.8,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 10,
+          "hit_at_k": 1.0,
+          "mrr_at_10": 1.0,
+          "precision_at_k": 0.25,
+          "recall_at_k": 1.0,
+          "ndcg_at_10": 1.0,
+          "evidence_recall_at_k": 1.0
+        }
+      },
+      "multi_hop": {
+        "total_queries": 10,
+        "scored_queries": 10,
+        "abstention_queries": 0,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 19.6,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 10,
+          "hit_at_k": 1.0,
+          "mrr_at_10": 1.0,
+          "precision_at_k": 0.39999999999999997,
+          "recall_at_k": 1.0,
+          "ndcg_at_10": 0.8530319465150841,
+          "evidence_recall_at_k": 1.0
+        }
+      },
+      "paraphrase": {
+        "total_queries": 10,
+        "scored_queries": 10,
+        "abstention_queries": 0,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 7.4,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 10,
+          "hit_at_k": 0.0,
+          "mrr_at_10": 0.0,
+          "precision_at_k": 0.0,
+          "recall_at_k": 0.0,
+          "ndcg_at_10": 0.0,
+          "evidence_recall_at_k": 0.0
+        }
+      },
+      "temporal": {
+        "total_queries": 10,
+        "scored_queries": 10,
+        "abstention_queries": 0,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.6,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 10,
+          "hit_at_k": 1.0,
+          "mrr_at_10": 0.7333333333333333,
+          "precision_at_k": 0.25,
+          "recall_at_k": 1.0,
+          "ndcg_at_10": 0.8,
+          "evidence_recall_at_k": 1.0
+        }
+      }
+    }
+  },
+  "recommendation": "candidate_outperforms_defaults_needs_decision",
+  "checks": {
+    "fixture_corpus_used": true,
+    "default_weights_in_grid": true,
+    "best_preserves_abstention": true,
+    "best_preserves_scored_query_count": true
+  },
+  "candidates": [
+    {
+      "rank": 1,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.259849306590875,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.006329119883355272,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.663257986628771,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8530319465150841,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 2,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.259849306590875,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.006329119883355272,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.663257986628771,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8530319465150841,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 3,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.259849306590875,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.006329119883355272,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.663257986628771,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8530319465150841,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 4,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.259849306590875,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.006329119883355272,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.663257986628771,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8530319465150841,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 5,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.259849306590875,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.006329119883355272,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.663257986628771,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8530319465150841,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 6,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.259849306590875,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.006329119883355272,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.663257986628771,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8530319465150841,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 7,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 8,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 9,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 10,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 11,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 12,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 13,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 14,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 15,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 16,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 17,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 18,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 19,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 20,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 21,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 22,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 23,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 24,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 25,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 26,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 27,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 28,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 29,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 30,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 31,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 32,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 33,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 34,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 35,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 36,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 37,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 38,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 39,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 40,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 41,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 42,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 43,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 44,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 45,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 46,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 47,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 48,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 49,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 50,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 51,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 52,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 53,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 54,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.258505786100711,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.012500000000000067,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.005657359638272852,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6833333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6625862263836886,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8503449055347547,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 55,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 0.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 56,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 0.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 57,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 58,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 59,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 60,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 61,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 62,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 63,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 64,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 65,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 66,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 67,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 68,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 69,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 70,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 71,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 72,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 73,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 74,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 75,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 76,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 77,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 78,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.5,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.23603458731433,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.000671760245082309,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.657600626990498,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8304025079619924,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 79,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 80,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 81,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 82,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 83,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 84,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 85,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 86,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 87,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 88,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 89,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 90,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 91,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 92,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 93,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 94,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 95,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 96,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 97,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 98,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 99,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 100,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 101,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 102,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 103,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 104,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 105,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 106,
+      "weights": {
+        "fts": 2.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 107,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 108,
+      "weights": {
+        "fts": 2.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.234691066824165,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": 0.0,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": 0.0,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6708333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6569288667454157,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.95,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.827715466981663,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 109,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 0.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 110,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 0.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 111,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 112,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 113,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 114,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 115,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 116,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 117,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 118,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 119,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 120,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 121,
+      "weights": {
+        "fts": 2.5,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 122,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 123,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 124,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 125,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 126,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1884051487612375,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.010642959031463506,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6462859077139522,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.785143630855809,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 127,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 0.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 128,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 0.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 129,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 0.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 130,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 0.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 131,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 0.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 132,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 0.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 133,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 134,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 135,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 136,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 137,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 138,
+      "weights": {
+        "fts": 2.5,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.187061628271073,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.025000000000000022,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.011314719276545815,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6458333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6456141474688699,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.85,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7824565898754796,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 139,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1753035838299315,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.033333333333333326,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.013027074830449958,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6375,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6439017919149658,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 140,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1753035838299315,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.033333333333333326,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.013027074830449958,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6375,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6439017919149658,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 141,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1753035838299315,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.033333333333333326,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.013027074830449958,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6375,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6439017919149658,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 142,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1753035838299315,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.033333333333333326,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.013027074830449958,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6375,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6439017919149658,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 143,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1753035838299315,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.033333333333333326,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.013027074830449958,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6375,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6439017919149658,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 144,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.1753035838299315,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.033333333333333326,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.013027074830449958,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6375,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6439017919149658,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 145,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.164590429484692,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.03749999999999998,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.01630031866973647,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6333333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6406285480756793,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 146,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.164590429484692,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.03749999999999998,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.01630031866973647,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6333333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6406285480756793,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 147,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.164590429484692,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.03749999999999998,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.01630031866973647,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6333333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6406285480756793,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 148,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.164590429484692,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.03749999999999998,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.01630031866973647,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6333333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6406285480756793,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 149,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.164590429484692,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.03749999999999998,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.01630031866973647,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6333333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6406285480756793,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 150,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.25,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.164590429484692,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.03749999999999998,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.01630031866973647,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6333333333333333,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6406285480756793,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.8,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.7625141923027173,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7333333333333333,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 151,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.127674145276839,
+      "distance_from_defaults": 0.75,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.05833333333333324,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.024341794106995773,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6125,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.63258707263842,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.717255315196534,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 152,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.127674145276839,
+      "distance_from_defaults": 0.9,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.05833333333333324,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.024341794106995773,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6125,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.63258707263842,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.717255315196534,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 153,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.127674145276839,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.05833333333333324,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.024341794106995773,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6125,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.63258707263842,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.717255315196534,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 154,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.127674145276839,
+      "distance_from_defaults": 1.0,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.05833333333333324,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.024341794106995773,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6125,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.63258707263842,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.717255315196534,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 155,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.127674145276839,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.05833333333333324,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.024341794106995773,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6125,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.63258707263842,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.717255315196534,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 156,
+      "weights": {
+        "fts": 3.0,
+        "vector": 3.0,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.127674145276839,
+      "distance_from_defaults": 1.15,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.05833333333333324,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.024341794106995773,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.6125,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.63258707263842,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.7,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.717255315196534,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 157,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.056229987447202,
+      "distance_from_defaults": 1.25,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.09583333333333333,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.04131387302181455,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.575,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6156149937236012,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.55,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.649366999537259,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 158,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.0,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.056229987447202,
+      "distance_from_defaults": 1.4,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.09583333333333333,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.04131387302181455,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.575,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6156149937236012,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.55,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.649366999537259,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 159,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.056229987447202,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.09583333333333333,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.04131387302181455,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.575,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6156149937236012,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.55,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.649366999537259,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 160,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.25,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.056229987447202,
+      "distance_from_defaults": 1.5,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.09583333333333333,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.04131387302181455,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.575,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6156149937236012,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.55,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.649366999537259,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 161,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 0.75,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.056229987447202,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.09583333333333333,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.04131387302181455,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.575,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6156149937236012,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.55,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.649366999537259,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    },
+    {
+      "rank": 162,
+      "weights": {
+        "fts": 3.0,
+        "vector": 2.5,
+        "entity": 1.0,
+        "temporal": 1.25,
+        "like_fallback": 0.1,
+        "max_vector_distance": 0.51,
+        "rrf_k": 60.0
+      },
+      "score": 7.056229987447202,
+      "distance_from_defaults": 1.65,
+      "deltas_vs_default": {
+        "hit_at_k": 0.0,
+        "mrr_at_10": -0.09583333333333333,
+        "precision_at_k": 0.0,
+        "recall_at_k": 0.0,
+        "ndcg_at_10": -0.04131387302181455,
+        "evidence_recall_at_k": 0.0,
+        "abstention_pass_rate": 0.0
+      },
+      "overall": {
+        "total_queries": 50,
+        "scored_queries": 40,
+        "abstention_queries": 10,
+        "abstention_passed": 0,
+        "query_tokens_per_query": 12.88,
+        "retrieval_latency_p50_ms": 0.0,
+        "retrieval_latency_p95_ms": 0.0,
+        "metrics": {
+          "count": 40,
+          "hit_at_k": 0.75,
+          "mrr_at_10": 0.575,
+          "precision_at_k": 0.2250000000000001,
+          "recall_at_k": 0.75,
+          "ndcg_at_10": 0.6156149937236012,
+          "evidence_recall_at_k": 0.75
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "total_queries": 10,
+          "scored_queries": 0,
+          "abstention_queries": 10,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": null
+        },
+        "knowledge_update": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 1.0,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "multi_hop": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.55,
+            "precision_at_k": 0.39999999999999997,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.649366999537259,
+            "evidence_recall_at_k": 1.0
+          }
+        },
+        "paraphrase": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0,
+            "ndcg_at_10": 0.0,
+            "evidence_recall_at_k": 0.0
+          }
+        },
+        "temporal": {
+          "total_queries": 10,
+          "scored_queries": 10,
+          "abstention_queries": 0,
+          "abstention_passed": 0,
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 0.0,
+          "retrieval_latency_p95_ms": 0.0,
+          "metrics": {
+            "count": 10,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 0.75,
+            "precision_at_k": 0.25,
+            "recall_at_k": 1.0,
+            "ndcg_at_10": 0.8130929753571458,
+            "evidence_recall_at_k": 1.0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.57",
+  "version": "0.5.58",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.57",
+  "version": "0.5.58",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.57": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.57",
+    "0.5.58": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.58",
       "assets": {}
     }
   }

--- a/src/cli/actions.rs
+++ b/src/cli/actions.rs
@@ -16,7 +16,7 @@ pub(super) use admin::run_admin;
 pub(super) use config_command::run_config;
 pub(super) use eval::{
     run_eval, run_eval_e2e, run_eval_extraction, run_eval_gates, run_eval_governance,
-    run_eval_graph_decision, run_eval_local,
+    run_eval_graph_decision, run_eval_local, run_eval_weight_grid,
 };
 pub(super) use import::run_import;
 pub(super) use maintenance::{

--- a/src/cli/actions/eval.rs
+++ b/src/cli/actions/eval.rs
@@ -145,3 +145,32 @@ pub(in crate::cli) fn run_eval_graph_decision(
     crate::eval::graph_decision::ensure_graph_decision_gate(&report)?;
     Ok(())
 }
+
+pub(in crate::cli) fn run_eval_weight_grid(
+    dataset_path: &str,
+    k: usize,
+    json_out: &str,
+    json: bool,
+) -> Result<()> {
+    let report =
+        crate::eval::weight_grid::run_weight_grid(crate::eval::weight_grid::WeightGridOptions {
+            dataset_path: dataset_path.to_string(),
+            k,
+        })?;
+    let report_json = serde_json::to_string_pretty(&report)?;
+    if let Some(parent) = Path::new(json_out).parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("create weight grid eval directory {}", parent.display())
+            })?;
+        }
+    }
+    fs::write(json_out, &report_json)
+        .with_context(|| format!("write weight grid eval JSON {json_out}"))?;
+    if json {
+        println!("{report_json}");
+    } else {
+        print!("{report}");
+    }
+    Ok(())
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -6,10 +6,11 @@ use super::actions::{
     run_admin, run_archive, run_audit_scope, run_backfill_embeddings, run_backfill_entities,
     run_cleanup, run_commit, run_config, run_current_state, run_dream, run_encrypt, run_eval,
     run_eval_e2e, run_eval_extraction, run_eval_gates, run_eval_governance,
-    run_eval_graph_decision, run_eval_local, run_governance, run_graph_review, run_import,
-    run_memory_cleanup, run_merge_preferences, run_model, run_pending, run_preferences, run_raw,
-    run_reroute, run_review, run_search, run_show, run_status, run_timeline, run_usage, run_why,
-    run_workstreams, GovernanceCliRequest, RerouteCliRequest,
+    run_eval_graph_decision, run_eval_local, run_eval_weight_grid, run_governance,
+    run_graph_review, run_import, run_memory_cleanup, run_merge_preferences, run_model,
+    run_pending, run_preferences, run_raw, run_reroute, run_review, run_search, run_show,
+    run_status, run_timeline, run_usage, run_why, run_workstreams, GovernanceCliRequest,
+    RerouteCliRequest,
 };
 use super::cwd::resolve_cwd_arg;
 use super::types::{Cli, Commands, ContextGateAction, MemoryAction};
@@ -258,6 +259,9 @@ pub(super) async fn run_cli(cli: Cli) -> Result<()> {
         }
         Commands::EvalGraphDecision(args) => {
             run_eval_graph_decision(&args.dataset, args.k, &args.json_out, args.json)?
+        }
+        Commands::EvalWeightGrid(args) => {
+            run_eval_weight_grid(&args.dataset, args.k, &args.json_out, args.json)?
         }
         Commands::EvalGates(args) => run_eval_gates(
             &args.baseline,

--- a/src/cli/eval_types.rs
+++ b/src/cli/eval_types.rs
@@ -39,3 +39,15 @@ pub(in crate::cli) struct EvalGraphDecisionArgs {
     #[arg(long)]
     pub(in crate::cli) json: bool,
 }
+
+#[derive(Args)]
+pub(in crate::cli) struct EvalWeightGridArgs {
+    #[arg(long, default_value = crate::eval::weight_grid::DEFAULT_DATASET_PATH)]
+    pub(in crate::cli) dataset: String,
+    #[arg(long, short = 'k', default_value = "5")]
+    pub(in crate::cli) k: usize,
+    #[arg(long, default_value = crate::eval::weight_grid::DEFAULT_REPORT_PATH)]
+    pub(in crate::cli) json_out: String,
+    #[arg(long)]
+    pub(in crate::cli) json: bool,
+}

--- a/src/cli/tests_eval.rs
+++ b/src/cli/tests_eval.rs
@@ -97,3 +97,28 @@ fn cli_parses_eval_graph_decision_options() {
         _ => panic!("expected eval-graph-decision command"),
     }
 }
+
+#[test]
+fn cli_parses_eval_weight_grid_options() {
+    let cli = Cli::parse_from([
+        "remem",
+        "eval-weight-grid",
+        "--dataset",
+        "fixtures/golden.json",
+        "--json-out",
+        "/tmp/weight-grid.json",
+        "--json",
+        "-k",
+        "7",
+    ]);
+
+    match cli.command {
+        Commands::EvalWeightGrid(args) => {
+            assert_eq!(args.dataset, "fixtures/golden.json");
+            assert_eq!(args.json_out, "/tmp/weight-grid.json");
+            assert_eq!(args.k, 7);
+            assert!(args.json);
+        }
+        _ => panic!("expected eval-weight-grid command"),
+    }
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -452,6 +452,8 @@ pub(super) enum Commands {
     EvalExtraction(super::eval_types::EvalExtractionArgs),
     #[command(name = "eval-graph-decision")]
     EvalGraphDecision(super::eval_types::EvalGraphDecisionArgs),
+    #[command(name = "eval-weight-grid")]
+    EvalWeightGrid(super::eval_types::EvalWeightGridArgs),
     #[command(name = "eval-gates")]
     EvalGates(super::eval_types::EvalGatesArgs),
     /// Run local retrieval diagnostics.
@@ -500,7 +502,6 @@ pub(super) enum Commands {
         action: ImportAction,
     },
 }
-
 #[derive(Subcommand)]
 pub(in crate::cli) enum ContextGateAction {
     /// Show recent read-only context injection rows.
@@ -519,7 +520,6 @@ pub(in crate::cli) enum ContextGateAction {
         json: bool,
     },
 }
-
 #[derive(Subcommand)]
 pub(in crate::cli) enum ModelAction {
     /// Show the currently effective memory AI model configuration.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -423,3 +423,4 @@ pub mod graph_decision;
 pub mod injection;
 pub mod local;
 pub mod metrics;
+pub mod weight_grid;

--- a/src/eval/weight_grid.rs
+++ b/src/eval/weight_grid.rs
@@ -1,0 +1,479 @@
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use anyhow::{bail, Context, Result};
+use rusqlite::Connection;
+use serde::Serialize;
+
+use super::golden::{self, CategoryEvaluation, GoldenDataset, MetricAverages};
+use crate::retrieval::search::SearchWeights;
+
+pub const DEFAULT_DATASET_PATH: &str = "eval/golden.json";
+pub const DEFAULT_REPORT_PATH: &str = "eval/weight-grid/report.json";
+const EPSILON: f64 = 0.000_001;
+
+#[derive(Debug, Clone)]
+pub struct WeightGridOptions {
+    pub dataset_path: String,
+    pub k: usize,
+}
+
+impl Default for WeightGridOptions {
+    fn default() -> Self {
+        Self {
+            dataset_path: DEFAULT_DATASET_PATH.to_string(),
+            k: 5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WeightGridReport {
+    pub version: String,
+    pub dataset_path: String,
+    pub k: usize,
+    pub scoring: WeightGridScoring,
+    pub default_weights: SearchWeights,
+    pub default_rank: usize,
+    pub default_score: f64,
+    pub best: WeightGridCandidate,
+    pub recommendation: WeightGridRecommendation,
+    pub checks: WeightGridChecks,
+    pub candidates: Vec<WeightGridCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WeightGridScoring {
+    pub evidence_recall_weight: f64,
+    pub hit_weight: f64,
+    pub ndcg_weight: f64,
+    pub mrr_weight: f64,
+    pub abstention_weight: f64,
+}
+
+impl Default for WeightGridScoring {
+    fn default() -> Self {
+        Self {
+            evidence_recall_weight: 4.0,
+            hit_weight: 3.0,
+            ndcg_weight: 2.0,
+            mrr_weight: 1.0,
+            abstention_weight: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WeightGridRecommendation {
+    KeepShippedDefaults,
+    CandidateOutperformsDefaultsNeedsDecision,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WeightGridChecks {
+    pub fixture_corpus_used: bool,
+    pub default_weights_in_grid: bool,
+    pub best_preserves_abstention: bool,
+    pub best_preserves_scored_query_count: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WeightGridCandidate {
+    pub rank: usize,
+    pub weights: SearchWeights,
+    pub score: f64,
+    pub distance_from_defaults: f64,
+    pub deltas_vs_default: WeightGridDeltas,
+    pub overall: CategoryEvaluation,
+    pub by_slice: BTreeMap<String, CategoryEvaluation>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct WeightGridDeltas {
+    pub hit_at_k: f64,
+    pub mrr_at_10: f64,
+    pub precision_at_k: f64,
+    pub recall_at_k: f64,
+    pub ndcg_at_10: f64,
+    pub evidence_recall_at_k: f64,
+    pub abstention_pass_rate: f64,
+}
+
+pub fn run_weight_grid(options: WeightGridOptions) -> Result<WeightGridReport> {
+    let dataset = golden::load_dataset(&options.dataset_path)?;
+    run_weight_grid_dataset(
+        dataset,
+        options.dataset_path,
+        options.k,
+        default_candidate_grid(),
+    )
+}
+
+fn run_weight_grid_dataset(
+    dataset: GoldenDataset,
+    dataset_path: String,
+    requested_k: usize,
+    candidates: Vec<SearchWeights>,
+) -> Result<WeightGridReport> {
+    if !dataset.has_fixture_corpus() {
+        bail!("weight grid eval requires a fixture-backed golden dataset");
+    }
+    if candidates.is_empty() {
+        bail!("weight grid requires at least one candidate");
+    }
+
+    let k = requested_k.max(1);
+    let conn = Connection::open_in_memory().context("open in-memory weight grid eval DB")?;
+    crate::migrate::run_migrations(&conn).context("migrate weight grid eval DB")?;
+    golden::run::seed_fixture_corpus(&conn, &dataset.corpus)?;
+
+    let default_weights = SearchWeights::default();
+    let scoring = WeightGridScoring::default();
+    let mut evaluated = Vec::with_capacity(candidates.len());
+    for weights in candidates {
+        evaluated.push(evaluate_candidate(&conn, &dataset, k, weights, &scoring)?);
+    }
+    let default_index = evaluated
+        .iter()
+        .position(|candidate| candidate.weights == default_weights)
+        .context("default search weights were not included in the grid")?;
+    let default_snapshot = evaluated[default_index].clone();
+    let default_score = default_snapshot.score;
+    let default_overall = default_snapshot.overall.clone();
+
+    for candidate in &mut evaluated {
+        candidate.distance_from_defaults = weight_distance(candidate.weights, default_weights);
+        candidate.deltas_vs_default = build_candidate_deltas(&default_overall, &candidate.overall);
+    }
+    evaluated.sort_by(compare_candidates);
+    for (index, candidate) in evaluated.iter_mut().enumerate() {
+        candidate.rank = index + 1;
+    }
+
+    let default_rank = evaluated
+        .iter()
+        .find(|candidate| candidate.weights == default_weights)
+        .map(|candidate| candidate.rank)
+        .context("default search weights disappeared after sorting")?;
+    let best = evaluated
+        .first()
+        .cloned()
+        .context("weight grid produced no evaluated candidates")?;
+    let recommendation = if best.weights == default_weights || best.score <= default_score + EPSILON
+    {
+        WeightGridRecommendation::KeepShippedDefaults
+    } else {
+        WeightGridRecommendation::CandidateOutperformsDefaultsNeedsDecision
+    };
+    let checks = WeightGridChecks {
+        fixture_corpus_used: true,
+        default_weights_in_grid: true,
+        best_preserves_abstention: best.overall.abstention_passed
+            >= default_overall.abstention_passed,
+        best_preserves_scored_query_count: best.overall.scored_queries
+            >= default_overall.scored_queries,
+    };
+
+    Ok(WeightGridReport {
+        version: "2026-06-12".to_string(),
+        dataset_path,
+        k,
+        scoring,
+        default_weights,
+        default_rank,
+        default_score,
+        best,
+        recommendation,
+        checks,
+        candidates: evaluated,
+    })
+}
+
+fn evaluate_candidate(
+    conn: &Connection,
+    dataset: &GoldenDataset,
+    k: usize,
+    weights: SearchWeights,
+    scoring: &WeightGridScoring,
+) -> Result<WeightGridCandidate> {
+    let mut overall = golden::run::CategoryAccumulator::default();
+    let mut by_slice = BTreeMap::<String, golden::run::CategoryAccumulator>::new();
+    let fetch_limit = k.max(10) as i64;
+
+    for query in &dataset.queries {
+        let results = crate::retrieval::search::search_with_branch_weights(
+            conn,
+            Some(&query.query),
+            query.project.as_deref(),
+            query.memory_type.as_deref(),
+            fetch_limit,
+            0,
+            false,
+            query.branch.as_deref(),
+            weights,
+        )?;
+        let query_tokens = golden::run::estimate_query_tokens(&query.query);
+        let evaluation = golden::run::evaluate_query(query, &results, k, query_tokens, 0.0);
+        golden::run::record_bucket(&mut overall, query, &evaluation);
+        golden::run::record_bucket(
+            by_slice.entry(query.slice_label().to_string()).or_default(),
+            query,
+            &evaluation,
+        );
+    }
+
+    let overall = golden::run::bucket_evaluation(overall);
+    let score = candidate_score(&overall, scoring);
+    Ok(WeightGridCandidate {
+        rank: 0,
+        weights,
+        score,
+        distance_from_defaults: 0.0,
+        deltas_vs_default: WeightGridDeltas::default(),
+        overall,
+        by_slice: by_slice
+            .into_iter()
+            .map(|(slice, bucket)| (slice, golden::run::bucket_evaluation(bucket)))
+            .collect(),
+    })
+}
+
+fn default_candidate_grid() -> Vec<SearchWeights> {
+    let default = SearchWeights::default();
+    let mut candidates = Vec::new();
+    for fts in [2.0, default.fts, 3.0] {
+        for vector in [2.5, default.vector, 3.5] {
+            for entity in [1.0, default.entity, 1.5] {
+                for temporal in [0.75, default.temporal, 1.25] {
+                    for like_fallback in [0.1, default.like_fallback] {
+                        push_unique(
+                            &mut candidates,
+                            SearchWeights {
+                                fts,
+                                vector,
+                                entity,
+                                temporal,
+                                like_fallback,
+                                ..default
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+    candidates
+}
+
+fn push_unique(candidates: &mut Vec<SearchWeights>, weights: SearchWeights) {
+    if !candidates.contains(&weights) {
+        candidates.push(weights);
+    }
+}
+
+fn compare_candidates(
+    left: &WeightGridCandidate,
+    right: &WeightGridCandidate,
+) -> std::cmp::Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| {
+            left.distance_from_defaults
+                .total_cmp(&right.distance_from_defaults)
+        })
+        .then_with(|| left.weights.fts.total_cmp(&right.weights.fts))
+        .then_with(|| left.weights.vector.total_cmp(&right.weights.vector))
+        .then_with(|| left.weights.entity.total_cmp(&right.weights.entity))
+        .then_with(|| left.weights.temporal.total_cmp(&right.weights.temporal))
+        .then_with(|| {
+            left.weights
+                .like_fallback
+                .total_cmp(&right.weights.like_fallback)
+        })
+}
+
+fn candidate_score(overall: &CategoryEvaluation, scoring: &WeightGridScoring) -> f64 {
+    let metric_score = overall.metrics.as_ref().map_or(0.0, |metrics| {
+        scoring.evidence_recall_weight * metrics.evidence_recall_at_k
+            + scoring.hit_weight * metrics.hit_at_k
+            + scoring.ndcg_weight * metrics.ndcg_at_10
+            + scoring.mrr_weight * metrics.mrr_at_10
+    });
+    metric_score + scoring.abstention_weight * abstention_pass_rate(overall)
+}
+
+fn abstention_pass_rate(evaluation: &CategoryEvaluation) -> f64 {
+    if evaluation.abstention_queries == 0 {
+        1.0
+    } else {
+        evaluation.abstention_passed as f64 / evaluation.abstention_queries as f64
+    }
+}
+
+fn build_candidate_deltas(
+    default_overall: &CategoryEvaluation,
+    candidate_overall: &CategoryEvaluation,
+) -> WeightGridDeltas {
+    WeightGridDeltas {
+        hit_at_k: metric_average_delta(
+            default_overall.metrics.as_ref(),
+            candidate_overall.metrics.as_ref(),
+            |m| m.hit_at_k,
+        ),
+        mrr_at_10: metric_average_delta(
+            default_overall.metrics.as_ref(),
+            candidate_overall.metrics.as_ref(),
+            |m| m.mrr_at_10,
+        ),
+        precision_at_k: metric_average_delta(
+            default_overall.metrics.as_ref(),
+            candidate_overall.metrics.as_ref(),
+            |m| m.precision_at_k,
+        ),
+        recall_at_k: metric_average_delta(
+            default_overall.metrics.as_ref(),
+            candidate_overall.metrics.as_ref(),
+            |m| m.recall_at_k,
+        ),
+        ndcg_at_10: metric_average_delta(
+            default_overall.metrics.as_ref(),
+            candidate_overall.metrics.as_ref(),
+            |m| m.ndcg_at_10,
+        ),
+        evidence_recall_at_k: metric_average_delta(
+            default_overall.metrics.as_ref(),
+            candidate_overall.metrics.as_ref(),
+            |m| m.evidence_recall_at_k,
+        ),
+        abstention_pass_rate: abstention_pass_rate(candidate_overall)
+            - abstention_pass_rate(default_overall),
+    }
+}
+
+fn metric_average_delta(
+    default: Option<&MetricAverages>,
+    candidate: Option<&MetricAverages>,
+    value: impl Fn(&MetricAverages) -> f64,
+) -> f64 {
+    match (default, candidate) {
+        (Some(default), Some(candidate)) => value(candidate) - value(default),
+        (None, Some(candidate)) => value(candidate),
+        (Some(default), None) => -value(default),
+        (None, None) => 0.0,
+    }
+}
+
+fn weight_distance(candidate: SearchWeights, default: SearchWeights) -> f64 {
+    (candidate.fts - default.fts).abs()
+        + (candidate.vector - default.vector).abs()
+        + (candidate.entity - default.entity).abs()
+        + (candidate.temporal - default.temporal).abs()
+        + (candidate.like_fallback - default.like_fallback).abs()
+        + f64::from((candidate.max_vector_distance - default.max_vector_distance).abs())
+        + (candidate.rrf_k - default.rrf_k).abs()
+}
+
+impl Display for WeightGridReport {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        writeln!(
+            f,
+            "remem weight grid — {} candidates, k={}, default_rank={}, recommendation={:?}",
+            self.candidates.len(),
+            self.k,
+            self.default_rank,
+            self.recommendation
+        )?;
+        writeln!(f, "dataset: {}", self.dataset_path)?;
+        writeln!(
+            f,
+            "default score={:.4}, best score={:.4}",
+            self.default_score, self.best.score
+        )?;
+        writeln!(f)?;
+        writeln!(f, "--- Top Candidates ---")?;
+        for candidate in self.candidates.iter().take(10) {
+            writeln!(
+                f,
+                "  #{:02} score={:.4} dist={:.2} fts={:.2} vector={:.2} entity={:.2} temporal={:.2} like={:.2}",
+                candidate.rank,
+                candidate.score,
+                candidate.distance_from_defaults,
+                candidate.weights.fts,
+                candidate.weights.vector,
+                candidate.weights.entity,
+                candidate.weights.temporal,
+                candidate.weights.like_fallback
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::golden::{EvidenceRef, GoldenMemory, GoldenQuery};
+
+    #[test]
+    fn grid_report_includes_defaults_and_ranks_candidates() -> Result<()> {
+        let default = SearchWeights::default();
+        let dataset = GoldenDataset {
+            version: Some("test".to_string()),
+            description: None,
+            corpus: vec![GoldenMemory {
+                project: "/repo-a".to_string(),
+                topic_key: Some("sqlcipher-store".to_string()),
+                title: "SQLCipher store".to_string(),
+                content: "SQLCipher encrypts the local memory database at rest.".to_string(),
+                memory_type: "architecture".to_string(),
+                branch: Some("main".to_string()),
+                scope: "project".to_string(),
+                status: "active".to_string(),
+                files: None,
+                created_at_epoch: Some(1),
+            }],
+            queries: vec![GoldenQuery {
+                id: "q1".to_string(),
+                query: "local database encryption".to_string(),
+                category: "retrieval".to_string(),
+                slice: Some("paraphrase".to_string()),
+                project: Some("/repo-a".to_string()),
+                branch: Some("main".to_string()),
+                memory_type: None,
+                relevant_ids: vec![],
+                evidence_refs: vec![EvidenceRef {
+                    topic_key: Some("sqlcipher-store".to_string()),
+                    text_contains: Some("encrypts the local memory database".to_string()),
+                    ..EvidenceRef::default()
+                }],
+                expect_abstain: false,
+                false_premise: false,
+                notes: None,
+            }],
+        };
+        let report = run_weight_grid_dataset(
+            dataset,
+            "test-golden.json".to_string(),
+            5,
+            vec![
+                default,
+                SearchWeights {
+                    vector: default.vector + 0.5,
+                    ..default
+                },
+            ],
+        )?;
+
+        assert_eq!(report.candidates.len(), 2);
+        assert!(report.checks.default_weights_in_grid);
+        assert!(report.default_rank >= 1);
+        assert!(report
+            .candidates
+            .iter()
+            .any(|candidate| candidate.weights == default));
+        assert_eq!(report.candidates[0].rank, 1);
+        Ok(())
+    }
+}

--- a/src/retrieval/search.rs
+++ b/src/retrieval/search.rs
@@ -6,4 +6,5 @@ pub use memory::{
     search, search_with_branch, search_with_branch_explain, ChannelContribution, ChannelHit,
     SearchExplain, SearchExplainChannel, SearchExplainResult,
 };
+pub(crate) use memory::{search_with_branch_weights, SearchWeights};
 pub use observation::search_observations;

--- a/src/retrieval/search/memory.rs
+++ b/src/retrieval/search/memory.rs
@@ -9,3 +9,4 @@ pub use explain::{
     ChannelContribution, ChannelHit, SearchExplain, SearchExplainChannel, SearchExplainResult,
 };
 pub use runner::{search, search_with_branch, search_with_branch_explain};
+pub(crate) use runner::{search_with_branch_weights, SearchWeights};

--- a/src/retrieval/search/memory/runner.rs
+++ b/src/retrieval/search/memory/runner.rs
@@ -4,7 +4,8 @@ use rusqlite::Connection;
 use crate::memory::Memory;
 
 use super::listing::search_without_query;
-use super::text::{search_with_query, search_with_query_explain};
+pub(crate) use super::text::SearchWeights;
+use super::text::{search_with_query, search_with_query_explain, search_with_query_weights};
 use super::SearchExplain;
 
 pub fn search(
@@ -48,6 +49,42 @@ pub fn search_with_branch(
             offset,
             include_stale,
             branch,
+        ),
+        _ => search_without_query(
+            conn,
+            project,
+            memory_type,
+            limit,
+            offset,
+            include_stale,
+            branch,
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn search_with_branch_weights(
+    conn: &Connection,
+    query: Option<&str>,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_stale: bool,
+    branch: Option<&str>,
+    weights: SearchWeights,
+) -> Result<Vec<Memory>> {
+    match query {
+        Some(query_text) if !query_text.is_empty() => search_with_query_weights(
+            conn,
+            query_text,
+            project,
+            memory_type,
+            limit,
+            offset,
+            include_stale,
+            branch,
+            weights,
         ),
         _ => search_without_query(
             conn,

--- a/src/retrieval/search/memory/text.rs
+++ b/src/retrieval/search/memory/text.rs
@@ -21,6 +21,31 @@ const ENTITY_WEIGHT: f64 = 1.25;
 const TEMPORAL_WEIGHT: f64 = 1.0;
 const LIKE_FALLBACK_WEIGHT: f64 = 0.25;
 
+#[derive(Debug, Clone, Copy, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct SearchWeights {
+    pub fts: f64,
+    pub vector: f64,
+    pub entity: f64,
+    pub temporal: f64,
+    pub like_fallback: f64,
+    pub max_vector_distance: f32,
+    pub rrf_k: f64,
+}
+
+impl Default for SearchWeights {
+    fn default() -> Self {
+        Self {
+            fts: FTS_WEIGHT,
+            vector: VECTOR_WEIGHT,
+            entity: ENTITY_WEIGHT,
+            temporal: TEMPORAL_WEIGHT,
+            like_fallback: LIKE_FALLBACK_WEIGHT,
+            max_vector_distance: MAX_VECTOR_DISTANCE,
+            rrf_k: RRF_K,
+        }
+    }
+}
+
 pub(super) struct QuerySearchWithExplain {
     pub memories: Vec<Memory>,
     pub explain: SearchExplain,
@@ -33,6 +58,7 @@ struct QuerySearchPlan {
     temporal_range: Option<(i64, i64)>,
     temporal_field: Option<String>,
     fetch_limit: i64,
+    weights: SearchWeights,
     channels: Vec<NamedChannel>,
 }
 
@@ -105,6 +131,31 @@ pub(super) fn search_with_query(
     include_stale: bool,
     branch: Option<&str>,
 ) -> Result<Vec<Memory>> {
+    search_with_query_weights(
+        conn,
+        query_text,
+        project,
+        memory_type,
+        limit,
+        offset,
+        include_stale,
+        branch,
+        SearchWeights::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn search_with_query_weights(
+    conn: &Connection,
+    query_text: &str,
+    project: Option<&str>,
+    memory_type: Option<&str>,
+    limit: i64,
+    offset: i64,
+    include_stale: bool,
+    branch: Option<&str>,
+    weights: SearchWeights,
+) -> Result<Vec<Memory>> {
     let plan = build_query_search_plan(
         conn,
         query_text,
@@ -114,13 +165,14 @@ pub(super) fn search_with_query(
         offset,
         include_stale,
         branch,
+        weights,
     )?;
     if plan.channels.is_empty() {
         return Ok(vec![]);
     }
 
     let channel_inputs = weighted_channel_inputs(&plan.channels);
-    let final_ids: Vec<i64> = weighted_ranked_fuse(&channel_inputs, RRF_K)
+    let final_ids: Vec<i64> = weighted_ranked_fuse(&channel_inputs, plan.weights.rrf_k)
         .iter()
         .map(|(id, _)| *id)
         .collect();
@@ -147,6 +199,7 @@ pub(super) fn search_with_query_explain(
         offset,
         include_stale,
         branch,
+        SearchWeights::default(),
     )?;
     if plan.channels.is_empty() {
         return Ok(QuerySearchWithExplain {
@@ -165,7 +218,7 @@ pub(super) fn search_with_query_explain(
                 fts_query: plan.fts_query,
                 temporal_range: plan.temporal_range,
                 temporal_field: plan.temporal_field,
-                rrf_k: RRF_K,
+                rrf_k: plan.weights.rrf_k,
                 channels: vec![],
                 results: vec![],
                 has_more: false,
@@ -175,7 +228,7 @@ pub(super) fn search_with_query_explain(
     }
 
     let channel_inputs = weighted_channel_inputs(&plan.channels);
-    let fused = weighted_ranked_fuse(&channel_inputs, RRF_K);
+    let fused = weighted_ranked_fuse(&channel_inputs, plan.weights.rrf_k);
     let final_ids: Vec<i64> = fused.iter().map(|(id, _)| *id).collect();
     let ordered = load_ordered_memories(conn, &final_ids)?;
     let paged = paginate_memories(ordered, limit, offset);
@@ -206,6 +259,7 @@ fn build_query_search_plan(
     offset: i64,
     include_stale: bool,
     branch: Option<&str>,
+    weights: SearchWeights,
 ) -> Result<QuerySearchPlan> {
     let page_target = (limit.max(1) + offset.max(0) + 1).max(2);
     let fetch = page_target * 3;
@@ -240,7 +294,7 @@ fn build_query_search_plan(
         if !fts.is_empty() {
             channels.push(NamedChannel::enabled_with_hits(
                 "fts",
-                FTS_WEIGHT,
+                weights.fts,
                 fts_normalized_hits(&fts),
             ));
         }
@@ -256,7 +310,7 @@ fn build_query_search_plan(
         include_stale,
     )?;
     if !entity_ids.is_empty() {
-        channels.push(NamedChannel::enabled("entity", ENTITY_WEIGHT, entity_ids));
+        channels.push(NamedChannel::enabled("entity", weights.entity, entity_ids));
     }
 
     if let Some(temporal_constraint) = crate::retrieval::temporal::extract_temporal(query_text) {
@@ -277,7 +331,7 @@ fn build_query_search_plan(
         if !temporal_ids.is_empty() {
             channels.push(NamedChannel::enabled(
                 "temporal",
-                TEMPORAL_WEIGHT,
+                weights.temporal,
                 temporal_ids,
             ));
         }
@@ -296,20 +350,20 @@ fn build_query_search_plan(
         fetch as usize,
     )?;
     if let Some(reason) = vector_outcome.disabled_reason {
-        channels.push(NamedChannel::disabled("vector", VECTOR_WEIGHT, reason));
+        channels.push(NamedChannel::disabled("vector", weights.vector, reason));
     } else {
         let hits = vector_outcome
             .hits
             .into_iter()
-            .filter(|hit| hit.distance <= MAX_VECTOR_DISTANCE)
+            .filter(|hit| hit.distance <= weights.max_vector_distance)
             .map(|hit| WeightedRankedHit {
                 id: hit.memory_id,
-                normalized_score: vector_similarity_score(hit.distance),
+                normalized_score: vector_similarity_score(hit.distance, weights),
             })
             .collect();
         channels.push(NamedChannel::enabled_with_hits(
             "vector",
-            VECTOR_WEIGHT,
+            weights.vector,
             hits,
         ));
     }
@@ -317,13 +371,13 @@ fn build_query_search_plan(
     if core_refs.is_empty() {
         channels.push(NamedChannel::disabled(
             "like_fallback",
-            LIKE_FALLBACK_WEIGHT,
+            weights.like_fallback,
             "no core terms for LIKE fallback",
         ));
     } else if channels.iter().any(NamedChannel::has_hits) {
         channels.push(NamedChannel::disabled(
             "like_fallback",
-            LIKE_FALLBACK_WEIGHT,
+            weights.like_fallback,
             "stronger retrieval channels returned hits",
         ));
     } else {
@@ -340,13 +394,13 @@ fn build_query_search_plan(
         if like.is_empty() {
             channels.push(NamedChannel::disabled(
                 "like_fallback",
-                LIKE_FALLBACK_WEIGHT,
+                weights.like_fallback,
                 "LIKE fallback returned no hits",
             ));
         } else {
             channels.push(NamedChannel::enabled(
                 "like_fallback",
-                LIKE_FALLBACK_WEIGHT,
+                weights.like_fallback,
                 like.iter().map(|memory| memory.id).collect(),
             ));
         }
@@ -359,6 +413,7 @@ fn build_query_search_plan(
         temporal_range,
         temporal_field,
         fetch_limit: fetch,
+        weights,
         channels,
     })
 }
@@ -407,7 +462,7 @@ fn build_explain(
             scope: memory.scope.clone(),
             visibility: visibility_label(memory, project).to_string(),
             staleness: memory::memory_staleness_label(memory, now_epoch),
-            contributions: contributions_for(memory.id, &plan.channels),
+            contributions: contributions_for(memory.id, plan),
         })
         .collect();
     SearchExplain {
@@ -424,7 +479,7 @@ fn build_explain(
         fts_query: plan.fts_query.clone(),
         temporal_range: plan.temporal_range,
         temporal_field: plan.temporal_field.clone(),
-        rrf_k: RRF_K,
+        rrf_k: plan.weights.rrf_k,
         channels,
         results,
         has_more: false,
@@ -432,8 +487,8 @@ fn build_explain(
     }
 }
 
-fn contributions_for(memory_id: i64, channels: &[NamedChannel]) -> Vec<ChannelContribution> {
-    channels
+fn contributions_for(memory_id: i64, plan: &QuerySearchPlan) -> Vec<ChannelContribution> {
+    plan.channels
         .iter()
         .filter_map(|channel| {
             channel
@@ -445,7 +500,7 @@ fn contributions_for(memory_id: i64, channels: &[NamedChannel]) -> Vec<ChannelCo
                     rank: index + 1,
                     score: weighted_rank_score(
                         channel.weight,
-                        RRF_K,
+                        plan.weights.rrf_k,
                         index,
                         channel.hits[index].normalized_score,
                     ),
@@ -465,8 +520,8 @@ fn weighted_channel_inputs(channels: &[NamedChannel]) -> Vec<WeightedRankedChann
         .collect()
 }
 
-fn vector_similarity_score(distance: f32) -> f64 {
-    let threshold = f64::from(MAX_VECTOR_DISTANCE);
+fn vector_similarity_score(distance: f32, weights: SearchWeights) -> f64 {
+    let threshold = f64::from(weights.max_vector_distance);
     ((threshold - f64::from(distance)) / threshold).clamp(0.0, 1.0)
 }
 


### PR DESCRIPTION
## Summary

- Add `remem eval-weight-grid` to run a deterministic 162-candidate retrieval channel-weight grid over the golden fixture set.
- Parameterize internal retrieval scoring with `SearchWeights` while preserving shipped production defaults.
- Commit `eval/weight-grid/report.json`; the shipped defaults rank 79/162 and the top candidate only improves MRR/nDCG, so this PR records `candidate_outperforms_defaults_needs_decision` without flipping defaults.
- Bump package/plugin versions to 0.5.58.

Partial #380 slice. This does not complete or close the umbrella issue.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check --message-format=short`
- `cargo clippy -- -D warnings`
- `cargo test eval::weight_grid -- --nocapture`
- `cargo test cli::tests_eval -- --nocapture`
- `cargo test`
- `cargo run -- eval-gates --json-out /tmp/remem-issue380-grid-eval-gates.json`
- `cargo run -- eval-gates --simulate-golden-regression --json-out /tmp/remem-issue380-grid-eval-gates-regression.json` (expected failure, confirmed regression gate fires)
- `cargo run -- eval-weight-grid --json-out /tmp/remem-issue380-weight-grid-verify.json`
- deterministic artifact check: regenerate `eval-weight-grid` output and `cmp` against `eval/weight-grid/report.json`
- `node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
