### PR TITLE
Add memory fact invalidation time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.61"
+version = "0.5.62"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.61"
+version = "0.5.62"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.61",
+  "version": "0.5.62",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.61",
+  "version": "0.5.62",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.61": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.61",
+    "0.5.62": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.62",
       "assets": {}
     }
   }

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -125,6 +125,7 @@ pub(crate) fn insert_temporal_fact_in_current_tx(
                      WHEN valid_to_epoch IS NULL OR valid_to_epoch > ?1 THEN ?1
                      ELSE valid_to_epoch
                  END,
+                 invalidated_at_epoch = COALESCE(invalidated_at_epoch, ?2),
                  updated_at_epoch = ?2
              WHERE id = ?3",
             params![superseded_at, now, old_id],

--- a/src/memory/facts/tests.rs
+++ b/src/memory/facts/tests.rs
@@ -45,17 +45,15 @@ fn supersession_preserves_historical_fact_but_hides_it_from_current() -> Result<
     );
     assert_eq!(current[0].object, "production");
 
-    let old: TemporalFact = conn.query_row(
-        "SELECT id, project, subject, predicate, object, valid_from_epoch,
-                valid_to_epoch, learned_at_epoch, source_memory_id,
-                source_observation_id, source_event_ids, confidence,
-                supersedes_fact_id, status
+    let old: (String, Option<i64>, Option<i64>) = conn.query_row(
+        "SELECT status, valid_to_epoch, invalidated_at_epoch
          FROM memory_facts WHERE id = ?1",
         [old_id],
-        map_fact_row,
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
     )?;
-    assert_eq!(old.status, "stale");
-    assert_eq!(old.valid_to_epoch, Some(200));
+    assert_eq!(old.0, "stale");
+    assert_eq!(old.1, Some(200));
+    assert!(old.2.is_some());
 
     let before = list_facts_as_of(
         &conn,
@@ -74,6 +72,32 @@ fn supersession_preserves_historical_fact_but_hides_it_from_current() -> Result<
         Some(FactPredicate::AffectsProject),
     )?;
     assert_eq!(after[0].object, "production");
+    Ok(())
+}
+
+#[test]
+fn supersession_records_transaction_time_invalidation() -> Result<()> {
+    let conn = setup_fact_conn()?;
+    let project = "test-temporal-invalidated";
+    let old_id = insert_temporal_fact_in_current_tx(&conn, &input(project, "staging", 100), 150)?;
+    let mut replacement = input(project, "production", 200);
+    replacement.supersedes_fact_id = Some(old_id);
+    let new_id = insert_temporal_fact_in_current_tx(&conn, &replacement, 250)?;
+
+    let old: (String, Option<i64>, Option<i64>, i64) = conn.query_row(
+        "SELECT status, valid_to_epoch, invalidated_at_epoch, updated_at_epoch
+         FROM memory_facts WHERE id = ?1",
+        [old_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    assert_eq!(old, ("stale".to_string(), Some(200), Some(250), 250));
+
+    let replacement_invalidated_at: Option<i64> = conn.query_row(
+        "SELECT invalidated_at_epoch FROM memory_facts WHERE id = ?1",
+        [new_id],
+        |row| row.get(0),
+    )?;
+    assert_eq!(replacement_invalidated_at, None);
     Ok(())
 }
 

--- a/src/migrate/tests_schema.rs
+++ b/src/migrate/tests_schema.rs
@@ -616,6 +616,95 @@ fn graph_edges_schema_installs_source_candidate_integrity_triggers() -> Result<(
 }
 
 #[test]
+fn memory_fact_invalidation_migration_upgrades_existing_fact_rows() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= 39)
+    {
+        conn.execute_batch(migration.sql)?;
+    }
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_epoch INTEGER NOT NULL
+        );",
+    )?;
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= 39)
+    {
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, ?2, ?3)",
+            params![migration.version, migration.name, 1_700_000_000_i64],
+        )?;
+    }
+
+    conn.execute(
+        "INSERT INTO memory_facts
+         (id, project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
+          learned_at_epoch, source_event_ids, confidence, status, created_at_epoch,
+          updated_at_epoch)
+         VALUES (1, 'proj', 'deploy-target', 'affects_project', 'staging',
+                 100, NULL, 110, '[]', 0.9, 'active', 120, 120)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO memory_facts
+         (id, project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
+          learned_at_epoch, source_event_ids, confidence, status, created_at_epoch,
+          updated_at_epoch)
+         VALUES (2, 'proj', 'deploy-target', 'affects_project', 'staging',
+                 50, 100, 60, '[]', 0.9, 'stale', 70, 220)",
+        [],
+    )?;
+
+    run_migrations(&conn)?;
+
+    let mut stmt = conn.prepare("PRAGMA table_info(memory_facts)")?;
+    let mut rows = stmt.query([])?;
+    let mut has_invalidated_at = false;
+    while let Some(row) = rows.next()? {
+        let column: String = row.get(1)?;
+        if column == "invalidated_at_epoch" {
+            has_invalidated_at = true;
+            break;
+        }
+    }
+    assert!(
+        has_invalidated_at,
+        "v040 must add memory_facts.invalidated_at_epoch"
+    );
+
+    let active_invalidated_at: Option<i64> = conn.query_row(
+        "SELECT invalidated_at_epoch FROM memory_facts WHERE id = 1",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(active_invalidated_at, None);
+
+    let stale_invalidated_at: Option<i64> = conn.query_row(
+        "SELECT invalidated_at_epoch FROM memory_facts WHERE id = 2",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(stale_invalidated_at, Some(220));
+
+    let index_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type = 'index' AND name = 'idx_memory_facts_invalidated'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(index_count, 1);
+    Ok(())
+}
+
+#[test]
 fn run_migrations_rejects_db_newer_than_binary() -> Result<()> {
     let conn = Connection::open_in_memory()?;
     run_migrations(&conn)?;

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -200,6 +200,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "context_injection_items",
         sql: include_str!("../migrations/v039_context_injection_items.sql"),
     },
+    Migration {
+        version: 40,
+        name: "memory_fact_invalidations",
+        sql: include_str!("../migrations/v040_memory_fact_invalidations.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v040_memory_fact_invalidations.sql
+++ b/src/migrations/v040_memory_fact_invalidations.sql
@@ -1,0 +1,18 @@
+-- v040_memory_fact_invalidations: record transaction-time invalidation for
+-- temporal facts. `valid_to_epoch` remains event-validity time; this column
+-- records when remem learned that the fact stopped being current.
+
+ALTER TABLE memory_facts
+    ADD COLUMN invalidated_at_epoch INTEGER;
+
+-- Pre-v040 rows cannot recover the exact time remem invalidated them. For rows
+-- already marked stale, updated_at_epoch is the best available transaction-time
+-- approximation and prevents NULL from meaning both "active" and "unknown stale".
+UPDATE memory_facts
+SET invalidated_at_epoch = updated_at_epoch
+WHERE status = 'stale'
+  AND invalidated_at_epoch IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_memory_facts_invalidated
+    ON memory_facts(project, invalidated_at_epoch)
+    WHERE invalidated_at_epoch IS NOT NULL;


### PR DESCRIPTION
## Summary
- add v040 `memory_facts.invalidated_at_epoch` for transaction-time invalidation
- set invalidation time when a temporal fact is superseded
- backfill pre-v040 stale facts from `updated_at_epoch` as the best available transaction-time approximation
- bump runtime/package metadata to 0.5.62

Refs #381

## Validation
- cargo fmt --check
- cargo check --message-format=short
- cargo test memory::facts
- cargo test migrate::tests_schema::memory_fact_invalidation_migration_upgrades_existing_fact_rows
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main WORKTREE
- git diff --check
- cargo clippy -- -D warnings
- cargo test
- node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js
- cargo run -- eval-extraction --json --check-baseline
- cargo run -- eval-gates --json-out /tmp/remem-eval-gates-issue381.json
- cargo run -- eval-gates --simulate-golden-regression --json-out /tmp/remem-eval-gates-regression-issue381.json (expected failure verified by grep)

## Notes
- This does not implement the broader #381 work: conflict branch, reference_time threading, temporal retrieval channel, git-anchored staleness, or state_key generalization.
- No merge performed by this run.