### PR TITLE
[codex] use hook-safe database open for capture hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
  "reqwest",
+ "ring",
  "rmcp",
  "rusqlite",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.63"
+version = "0.5.64"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ getrandom = "0.3"
 toml_edit = "0.22"
 libc = "0.2"
 sha2 = "0.10"
+ring = "0.17"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.63"
+version = "0.5.64"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.63",
+  "version": "0.5.64",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.63",
+  "version": "0.5.64",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.63": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.63",
+    "0.5.64": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.64",
       "assets": {}
     }
   }

--- a/src/db.rs
+++ b/src/db.rs
@@ -9,6 +9,7 @@ pub mod models;
 pub mod observation;
 pub mod pending;
 pub mod query;
+pub(crate) mod spill_crypto;
 pub mod summarize;
 #[cfg(test)]
 pub mod test_support;

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -129,6 +129,12 @@ pub fn open_db_no_migrate() -> Result<Connection> {
     Ok(conn)
 }
 
+pub fn open_db_for_hook() -> Result<Connection> {
+    open_db_no_migrate().context(
+        "hook database open requires an existing current schema; run `remem install` or `remem migrate` outside the hook path",
+    )
+}
+
 pub fn open_db_read_only() -> Result<Connection> {
     let path = db_path();
     let key = super::crypto::require_cipher_key_or_plaintext_override()?;
@@ -258,6 +264,72 @@ mod tests {
     use super::*;
     use crate::db::crypto::ALLOW_PLAINTEXT_ENV;
     use crate::db::test_support::ScopedTestDataDir;
+
+    #[test]
+    fn open_db_for_hook_does_not_create_missing_database() {
+        let test_dir = ScopedTestDataDir::new("hook-open-missing");
+        test_dir.remove_db_files();
+
+        let err = open_db_for_hook().expect_err("missing database should fail");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("hook database open requires"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !test_dir.path.exists(),
+            "hook open must not create data dir"
+        );
+        assert!(
+            !test_dir.db_path().exists(),
+            "hook open must not create database file"
+        );
+    }
+
+    #[test]
+    fn open_db_for_hook_opens_current_schema_read_write() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("hook-open-current-rw");
+        let setup = crate::db::open_db()?;
+        drop(setup);
+
+        let conn = crate::db::open_db_for_hook()?;
+        conn.execute("CREATE TABLE hook_rw_probe(id INTEGER PRIMARY KEY)", [])?;
+        conn.execute("INSERT INTO hook_rw_probe(id) VALUES (1)", [])?;
+        let count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM hook_rw_probe", [], |row| row.get(0))?;
+
+        assert_eq!(count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn open_db_for_hook_rejects_older_schema_without_migrating() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("hook-open-older-schema");
+        let setup = crate::db::open_db()?;
+        let latest = crate::migrate::latest_schema_version();
+        setup.execute(
+            "DELETE FROM _schema_migrations WHERE version = ?1",
+            [latest],
+        )?;
+        drop(setup);
+
+        let err = crate::db::open_db_for_hook()
+            .expect_err("older schema should require foreground migration");
+
+        assert!(
+            err.to_string().contains("hook database open requires"),
+            "unexpected error: {err:#}"
+        );
+        let check = Connection::open(crate::db::db_path())?;
+        let latest_rows: i64 = check.query_row(
+            "SELECT COUNT(*) FROM _schema_migrations WHERE version = ?1",
+            [latest],
+            |row| row.get(0),
+        )?;
+        assert_eq!(latest_rows, 0);
+        Ok(())
+    }
 
     #[test]
     fn open_db_read_only_does_not_create_missing_database() {

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -130,9 +130,17 @@ pub fn open_db_no_migrate() -> Result<Connection> {
 }
 
 pub fn open_db_for_hook() -> Result<Connection> {
-    open_db_no_migrate().context(
+    let conn = open_db_no_migrate().context(
         "hook database open requires an existing current schema; run `remem install` or `remem migrate` outside the hook path",
-    )
+    )?;
+    let invariant_errors = crate::migrate::validate_schema_invariants(&conn)?;
+    if !invariant_errors.is_empty() {
+        anyhow::bail!(
+            "hook database schema drift requires foreground migration: {}",
+            invariant_errors.join("; ")
+        );
+    }
+    Ok(conn)
 }
 
 pub fn open_db_read_only() -> Result<Connection> {
@@ -259,7 +267,7 @@ pub fn detect_git_commit(cwd: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use rusqlite::Connection;
+    use rusqlite::{params, Connection};
 
     use super::*;
     use crate::db::crypto::ALLOW_PLAINTEXT_ENV;
@@ -328,6 +336,31 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(latest_rows, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn open_db_for_hook_rejects_schema_drift_without_repairing() -> Result<()> {
+        let test_dir = ScopedTestDataDir::new("hook-open-schema-drift");
+        create_current_schema_with_v022_missing_objects(&test_dir.db_path())?;
+
+        let err = crate::db::open_db_for_hook().expect_err("schema drift should fail closed");
+
+        assert!(
+            err.to_string().contains("hook database schema drift"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            format!("{err:#}").contains("schema drift"),
+            "unexpected error: {err:#}"
+        );
+        let check = Connection::open(test_dir.db_path())?;
+        let state_keys_exists: i64 = check.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'memory_state_keys'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state_keys_exists, 0);
         Ok(())
     }
 
@@ -610,6 +643,39 @@ mod tests {
             .execute("INSERT INTO readonly_probe(id) VALUES (2)", [])
             .expect_err("read-only connection must reject writes");
         assert_eq!(err.sqlite_error_code(), Some(rusqlite::ErrorCode::ReadOnly));
+        Ok(())
+    }
+
+    fn create_current_schema_with_v022_missing_objects(path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(path)?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=OFF;")?;
+        for migration in crate::migrate::MIGRATIONS
+            .iter()
+            .filter(|migration| migration.version != 22)
+        {
+            conn.execute_batch(migration.sql)?;
+        }
+        conn.execute_batch(
+            "CREATE TABLE _schema_migrations (
+                version INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                applied_at_epoch INTEGER NOT NULL
+            );",
+        )?;
+        for migration in crate::migrate::MIGRATIONS {
+            conn.execute(
+                "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+                 VALUES (?1, ?2, 1700000000)",
+                params![migration.version, migration.name],
+            )?;
+        }
+        conn.execute_batch(&format!(
+            "PRAGMA user_version = {}; PRAGMA foreign_keys=ON;",
+            crate::migrate::latest_schema_version()
+        ))?;
         Ok(())
     }
 }

--- a/src/db/spill_crypto.rs
+++ b/src/db/spill_crypto.rs
@@ -1,0 +1,187 @@
+use anyhow::{Context, Result};
+use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, AES_256_GCM};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::CipherKey;
+
+const SPILL_PROTECTION: &str = "remem-spill-v1";
+const SPILL_AAD: &[u8] = b"remem-spill-v1";
+const NONCE_LEN: usize = 12;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SpillEnvelope {
+    version: u32,
+    protected: String,
+    nonce_hex: String,
+    ciphertext_hex: String,
+}
+
+pub(crate) fn encode_json_line<T: Serialize>(value: &T) -> Result<String> {
+    let plaintext = serde_json::to_vec(value)?;
+    let Some(key) = super::load_cipher_key()? else {
+        if !super::plaintext_db_allowed() {
+            anyhow::bail!(
+                "spill payload requires SQLCipher key or explicit plaintext database override"
+            );
+        }
+        return Ok(serde_json::to_string(value)?);
+    };
+    let envelope = protect_bytes(&plaintext, &key)?;
+    Ok(serde_json::to_string(&envelope)?)
+}
+
+pub(crate) fn decode_json_line<T: DeserializeOwned>(line: &str) -> Result<T> {
+    let value: serde_json::Value = serde_json::from_str(line)?;
+    if value
+        .get("protected")
+        .and_then(|protected| protected.as_str())
+        == Some(SPILL_PROTECTION)
+    {
+        let envelope: SpillEnvelope = serde_json::from_value(value)?;
+        let plaintext = open_envelope(&envelope)?;
+        return Ok(serde_json::from_slice(&plaintext)?);
+    }
+    Ok(serde_json::from_value(value)?)
+}
+
+fn protect_bytes(plaintext: &[u8], key: &CipherKey) -> Result<SpillEnvelope> {
+    let mut nonce = [0_u8; NONCE_LEN];
+    getrandom::fill(&mut nonce)
+        .map_err(|error| anyhow::anyhow!("generate spill encryption nonce: {error}"))?;
+    let key = LessSafeKey::new(
+        UnboundKey::new(&AES_256_GCM, &spill_key_bytes(key)?)
+            .map_err(|_| anyhow::anyhow!("initialize spill encryption key"))?,
+    );
+    let mut ciphertext = plaintext.to_vec();
+    key.seal_in_place_append_tag(
+        Nonce::assume_unique_for_key(nonce),
+        Aad::from(SPILL_AAD),
+        &mut ciphertext,
+    )
+    .map_err(|_| anyhow::anyhow!("encrypt spill payload"))?;
+    Ok(SpillEnvelope {
+        version: 1,
+        protected: SPILL_PROTECTION.to_string(),
+        nonce_hex: hex_encode(&nonce),
+        ciphertext_hex: hex_encode(&ciphertext),
+    })
+}
+
+fn open_envelope(envelope: &SpillEnvelope) -> Result<Vec<u8>> {
+    if envelope.version != 1 || envelope.protected != SPILL_PROTECTION {
+        anyhow::bail!("unsupported spill protection envelope");
+    }
+    let key =
+        super::load_cipher_key()?.context("encrypted spill payload requires SQLCipher key")?;
+    let nonce = fixed_hex::<NONCE_LEN>(&envelope.nonce_hex).context("decode spill nonce")?;
+    let mut ciphertext = hex_decode(&envelope.ciphertext_hex).context("decode spill ciphertext")?;
+    let key = LessSafeKey::new(
+        UnboundKey::new(&AES_256_GCM, &spill_key_bytes(&key)?)
+            .map_err(|_| anyhow::anyhow!("initialize spill decryption key"))?,
+    );
+    let plaintext = key
+        .open_in_place(
+            Nonce::assume_unique_for_key(nonce),
+            Aad::from(SPILL_AAD),
+            &mut ciphertext,
+        )
+        .map_err(|_| anyhow::anyhow!("decrypt spill payload"))?;
+    Ok(plaintext.to_vec())
+}
+
+fn spill_key_bytes(key: &CipherKey) -> Result<[u8; 32]> {
+    match key {
+        CipherKey::Raw(hex) => fixed_hex::<32>(hex),
+        CipherKey::Passphrase(passphrase) => {
+            let digest = Sha256::digest(passphrase.as_bytes());
+            let mut bytes = [0_u8; 32];
+            bytes.copy_from_slice(&digest);
+            Ok(bytes)
+        }
+    }
+}
+
+fn fixed_hex<const N: usize>(value: &str) -> Result<[u8; N]> {
+    let bytes = hex_decode(value)?;
+    bytes
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("expected {} hex-decoded bytes", N))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn hex_decode(value: &str) -> Result<Vec<u8>> {
+    let bytes = value.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        anyhow::bail!("hex value must have even length");
+    }
+    bytes
+        .chunks_exact(2)
+        .map(|pair| Ok((hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?))
+        .collect()
+}
+
+fn hex_nibble(byte: u8) -> Result<u8> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => anyhow::bail!("invalid hex byte"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_support::ScopedTestDataDir;
+
+    #[test]
+    fn protected_json_line_round_trips_without_plaintext() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("spill-crypto-protected");
+        std::env::set_var("REMEM_CIPHER_KEY", format!("v2:{}", "1".repeat(64)));
+        let value = serde_json::json!({"message": "assistant fallback content"});
+
+        let line = encode_json_line(&value)?;
+
+        assert!(line.contains(SPILL_PROTECTION));
+        assert!(!line.contains("assistant fallback content"));
+        let decoded: serde_json::Value = decode_json_line(&line)?;
+        assert_eq!(decoded, value);
+        Ok(())
+    }
+
+    #[test]
+    fn plaintext_json_line_keeps_legacy_shape_without_key() -> Result<()> {
+        let _test_dir = ScopedTestDataDir::new("spill-crypto-plaintext");
+        std::env::remove_var("REMEM_CIPHER_KEY");
+        let value = serde_json::json!({"message": "legacy plaintext"});
+
+        let line = encode_json_line(&value)?;
+
+        assert!(line.contains("legacy plaintext"));
+        let decoded: serde_json::Value = decode_json_line(&line)?;
+        assert_eq!(decoded, value);
+        Ok(())
+    }
+
+    #[test]
+    fn no_key_without_plaintext_override_refuses_plaintext_spill() {
+        let _test_dir = ScopedTestDataDir::new("spill-crypto-no-plaintext");
+        std::env::remove_var("REMEM_CIPHER_KEY");
+        std::env::remove_var(crate::db::ALLOW_PLAINTEXT_ENV);
+
+        let err = encode_json_line(&serde_json::json!({"message": "private"}))
+            .expect_err("plaintext spill should require explicit override");
+
+        assert!(err.to_string().contains("explicit plaintext"));
+    }
+}

--- a/src/observe/hook.rs
+++ b/src/observe/hook.rs
@@ -44,7 +44,7 @@ async fn observe_input(input: &str, host: Option<&str>) -> Result<()> {
 
     let content = capture_event_content(&event, &summary);
     let event_id = db::unique_capture_event_id("tool_result", &content);
-    let conn = match db::open_db() {
+    let conn = match db::open_db_for_hook() {
         Ok(conn) => conn,
         Err(error) => {
             let path = spill_capture_event(
@@ -308,7 +308,7 @@ mod tests {
     use super::super::spill::spill_capture_event;
     use super::{
         event_skip_reason, observe_input, record_capture_event, skip_detail,
-        SPILL_REASON_CAPTURE_PERSISTENCE_FAILED,
+        SPILL_REASON_CAPTURE_PERSISTENCE_FAILED, SPILL_REASON_DB_OPEN_FAILED,
     };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -340,6 +340,8 @@ mod tests {
         let _guard = ENV_LOCK.lock().expect("env lock should acquire");
         unsafe { std::env::remove_var("REMEM_ENABLE_CODEX_BASH_OBSERVE") };
         let _test_dir = ScopedTestDataDir::new("observe-codex-bash-drop");
+        let setup = db::open_db()?;
+        drop(setup);
         let input = serde_json::json!({
             "session_id": "sess-bash-skip",
             "cwd": "/tmp/remem",
@@ -359,6 +361,76 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(reason, "codex_bash_disabled");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observe_spills_when_hook_db_open_would_need_migration() -> anyhow::Result<()> {
+        let test_dir = ScopedTestDataDir::new("observe-hook-open-stale-schema");
+        std::fs::create_dir_all(&test_dir.path)?;
+        let setup = rusqlite::Connection::open(test_dir.db_path())?;
+        setup.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)", [])?;
+        drop(setup);
+        let input = serde_json::json!({
+            "session_id": "sess-stale-hook-db",
+            "cwd": "/tmp/remem",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/lib.rs"},
+            "tool_response": {"content": "edited"}
+        })
+        .to_string();
+
+        let err = observe_input(&input, Some("claude-code"))
+            .await
+            .expect_err("stale hook database should fail closed");
+
+        assert!(
+            err.to_string().contains("hook database open requires"),
+            "unexpected error: {err:#}"
+        );
+        assert!(crate::db::data_dir().join("capture-spill.jsonl").exists());
+        let check = rusqlite::Connection::open(test_dir.db_path())?;
+        let migrations_exists: i64 = check.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '_schema_migrations'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(migrations_exists, 0);
+        let spill = std::fs::read_to_string(crate::db::data_dir().join("capture-spill.jsonl"))?;
+        assert!(spill.contains(SPILL_REASON_DB_OPEN_FAILED));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observe_skip_drop_does_not_migrate_stale_database() -> anyhow::Result<()> {
+        let _guard = ENV_LOCK
+            .lock()
+            .map_err(|_| anyhow::anyhow!("env lock poisoned"))?;
+        unsafe { std::env::remove_var("REMEM_ENABLE_CODEX_BASH_OBSERVE") };
+        let test_dir = ScopedTestDataDir::new("observe-skip-stale-schema");
+        std::fs::create_dir_all(&test_dir.path)?;
+        let setup = rusqlite::Connection::open(test_dir.db_path())?;
+        setup.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)", [])?;
+        drop(setup);
+        let input = serde_json::json!({
+            "session_id": "sess-skip-stale",
+            "cwd": "/tmp/remem",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": "cargo test" },
+            "tool_result": { "exitCode": 0 }
+        })
+        .to_string();
+
+        observe_input(&input, Some("codex-cli")).await?;
+
+        let check = rusqlite::Connection::open(test_dir.db_path())?;
+        let migrations_exists: i64 = check.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '_schema_migrations'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(migrations_exists, 0);
         Ok(())
     }
 
@@ -456,6 +528,8 @@ mod tests {
     #[tokio::test]
     async fn observe_writes_only_normalized_capture_pipeline() -> anyhow::Result<()> {
         let _test_dir = ScopedTestDataDir::new("observe-normalized-only");
+        let setup = db::open_db()?;
+        drop(setup);
         let project_dir = std::env::temp_dir().join(format!(
             "remem-observe-project-{}-{}",
             std::process::id(),
@@ -509,6 +583,8 @@ mod tests {
     #[tokio::test]
     async fn observe_appends_legacy_events_for_identical_normal_events() -> anyhow::Result<()> {
         let _test_dir = ScopedTestDataDir::new("observe-identical-normal-events");
+        let setup = db::open_db()?;
+        drop(setup);
         let project_dir = std::env::temp_dir().join(format!(
             "remem-observe-duplicates-{}-{}",
             std::process::id(),

--- a/src/observe/session_init.rs
+++ b/src/observe/session_init.rs
@@ -35,7 +35,7 @@ async fn session_init_input(input: &str, host: Option<&str>) -> Result<Option<St
     };
 
     let project = event.project.clone();
-    let conn = db::open_db()?;
+    let conn = db::open_db_for_hook()?;
     db::upsert_session(&conn, &event.session_id, &event.project, None)?;
     let output = if let Some(prompt) = user_prompt_submit_prompt(input) {
         let cwd = event.cwd.as_deref().unwrap_or(&event.project);
@@ -158,6 +158,38 @@ mod tests {
             std::env::remove_var("REMEM_DEBUG");
             std::env::remove_var("REMEM_STDERR_TO_LOG");
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn session_init_rejects_stale_schema_without_migrating() -> anyhow::Result<()> {
+        let test_dir = ScopedTestDataDir::new("session-init-stale-schema");
+        std::fs::create_dir_all(&test_dir.path)?;
+        let setup = rusqlite::Connection::open(test_dir.db_path())?;
+        setup.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)", [])?;
+        drop(setup);
+        let input = serde_json::json!({
+            "session_id": "sess-session-init-stale",
+            "cwd": "/tmp/remem",
+            "hook_event_name": "SessionStart"
+        })
+        .to_string();
+
+        let err = session_init_input(&input, Some("claude-code"))
+            .await
+            .expect_err("stale hook database should fail closed");
+
+        assert!(
+            err.to_string().contains("hook database open requires"),
+            "unexpected error: {err:#}"
+        );
+        let check = rusqlite::Connection::open(test_dir.db_path())?;
+        let migrations_exists: i64 = check.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '_schema_migrations'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(migrations_exists, 0);
         Ok(())
     }
 

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -60,7 +60,7 @@ pub(super) fn record_capture_drop_lossy(
     reason: &str,
     detail: Option<&str>,
 ) {
-    let Ok(conn) = crate::db::open_db() else {
+    let Ok(conn) = crate::db::open_db_for_hook() else {
         crate::log::warn(
             "observe",
             &format!("capture drop could not be recorded: reason={reason}"),

--- a/src/observe/spill.rs
+++ b/src/observe/spill.rs
@@ -115,13 +115,7 @@ pub(super) fn spill_capture_event(
         .to_string(),
         created_at_epoch: chrono::Utc::now().timestamp(),
     };
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .with_context(|| format!("open capture spill {}", path.display()))?;
-    serde_json::to_writer(&mut file, &record)?;
-    file.write_all(b"\n")?;
+    append_spill_record(&path, &record)?;
     Ok(path)
 }
 
@@ -213,14 +207,12 @@ fn replay_spill_record(
     Ok(true)
 }
 
-fn append_failed_spill_line(path: &PathBuf, line: &str, error: &anyhow::Error) -> Result<()> {
+fn append_failed_spill_line(path: &Path, line: &str, error: &anyhow::Error) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create failed capture spill dir {}", parent.display()))?;
     }
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
+    let mut file = spill_open_options()
         .open(path)
         .with_context(|| format!("open failed capture spill {}", path.display()))?;
     writeln!(file, "{line}")?;
@@ -229,7 +221,7 @@ fn append_failed_spill_line(path: &PathBuf, line: &str, error: &anyhow::Error) -
 }
 
 fn append_failed_spill_record(
-    path: &PathBuf,
+    path: &Path,
     record: &CaptureSpillRecord,
     error: &anyhow::Error,
 ) -> Result<()> {
@@ -237,15 +229,34 @@ fn append_failed_spill_record(
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create failed capture spill dir {}", parent.display()))?;
     }
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("open failed capture spill {}", path.display()))?;
-    serde_json::to_writer(&mut file, record)?;
-    file.write_all(b"\n")?;
+    append_spill_record(path, record)?;
     crate::log::warn("observe", &format!("capture spill replay failed: {error}"));
     Ok(())
+}
+
+fn append_spill_record(path: &Path, record: &CaptureSpillRecord) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create capture spill dir {}", parent.display()))?;
+    }
+    let line = crate::db::spill_crypto::encode_json_line(record)?;
+    let mut file = spill_open_options()
+        .open(path)
+        .with_context(|| format!("open capture spill {}", path.display()))?;
+    file.write_all(line.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn spill_open_options() -> std::fs::OpenOptions {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options
 }
 
 fn sanitize_event(event: &ParsedHookEvent) -> ParsedHookEvent {
@@ -279,7 +290,7 @@ fn sanitize_summary(summary: &EventSummary) -> EventSummary {
 }
 
 fn parse_spill_record(line: &str, line_index: usize) -> Result<CaptureSpillRecord> {
-    let record: CaptureSpillRecordCompat = serde_json::from_str(line)?;
+    let record: CaptureSpillRecordCompat = crate::db::spill_crypto::decode_json_line(line)?;
     Ok(record.into_record(legacy_spill_event_id(line, line_index)))
 }
 
@@ -684,6 +695,50 @@ mod tests {
         assert!(!stored.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
         assert!(!stored.contains("hunter2"));
         assert!(!stored.contains("github_pat_secret"));
+        Ok(())
+    }
+
+    #[test]
+    fn encrypted_capture_spill_hides_payload_and_replays() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("capture-spill-encrypted");
+        std::env::set_var("REMEM_CIPHER_KEY", format!("v2:{}", "2".repeat(64)));
+        let err = anyhow::anyhow!("database is locked");
+        let event = ParsedHookEvent {
+            session_id: "session-encrypted-spill".to_string(),
+            cwd: Some("/tmp/remem".to_string()),
+            project: "/tmp/remem".to_string(),
+            tool_name: "Write".to_string(),
+            tool_input: Some(serde_json::json!({"content": "ordinary source content"})),
+            tool_response: Some(serde_json::json!({"ok": true})),
+        };
+        let summary = EventSummary {
+            event_type: "file_write".to_string(),
+            summary: "Wrote ordinary source content".to_string(),
+            detail: Some("ordinary source content".to_string()),
+            files_json: None,
+            exit_code: None,
+        };
+
+        spill_capture_event(
+            "codex-cli",
+            "tool_result-encrypted-spill",
+            &event,
+            &summary,
+            SPILL_REASON_DB_OPEN_FAILED,
+            &err,
+        )?;
+        let stored = std::fs::read_to_string(crate::db::data_dir().join("capture-spill.jsonl"))?;
+        assert!(stored.contains("remem-spill-v1"));
+        assert!(!stored.contains("ordinary source content"));
+
+        let conn = db::open_db()?;
+        assert_eq!(replay_spilled_capture_events(&conn)?, 1);
+        let replayed_summary: String = conn.query_row(
+            "SELECT summary FROM events WHERE session_id = 'session-encrypted-spill'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(replayed_summary.contains("ordinary source content"));
         Ok(())
     }
 }

--- a/src/summarize/summary_job.rs
+++ b/src/summarize/summary_job.rs
@@ -1,6 +1,7 @@
 mod hook;
 mod persist;
 mod process;
+mod spill;
 
 pub use hook::summarize;
 pub use process::process_summary_job_input;

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -15,7 +15,7 @@ pub async fn summarize(host: Option<&str>, profile: Option<&str>) -> Result<()> 
 }
 
 async fn summarize_input(input: &str, host: Option<&str>, profile: Option<&str>) -> Result<()> {
-    let hook: SummarizeInput = match serde_json::from_str(&input) {
+    let hook: SummarizeInput = match serde_json::from_str(input) {
         Ok(value) => value,
         Err(err) => {
             crate::log::warn(
@@ -32,7 +32,7 @@ async fn summarize_input(input: &str, host: Option<&str>, profile: Option<&str>)
     let project = db::project_from_cwd(&cwd);
     let host = resolve_hook_host(host)?;
     let conn = db::open_db_for_hook()?;
-    let summary_payload = summary_payload_with_cwd(&input, &cwd, profile)?;
+    let summary_payload = summary_payload_with_cwd(input, &cwd, profile)?;
     let compress_payload = compress_payload(profile)?;
 
     record_summary_capture_event(&conn, &host, session_id, &project, &cwd, &summary_payload);

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -11,6 +11,10 @@ pub async fn summarize(host: Option<&str>, profile: Option<&str>) -> Result<()> 
         return Ok(());
     };
 
+    summarize_input(&input, host, profile).await
+}
+
+async fn summarize_input(input: &str, host: Option<&str>, profile: Option<&str>) -> Result<()> {
     let hook: SummarizeInput = match serde_json::from_str(&input) {
         Ok(value) => value,
         Err(err) => {
@@ -27,7 +31,7 @@ pub async fn summarize(host: Option<&str>, profile: Option<&str>) -> Result<()> 
     let cwd = effective_cwd(&hook)?;
     let project = db::project_from_cwd(&cwd);
     let host = resolve_hook_host(host)?;
-    let conn = db::open_db()?;
+    let conn = db::open_db_for_hook()?;
     let summary_payload = summary_payload_with_cwd(&input, &cwd, profile)?;
     let compress_payload = compress_payload(profile)?;
 
@@ -281,7 +285,7 @@ mod tests {
 
     use super::{
         compress_payload, enqueue_summary_jobs, record_summary_capture_event, resolve_hook_host,
-        should_spawn_worker_once, stable_worker_dir, summary_payload_with_cwd,
+        should_spawn_worker_once, stable_worker_dir, summarize_input, summary_payload_with_cwd,
     };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -437,6 +441,42 @@ mod tests {
 
         assert_eq!(host, "codex-cli");
         assert_eq!(parsed["remem_ai_profile"].as_str(), Some("custom"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn summarize_hook_rejects_stale_schema_without_migrating() -> anyhow::Result<()> {
+        let test_dir = ScopedTestDataDir::new("summary-hook-stale-schema");
+        std::fs::create_dir_all(&test_dir.path)?;
+        let setup = rusqlite::Connection::open(test_dir.db_path())?;
+        setup.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)", [])?;
+        drop(setup);
+        let input = serde_json::json!({
+            "session_id": "sess-summary-stale",
+            "cwd": "/tmp/remem"
+        })
+        .to_string();
+
+        let err = summarize_input(&input, Some("codex-cli"), None)
+            .await
+            .expect_err("stale hook database should fail closed");
+
+        assert!(
+            err.to_string().contains("hook database open requires"),
+            "unexpected error: {err:#}"
+        );
+        let check = rusqlite::Connection::open(test_dir.db_path())?;
+        let (migrations_exists, jobs_exists): (i64, i64) = check.query_row(
+            "SELECT
+                SUM(CASE WHEN name = '_schema_migrations' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN name = 'jobs' THEN 1 ELSE 0 END)
+             FROM sqlite_master
+             WHERE type = 'table'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(migrations_exists, 0);
+        assert_eq!(jobs_exists, 0);
         Ok(())
     }
 

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -34,10 +34,11 @@ pub(super) async fn summarize_input(
         return Ok(());
     }
     let host = resolve_hook_host(host)?;
+    let cwd = effective_cwd(&hook)?;
     let conn = match db::open_db_for_hook() {
         Ok(conn) => conn,
         Err(error) => {
-            let path = spill_summary_hook_payload(input, Some(&host), profile, &error)?;
+            let path = spill_summary_hook_payload(input, Some(&host), profile, Some(&cwd), &error)?;
             crate::log::error(
                 "summarize",
                 &format!(
@@ -90,13 +91,27 @@ fn enqueue_summary_payload(
         &summary_payload,
         &compress_payload,
     )?;
-    if should_spawn_worker_once(conn)? {
-        spawn_worker_once()?;
-    } else {
-        crate::log::info(
-            "summarize",
-            "worker daemon heartbeat healthy; skip worker --once",
-        );
+    match should_spawn_worker_once(conn) {
+        Ok(true) => {
+            if let Err(error) = spawn_worker_once() {
+                crate::log::error(
+                    "summarize",
+                    &format!("summary jobs queued but worker --once spawn failed: {error}"),
+                );
+            }
+        }
+        Ok(false) => {
+            crate::log::info(
+                "summarize",
+                "worker daemon heartbeat healthy; skip worker --once",
+            );
+        }
+        Err(error) => {
+            crate::log::error(
+                "summarize",
+                &format!("summary jobs queued but worker spawn check failed: {error}"),
+            );
+        }
     }
     Ok(())
 }

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -50,6 +50,7 @@ pub(super) async fn summarize_input(
             return Err(error);
         }
     };
+    enqueue_summary_payload(&conn, input, Some(&host), profile)?;
     if let Err(error) = replay_spilled_summary_hook_payloads(&conn, |conn, record| {
         enqueue_summary_payload(
             conn,
@@ -63,7 +64,29 @@ pub(super) async fn summarize_input(
             &format!("summary hook spill replay failed; continuing with current payload: {error}"),
         );
     }
-    enqueue_summary_payload(&conn, input, Some(&host), profile)
+    match should_spawn_worker_once(&conn) {
+        Ok(true) => {
+            if let Err(error) = spawn_worker_once() {
+                crate::log::error(
+                    "summarize",
+                    &format!("summary jobs queued but worker --once spawn failed: {error}"),
+                );
+            }
+        }
+        Ok(false) => {
+            crate::log::info(
+                "summarize",
+                "worker daemon heartbeat healthy; skip worker --once",
+            );
+        }
+        Err(error) => {
+            crate::log::error(
+                "summarize",
+                &format!("summary jobs queued but worker spawn check failed: {error}"),
+            );
+        }
+    }
+    Ok(())
 }
 
 fn enqueue_summary_payload(
@@ -91,28 +114,6 @@ fn enqueue_summary_payload(
         &summary_payload,
         &compress_payload,
     )?;
-    match should_spawn_worker_once(conn) {
-        Ok(true) => {
-            if let Err(error) = spawn_worker_once() {
-                crate::log::error(
-                    "summarize",
-                    &format!("summary jobs queued but worker --once spawn failed: {error}"),
-                );
-            }
-        }
-        Ok(false) => {
-            crate::log::info(
-                "summarize",
-                "worker daemon heartbeat healthy; skip worker --once",
-            );
-        }
-        Err(error) => {
-            crate::log::error(
-                "summarize",
-                &format!("summary jobs queued but worker spawn check failed: {error}"),
-            );
-        }
-    }
     Ok(())
 }
 

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -5,6 +5,7 @@ use crate::hook_stdin::read_stdin_with_timeout;
 
 use super::super::constants::SUMMARIZE_STDIN_TIMEOUT_MS;
 use super::super::input::SummarizeInput;
+use super::spill::{replay_spilled_summary_hook_payloads, spill_summary_hook_payload};
 
 pub async fn summarize(host: Option<&str>, profile: Option<&str>) -> Result<()> {
     let Some(input) = read_stdin_with_timeout(SUMMARIZE_STDIN_TIMEOUT_MS)? else {
@@ -14,7 +15,11 @@ pub async fn summarize(host: Option<&str>, profile: Option<&str>) -> Result<()> 
     summarize_input(&input, host, profile).await
 }
 
-async fn summarize_input(input: &str, host: Option<&str>, profile: Option<&str>) -> Result<()> {
+pub(super) async fn summarize_input(
+    input: &str,
+    host: Option<&str>,
+    profile: Option<&str>,
+) -> Result<()> {
     let hook: SummarizeInput = match serde_json::from_str(input) {
         Ok(value) => value,
         Err(err) => {
@@ -25,26 +30,62 @@ async fn summarize_input(input: &str, host: Option<&str>, profile: Option<&str>)
             return Ok(());
         }
     };
+    if hook.session_id.is_none() {
+        return Ok(());
+    }
+    let host = resolve_hook_host(host)?;
+    let conn = match db::open_db_for_hook() {
+        Ok(conn) => conn,
+        Err(error) => {
+            let path = spill_summary_hook_payload(input, Some(&host), profile, &error)?;
+            crate::log::error(
+                "summarize",
+                &format!(
+                    "database open failed; spilled summary hook payload to {}: {}",
+                    path.display(),
+                    error
+                ),
+            );
+            return Err(error);
+        }
+    };
+    replay_spilled_summary_hook_payloads(&conn, |conn, record| {
+        enqueue_summary_payload(
+            conn,
+            &record.input,
+            record.host.as_deref(),
+            record.profile.as_deref(),
+        )
+    })?;
+    enqueue_summary_payload(&conn, input, Some(&host), profile)
+}
+
+fn enqueue_summary_payload(
+    conn: &rusqlite::Connection,
+    input: &str,
+    host: Option<&str>,
+    profile: Option<&str>,
+) -> Result<()> {
+    let hook: SummarizeInput = serde_json::from_str(input)?;
     let Some(session_id) = &hook.session_id else {
         return Ok(());
     };
     let cwd = effective_cwd(&hook)?;
     let project = db::project_from_cwd(&cwd);
     let host = resolve_hook_host(host)?;
-    let conn = db::open_db_for_hook()?;
     let summary_payload = summary_payload_with_cwd(input, &cwd, profile)?;
     let compress_payload = compress_payload(profile)?;
 
-    record_summary_capture_event(&conn, &host, session_id, &project, &cwd, &summary_payload);
+    record_summary_capture_event(conn, &host, session_id, &project, &cwd, &summary_payload);
     enqueue_summary_jobs(
-        &conn,
+        conn,
         &host,
         session_id,
         &project,
         &summary_payload,
         &compress_payload,
     )?;
-    if should_spawn_worker_once(&conn)? {
+    if should_spawn_worker_once(conn)? {
         spawn_worker_once()?;
     } else {
         crate::log::info(
@@ -477,6 +518,7 @@ mod tests {
         )?;
         assert_eq!(migrations_exists, 0);
         assert_eq!(jobs_exists, 0);
+        assert!(super::super::spill::summary_spill_path().exists());
         Ok(())
     }
 

--- a/src/summarize/summary_job/hook.rs
+++ b/src/summarize/summary_job/hook.rs
@@ -49,14 +49,19 @@ pub(super) async fn summarize_input(
             return Err(error);
         }
     };
-    replay_spilled_summary_hook_payloads(&conn, |conn, record| {
+    if let Err(error) = replay_spilled_summary_hook_payloads(&conn, |conn, record| {
         enqueue_summary_payload(
             conn,
             &record.input,
             record.host.as_deref(),
             record.profile.as_deref(),
         )
-    })?;
+    }) {
+        crate::log::error(
+            "summarize",
+            &format!("summary hook spill replay failed; continuing with current payload: {error}"),
+        );
+    }
     enqueue_summary_payload(&conn, input, Some(&host), profile)
 }
 

--- a/src/summarize/summary_job/spill.rs
+++ b/src/summarize/summary_job/spill.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use fs2::FileExt;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::io::{ErrorKind, Write};
@@ -22,16 +23,13 @@ pub(super) fn spill_summary_hook_payload(
     input: &str,
     host: Option<&str>,
     profile: Option<&str>,
+    resolved_cwd: Option<&str>,
     db_error: &anyhow::Error,
 ) -> Result<PathBuf> {
     let path = summary_spill_path();
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("create summary hook spill dir {}", parent.display()))?;
-    }
     let record = SummaryHookSpillRecord {
         version: 1,
-        input: input.to_string(),
+        input: summary_spill_input(input, resolved_cwd, profile)?,
         host: host.map(crate::runtime_config::normalize_host),
         profile: profile.map(str::to_string),
         db_error: crate::db::truncate_str(
@@ -41,13 +39,7 @@ pub(super) fn spill_summary_hook_payload(
         .to_string(),
         created_at_epoch: chrono::Utc::now().timestamp(),
     };
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .with_context(|| format!("open summary hook spill {}", path.display()))?;
-    serde_json::to_writer(&mut file, &record)?;
-    file.write_all(b"\n")?;
+    append_record_to_spill(&path, &record)?;
     Ok(path)
 }
 
@@ -57,13 +49,19 @@ pub(super) fn replay_spilled_summary_hook_payloads(
 ) -> Result<usize> {
     let path = summary_spill_path();
     let claimed_path = claimed_summary_spill_path();
-    match std::fs::rename(&path, &claimed_path) {
+    match with_summary_spill_lock(|| {
+        std::fs::rename(&path, &claimed_path)
+            .with_context(|| format!("claim summary hook spill {}", path.display()))
+    }) {
         Ok(()) => {}
-        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(0),
-        Err(error) => {
-            return Err(error)
-                .with_context(|| format!("claim summary hook spill {}", path.display()));
+        Err(error)
+            if error
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|io| io.kind() == ErrorKind::NotFound) =>
+        {
+            return Ok(0)
         }
+        Err(error) => return Err(error),
     }
     let failed_path = failed_summary_spill_path_for_claim(&claimed_path);
 
@@ -102,9 +100,7 @@ fn replay_claimed_summary_hook_payloads(
     }
 
     if failed_path.exists() {
-        append_file_to_spill(path, failed_path)?;
-        std::fs::remove_file(failed_path)
-            .with_context(|| format!("remove {}", failed_path.display()))?;
+        append_file_to_spill_then_remove(path, failed_path)?;
     }
     match std::fs::remove_file(claimed_path) {
         Ok(()) => {}
@@ -123,15 +119,106 @@ fn replay_claimed_summary_hook_payloads(
     Ok(replayed)
 }
 
+fn summary_spill_input(
+    input: &str,
+    resolved_cwd: Option<&str>,
+    profile: Option<&str>,
+) -> Result<String> {
+    let mut payload: serde_json::Value = serde_json::from_str(input)?;
+    let Some(obj) = payload.as_object_mut() else {
+        return Ok(input.to_string());
+    };
+    if let Some(cwd) = resolved_cwd.filter(|cwd| !cwd.trim().is_empty()) {
+        let needs_cwd = obj
+            .get("cwd")
+            .and_then(|value| value.as_str())
+            .is_none_or(|value| value.trim().is_empty());
+        if needs_cwd {
+            obj.insert(
+                "cwd".to_string(),
+                serde_json::Value::String(cwd.to_string()),
+            );
+        }
+    }
+    if let Some(profile) = profile.map(str::trim).filter(|profile| !profile.is_empty()) {
+        obj.insert(
+            crate::runtime_config::MEMORY_AI_PROFILE_FIELD.to_string(),
+            serde_json::Value::String(profile.to_string()),
+        );
+    }
+    obj.remove("last_assistant_message");
+    Ok(serde_json::to_string(&payload)?)
+}
+
+fn append_record_to_spill(path: &Path, record: &SummaryHookSpillRecord) -> Result<()> {
+    let mut line = serde_json::to_vec(record)?;
+    line.push(b'\n');
+    append_bytes_to_spill(path, &line)
+}
+
+fn append_bytes_to_spill(path: &Path, contents: &[u8]) -> Result<()> {
+    if contents.is_empty() {
+        return Ok(());
+    }
+    with_summary_spill_lock(|| append_bytes_to_spill_unlocked(path, contents))
+}
+
+fn append_bytes_to_spill_unlocked(path: &Path, contents: &[u8]) -> Result<()> {
+    if contents.is_empty() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create summary hook spill dir {}", parent.display()))?;
+    }
+    let mut file = append_open_options()
+        .open(path)
+        .with_context(|| format!("open summary hook spill {}", path.display()))?;
+    file.write_all(contents)?;
+    Ok(())
+}
+
+fn with_summary_spill_lock<T>(f: impl FnOnce() -> Result<T>) -> Result<T> {
+    let lock_path = summary_spill_lock_path();
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create summary hook spill lock dir {}", parent.display()))?;
+    }
+    let lock_file = append_open_options()
+        .open(&lock_path)
+        .with_context(|| format!("open summary hook spill lock {}", lock_path.display()))?;
+    lock_file
+        .lock_exclusive()
+        .with_context(|| format!("lock summary hook spill {}", lock_path.display()))?;
+    let result = f();
+    let unlock = lock_file
+        .unlock()
+        .with_context(|| format!("unlock summary hook spill {}", lock_path.display()));
+    match (result, unlock) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Err(unlock_error)) => Err(error.context(unlock_error.to_string())),
+    }
+}
+
+fn append_open_options() -> std::fs::OpenOptions {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options
+}
+
 fn restore_claimed_and_failed_spill(claimed_path: &Path, failed_path: &Path, path: &Path) {
     if claimed_path.exists() {
         restore_claimed_spill(claimed_path, path);
         remove_redundant_failed_spill(failed_path);
     } else if failed_path.exists() {
-        let result = append_file_to_spill(path, failed_path).and_then(|()| {
-            std::fs::remove_file(failed_path)
-                .with_context(|| format!("remove {}", failed_path.display()))
-        });
+        let result = append_file_to_spill_then_remove(path, failed_path);
         if let Err(error) = result {
             crate::log::error(
                 "summarize",
@@ -155,40 +242,18 @@ fn remove_redundant_failed_spill(failed_path: &Path) {
     }
 }
 
-fn append_file_to_spill(path: &Path, records_path: &Path) -> Result<()> {
+fn append_file_to_spill_then_remove(path: &Path, records_path: &Path) -> Result<()> {
     let contents = std::fs::read_to_string(records_path)
         .with_context(|| format!("read {}", records_path.display()))?;
-    if contents.is_empty() {
-        return Ok(());
-    }
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("create summary hook spill dir {}", parent.display()))?;
-    }
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("open summary hook spill {}", path.display()))?;
-    file.write_all(contents.as_bytes())?;
-    Ok(())
+    with_summary_spill_lock(|| {
+        append_bytes_to_spill_unlocked(path, contents.as_bytes())?;
+        std::fs::remove_file(records_path)
+            .with_context(|| format!("remove {}", records_path.display()))
+    })
 }
 
 fn restore_claimed_spill(claimed_path: &Path, path: &Path) {
-    let result = if path.exists() {
-        append_file_to_spill(path, claimed_path).and_then(|()| {
-            std::fs::remove_file(claimed_path)
-                .with_context(|| format!("remove {}", claimed_path.display()))
-        })
-    } else {
-        std::fs::rename(claimed_path, path).with_context(|| {
-            format!(
-                "restore summary hook spill {} to {}",
-                claimed_path.display(),
-                path.display()
-            )
-        })
-    };
+    let result = append_file_to_spill_then_remove(path, claimed_path);
     if let Err(error) = result {
         crate::log::error(
             "summarize",
@@ -198,17 +263,9 @@ fn restore_claimed_spill(claimed_path: &Path, path: &Path) {
 }
 
 fn append_failed_line(path: &Path, line: &str, error: &anyhow::Error) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).with_context(|| {
-            format!("create failed summary hook spill dir {}", parent.display())
-        })?;
-    }
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("open failed summary hook spill {}", path.display()))?;
-    writeln!(file, "{line}")?;
+    let mut contents = line.as_bytes().to_vec();
+    contents.push(b'\n');
+    append_bytes_to_spill(path, &contents)?;
     crate::log::warn(
         "summarize",
         &format!("summary hook spill replay failed: {error}"),
@@ -221,18 +278,7 @@ fn append_failed_record(
     record: &SummaryHookSpillRecord,
     error: &anyhow::Error,
 ) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).with_context(|| {
-            format!("create failed summary hook spill dir {}", parent.display())
-        })?;
-    }
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("open failed summary hook spill {}", path.display()))?;
-    serde_json::to_writer(&mut file, record)?;
-    file.write_all(b"\n")?;
+    append_record_to_spill(path, record)?;
     crate::log::warn(
         "summarize",
         &format!("summary hook spill replay failed: {error}"),
@@ -258,6 +304,10 @@ fn claimed_summary_spill_path() -> PathBuf {
 
 fn failed_summary_spill_path_for_claim(claimed_path: &Path) -> PathBuf {
     claimed_path.with_extension("failed.jsonl")
+}
+
+fn summary_spill_lock_path() -> PathBuf {
+    crate::db::data_dir().join("summary-hook-spill.lock")
 }
 
 #[cfg(test)]
@@ -341,6 +391,7 @@ mod tests {
             &first_input,
             Some("codex-cli"),
             None,
+            Some("/tmp/remem"),
             &anyhow::anyhow!("stale db"),
         )?;
 
@@ -352,6 +403,7 @@ mod tests {
                     &later_input,
                     Some("codex-cli"),
                     None,
+                    Some("/tmp/remem"),
                     &anyhow::anyhow!("still stale"),
                 )?;
                 wrote_later = true;
@@ -367,6 +419,33 @@ mod tests {
     }
 
     #[test]
+    fn spill_payload_fills_cwd_and_omits_last_assistant_message() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-hook-spill-sanitize");
+        let input = serde_json::json!({
+            "session_id": "sess-summary-sensitive",
+            "last_assistant_message": "private assistant answer"
+        })
+        .to_string();
+
+        spill_summary_hook_payload(
+            &input,
+            Some("codex-cli"),
+            Some("quality"),
+            Some("/tmp/original-project"),
+            &anyhow::anyhow!("stale db"),
+        )?;
+
+        let stored = std::fs::read_to_string(summary_spill_path())?;
+        assert!(!stored.contains("private assistant answer"));
+        let record: super::SummaryHookSpillRecord = serde_json::from_str(stored.trim())?;
+        let payload: serde_json::Value = serde_json::from_str(&record.input)?;
+        assert_eq!(payload["cwd"].as_str(), Some("/tmp/original-project"));
+        assert_eq!(payload["remem_ai_profile"].as_str(), Some("quality"));
+        assert!(payload.get("last_assistant_message").is_none());
+        Ok(())
+    }
+
+    #[test]
     fn restore_claimed_spill_makes_records_visible_to_future_replay() -> anyhow::Result<()> {
         let _test_dir = ScopedTestDataDir::new("summary-hook-spill-restore-claim");
         std::fs::create_dir_all(db::data_dir())?;
@@ -374,11 +453,24 @@ mod tests {
         let failed_path = super::failed_summary_spill_path_for_claim(&claimed_path);
         std::fs::write(
             &claimed_path,
-            r#"{"version":1,"input":"{\"session_id\":\"sess-restored\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#,
+            format!(
+                "{}\n",
+                r#"{"version":1,"input":"{\"session_id\":\"sess-restored\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#
+            ),
         )?;
         std::fs::write(
             &failed_path,
-            r#"{"version":1,"input":"{\"session_id\":\"sess-duplicate\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#,
+            format!(
+                "{}\n",
+                r#"{"version":1,"input":"{\"session_id\":\"sess-duplicate\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#
+            ),
+        )?;
+        std::fs::write(
+            summary_spill_path(),
+            format!(
+                "{}\n",
+                r#"{"version":1,"input":"{\"session_id\":\"sess-active\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#
+            ),
         )?;
 
         super::restore_claimed_and_failed_spill(&claimed_path, &failed_path, &summary_spill_path());
@@ -386,6 +478,7 @@ mod tests {
         assert!(!claimed_path.exists());
         assert!(!failed_path.exists());
         let restored = std::fs::read_to_string(summary_spill_path())?;
+        assert!(restored.contains("sess-active"));
         assert!(restored.contains("sess-restored"));
         assert!(!restored.contains("sess-duplicate"));
         Ok(())

--- a/src/summarize/summary_job/spill.rs
+++ b/src/summarize/summary_job/spill.rs
@@ -94,12 +94,12 @@ fn replay_claimed_summary_hook_payloads(
 
     let mut replayed = 0;
     for line in contents.lines().filter(|line| !line.trim().is_empty()) {
-        match serde_json::from_str::<SummaryHookSpillRecord>(line) {
+        match crate::db::spill_crypto::decode_json_line::<SummaryHookSpillRecord>(line) {
             Ok(record) => match replay(conn, &record) {
                 Ok(()) => replayed += 1,
                 Err(error) => append_failed_record(failed_path, &record, &error)?,
             },
-            Err(error) => append_failed_line(failed_path, line, &error.into())?,
+            Err(error) => append_failed_line(failed_path, line, &error)?,
         }
     }
 
@@ -150,12 +150,11 @@ fn summary_spill_input(
             serde_json::Value::String(profile.to_string()),
         );
     }
-    obj.remove("last_assistant_message");
     Ok(serde_json::to_string(&payload)?)
 }
 
 fn append_record_to_spill(path: &Path, record: &SummaryHookSpillRecord) -> Result<()> {
-    let mut line = serde_json::to_vec(record)?;
+    let mut line = crate::db::spill_crypto::encode_json_line(record)?.into_bytes();
     line.push(b'\n');
     append_bytes_to_spill(path, &line)
 }
@@ -566,8 +565,9 @@ mod tests {
     }
 
     #[test]
-    fn spill_payload_fills_cwd_and_omits_last_assistant_message() -> anyhow::Result<()> {
+    fn spill_payload_fills_cwd_and_protects_last_assistant_message() -> anyhow::Result<()> {
         let _test_dir = ScopedTestDataDir::new("summary-hook-spill-sanitize");
+        std::env::set_var("REMEM_CIPHER_KEY", format!("v2:{}", "1".repeat(64)));
         let input = serde_json::json!({
             "session_id": "sess-summary-sensitive",
             "last_assistant_message": "private assistant answer"
@@ -584,11 +584,15 @@ mod tests {
 
         let stored = std::fs::read_to_string(summary_spill_path())?;
         assert!(!stored.contains("private assistant answer"));
-        let record: super::SummaryHookSpillRecord = serde_json::from_str(stored.trim())?;
+        let record: super::SummaryHookSpillRecord =
+            crate::db::spill_crypto::decode_json_line(stored.trim())?;
         let payload: serde_json::Value = serde_json::from_str(&record.input)?;
         assert_eq!(payload["cwd"].as_str(), Some("/tmp/original-project"));
         assert_eq!(payload["remem_ai_profile"].as_str(), Some("quality"));
-        assert!(payload.get("last_assistant_message").is_none());
+        assert_eq!(
+            payload["last_assistant_message"].as_str(),
+            Some("private assistant answer")
+        );
         Ok(())
     }
 

--- a/src/summarize/summary_job/spill.rs
+++ b/src/summarize/summary_job/spill.rs
@@ -5,9 +5,10 @@ use serde::{Deserialize, Serialize};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 static SUMMARY_SPILL_CLAIM_COUNTER: AtomicU64 = AtomicU64::new(0);
+const ORPHANED_SUMMARY_SPILL_CLAIM_MIN_AGE_SECS: u64 = 60;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct SummaryHookSpillRecord {
@@ -48,6 +49,9 @@ pub(super) fn replay_spilled_summary_hook_payloads(
     mut replay: impl FnMut(&Connection, &SummaryHookSpillRecord) -> Result<()>,
 ) -> Result<usize> {
     let path = summary_spill_path();
+    restore_orphaned_summary_spill_claims(Duration::from_secs(
+        ORPHANED_SUMMARY_SPILL_CLAIM_MIN_AGE_SECS,
+    ))?;
     let claimed_path = claimed_summary_spill_path();
     match with_summary_spill_lock(|| {
         std::fs::rename(&path, &claimed_path)
@@ -213,6 +217,104 @@ fn append_open_options() -> std::fs::OpenOptions {
     options
 }
 
+fn restore_orphaned_summary_spill_claims(min_age: Duration) -> Result<usize> {
+    let dir = crate::db::data_dir();
+    let path = summary_spill_path();
+    with_summary_spill_lock(|| {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(0),
+            Err(error) => return Err(error).with_context(|| format!("read {}", dir.display())),
+        };
+        let mut restored = 0;
+        for entry in entries {
+            let entry = entry?;
+            let claimed_path = entry.path();
+            if !is_summary_spill_claim_path(&claimed_path)
+                || !is_stale_summary_spill_claim(&claimed_path, min_age)?
+            {
+                continue;
+            }
+            let contents = std::fs::read_to_string(&claimed_path)
+                .with_context(|| format!("read {}", claimed_path.display()))?;
+            append_bytes_to_spill_unlocked(&path, contents.as_bytes())?;
+            std::fs::remove_file(&claimed_path)
+                .with_context(|| format!("remove {}", claimed_path.display()))?;
+            remove_file_if_exists(&failed_summary_spill_path_for_claim(&claimed_path))?;
+            restored += 1;
+        }
+        Ok(restored)
+    })
+}
+
+fn is_summary_spill_claim_path(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    file_name.starts_with("summary-hook-spill.replay-")
+        && file_name.ends_with(".jsonl")
+        && !file_name.ends_with(".failed.jsonl")
+}
+
+fn is_stale_summary_spill_claim(path: &Path, min_age: Duration) -> Result<bool> {
+    if min_age.is_zero() {
+        return Ok(true);
+    }
+    let Some(claim) = summary_spill_claim_fields(path) else {
+        return Ok(false);
+    };
+    if process_alive(claim.pid) {
+        return Ok(false);
+    }
+    let now_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    Ok(now_nanos.saturating_sub(claim.epoch_nanos) >= min_age.as_nanos())
+}
+
+struct SummarySpillClaimFields {
+    pid: i64,
+    epoch_nanos: u128,
+}
+
+fn summary_spill_claim_fields(path: &Path) -> Option<SummarySpillClaimFields> {
+    let file_name = path.file_name()?.to_str()?;
+    let rest = file_name.strip_prefix("summary-hook-spill.replay-")?;
+    let rest = rest.strip_suffix(".jsonl")?;
+    let (before_sequence, _sequence) = rest.rsplit_once('-')?;
+    let (pid, nanos) = before_sequence.rsplit_once('-')?;
+    Some(SummarySpillClaimFields {
+        pid: pid.parse().ok()?,
+        epoch_nanos: nanos.parse().ok()?,
+    })
+}
+
+fn process_alive(pid: i64) -> bool {
+    if pid <= 0 || pid > i64::from(i32::MAX) {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("remove {}", path.display())),
+    }
+}
+
 fn restore_claimed_and_failed_spill(claimed_path: &Path, failed_path: &Path, path: &Path) {
     if claimed_path.exists() {
         restore_claimed_spill(claimed_path, path);
@@ -373,6 +475,51 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn current_stop_payload_wins_over_same_session_spill_replay() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-hook-current-wins");
+        let conn = db::open_db()?;
+        let now = chrono::Utc::now().timestamp();
+        db::upsert_worker_heartbeat(
+            &conn,
+            "worker-daemon",
+            i64::from(std::process::id()),
+            now,
+            now,
+        )?;
+        let old_input = serde_json::json!({
+            "session_id": "sess-summary-current-wins",
+            "cwd": "/tmp/remem",
+            "transcript_path": "/tmp/old-transcript.jsonl"
+        })
+        .to_string();
+        spill_summary_hook_payload(
+            &old_input,
+            Some("codex-cli"),
+            None,
+            Some("/tmp/remem"),
+            &anyhow::anyhow!("stale db"),
+        )?;
+
+        let current_input = serde_json::json!({
+            "session_id": "sess-summary-current-wins",
+            "cwd": "/tmp/remem",
+            "transcript_path": "/tmp/current-transcript.jsonl"
+        })
+        .to_string();
+        super::super::hook::summarize_input(&current_input, Some("codex-cli"), None).await?;
+
+        let payload: String = conn.query_row(
+            "SELECT payload_json FROM jobs
+             WHERE job_type = 'summary' AND session_id = 'sess-summary-current-wins'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(payload.contains("/tmp/current-transcript.jsonl"));
+        assert!(!payload.contains("/tmp/old-transcript.jsonl"));
+        Ok(())
+    }
+
     #[test]
     fn replay_preserves_spills_appended_after_claim() -> anyhow::Result<()> {
         let _test_dir = ScopedTestDataDir::new("summary-hook-spill-claim-race");
@@ -481,6 +628,112 @@ mod tests {
         assert!(restored.contains("sess-active"));
         assert!(restored.contains("sess-restored"));
         assert!(!restored.contains("sess-duplicate"));
+        Ok(())
+    }
+
+    #[test]
+    fn orphaned_claimed_spill_is_restored_to_active_queue() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-hook-spill-orphan-claim");
+        std::fs::create_dir_all(db::data_dir())?;
+        let claimed_path = db::data_dir().join("summary-hook-spill.replay-orphan.jsonl");
+        let failed_path = super::failed_summary_spill_path_for_claim(&claimed_path);
+        std::fs::write(
+            &claimed_path,
+            format!(
+                "{}\n",
+                r#"{"version":1,"input":"{\"session_id\":\"sess-orphan\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#
+            ),
+        )?;
+        std::fs::write(
+            &failed_path,
+            format!(
+                "{}\n",
+                r#"{"version":1,"input":"{\"session_id\":\"sess-orphan-failed\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#
+            ),
+        )?;
+
+        let restored = super::restore_orphaned_summary_spill_claims(std::time::Duration::ZERO)?;
+
+        assert_eq!(restored, 1);
+        assert!(!claimed_path.exists());
+        assert!(!failed_path.exists());
+        let active = std::fs::read_to_string(summary_spill_path())?;
+        assert!(active.contains("sess-orphan"));
+        assert!(!active.contains("sess-orphan-failed"));
+        Ok(())
+    }
+
+    #[test]
+    fn fresh_claimed_spill_is_not_restored_as_orphan() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-hook-spill-fresh-claim");
+        std::fs::create_dir_all(db::data_dir())?;
+        let claimed_path = super::claimed_summary_spill_path();
+        std::fs::write(
+            &claimed_path,
+            format!(
+                "{}\n",
+                r#"{"version":1,"input":"{\"session_id\":\"sess-fresh-claim\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#
+            ),
+        )?;
+
+        let restored =
+            super::restore_orphaned_summary_spill_claims(std::time::Duration::from_secs(60))?;
+
+        assert_eq!(restored, 0);
+        assert!(claimed_path.exists());
+        assert!(!summary_spill_path().exists());
+        Ok(())
+    }
+
+    #[test]
+    fn live_claimed_spill_is_not_restored_as_orphan() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-hook-spill-live-claim");
+        std::fs::create_dir_all(db::data_dir())?;
+        let claimed_path = db::data_dir().join(format!(
+            "summary-hook-spill.replay-{}-1-0.jsonl",
+            std::process::id()
+        ));
+        std::fs::write(
+            &claimed_path,
+            format!(
+                "{}\n",
+                r#"{"version":1,"input":"{\"session_id\":\"sess-live-claim\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#
+            ),
+        )?;
+
+        let restored =
+            super::restore_orphaned_summary_spill_claims(std::time::Duration::from_secs(60))?;
+
+        assert_eq!(restored, 0);
+        assert!(claimed_path.exists());
+        assert!(!summary_spill_path().exists());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stale_dead_claimed_spill_is_restored_as_orphan() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-hook-spill-dead-claim");
+        std::fs::create_dir_all(db::data_dir())?;
+        let claimed_path = db::data_dir().join(format!(
+            "summary-hook-spill.replay-{}-1-0.jsonl",
+            i64::from(i32::MAX)
+        ));
+        std::fs::write(
+            &claimed_path,
+            format!(
+                "{}\n",
+                r#"{"version":1,"input":"{\"session_id\":\"sess-dead-claim\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#
+            ),
+        )?;
+
+        let restored =
+            super::restore_orphaned_summary_spill_claims(std::time::Duration::from_secs(60))?;
+
+        assert_eq!(restored, 1);
+        assert!(!claimed_path.exists());
+        let active = std::fs::read_to_string(summary_spill_path())?;
+        assert!(active.contains("sess-dead-claim"));
         Ok(())
     }
 

--- a/src/summarize/summary_job/spill.rs
+++ b/src/summarize/summary_job/spill.rs
@@ -1,8 +1,12 @@
 use anyhow::{Context, Result};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static SUMMARY_SPILL_CLAIM_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct SummaryHookSpillRecord {
@@ -52,38 +56,62 @@ pub(super) fn replay_spilled_summary_hook_payloads(
     mut replay: impl FnMut(&Connection, &SummaryHookSpillRecord) -> Result<()>,
 ) -> Result<usize> {
     let path = summary_spill_path();
-    if !path.exists() {
-        return Ok(0);
+    let claimed_path = claimed_summary_spill_path();
+    match std::fs::rename(&path, &claimed_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(0),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("claim summary hook spill {}", path.display()));
+        }
     }
+    let failed_path = failed_summary_spill_path_for_claim(&claimed_path);
 
-    let contents =
-        std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
-    let failed_path = failed_summary_spill_path();
-    if failed_path.exists() {
-        std::fs::remove_file(&failed_path)
-            .with_context(|| format!("remove stale {}", failed_path.display()))?;
+    let result =
+        replay_claimed_summary_hook_payloads(conn, &path, &claimed_path, &failed_path, &mut replay);
+    if result.is_err() {
+        restore_claimed_and_failed_spill(&claimed_path, &failed_path, &path);
     }
+    result
+}
+
+fn replay_claimed_summary_hook_payloads(
+    conn: &Connection,
+    path: &Path,
+    claimed_path: &Path,
+    failed_path: &Path,
+    replay: &mut impl FnMut(&Connection, &SummaryHookSpillRecord) -> Result<()>,
+) -> Result<usize> {
+    let contents = match std::fs::read_to_string(claimed_path) {
+        Ok(contents) => contents,
+        Err(error) => {
+            restore_claimed_spill(claimed_path, path);
+            return Err(error).with_context(|| format!("read {}", claimed_path.display()));
+        }
+    };
 
     let mut replayed = 0;
     for line in contents.lines().filter(|line| !line.trim().is_empty()) {
         match serde_json::from_str::<SummaryHookSpillRecord>(line) {
             Ok(record) => match replay(conn, &record) {
                 Ok(()) => replayed += 1,
-                Err(error) => append_failed_record(&failed_path, &record, &error)?,
+                Err(error) => append_failed_record(failed_path, &record, &error)?,
             },
-            Err(error) => append_failed_line(&failed_path, line, &error.into())?,
+            Err(error) => append_failed_line(failed_path, line, &error.into())?,
         }
     }
 
-    std::fs::remove_file(&path).with_context(|| format!("remove {}", path.display()))?;
     if failed_path.exists() {
-        std::fs::rename(&failed_path, &path).with_context(|| {
-            format!(
-                "move unreplayed summary hook spill {} to {}",
-                failed_path.display(),
-                path.display()
-            )
-        })?;
+        append_file_to_spill(path, failed_path)?;
+        std::fs::remove_file(failed_path)
+            .with_context(|| format!("remove {}", failed_path.display()))?;
+    }
+    match std::fs::remove_file(claimed_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| format!("remove {}", claimed_path.display()));
+        }
     }
 
     if replayed > 0 {
@@ -93,6 +121,80 @@ pub(super) fn replay_spilled_summary_hook_payloads(
         );
     }
     Ok(replayed)
+}
+
+fn restore_claimed_and_failed_spill(claimed_path: &Path, failed_path: &Path, path: &Path) {
+    if claimed_path.exists() {
+        restore_claimed_spill(claimed_path, path);
+        remove_redundant_failed_spill(failed_path);
+    } else if failed_path.exists() {
+        let result = append_file_to_spill(path, failed_path).and_then(|()| {
+            std::fs::remove_file(failed_path)
+                .with_context(|| format!("remove {}", failed_path.display()))
+        });
+        if let Err(error) = result {
+            crate::log::error(
+                "summarize",
+                &format!("failed to restore failed summary hook spill: {error}"),
+            );
+        }
+    }
+}
+
+fn remove_redundant_failed_spill(failed_path: &Path) {
+    match std::fs::remove_file(failed_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => crate::log::warn(
+            "summarize",
+            &format!(
+                "failed to remove redundant summary hook spill {}: {error}",
+                failed_path.display()
+            ),
+        ),
+    }
+}
+
+fn append_file_to_spill(path: &Path, records_path: &Path) -> Result<()> {
+    let contents = std::fs::read_to_string(records_path)
+        .with_context(|| format!("read {}", records_path.display()))?;
+    if contents.is_empty() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create summary hook spill dir {}", parent.display()))?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open summary hook spill {}", path.display()))?;
+    file.write_all(contents.as_bytes())?;
+    Ok(())
+}
+
+fn restore_claimed_spill(claimed_path: &Path, path: &Path) {
+    let result = if path.exists() {
+        append_file_to_spill(path, claimed_path).and_then(|()| {
+            std::fs::remove_file(claimed_path)
+                .with_context(|| format!("remove {}", claimed_path.display()))
+        })
+    } else {
+        std::fs::rename(claimed_path, path).with_context(|| {
+            format!(
+                "restore summary hook spill {} to {}",
+                claimed_path.display(),
+                path.display()
+            )
+        })
+    };
+    if let Err(error) = result {
+        crate::log::error(
+            "summarize",
+            &format!("failed to restore claimed summary hook spill: {error}"),
+        );
+    }
 }
 
 fn append_failed_line(path: &Path, line: &str, error: &anyhow::Error) -> Result<()> {
@@ -142,15 +244,29 @@ pub(super) fn summary_spill_path() -> PathBuf {
     crate::db::data_dir().join("summary-hook-spill.jsonl")
 }
 
-fn failed_summary_spill_path() -> PathBuf {
-    crate::db::data_dir().join("summary-hook-spill.failed.jsonl")
+fn claimed_summary_spill_path() -> PathBuf {
+    let sequence = SUMMARY_SPILL_CLAIM_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let now_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    crate::db::data_dir().join(format!(
+        "summary-hook-spill.replay-{}-{now_nanos}-{sequence}.jsonl",
+        std::process::id()
+    ))
+}
+
+fn failed_summary_spill_path_for_claim(claimed_path: &Path) -> PathBuf {
+    claimed_path.with_extension("failed.jsonl")
 }
 
 #[cfg(test)]
 mod tests {
     use crate::db::{self, test_support::ScopedTestDataDir};
 
-    use super::summary_spill_path;
+    use super::{
+        replay_spilled_summary_hook_payloads, spill_summary_hook_payload, summary_spill_path,
+    };
 
     #[tokio::test]
     async fn stale_db_spill_replays_after_schema_is_initialized() -> anyhow::Result<()> {
@@ -204,6 +320,108 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(summary_jobs, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn replay_preserves_spills_appended_after_claim() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-hook-spill-claim-race");
+        let conn = db::open_db()?;
+        let first_input = serde_json::json!({
+            "session_id": "sess-summary-first",
+            "cwd": "/tmp/remem"
+        })
+        .to_string();
+        let later_input = serde_json::json!({
+            "session_id": "sess-summary-later",
+            "cwd": "/tmp/remem"
+        })
+        .to_string();
+        spill_summary_hook_payload(
+            &first_input,
+            Some("codex-cli"),
+            None,
+            &anyhow::anyhow!("stale db"),
+        )?;
+
+        let mut wrote_later = false;
+        let replayed = replay_spilled_summary_hook_payloads(&conn, |_conn, record| {
+            assert_eq!(record.input, first_input);
+            if !wrote_later {
+                spill_summary_hook_payload(
+                    &later_input,
+                    Some("codex-cli"),
+                    None,
+                    &anyhow::anyhow!("still stale"),
+                )?;
+                wrote_later = true;
+            }
+            Ok(())
+        })?;
+
+        assert_eq!(replayed, 1);
+        let remaining = std::fs::read_to_string(summary_spill_path())?;
+        assert!(remaining.contains("sess-summary-later"));
+        assert!(!remaining.contains("sess-summary-first"));
+        Ok(())
+    }
+
+    #[test]
+    fn restore_claimed_spill_makes_records_visible_to_future_replay() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-hook-spill-restore-claim");
+        std::fs::create_dir_all(db::data_dir())?;
+        let claimed_path = db::data_dir().join("summary-hook-spill.replay-test.jsonl");
+        let failed_path = super::failed_summary_spill_path_for_claim(&claimed_path);
+        std::fs::write(
+            &claimed_path,
+            r#"{"version":1,"input":"{\"session_id\":\"sess-restored\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#,
+        )?;
+        std::fs::write(
+            &failed_path,
+            r#"{"version":1,"input":"{\"session_id\":\"sess-duplicate\"}","host":"codex-cli","profile":null,"db_error":"stale","created_at_epoch":1}"#,
+        )?;
+
+        super::restore_claimed_and_failed_spill(&claimed_path, &failed_path, &summary_spill_path());
+
+        assert!(!claimed_path.exists());
+        assert!(!failed_path.exists());
+        let restored = std::fs::read_to_string(summary_spill_path())?;
+        assert!(restored.contains("sess-restored"));
+        assert!(!restored.contains("sess-duplicate"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn replay_error_does_not_drop_current_summary_payload() -> anyhow::Result<()> {
+        let _test_dir = ScopedTestDataDir::new("summary-hook-replay-error-current");
+        let conn = db::open_db()?;
+        let now = chrono::Utc::now().timestamp();
+        db::upsert_worker_heartbeat(
+            &conn,
+            "worker-daemon",
+            i64::from(std::process::id()),
+            now,
+            now,
+        )?;
+        drop(conn);
+        std::fs::create_dir_all(summary_spill_path())?;
+
+        let current_input = serde_json::json!({
+            "session_id": "sess-summary-current-after-replay-error",
+            "cwd": "/tmp/remem"
+        })
+        .to_string();
+        super::super::hook::summarize_input(&current_input, Some("codex-cli"), None).await?;
+
+        let conn = db::open_db()?;
+        let summary_jobs: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM jobs
+             WHERE job_type = 'summary'
+               AND session_id = 'sess-summary-current-after-replay-error'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(summary_jobs, 1);
         Ok(())
     }
 }

--- a/src/summarize/summary_job/spill.rs
+++ b/src/summarize/summary_job/spill.rs
@@ -1,0 +1,209 @@
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct SummaryHookSpillRecord {
+    version: u32,
+    pub(super) input: String,
+    pub(super) host: Option<String>,
+    pub(super) profile: Option<String>,
+    db_error: String,
+    created_at_epoch: i64,
+}
+
+pub(super) fn spill_summary_hook_payload(
+    input: &str,
+    host: Option<&str>,
+    profile: Option<&str>,
+    db_error: &anyhow::Error,
+) -> Result<PathBuf> {
+    let path = summary_spill_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create summary hook spill dir {}", parent.display()))?;
+    }
+    let record = SummaryHookSpillRecord {
+        version: 1,
+        input: input.to_string(),
+        host: host.map(crate::runtime_config::normalize_host),
+        profile: profile.map(str::to_string),
+        db_error: crate::db::truncate_str(
+            &crate::db::capture::redact_capture_content(&db_error.to_string()),
+            1000,
+        )
+        .to_string(),
+        created_at_epoch: chrono::Utc::now().timestamp(),
+    };
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("open summary hook spill {}", path.display()))?;
+    serde_json::to_writer(&mut file, &record)?;
+    file.write_all(b"\n")?;
+    Ok(path)
+}
+
+pub(super) fn replay_spilled_summary_hook_payloads(
+    conn: &Connection,
+    mut replay: impl FnMut(&Connection, &SummaryHookSpillRecord) -> Result<()>,
+) -> Result<usize> {
+    let path = summary_spill_path();
+    if !path.exists() {
+        return Ok(0);
+    }
+
+    let contents =
+        std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let failed_path = failed_summary_spill_path();
+    if failed_path.exists() {
+        std::fs::remove_file(&failed_path)
+            .with_context(|| format!("remove stale {}", failed_path.display()))?;
+    }
+
+    let mut replayed = 0;
+    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+        match serde_json::from_str::<SummaryHookSpillRecord>(line) {
+            Ok(record) => match replay(conn, &record) {
+                Ok(()) => replayed += 1,
+                Err(error) => append_failed_record(&failed_path, &record, &error)?,
+            },
+            Err(error) => append_failed_line(&failed_path, line, &error.into())?,
+        }
+    }
+
+    std::fs::remove_file(&path).with_context(|| format!("remove {}", path.display()))?;
+    if failed_path.exists() {
+        std::fs::rename(&failed_path, &path).with_context(|| {
+            format!(
+                "move unreplayed summary hook spill {} to {}",
+                failed_path.display(),
+                path.display()
+            )
+        })?;
+    }
+
+    if replayed > 0 {
+        crate::log::info(
+            "summarize",
+            &format!("replayed {replayed} spilled summary hook payload(s)"),
+        );
+    }
+    Ok(replayed)
+}
+
+fn append_failed_line(path: &Path, line: &str, error: &anyhow::Error) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!("create failed summary hook spill dir {}", parent.display())
+        })?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open failed summary hook spill {}", path.display()))?;
+    writeln!(file, "{line}")?;
+    crate::log::warn(
+        "summarize",
+        &format!("summary hook spill replay failed: {error}"),
+    );
+    Ok(())
+}
+
+fn append_failed_record(
+    path: &Path,
+    record: &SummaryHookSpillRecord,
+    error: &anyhow::Error,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!("create failed summary hook spill dir {}", parent.display())
+        })?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open failed summary hook spill {}", path.display()))?;
+    serde_json::to_writer(&mut file, record)?;
+    file.write_all(b"\n")?;
+    crate::log::warn(
+        "summarize",
+        &format!("summary hook spill replay failed: {error}"),
+    );
+    Ok(())
+}
+
+pub(super) fn summary_spill_path() -> PathBuf {
+    crate::db::data_dir().join("summary-hook-spill.jsonl")
+}
+
+fn failed_summary_spill_path() -> PathBuf {
+    crate::db::data_dir().join("summary-hook-spill.failed.jsonl")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::{self, test_support::ScopedTestDataDir};
+
+    use super::summary_spill_path;
+
+    #[tokio::test]
+    async fn stale_db_spill_replays_after_schema_is_initialized() -> anyhow::Result<()> {
+        let test_dir = ScopedTestDataDir::new("summary-hook-spill-replay");
+        std::fs::create_dir_all(&test_dir.path)?;
+        let setup = rusqlite::Connection::open(test_dir.db_path())?;
+        setup.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)", [])?;
+        drop(setup);
+        let spilled_input = serde_json::json!({
+            "session_id": "sess-summary-spilled",
+            "cwd": "/tmp/remem"
+        })
+        .to_string();
+
+        let err = super::super::hook::summarize_input(&spilled_input, Some("codex-cli"), None)
+            .await
+            .expect_err("stale hook database should spill and fail closed");
+
+        assert!(
+            err.to_string().contains("hook database open requires"),
+            "unexpected error: {err:#}"
+        );
+        assert!(summary_spill_path().exists());
+        std::fs::remove_file(test_dir.db_path())?;
+
+        let conn = db::open_db()?;
+        let now = chrono::Utc::now().timestamp();
+        db::upsert_worker_heartbeat(
+            &conn,
+            "worker-daemon",
+            i64::from(std::process::id()),
+            now,
+            now,
+        )?;
+        drop(conn);
+
+        let current_input = serde_json::json!({
+            "session_id": "sess-summary-current",
+            "cwd": "/tmp/remem"
+        })
+        .to_string();
+        super::super::hook::summarize_input(&current_input, Some("codex-cli"), None).await?;
+
+        assert!(!summary_spill_path().exists());
+        let conn = db::open_db()?;
+        let summary_jobs: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM jobs
+             WHERE job_type = 'summary'
+               AND session_id IN ('sess-summary-spilled', 'sess-summary-current')",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(summary_jobs, 2);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add an explicit hook-safe DB open wrapper that requires an existing current schema
- switch observe, capture-drop, session_init, and Stop summarize hook scheduling away from migration-capable open_db()
- add stale-schema/current-schema tests proving hook paths do not migrate or create DBs
- bump runtime/package metadata to 0.5.64

Fixes #467

## Validation
- cargo fmt --check
- git diff --check
- python3 scripts/ci/check_plugin_version_sync.py
- python3 scripts/ci/check_version_bump.py origin/main WORKTREE
- cargo test db::core::tests::open_db_for_hook --lib -- --test-threads=1
- cargo test observe::hook::tests::observe_ --lib -- --test-threads=1
- cargo test observe::session_init::tests::session_init --lib -- --test-threads=1
- cargo test summarize::summary_job::hook::tests::summarize_hook_rejects_stale_schema_without_migrating --lib -- --test-threads=1
- cargo check
- node --test plugins/remem/scripts/remem-runtime.test.js plugins/remem/apps/remem/server.test.js npm/remem/scripts/install.test.js
- cargo test
