### PR TITLE
Migrate capture/raw content identity to sha256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.64"
+version = "0.5.65"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.64",
+  "version": "0.5.65",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.64",
+  "version": "0.5.65",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.64": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.64",
+    "0.5.65": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.65",
       "assets": {}
     }
   }

--- a/src/db/capture.rs
+++ b/src/db/capture.rs
@@ -298,6 +298,14 @@ fn store_content(
     }
 
     let bytes = content.as_bytes();
+    if let Some(blob_id) = matching_legacy_blob_id(conn, content)? {
+        return Ok((
+            compact_preview(content, DIRECT_CONTENT_BYTES),
+            Some(blob_id),
+            "raw_compact",
+        ));
+    }
+
     conn.execute(
         "INSERT INTO event_blobs(content_hash, content_encoding, content_bytes, original_bytes, stored_bytes, created_at_epoch)
          VALUES (?1, 'plain', ?2, ?3, ?3, ?4)
@@ -317,6 +325,32 @@ fn store_content(
         Some(blob_id),
         "raw_compact",
     ))
+}
+
+fn matching_legacy_blob_id(conn: &Connection, content: &str) -> Result<Option<i64>> {
+    let legacy_hash = legacy_exact_hash(content);
+    let Some((id, encoding, bytes)) = conn
+        .query_row(
+            "SELECT id, content_encoding, content_bytes FROM event_blobs WHERE content_hash = ?1",
+            params![legacy_hash],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                ))
+            },
+        )
+        .optional()?
+    else {
+        return Ok(None);
+    };
+
+    if encoding == "plain" && bytes == content.as_bytes() {
+        Ok(Some(id))
+    } else {
+        Ok(None)
+    }
 }
 
 fn coalesce_extraction_task(
@@ -378,7 +412,11 @@ fn coalesce_extraction_task(
 }
 
 fn exact_hash(content: &str) -> String {
-    format!("{:016x}", crate::db::deterministic_hash(content.as_bytes()))
+    crate::db::content_identity_hash(content.as_bytes())
+}
+
+fn legacy_exact_hash(content: &str) -> String {
+    crate::db::legacy_content_identity_hash(content.as_bytes())
 }
 
 pub fn unique_capture_event_id(event_type: &str, content: &str) -> String {
@@ -501,7 +539,7 @@ mod tests {
     }
 
     #[test]
-    fn large_capture_uses_blob_and_compact_preview() {
+    fn large_capture_uses_blob_and_compact_preview() -> Result<()> {
         let conn = setup_conn();
         let content = "x".repeat(DIRECT_CONTENT_BYTES + 2048);
         let outcome = record_captured_event(
@@ -517,22 +555,116 @@ mod tests {
                 content: &content,
                 task_kind: Some(ExtractionTaskKind::ObservationExtract),
             },
-        )
-        .expect("large capture should insert");
+        )?;
 
-        let (retention, blob_id): (String, Option<i64>) = conn
+        let (retention, blob_id, event_hash): (String, Option<i64>, String) = conn
             .query_row(
-                "SELECT retention_class, content_blob_id FROM captured_events WHERE id = ?1",
+                "SELECT retention_class, content_blob_id, content_hash FROM captured_events WHERE id = ?1",
                 params![outcome.event_row_id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .unwrap();
-        let blob_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM event_blobs", [], |row| row.get(0))
-            .unwrap();
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
+        let blob_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM event_blobs", [], |row| row.get(0))?;
+        let blob_hash: String =
+            conn.query_row("SELECT content_hash FROM event_blobs", [], |row| row.get(0))?;
         assert_eq!(retention, "raw_compact");
         assert!(blob_id.is_some());
         assert_eq!(blob_count, 1);
+        assert!(event_hash.starts_with("sha256:content-v1:"));
+        assert!(blob_hash.starts_with("sha256:content-v1:"));
+        Ok(())
+    }
+
+    #[test]
+    fn large_capture_reuses_matching_legacy_blob() -> Result<()> {
+        let conn = setup_conn();
+        let content = "legacy blob content ".repeat(1200);
+        let sanitized_content = redact_capture_content(&content);
+        let legacy_hash = legacy_exact_hash(&sanitized_content);
+        conn.execute(
+            "INSERT INTO event_blobs
+             (content_hash, content_encoding, content_bytes, original_bytes, stored_bytes, created_at_epoch)
+             VALUES (?1, 'plain', ?2, ?3, ?3, 100)",
+            params![
+                legacy_hash,
+                sanitized_content.as_bytes(),
+                sanitized_content.len() as i64
+            ],
+        )?;
+        let legacy_blob_id = conn.last_insert_rowid();
+
+        let outcome = record_captured_event(
+            &conn,
+            &CaptureEventInput {
+                host: "claude-code",
+                session_id: "sess-legacy-blob",
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Task"),
+                content: &content,
+                task_kind: None,
+            },
+        )?;
+
+        let (event_hash, blob_id): (String, Option<i64>) = conn.query_row(
+            "SELECT content_hash, content_blob_id FROM captured_events WHERE id = ?1",
+            params![outcome.event_row_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let blob_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM event_blobs", [], |row| row.get(0))?;
+        assert!(event_hash.starts_with("sha256:content-v1:"));
+        assert_eq!(blob_id, Some(legacy_blob_id));
+        assert_eq!(blob_count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn large_capture_does_not_reuse_mismatched_legacy_blob() -> Result<()> {
+        let conn = setup_conn();
+        let content = "target blob content ".repeat(1200);
+        let sanitized_content = redact_capture_content(&content);
+        let legacy_hash = legacy_exact_hash(&sanitized_content);
+        let wrong_content = "different blob content".repeat(1200);
+        conn.execute(
+            "INSERT INTO event_blobs
+             (content_hash, content_encoding, content_bytes, original_bytes, stored_bytes, created_at_epoch)
+             VALUES (?1, 'plain', ?2, ?3, ?3, 100)",
+            params![
+                legacy_hash,
+                wrong_content.as_bytes(),
+                wrong_content.len() as i64
+            ],
+        )?;
+        let wrong_blob_id = conn.last_insert_rowid();
+
+        let outcome = record_captured_event(
+            &conn,
+            &CaptureEventInput {
+                host: "claude-code",
+                session_id: "sess-mismatched-legacy-blob",
+                project: "/tmp/remem",
+                cwd: None,
+                event_type: "tool_result",
+                role: None,
+                tool_name: Some("Task"),
+                content: &content,
+                task_kind: None,
+            },
+        )?;
+
+        let blob_id: i64 = conn.query_row(
+            "SELECT content_blob_id FROM captured_events WHERE id = ?1",
+            params![outcome.event_row_id],
+            |row| row.get(0),
+        )?;
+        let blob_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM event_blobs", [], |row| row.get(0))?;
+        assert_ne!(blob_id, wrong_blob_id);
+        assert_eq!(blob_count, 2);
+        Ok(())
     }
 
     #[test]

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags};
+use sha2::{Digest, Sha256};
 
 thread_local! {
     static DATA_DIR_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
@@ -42,6 +43,16 @@ pub fn deterministic_hash(data: &[u8]) -> u64 {
         hash = hash.wrapping_mul(FNV_PRIME);
     }
     hash
+}
+
+pub fn content_identity_hash(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("sha256:content-v1:{:x}", hasher.finalize())
+}
+
+pub fn legacy_content_identity_hash(data: &[u8]) -> String {
+    format!("{:016x}", deterministic_hash(data))
 }
 
 pub fn to_sql_refs(params: &[Box<dyn rusqlite::types::ToSql>]) -> Vec<&dyn rusqlite::types::ToSql> {
@@ -272,6 +283,19 @@ mod tests {
     use super::*;
     use crate::db::crypto::ALLOW_PLAINTEXT_ENV;
     use crate::db::test_support::ScopedTestDataDir;
+
+    #[test]
+    fn content_identity_hash_is_versioned_sha256() {
+        let hash = content_identity_hash(b"hello world");
+
+        assert_eq!(
+            hash,
+            "sha256:content-v1:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+        let legacy_hash = legacy_content_identity_hash(b"hello world");
+        assert_eq!(legacy_hash.len(), 16);
+        assert!(!legacy_hash.starts_with("sha256:"));
+    }
 
     #[test]
     fn open_db_for_hook_does_not_create_missing_database() {

--- a/src/memory/dedup/funnel.rs
+++ b/src/memory/dedup/funnel.rs
@@ -11,7 +11,7 @@ pub fn check_duplicate(
     narrative: &str,
     _embedding: Option<&[f32]>,
 ) -> Result<Option<i64>> {
-    let content_hash = format!("{:x}", crate::db::deterministic_hash(narrative.as_bytes()));
+    let content_hash = crate::db::content_identity_hash(narrative.as_bytes());
     let hash_window_secs = 15 * 60;
 
     let hash_dups = find_hash_duplicates(conn, project, &content_hash, hash_window_secs)?;

--- a/src/memory/dedup/hash.rs
+++ b/src/memory/dedup/hash.rs
@@ -29,11 +29,9 @@ pub fn find_hash_duplicates(
             params![id],
             |row| row.get(0),
         )?;
-        let obs_hash = format!(
-            "{:x}",
-            crate::db::deterministic_hash(obs_narrative.as_bytes())
-        );
-        if obs_hash == content_hash {
+        let obs_hash = crate::db::content_identity_hash(obs_narrative.as_bytes());
+        let legacy_obs_hash = crate::db::legacy_content_identity_hash(obs_narrative.as_bytes());
+        if obs_hash == content_hash || legacy_obs_hash == content_hash {
             candidates.push(id);
         }
     }

--- a/src/memory/dedup/tests.rs
+++ b/src/memory/dedup/tests.rs
@@ -69,8 +69,23 @@ fn test_hash_dedup_finds_exact_match() -> Result<()> {
     let narrative = "Fixed authentication bug in login flow";
     insert_observation(&conn, "test-project", narrative)?;
 
-    let content_hash = format!("{:x}", crate::db::deterministic_hash(narrative.as_bytes()));
+    let content_hash = crate::db::content_identity_hash(narrative.as_bytes());
     let dups = find_hash_duplicates(&conn, "test-project", &content_hash, 900)?;
+
+    assert_eq!(dups.len(), 1);
+    Ok(())
+}
+
+#[test]
+fn test_hash_dedup_accepts_legacy_fnv_hash() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_dedup_schema(&conn)?;
+
+    let narrative = "Fixed authentication bug in login flow";
+    insert_observation(&conn, "test-project", narrative)?;
+
+    let legacy_hash = crate::db::legacy_content_identity_hash(narrative.as_bytes());
+    let dups = find_hash_duplicates(&conn, "test-project", &legacy_hash, 900)?;
 
     assert_eq!(dups.len(), 1);
     Ok(())

--- a/src/memory/raw_archive.rs
+++ b/src/memory/raw_archive.rs
@@ -4,7 +4,7 @@
 //! Spec: SPEC-raw-archive-vs-curated-memory-2026-04-22.md
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 pub const ROLE_USER: &str = "user";
 pub const ROLE_ASSISTANT: &str = "assistant";
@@ -30,7 +30,11 @@ pub struct RawMessage {
 /// `memory::promote::slug::content_hash`, which normalizes whitespace/case for
 /// semantic dedup of curated memories.
 fn exact_content_hash(content: &str) -> String {
-    format!("{:016x}", crate::db::deterministic_hash(content.as_bytes()))
+    crate::db::content_identity_hash(content.as_bytes())
+}
+
+fn legacy_exact_content_hash(content: &str) -> String {
+    crate::db::legacy_content_identity_hash(content.as_bytes())
 }
 
 /// Insert one raw message. UNIQUE(project, session_id, role, content_hash)
@@ -106,6 +110,12 @@ pub fn insert_raw_message(
         return Ok(None);
     }
     let hash = exact_content_hash(trimmed);
+    if let Some(id) = find_matching_legacy_raw_message(conn, session_id, project, role, trimmed)? {
+        return Ok(Some(RawInsertOutcome {
+            id,
+            inserted: false,
+        }));
+    }
     let now = chrono::Utc::now().timestamp();
 
     let inserted = conn.execute(
@@ -132,6 +142,33 @@ pub fn insert_raw_message(
             id: existing,
             inserted: false,
         }))
+    }
+}
+
+fn find_matching_legacy_raw_message(
+    conn: &Connection,
+    session_id: &str,
+    project: &str,
+    role: &str,
+    content: &str,
+) -> Result<Option<i64>> {
+    let legacy_hash = legacy_exact_content_hash(content);
+    let Some((id, stored_content)) = conn
+        .query_row(
+            "SELECT id, content FROM raw_messages
+             WHERE project = ?1 AND session_id = ?2 AND role = ?3 AND content_hash = ?4",
+            params![project, session_id, role, legacy_hash],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?
+    else {
+        return Ok(None);
+    };
+
+    if stored_content == content {
+        Ok(Some(id))
+    } else {
+        Ok(None)
     }
 }
 
@@ -373,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_is_idempotent_per_session_role_content() {
+    fn insert_is_idempotent_per_session_role_content() -> Result<()> {
         let conn = setup_conn();
         let id1 = insert_raw_message(
             &conn,
@@ -384,9 +421,8 @@ mod tests {
             SOURCE_HOOK,
             None,
             None,
-        )
-        .unwrap()
-        .expect("first insert returns Some");
+        )?
+        .ok_or_else(|| anyhow::anyhow!("first insert returned None"))?;
         // Same session + same text => deduped onto the existing row.
         let id2 = insert_raw_message(
             &conn,
@@ -397,16 +433,92 @@ mod tests {
             SOURCE_HOOK,
             None,
             None,
-        )
-        .unwrap()
-        .expect("second insert returns Some");
+        )?
+        .ok_or_else(|| anyhow::anyhow!("second insert returned None"))?;
         assert_eq!(id1.id, id2.id);
         assert!(id1.inserted, "first call must mark inserted");
         assert!(!id2.inserted, "second call must mark not-inserted");
-        let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))
-            .unwrap();
+        let count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))?;
         assert_eq!(count, 1);
+        let stored_hash: String = conn.query_row(
+            "SELECT content_hash FROM raw_messages WHERE id = ?1",
+            params![id1.id],
+            |row| row.get(0),
+        )?;
+        assert!(stored_hash.starts_with("sha256:content-v1:"));
+        assert_eq!(stored_hash.len(), "sha256:content-v1:".len() + 64);
+        Ok(())
+    }
+
+    #[test]
+    fn insert_reuses_matching_legacy_content_hash() -> Result<()> {
+        let conn = setup_conn();
+        let content = "legacy exact raw message";
+        let legacy_hash = legacy_exact_content_hash(content);
+        conn.execute(
+            "INSERT INTO raw_messages
+             (session_id, project, role, content, content_hash, source, branch, cwd, created_at_epoch)
+             VALUES ('s1', '/proj', ?1, ?2, ?3, ?4, NULL, NULL, 100)",
+            params![ROLE_USER, content, legacy_hash, SOURCE_HOOK],
+        )?;
+        let legacy_id = conn.last_insert_rowid();
+
+        let outcome = insert_raw_message(
+            &conn,
+            "s1",
+            "/proj",
+            ROLE_USER,
+            content,
+            SOURCE_HOOK,
+            None,
+            None,
+        )?
+        .ok_or_else(|| anyhow::anyhow!("non-empty content returned None"))?;
+        let count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))?;
+
+        assert_eq!(outcome.id, legacy_id);
+        assert!(!outcome.inserted);
+        assert_eq!(count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn insert_does_not_reuse_mismatched_legacy_content_hash() -> Result<()> {
+        let conn = setup_conn();
+        let content = "target raw content";
+        let legacy_hash = legacy_exact_content_hash(content);
+        conn.execute(
+            "INSERT INTO raw_messages
+             (session_id, project, role, content, content_hash, source, branch, cwd, created_at_epoch)
+             VALUES ('s1', '/proj', ?1, 'different raw content', ?2, ?3, NULL, NULL, 100)",
+            params![ROLE_USER, legacy_hash, SOURCE_HOOK],
+        )?;
+
+        let outcome = insert_raw_message(
+            &conn,
+            "s1",
+            "/proj",
+            ROLE_USER,
+            content,
+            SOURCE_HOOK,
+            None,
+            None,
+        )?
+        .ok_or_else(|| anyhow::anyhow!("non-empty content returned None"))?;
+        let count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM raw_messages", [], |row| row.get(0))?;
+        let stored_hash: String = conn.query_row(
+            "SELECT content_hash FROM raw_messages WHERE id = ?1",
+            params![outcome.id],
+            |row| row.get(0),
+        )?;
+
+        assert!(outcome.inserted);
+        assert_eq!(count, 2);
+        assert!(stored_hash.starts_with("sha256:content-v1:"));
+        Ok(())
     }
 
     /// Regression for #237: the same text spoken in two different sessions must

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,3 +1,4 @@
+mod content_identity;
 mod dry_run;
 mod run;
 mod schema_drift;
@@ -6,6 +7,8 @@ mod state;
 mod tests;
 #[cfg(test)]
 mod tests_compression_provenance;
+#[cfg(test)]
+mod tests_content_identity;
 #[cfg(test)]
 mod tests_convergence;
 #[cfg(test)]

--- a/src/migrate/content_identity.rs
+++ b/src/migrate/content_identity.rs
@@ -1,0 +1,225 @@
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+pub(super) fn backfill_content_identity_hashes(conn: &Connection) -> Result<()> {
+    let raw_updates =
+        backfill_raw_messages(conn).context("backfill raw_messages content hashes")?;
+    let blob_updates = backfill_event_blobs(conn).context("backfill event_blobs content hashes")?;
+    let capture_updates =
+        backfill_captured_events(conn).context("backfill captured_events content hashes")?;
+    crate::log::info(
+        "migrate",
+        &format!(
+            "backfilled content identity hashes: raw_messages={raw_updates} event_blobs={blob_updates} captured_events={capture_updates}"
+        ),
+    );
+    Ok(())
+}
+
+fn backfill_raw_messages(conn: &Connection) -> Result<usize> {
+    let ids = row_ids(conn, "raw_messages")?;
+    let mut changed = 0;
+
+    for id in ids {
+        let Some((project, session_id, role, content, current_hash)) = conn
+            .query_row(
+                "SELECT project, session_id, role, content, content_hash
+                 FROM raw_messages WHERE id = ?1",
+                params![id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                    ))
+                },
+            )
+            .optional()?
+        else {
+            continue;
+        };
+        let next_hash = crate::db::content_identity_hash(content.as_bytes());
+        if current_hash == next_hash {
+            continue;
+        }
+
+        if let Some((existing_id, existing_content)) = conn
+            .query_row(
+                "SELECT id, content FROM raw_messages
+                 WHERE project = ?1 AND session_id = ?2 AND role = ?3
+                   AND content_hash = ?4 AND id != ?5",
+                params![project, session_id, role, next_hash, id],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?
+        {
+            if existing_content != content {
+                bail!(
+                    "sha256 content identity collision in raw_messages: ids {id} and {existing_id}"
+                );
+            }
+            if existing_id < id {
+                conn.execute("DELETE FROM raw_messages WHERE id = ?1", params![id])?;
+            } else {
+                conn.execute(
+                    "DELETE FROM raw_messages WHERE id = ?1",
+                    params![existing_id],
+                )?;
+                conn.execute(
+                    "UPDATE raw_messages SET content_hash = ?1 WHERE id = ?2",
+                    params![next_hash, id],
+                )?;
+            }
+            changed += 1;
+            continue;
+        }
+
+        conn.execute(
+            "UPDATE raw_messages SET content_hash = ?1 WHERE id = ?2",
+            params![next_hash, id],
+        )?;
+        changed += 1;
+    }
+
+    Ok(changed)
+}
+
+fn backfill_event_blobs(conn: &Connection) -> Result<usize> {
+    let ids = row_ids(conn, "event_blobs")?;
+    let mut changed = 0;
+
+    for id in ids {
+        let Some((current_hash, encoding, bytes)) = conn
+            .query_row(
+                "SELECT content_hash, content_encoding, content_bytes
+                 FROM event_blobs WHERE id = ?1",
+                params![id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Vec<u8>>(2)?,
+                    ))
+                },
+            )
+            .optional()?
+        else {
+            continue;
+        };
+        let next_hash = crate::db::content_identity_hash(&bytes);
+        if current_hash == next_hash {
+            continue;
+        }
+
+        if let Some((existing_id, existing_encoding, existing_bytes)) = conn
+            .query_row(
+                "SELECT id, content_encoding, content_bytes
+                 FROM event_blobs WHERE content_hash = ?1 AND id != ?2",
+                params![next_hash, id],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Vec<u8>>(2)?,
+                    ))
+                },
+            )
+            .optional()?
+        {
+            if existing_encoding != encoding || existing_bytes != bytes {
+                bail!(
+                    "sha256 content identity collision in event_blobs: ids {id} and {existing_id}"
+                );
+            }
+            if existing_id < id {
+                conn.execute(
+                    "UPDATE captured_events SET content_blob_id = ?1 WHERE content_blob_id = ?2",
+                    params![existing_id, id],
+                )?;
+                conn.execute("DELETE FROM event_blobs WHERE id = ?1", params![id])?;
+            } else {
+                conn.execute(
+                    "UPDATE captured_events SET content_blob_id = ?1 WHERE content_blob_id = ?2",
+                    params![id, existing_id],
+                )?;
+                conn.execute(
+                    "DELETE FROM event_blobs WHERE id = ?1",
+                    params![existing_id],
+                )?;
+                conn.execute(
+                    "UPDATE event_blobs SET content_hash = ?1 WHERE id = ?2",
+                    params![next_hash, id],
+                )?;
+            }
+            changed += 1;
+            continue;
+        }
+
+        conn.execute(
+            "UPDATE event_blobs SET content_hash = ?1 WHERE id = ?2",
+            params![next_hash, id],
+        )?;
+        changed += 1;
+    }
+
+    Ok(changed)
+}
+
+fn backfill_captured_events(conn: &Connection) -> Result<usize> {
+    let ids = row_ids(conn, "captured_events")?;
+    let mut changed = 0;
+
+    for id in ids {
+        let (current_hash, content_text, content_blob_id): (String, Option<String>, Option<i64>) =
+            conn.query_row(
+                "SELECT content_hash, content_text, content_blob_id
+                 FROM captured_events WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
+        let content_bytes = if let Some(blob_id) = content_blob_id {
+            conn.query_row(
+                "SELECT content_bytes FROM event_blobs WHERE id = ?1",
+                params![blob_id],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .with_context(|| {
+                format!("captured_events.id={id} references missing event_blobs.id={blob_id}")
+            })?
+        } else if let Some(content) = content_text {
+            content.into_bytes()
+        } else {
+            bail!("captured_events.id={id} has neither content_text nor content_blob_id");
+        };
+        let next_hash = crate::db::content_identity_hash(&content_bytes);
+        if current_hash == next_hash {
+            continue;
+        }
+
+        conn.execute(
+            "UPDATE captured_events SET content_hash = ?1 WHERE id = ?2",
+            params![next_hash, id],
+        )?;
+        changed += 1;
+    }
+
+    Ok(changed)
+}
+
+fn row_ids(conn: &Connection, table: &str) -> Result<Vec<i64>> {
+    let sql = match table {
+        "raw_messages" => "SELECT id FROM raw_messages ORDER BY id",
+        "event_blobs" => "SELECT id FROM event_blobs ORDER BY id",
+        "captured_events" => "SELECT id FROM captured_events ORDER BY id",
+        _ => bail!("unsupported content identity backfill table: {table}"),
+    };
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+    let mut ids = Vec::new();
+    for row in rows {
+        ids.push(row?);
+    }
+    Ok(ids)
+}

--- a/src/migrate/run.rs
+++ b/src/migrate/run.rs
@@ -142,5 +142,10 @@ pub(super) fn run_post_migration_hook(conn: &Connection, version: i64, name: &st
             format!("migration v{version:03}_{name} failed to install graph edge cleanup triggers")
         })?;
     }
+    if version == 41 {
+        super::content_identity::backfill_content_identity_hashes(conn).with_context(|| {
+            format!("migration v{version:03}_{name} failed to backfill content identity hashes")
+        })?;
+    }
     Ok(())
 }

--- a/src/migrate/tests_content_identity.rs
+++ b/src/migrate/tests_content_identity.rs
@@ -1,0 +1,204 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use super::{run_migrations, MIGRATIONS};
+
+fn setup_v040_db() -> Result<Connection> {
+    let conn = Connection::open_in_memory()?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= 40)
+    {
+        conn.execute_batch(migration.sql)?;
+    }
+    conn.execute_batch(
+        "CREATE TABLE _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_epoch INTEGER NOT NULL
+        );",
+    )?;
+    for migration in MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= 40)
+    {
+        conn.execute(
+            "INSERT INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, ?2, ?3)",
+            params![migration.version, migration.name, 1_700_000_000_i64],
+        )?;
+    }
+    Ok(conn)
+}
+
+#[test]
+fn content_identity_migration_backfills_legacy_hashes() -> Result<()> {
+    let conn = setup_v040_db()?;
+    let raw_content = "legacy searchable raw message";
+    conn.execute(
+        "INSERT INTO raw_messages
+         (session_id, project, role, content, content_hash, source, created_at_epoch)
+         VALUES ('session-a', '/tmp/remem-content-id', 'user', ?1, ?2, 'hook', 100)",
+        params![
+            raw_content,
+            crate::db::legacy_content_identity_hash(raw_content.as_bytes())
+        ],
+    )?;
+
+    let now = 1_700_000_000_i64;
+    let host_id: i64 =
+        conn.query_row("SELECT id FROM hosts WHERE name = 'codex-cli'", [], |row| {
+            row.get(0)
+        })?;
+    conn.execute(
+        "INSERT INTO workspaces(root_path, created_at_epoch, updated_at_epoch)
+         VALUES ('/tmp/remem-content-id', ?1, ?1)",
+        [now],
+    )?;
+    let workspace_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO projects(workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
+         VALUES (?1, '/tmp/remem-content-id', 'tmp-remem-content-id', ?2, ?2)",
+        params![workspace_id, now],
+    )?;
+    let project_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO sessions(host_id, workspace_id, project_id, session_id, last_seen_at_epoch, status)
+         VALUES (?1, ?2, ?3, 'session-a', ?4, 'active')",
+        params![host_id, workspace_id, project_id, now],
+    )?;
+    let session_row_id = conn.last_insert_rowid();
+
+    let inline_content = "legacy inline captured content";
+    conn.execute(
+        "INSERT INTO captured_events
+         (host_id, workspace_id, project_id, session_row_id, session_id, event_id,
+          event_type, content_text, content_hash, token_estimate, retention_class,
+          created_at_epoch, inserted_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, 'session-a', 'inline-event', 'message',
+                 ?5, ?6, 1, 'raw_keep', ?7, ?7)",
+        params![
+            host_id,
+            workspace_id,
+            project_id,
+            session_row_id,
+            inline_content,
+            crate::db::legacy_content_identity_hash(inline_content.as_bytes()),
+            now
+        ],
+    )?;
+
+    let blob_bytes = b"legacy full blob bytes for v041";
+    conn.execute(
+        "INSERT INTO event_blobs
+         (content_hash, content_encoding, content_bytes, original_bytes, stored_bytes, created_at_epoch)
+         VALUES (?1, 'plain', ?2, ?3, ?3, ?4)",
+        params![
+            crate::db::legacy_content_identity_hash(blob_bytes),
+            blob_bytes,
+            blob_bytes.len() as i64,
+            now
+        ],
+    )?;
+    let blob_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO captured_events
+         (host_id, workspace_id, project_id, session_row_id, session_id, event_id,
+          event_type, content_text, content_blob_id, content_hash, token_estimate,
+          retention_class, created_at_epoch, inserted_at_epoch)
+         VALUES (?1, ?2, ?3, ?4, 'session-a', 'blob-event', 'tool_result',
+                 'compact preview should not be hashed', ?5, ?6, 10, 'raw_compact', ?7, ?7)",
+        params![
+            host_id,
+            workspace_id,
+            project_id,
+            session_row_id,
+            blob_id,
+            crate::db::legacy_content_identity_hash(blob_bytes),
+            now
+        ],
+    )?;
+
+    run_migrations(&conn)?;
+
+    let raw_hash: String = conn.query_row("SELECT content_hash FROM raw_messages", [], |row| {
+        row.get(0)
+    })?;
+    let blob_hash: String =
+        conn.query_row("SELECT content_hash FROM event_blobs", [], |row| row.get(0))?;
+    let inline_hash: String = conn.query_row(
+        "SELECT content_hash FROM captured_events WHERE event_id = 'inline-event'",
+        [],
+        |row| row.get(0),
+    )?;
+    let blob_event_hash: String = conn.query_row(
+        "SELECT content_hash FROM captured_events WHERE event_id = 'blob-event'",
+        [],
+        |row| row.get(0),
+    )?;
+    let fts_hits: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM raw_messages_fts WHERE raw_messages_fts MATCH 'searchable'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(
+        raw_hash,
+        crate::db::content_identity_hash(raw_content.as_bytes())
+    );
+    assert_eq!(blob_hash, crate::db::content_identity_hash(blob_bytes));
+    assert_eq!(
+        inline_hash,
+        crate::db::content_identity_hash(inline_content.as_bytes())
+    );
+    assert_eq!(
+        blob_event_hash,
+        crate::db::content_identity_hash(blob_bytes)
+    );
+    assert_eq!(fts_hits, 1);
+    Ok(())
+}
+
+#[test]
+fn content_identity_migration_collapses_mixed_raw_duplicates() -> Result<()> {
+    let conn = setup_v040_db()?;
+    let content = "mixed legacy and sha duplicate raw message";
+    let legacy_hash = crate::db::legacy_content_identity_hash(content.as_bytes());
+    let sha_hash = crate::db::content_identity_hash(content.as_bytes());
+
+    conn.execute(
+        "INSERT INTO raw_messages
+         (id, session_id, project, role, content, content_hash, source, created_at_epoch)
+         VALUES (1, 'session-a', '/tmp/remem-content-id', 'user', ?1, ?2, 'hook', 100)",
+        params![content, legacy_hash],
+    )?;
+    conn.execute(
+        "INSERT INTO raw_messages
+         (id, session_id, project, role, content, content_hash, source, created_at_epoch)
+         VALUES (2, 'session-a', '/tmp/remem-content-id', 'user', ?1, ?2, 'hook', 101)",
+        params![content, sha_hash],
+    )?;
+
+    run_migrations(&conn)?;
+
+    let rows: Vec<(i64, String)> = {
+        let mut stmt = conn.prepare("SELECT id, content_hash FROM raw_messages ORDER BY id")?;
+        let mapped = stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        let mut rows = Vec::new();
+        for row in mapped {
+            rows.push(row?);
+        }
+        rows
+    };
+    let fts_hits: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM raw_messages_fts WHERE raw_messages_fts MATCH 'duplicate'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(rows, vec![(1, sha_hash)]);
+    assert_eq!(fts_hits, 1);
+    Ok(())
+}

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -205,6 +205,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "memory_fact_invalidations",
         sql: include_str!("../migrations/v040_memory_fact_invalidations.sql"),
     },
+    Migration {
+        version: 41,
+        name: "content_identity_sha256",
+        sql: include_str!("../migrations/v041_content_identity_sha256.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v041_content_identity_sha256.sql
+++ b/src/migrations/v041_content_identity_sha256.sql
@@ -1,0 +1,6 @@
+-- v041_content_identity_sha256: migrate durable content identity hashes from
+-- legacy unversioned FNV64 to sha256:content-v1:<hex>.
+--
+-- SQLite has no built-in SHA-256 helper in this binary, so the actual data
+-- backfill runs in the Rust post-migration hook for v041.
+SELECT 1;


### PR DESCRIPTION
## Summary
- add versioned `sha256:content-v1:<hex>` content identity helpers while keeping FNV64 as a legacy helper
- write SHA content identity for new capture blobs/events and raw archive rows, with byte/content-checked legacy FNV compatibility reads
- add v041 Rust post-migration backfill for raw_messages, event_blobs, and captured_events plus mixed legacy/SHA duplicate coverage
- bump package/plugin/npm release metadata to 0.5.65

Fixes #469

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- independent threads review lane: Sagan found one migration edge case; fixed with `content_identity_migration_collapses_mixed_raw_duplicates`; follow-up review reported no blocking findings
