### PR TITLE
Harden release preflight and promotion doctor checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,25 @@ permissions:
   contents: write
 
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check release secrets
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          missing=0
+          for name in CRATES_IO_TOKEN NPM_TOKEN; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing required release secret: ${name}"
+              missing=1
+            fi
+          done
+          exit "$missing"
+
   build:
+    needs: preflight
     strategy:
       matrix:
         include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.65"
+version = "0.5.66"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.65"
+version = "0.5.66"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.65",
+  "version": "0.5.66",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.65",
+  "version": "0.5.66",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.65": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.65",
+    "0.5.66": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.66",
       "assets": {}
     }
   }

--- a/src/doctor/database.rs
+++ b/src/doctor/database.rs
@@ -349,6 +349,17 @@ pub(super) fn check_promotion_funnel(conn: Option<&Connection>) -> Check {
             Status::Warn,
             format!("{detail}; promotion is not producing candidates"),
         )
+    } else if stats.total_memory_candidates > 0
+        && stats.promoted_memory_candidates == 0
+        && stats.pending_review_memory_candidates == stats.total_memory_candidates
+    {
+        Check::new(
+            "Promotion funnel",
+            Status::Warn,
+            format!(
+                "{detail}; candidates are all pending review, so automatic capture is not producing usable memories"
+            ),
+        )
     } else {
         Check::new("Promotion funnel", Status::Ok, detail)
     }
@@ -595,6 +606,43 @@ mod tests {
         assert!(check
             .detail
             .contains("promotion is not producing candidates"));
+        Ok(())
+    }
+
+    #[test]
+    fn promotion_funnel_warns_when_all_candidates_stay_pending_review() -> anyhow::Result<()> {
+        let conn = setup_conn()?;
+        record_capture(&conn)?;
+        crate::db::insert_observation(
+            &conn,
+            "sess-doctor",
+            "/tmp/remem-doctor",
+            "feature",
+            Some("observed feature"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            1,
+        )?;
+        conn.execute(
+            "INSERT INTO memory_candidates
+             (scope, memory_type, topic_key, text, evidence_event_ids, confidence,
+              risk_class, review_status, created_at_epoch, updated_at_epoch)
+             VALUES ('project', 'decision', 'doctor-promotion',
+                     'Doctor should flag stalled candidate review.', '[1]', 0.9,
+                     'low', 'pending_review', 1, 1)",
+            [],
+        )?;
+
+        let check = check_promotion_funnel(Some(&conn));
+
+        assert!(matches!(check.status, Status::Warn));
+        assert!(check.detail.contains("candidates=1"));
+        assert!(check.detail.contains("candidates are all pending review"));
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- add a tag-release preflight job that fails before build/release/publish when required publishing secrets are missing
- warn in doctor when promotion candidates exist but every candidate is still pending review and nothing has been promoted
- cover the all-pending promotion funnel with a regression test
- bump the next binary version metadata to 0.5.66 for this source change

## Issues

Closes #475
Closes #476

## Verification

- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/ci/check_plugin_version_sync.py --expected-version 0.5.66`
- `python3 scripts/ci/check_version_bump.py 9c8e1289689d77bd76c3440c651c673aeb0099f5 HEAD`
- `node --test npm/remem/scripts/install.test.js`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parsed"'`\n- `cargo check`\n- `cargo clippy -- -D warnings`\n- `cargo test`\n