### PR TITLE
Respect invalidated temporal facts in current reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.66"
+version = "0.5.67"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.66"
+version = "0.5.67"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/docs/temporal-facts.md
+++ b/docs/temporal-facts.md
@@ -16,6 +16,7 @@ Migration `v013_memory_temporal_facts` creates `memory_facts`:
 | `object` | Relation target, stored as text so it can point to commands, files, issues, PRs, or memory ids. |
 | `valid_from_epoch` / `valid_to_epoch` | Validity interval for the fact. `valid_to_epoch` is exclusive. |
 | `learned_at_epoch` | When remem learned the fact; separate from validity time. |
+| `invalidated_at_epoch` | Transaction time when remem learned the fact stopped being current. `NULL` means still current. |
 | `source_memory_id` | Optional link to the durable memory that produced the fact. |
 | `source_observation_id` | Optional link to the observation that produced the fact. |
 | `source_event_ids` | JSON array of raw `captured_events` ids. |
@@ -26,9 +27,10 @@ Migration `v013_memory_temporal_facts` creates `memory_facts`:
 ## Query Path
 
 Current-fact queries filter by project, optional subject, optional predicate,
-`status='active'`, and the current validity interval. Historical queries use
-`list_facts_as_of(project, as_of_epoch, ...)` and include stale rows when their
-validity interval covered the requested time.
+`status='active'`, `invalidated_at_epoch IS NULL`, and the current validity
+interval. Historical queries use `list_facts_as_of(project, as_of_epoch, ...)`
+and include rows only when remem had learned them and had not invalidated them
+at the requested transaction time.
 
 This split is intentional:
 
@@ -44,7 +46,8 @@ Inserting a fact with `supersedes_fact_id` performs one transaction:
 2. mark the old fact `stale`
 3. set the old `valid_to_epoch` to the replacement's `valid_from_epoch`, or to
    `learned_at_epoch` when validity is unknown
-4. insert the replacement as `active`
+4. set the old `invalidated_at_epoch` to the transaction time
+5. insert the replacement as `active`
 
 The old fact is preserved rather than deleted. This mirrors the memory lifecycle
 rule that invalidation is a soft state transition unless a future privacy or

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.66",
+  "version": "0.5.67",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.66",
+  "version": "0.5.67",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.66": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.66",
+    "0.5.67": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.67",
       "assets": {}
     }
   }

--- a/src/context/hybrid_context.rs
+++ b/src/context/hybrid_context.rs
@@ -357,7 +357,13 @@ fn query_local_temporal_channel(
         return Ok(vec![]);
     };
     let has_memory_facts = sqlite_table_available(conn, "memory_facts")?;
-    let (temporal_condition, order_epoch) = local_temporal_sql(constraint.field, has_memory_facts);
+    let has_memory_fact_invalidations =
+        has_memory_facts && crate::memory::facts::invalidated_at_epoch_available(conn)?;
+    let (temporal_condition, order_epoch) = local_temporal_sql(
+        constraint.field,
+        has_memory_facts,
+        has_memory_fact_invalidations,
+    );
     let mut conditions = vec![temporal_condition];
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
         Box::new(constraint.start_epoch),
@@ -559,6 +565,7 @@ fn table_ref(alias: &str) -> &str {
 fn local_temporal_sql(
     field: crate::retrieval::temporal::TemporalField,
     has_memory_facts: bool,
+    has_memory_fact_invalidations: bool,
 ) -> (String, String) {
     match field {
         crate::retrieval::temporal::TemporalField::UpdatedAt => (
@@ -566,14 +573,20 @@ fn local_temporal_sql(
             "m.updated_at_epoch".to_string(),
         ),
         crate::retrieval::temporal::TemporalField::EventTime if has_memory_facts => {
-            let fact_event_overlap = "f.source_memory_id = m.id \
-                 AND f.status = 'active' \
+            let current_fact_filter =
+                crate::memory::facts::current_fact_filter_sql("f", has_memory_fact_invalidations);
+            let fact_event_overlap = format!(
+                "f.source_memory_id = m.id \
+                 AND {current_fact_filter} \
                  AND f.valid_from_epoch IS NOT NULL \
                  AND f.valid_from_epoch <= ?2 \
-                 AND (f.valid_to_epoch IS NULL OR f.valid_to_epoch > ?1)";
-            let any_fact_event = "f.source_memory_id = m.id \
-                 AND f.status = 'active' \
-                 AND f.valid_from_epoch IS NOT NULL";
+                 AND (f.valid_to_epoch IS NULL OR f.valid_to_epoch > ?1)"
+            );
+            let any_fact_event = format!(
+                "f.source_memory_id = m.id \
+                 AND {current_fact_filter} \
+                 AND f.valid_from_epoch IS NOT NULL"
+            );
             (
                 format!(
                     "(EXISTS (

--- a/src/db/query/stats.rs
+++ b/src/db/query/stats.rs
@@ -284,20 +284,23 @@ pub fn query_memory_facts_stats(conn: &Connection) -> Result<MemoryFactsStats> {
         0
     };
     let retrieval_eligible = if memory_facts_exists && memories_exists {
-        conn.query_row(
+        let fact_current_filter = crate::memory::facts::current_fact_filter_sql(
+            "f",
+            crate::memory::facts::invalidated_at_epoch_available(conn)?,
+        );
+        let sql = format!(
             "SELECT COUNT(*)
              FROM memory_facts f
              JOIN memories m ON m.id = f.source_memory_id
-             WHERE f.status = 'active'
+             WHERE {fact_current_filter}
                AND f.valid_from_epoch IS NOT NULL
                AND m.status = 'active'
                AND (
                  m.expires_at_epoch IS NULL
                  OR m.expires_at_epoch > CAST(strftime('%s', 'now') AS INTEGER)
-               )",
-            [],
-            |row| row.get(0),
-        )?
+               )"
+        );
+        conn.query_row(&sql, [], |row| row.get(0))?
     } else {
         0
     };

--- a/src/db/query/stats/tests.rs
+++ b/src/db/query/stats/tests.rs
@@ -405,6 +405,29 @@ fn query_memory_facts_stats_excludes_expired_source_memories() -> anyhow::Result
 }
 
 #[test]
+fn query_memory_facts_stats_excludes_invalidated_active_facts() -> anyhow::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_stats_schema(&conn);
+    conn.execute_batch("ALTER TABLE memory_facts ADD COLUMN invalidated_at_epoch INTEGER;")?;
+
+    conn.execute_batch(
+        "INSERT INTO memories (id, project, status, created_at_epoch, expires_at_epoch)
+         VALUES (1, 'alpha', 'active', 100, NULL);
+         INSERT INTO memory_facts
+            (status, valid_from_epoch, source_memory_id, invalidated_at_epoch)
+         VALUES
+            ('active', 100, 1, NULL),
+            ('active', 100, 1, 150);",
+    )?;
+
+    let stats = query_memory_facts_stats(&conn)?;
+
+    assert_eq!(stats.total, 2);
+    assert_eq!(stats.retrieval_eligible, 1);
+    Ok(())
+}
+
+#[test]
 fn query_system_stats_reports_daemon_heartbeat_not_once() -> anyhow::Result<()> {
     let conn = Connection::open_in_memory()?;
     setup_stats_schema(&conn);

--- a/src/memory/current_state.rs
+++ b/src/memory/current_state.rs
@@ -559,6 +559,7 @@ fn load_facts_for_memory(
     let mut conditions = vec!["source_memory_id = ?1".to_string()];
     let mut params_vec: Vec<Box<dyn ToSql>> = vec![Box::new(memory_id)];
     let mut idx = 2;
+    let has_invalidated_at_epoch = crate::memory::facts::invalidated_at_epoch_available(conn)?;
     let effective_epoch = as_of_epoch.unwrap_or_else(|| chrono::Utc::now().timestamp());
     conditions.push(format!(
         "(valid_from_epoch IS NULL OR valid_from_epoch <= ?{idx})"
@@ -570,11 +571,19 @@ fn load_facts_for_memory(
     idx += 1;
     if let Some(as_of_epoch) = as_of_epoch {
         conditions.push(format!("learned_at_epoch <= ?{idx}"));
+        if has_invalidated_at_epoch {
+            conditions.push(format!(
+                "(invalidated_at_epoch IS NULL OR invalidated_at_epoch > ?{idx})"
+            ));
+        }
         params_vec.push(Box::new(as_of_epoch));
         idx += 1;
     }
     if as_of_epoch.is_none() {
-        conditions.push("status = 'active'".to_string());
+        conditions.push(crate::memory::facts::current_fact_filter_sql(
+            "",
+            has_invalidated_at_epoch,
+        ));
     }
 
     let sql = format!(

--- a/src/memory/current_state/tests.rs
+++ b/src/memory/current_state/tests.rs
@@ -763,3 +763,61 @@ fn as_of_facts_exclude_facts_learned_after_cutoff() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn current_facts_exclude_invalidated_rows_even_when_status_is_active() -> Result<()> {
+    let conn = current_state_test_conn()?;
+    insert_state_key(&conn)?;
+    insert_current_state_memory_at(
+        &conn,
+        2,
+        "/repo",
+        "Deploy target",
+        "Use production.",
+        "active",
+        10,
+        100,
+        Some(100),
+        None,
+    )?;
+    set_current_memory(&conn, 2)?;
+    conn.execute(
+        "INSERT INTO memory_facts
+         (id, project, subject, predicate, object, valid_from_epoch,
+          valid_to_epoch, learned_at_epoch, source_memory_id, source_event_ids,
+          confidence, status, invalidated_at_epoch, created_at_epoch, updated_at_epoch)
+         VALUES
+          (1, '/repo', 'deploy-target', 'affects_project', 'staging', 100,
+           NULL, 110, 2, '[]', 0.9, 'active', 150, 110, 150),
+          (2, '/repo', 'deploy-target', 'affects_project', 'production', 160,
+           NULL, 160, 2, '[]', 0.9, 'active', NULL, 160, 160)",
+        [],
+    )?;
+
+    let current = current_state(&conn, &request())?;
+    assert_eq!(
+        current
+            .facts
+            .iter()
+            .map(|fact| fact.object.as_str())
+            .collect::<Vec<_>>(),
+        vec!["production"]
+    );
+
+    let before_invalidation = current_state(
+        &conn,
+        &CurrentStateRequest {
+            as_of_epoch: Some(120),
+            ..request()
+        },
+    )?;
+    assert_eq!(
+        before_invalidation
+            .facts
+            .iter()
+            .map(|fact| fact.object.as_str())
+            .collect::<Vec<_>>(),
+        vec!["staging"]
+    );
+    Ok(())
+}

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -73,6 +73,32 @@ pub struct TemporalFact {
     pub status: String,
 }
 
+pub(crate) fn invalidated_at_epoch_available(conn: &Connection) -> Result<bool> {
+    let exists: i64 = conn.query_row(
+        "SELECT EXISTS (
+             SELECT 1 FROM pragma_table_info('memory_facts')
+             WHERE name = 'invalidated_at_epoch'
+         )",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(exists != 0)
+}
+
+pub(crate) fn current_fact_filter_sql(alias: &str, has_invalidated_at_epoch: bool) -> String {
+    let alias = alias.trim();
+    let prefix = if alias.is_empty() {
+        String::new()
+    } else {
+        format!("{alias}.")
+    };
+    if has_invalidated_at_epoch {
+        format!("{prefix}status = 'active' AND {prefix}invalidated_at_epoch IS NULL")
+    } else {
+        format!("{prefix}status = 'active'")
+    }
+}
+
 pub fn insert_temporal_fact(conn: &mut Connection, input: &TemporalFactInput<'_>) -> Result<i64> {
     validate_input(input)?;
     let now = chrono::Utc::now().timestamp();
@@ -186,6 +212,7 @@ fn query_facts(
     as_of_epoch: Option<i64>,
     active_only: bool,
 ) -> Result<Vec<TemporalFact>> {
+    let has_invalidated_at_epoch = invalidated_at_epoch_available(conn)?;
     let mut conditions = vec!["project = ?1".to_string()];
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(project.to_string())];
     let mut idx = 2;
@@ -206,10 +233,16 @@ fn query_facts(
         conditions.push(format!(
             "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx})"
         ));
+        conditions.push(format!("learned_at_epoch <= ?{idx}"));
+        if has_invalidated_at_epoch {
+            conditions.push(format!(
+                "(invalidated_at_epoch IS NULL OR invalidated_at_epoch > ?{idx})"
+            ));
+        }
         params.push(Box::new(as_of_epoch));
     }
     if active_only {
-        conditions.push("status = 'active'".to_string());
+        conditions.push(current_fact_filter_sql("", has_invalidated_at_epoch));
     }
 
     let sql = format!(

--- a/src/memory/facts/tests.rs
+++ b/src/memory/facts/tests.rs
@@ -102,6 +102,125 @@ fn supersession_records_transaction_time_invalidation() -> Result<()> {
 }
 
 #[test]
+fn current_queries_exclude_invalidated_active_rows() -> Result<()> {
+    let mut conn = setup_fact_conn()?;
+    let project = "test-temporal-current-invalidated";
+    let old_id = insert_temporal_fact(&mut conn, &input(project, "staging", 100))?;
+    conn.execute(
+        "UPDATE memory_facts
+         SET invalidated_at_epoch = 150
+         WHERE id = ?1",
+        [old_id],
+    )?;
+    let current_id = insert_temporal_fact(&mut conn, &input(project, "production", 200))?;
+
+    let current = list_current_facts(
+        &conn,
+        project,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert_eq!(
+        current.iter().map(|fact| fact.id).collect::<Vec<_>>(),
+        vec![current_id]
+    );
+
+    let before_invalidation = list_facts_as_of(
+        &conn,
+        project,
+        140,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert_eq!(
+        before_invalidation
+            .iter()
+            .map(|fact| fact.id)
+            .collect::<Vec<_>>(),
+        vec![old_id]
+    );
+
+    let after_invalidation_before_replacement = list_facts_as_of(
+        &conn,
+        project,
+        160,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert!(after_invalidation_before_replacement.is_empty());
+    Ok(())
+}
+
+#[test]
+fn supersession_sequence_preserves_all_fact_history_without_hard_deletes() -> Result<()> {
+    let conn = setup_fact_conn()?;
+    let project = "test-temporal-sequence";
+    let mut current_id =
+        insert_temporal_fact_in_current_tx(&conn, &input(project, "target-0", 100), 110)?;
+    let mut expected_total = 1_i64;
+    let mut seed = 0x5eed_u64;
+    let mut valid_from = 100_i64;
+
+    for step in 1..=12_i64 {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        valid_from += 10 + (seed % 17) as i64;
+        let invalidated_at = valid_from + 1_000 + step;
+        let old_id = current_id;
+        let object = format!("target-{step}");
+        let mut replacement = input(project, &object, valid_from);
+        replacement.learned_at_epoch = Some(invalidated_at);
+        replacement.supersedes_fact_id = Some(old_id);
+
+        current_id = insert_temporal_fact_in_current_tx(&conn, &replacement, invalidated_at)?;
+        expected_total += 1;
+
+        let old: (String, Option<i64>, Option<i64>) = conn.query_row(
+            "SELECT status, valid_to_epoch, invalidated_at_epoch
+             FROM memory_facts WHERE id = ?1",
+            [old_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(
+            old,
+            ("stale".to_string(), Some(valid_from), Some(invalidated_at))
+        );
+
+        let row_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memory_facts WHERE project = ?1",
+            [project],
+            |row| row.get(0),
+        )?;
+        assert_eq!(row_count, expected_total);
+    }
+
+    let (active_count, stale_count, invalidated_count): (i64, i64, i64) = conn.query_row(
+        "SELECT
+             SUM(CASE WHEN status = 'active' AND invalidated_at_epoch IS NULL THEN 1 ELSE 0 END),
+             SUM(CASE WHEN status = 'stale' THEN 1 ELSE 0 END),
+             SUM(CASE WHEN invalidated_at_epoch IS NOT NULL THEN 1 ELSE 0 END)
+         FROM memory_facts
+         WHERE project = ?1",
+        [project],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    assert_eq!(active_count, 1);
+    assert_eq!(stale_count, expected_total - 1);
+    assert_eq!(invalidated_count, expected_total - 1);
+
+    let current = list_current_facts(
+        &conn,
+        project,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert_eq!(
+        current.iter().map(|fact| fact.id).collect::<Vec<_>>(),
+        vec![current_id]
+    );
+    Ok(())
+}
+
+#[test]
 fn provenance_links_to_source_memory_and_events() -> Result<()> {
     let mut conn = setup_fact_conn()?;
     let memory_id = crate::memory::insert_memory(

--- a/src/retrieval/temporal/search.rs
+++ b/src/retrieval/temporal/search.rs
@@ -24,7 +24,13 @@ pub fn search_by_time_filtered(
 ) -> Result<Vec<i64>> {
     let mut ids = Vec::new();
     let has_memory_facts = table_exists(conn, "memory_facts")?;
-    let (temporal_condition, order_epoch) = temporal_sql(constraint.field, has_memory_facts);
+    let has_memory_fact_invalidations =
+        has_memory_facts && crate::memory::facts::invalidated_at_epoch_available(conn)?;
+    let (temporal_condition, order_epoch) = temporal_sql(
+        constraint.field,
+        has_memory_facts,
+        has_memory_fact_invalidations,
+    );
     let mut conditions = vec![temporal_condition];
     let mut params_vec: Vec<Box<dyn ToSql>> = vec![
         Box::new(constraint.start_epoch),
@@ -73,21 +79,31 @@ pub fn search_by_time_filtered(
     Ok(ids)
 }
 
-fn temporal_sql(field: TemporalField, has_memory_facts: bool) -> (String, String) {
+fn temporal_sql(
+    field: TemporalField,
+    has_memory_facts: bool,
+    has_memory_fact_invalidations: bool,
+) -> (String, String) {
     match field {
         TemporalField::UpdatedAt => (
             "updated_at_epoch BETWEEN ?1 AND ?2".to_string(),
             "updated_at_epoch".to_string(),
         ),
         TemporalField::EventTime if has_memory_facts => {
-            let fact_event_overlap = "f.source_memory_id = memories.id \
-                 AND f.status = 'active' \
+            let current_fact_filter =
+                crate::memory::facts::current_fact_filter_sql("f", has_memory_fact_invalidations);
+            let fact_event_overlap = format!(
+                "f.source_memory_id = memories.id \
+                 AND {current_fact_filter} \
                  AND f.valid_from_epoch IS NOT NULL \
                  AND f.valid_from_epoch <= ?2 \
-                 AND (f.valid_to_epoch IS NULL OR f.valid_to_epoch > ?1)";
-            let any_fact_event = "f.source_memory_id = memories.id \
-                 AND f.status = 'active' \
-                 AND f.valid_from_epoch IS NOT NULL";
+                 AND (f.valid_to_epoch IS NULL OR f.valid_to_epoch > ?1)"
+            );
+            let any_fact_event = format!(
+                "f.source_memory_id = memories.id \
+                 AND {current_fact_filter} \
+                 AND f.valid_from_epoch IS NOT NULL"
+            );
             (
                 format!(
                     "(EXISTS (

--- a/src/retrieval/temporal/tests.rs
+++ b/src/retrieval/temporal/tests.rs
@@ -392,3 +392,62 @@ fn search_by_time_ignores_stale_temporal_facts() -> Result<()> {
     assert_eq!(created_at_ids, vec![1]);
     Ok(())
 }
+
+#[test]
+fn search_by_time_ignores_invalidated_active_temporal_facts() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    crate::migrate::run_migrations(&conn)?;
+    let now = chrono::Utc::now().timestamp();
+    let invalidated_fact_time = now - 45 * 86_400;
+
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files, created_at_epoch,
+          updated_at_epoch, status, branch, scope)
+         VALUES
+         (1, NULL, 'alpha', NULL, 'current event', 'invalidated fact should not override created_at', 'decision', NULL, ?1, ?1, 'active', 'main', 'project')",
+        rusqlite::params![now],
+    )?;
+    conn.execute(
+        "INSERT INTO memory_facts
+         (project, subject, predicate, object, valid_from_epoch, valid_to_epoch,
+          learned_at_epoch, source_memory_id, source_observation_id, source_event_ids,
+          confidence, supersedes_fact_id, status, invalidated_at_epoch, created_at_epoch,
+          updated_at_epoch)
+         VALUES
+         ('alpha', 'old invalidated fact', 'affects_project', 'alpha', ?1, NULL,
+          ?2, 1, NULL, '[]', 0.9, NULL, 'active', ?2, ?2, ?2)",
+        rusqlite::params![invalidated_fact_time, now - 10],
+    )?;
+
+    let invalidated_fact_ids = search_by_time_filtered(
+        &conn,
+        &TemporalConstraint {
+            start_epoch: invalidated_fact_time - 10,
+            end_epoch: invalidated_fact_time + 10,
+            field: TemporalField::EventTime,
+        },
+        Some("alpha"),
+        Some("decision"),
+        Some("main"),
+        10,
+        false,
+    )?;
+    assert!(invalidated_fact_ids.is_empty());
+
+    let created_at_ids = search_by_time_filtered(
+        &conn,
+        &TemporalConstraint {
+            start_epoch: now - 10,
+            end_epoch: now + 10,
+            field: TemporalField::EventTime,
+        },
+        Some("alpha"),
+        Some("decision"),
+        Some("main"),
+        10,
+        false,
+    )?;
+    assert_eq!(created_at_ids, vec![1]);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- filter current temporal fact reads with `invalidated_at_epoch IS NULL` when the v040 column exists
- preserve historical/as-of reconstruction with learned/invalidation transaction-time bounds
- cover invalidated active rows across fact APIs, temporal retrieval, current-state facts, and stats/doctor eligibility
- add deterministic supersession sequence coverage proving fact rows are preserved rather than hard-deleted
- bump release metadata to 0.5.67

Closes #478

## Verification

- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/ci/check_plugin_version_sync.py --expected-version 0.5.67`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `cargo test invalidated -- --nocapture`
- `cargo test supersession_sequence_preserves_all_fact_history_without_hard_deletes -- --nocapture`
- `cargo test memory::facts::tests -- --nocapture`
- `cargo test retrieval::temporal::tests -- --nocapture`
- `cargo test memory::current_state::tests -- --nocapture`
- `cargo test db::query::stats::tests -- --nocapture`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`

## Review

Independent read-only reviewer: no blocking findings.
