### PR TITLE
Preserve backdated fact history until invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.67"
+version = "0.5.68"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.67"
+version = "0.5.68"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.67",
+  "version": "0.5.68",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.67",
+  "version": "0.5.68",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.67": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.67",
+    "0.5.68": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.68",
       "assets": {}
     }
   }

--- a/src/memory/current_state.rs
+++ b/src/memory/current_state.rs
@@ -564,9 +564,16 @@ fn load_facts_for_memory(
     conditions.push(format!(
         "(valid_from_epoch IS NULL OR valid_from_epoch <= ?{idx})"
     ));
-    conditions.push(format!(
-        "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx})"
-    ));
+    if has_invalidated_at_epoch {
+        conditions.push(format!(
+            "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx} \
+              OR (invalidated_at_epoch IS NOT NULL AND invalidated_at_epoch > ?{idx}))"
+        ));
+    } else {
+        conditions.push(format!(
+            "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx})"
+        ));
+    }
     params_vec.push(Box::new(effective_epoch));
     idx += 1;
     if let Some(as_of_epoch) = as_of_epoch {

--- a/src/memory/current_state/tests.rs
+++ b/src/memory/current_state/tests.rs
@@ -821,3 +821,68 @@ fn current_facts_exclude_invalidated_rows_even_when_status_is_active() -> Result
     );
     Ok(())
 }
+
+#[test]
+fn as_of_facts_keep_backdated_superseded_fact_until_invalidation_time() -> Result<()> {
+    let conn = current_state_test_conn()?;
+    insert_state_key(&conn)?;
+    insert_current_state_memory_at(
+        &conn,
+        2,
+        "/repo",
+        "Deploy target",
+        "Use production.",
+        "active",
+        10,
+        100,
+        Some(100),
+        None,
+    )?;
+    set_current_memory(&conn, 2)?;
+    conn.execute(
+        "INSERT INTO memory_facts
+         (id, project, subject, predicate, object, valid_from_epoch,
+          valid_to_epoch, learned_at_epoch, source_memory_id, source_event_ids,
+          confidence, supersedes_fact_id, status, invalidated_at_epoch,
+          created_at_epoch, updated_at_epoch)
+         VALUES
+          (1, '/repo', 'deploy-target', 'affects_project', 'staging', 100,
+           200, 110, 2, '[]', 0.9, NULL, 'stale', 250, 110, 250),
+          (2, '/repo', 'deploy-target', 'affects_project', 'production', 200,
+           NULL, 250, 2, '[]', 0.9, 1, 'active', NULL, 250, 250)",
+        [],
+    )?;
+
+    let before_invalidation = current_state(
+        &conn,
+        &CurrentStateRequest {
+            as_of_epoch: Some(225),
+            ..request()
+        },
+    )?;
+    assert_eq!(
+        before_invalidation
+            .facts
+            .iter()
+            .map(|fact| fact.object.as_str())
+            .collect::<Vec<_>>(),
+        vec!["staging"]
+    );
+
+    let after_invalidation = current_state(
+        &conn,
+        &CurrentStateRequest {
+            as_of_epoch: Some(260),
+            ..request()
+        },
+    )?;
+    assert_eq!(
+        after_invalidation
+            .facts
+            .iter()
+            .map(|fact| fact.object.as_str())
+            .collect::<Vec<_>>(),
+        vec!["production"]
+    );
+    Ok(())
+}

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -230,9 +230,16 @@ fn query_facts(
         conditions.push(format!(
             "(valid_from_epoch IS NULL OR valid_from_epoch <= ?{idx})"
         ));
-        conditions.push(format!(
-            "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx})"
-        ));
+        if has_invalidated_at_epoch {
+            conditions.push(format!(
+                "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx} \
+                  OR (invalidated_at_epoch IS NOT NULL AND invalidated_at_epoch > ?{idx}))"
+            ));
+        } else {
+            conditions.push(format!(
+                "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx})"
+            ));
+        }
         conditions.push(format!("learned_at_epoch <= ?{idx}"));
         if has_invalidated_at_epoch {
             conditions.push(format!(

--- a/src/memory/facts/tests.rs
+++ b/src/memory/facts/tests.rs
@@ -102,6 +102,48 @@ fn supersession_records_transaction_time_invalidation() -> Result<()> {
 }
 
 #[test]
+fn backdated_supersession_preserves_prior_belief_until_invalidation_time() -> Result<()> {
+    let conn = setup_fact_conn()?;
+    let project = "test-temporal-backdated";
+    let old_id = insert_temporal_fact_in_current_tx(&conn, &input(project, "staging", 100), 150)?;
+    let mut replacement = input(project, "production", 200);
+    replacement.learned_at_epoch = Some(250);
+    replacement.supersedes_fact_id = Some(old_id);
+    let new_id = insert_temporal_fact_in_current_tx(&conn, &replacement, 250)?;
+
+    let before_invalidation = list_facts_as_of(
+        &conn,
+        project,
+        225,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert_eq!(
+        before_invalidation
+            .iter()
+            .map(|fact| (fact.id, fact.object.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(old_id, "staging")]
+    );
+
+    let after_invalidation = list_facts_as_of(
+        &conn,
+        project,
+        260,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert_eq!(
+        after_invalidation
+            .iter()
+            .map(|fact| (fact.id, fact.object.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(new_id, "production")]
+    );
+    Ok(())
+}
+
+#[test]
 fn current_queries_exclude_invalidated_active_rows() -> Result<()> {
     let mut conn = setup_fact_conn()?;
     let project = "test-temporal-current-invalidated";


### PR DESCRIPTION
## Summary
- keep backdated superseded facts visible in as-of reads until their transaction-time invalidation
- apply the same as-of predicate to current-state fact loading
- add regression coverage for facts and current_state
- bump release metadata to 0.5.68

## Why
This addresses late review feedback on #482: a replacement fact learned at t=250 but valid from t=200 must not erase the prior belief from an as-of t=225 reconstruction.

## Verification
- cargo fmt --check
- git diff --check
- python3 scripts/ci/check_plugin_version_sync.py --expected-version 0.5.68
- python3 scripts/ci/check_version_bump.py origin/main WORKTREE
- cargo test backdated_supersession_preserves_prior_belief_until_invalidation_time -- --nocapture
- cargo test as_of_facts_keep_backdated_superseded_fact_until_invalidation_time -- --nocapture
- cargo test memory::facts::tests -- --nocapture
- cargo test memory::current_state::tests -- --nocapture
- cargo check
- cargo clippy -- -D warnings
- cargo test

## Review
Independent read-only thread reviewer `019ec697-7b48-7642-88a8-c8dd258140cb` found no blocking issues.