### PR TITLE
Avoid duplicate facts for known replacements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.68"
+version = "0.5.69"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.68"
+version = "0.5.69"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.68",
+  "version": "0.5.69",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.68",
+  "version": "0.5.69",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.68": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.68",
+    "0.5.69": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.69",
       "assets": {}
     }
   }

--- a/src/memory/current_state.rs
+++ b/src/memory/current_state.rs
@@ -564,16 +564,11 @@ fn load_facts_for_memory(
     conditions.push(format!(
         "(valid_from_epoch IS NULL OR valid_from_epoch <= ?{idx})"
     ));
-    if has_invalidated_at_epoch {
-        conditions.push(format!(
-            "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx} \
-              OR (invalidated_at_epoch IS NOT NULL AND invalidated_at_epoch > ?{idx}))"
-        ));
-    } else {
-        conditions.push(format!(
-            "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx})"
-        ));
-    }
+    conditions.push(crate::memory::facts::as_of_validity_filter_sql(
+        "",
+        idx,
+        has_invalidated_at_epoch,
+    ));
     params_vec.push(Box::new(effective_epoch));
     idx += 1;
     if let Some(as_of_epoch) = as_of_epoch {

--- a/src/memory/current_state/tests.rs
+++ b/src/memory/current_state/tests.rs
@@ -886,3 +886,52 @@ fn as_of_facts_keep_backdated_superseded_fact_until_invalidation_time() -> Resul
     );
     Ok(())
 }
+
+#[test]
+fn as_of_facts_use_known_replacement_without_returning_superseded_fact() -> Result<()> {
+    let conn = current_state_test_conn()?;
+    insert_state_key(&conn)?;
+    insert_current_state_memory_at(
+        &conn,
+        2,
+        "/repo",
+        "Deploy target",
+        "Use production.",
+        "active",
+        10,
+        100,
+        Some(100),
+        None,
+    )?;
+    set_current_memory(&conn, 2)?;
+    conn.execute(
+        "INSERT INTO memory_facts
+         (id, project, subject, predicate, object, valid_from_epoch,
+          valid_to_epoch, learned_at_epoch, source_memory_id, source_event_ids,
+          confidence, supersedes_fact_id, status, invalidated_at_epoch,
+          created_at_epoch, updated_at_epoch)
+         VALUES
+          (1, '/repo', 'deploy-target', 'affects_project', 'staging', 100,
+           200, 110, 2, '[]', 0.9, NULL, 'stale', 250, 110, 250),
+          (2, '/repo', 'deploy-target', 'affects_project', 'production', 200,
+           NULL, 200, 2, '[]', 0.9, 1, 'active', NULL, 250, 250)",
+        [],
+    )?;
+
+    let as_of = current_state(
+        &conn,
+        &CurrentStateRequest {
+            as_of_epoch: Some(225),
+            ..request()
+        },
+    )?;
+    assert_eq!(
+        as_of
+            .facts
+            .iter()
+            .map(|fact| fact.object.as_str())
+            .collect::<Vec<_>>(),
+        vec!["production"]
+    );
+    Ok(())
+}

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -99,6 +99,38 @@ pub(crate) fn current_fact_filter_sql(alias: &str, has_invalidated_at_epoch: boo
     }
 }
 
+pub(crate) fn as_of_validity_filter_sql(
+    alias: &str,
+    epoch_param_idx: usize,
+    has_invalidated_at_epoch: bool,
+) -> String {
+    let alias = alias.trim();
+    let prefix = if alias.is_empty() {
+        String::new()
+    } else {
+        format!("{alias}.")
+    };
+    if has_invalidated_at_epoch {
+        let outer_id = if alias.is_empty() {
+            "memory_facts.id".to_string()
+        } else {
+            format!("{alias}.id")
+        };
+        format!(
+            "({prefix}valid_to_epoch IS NULL OR {prefix}valid_to_epoch > ?{epoch_param_idx} \
+              OR ({prefix}invalidated_at_epoch IS NOT NULL \
+                  AND {prefix}invalidated_at_epoch > ?{epoch_param_idx} \
+                  AND NOT EXISTS (
+                      SELECT 1 FROM memory_facts AS replacement
+                      WHERE replacement.supersedes_fact_id = {outer_id}
+                        AND replacement.learned_at_epoch <= ?{epoch_param_idx}
+                  )))"
+        )
+    } else {
+        format!("({prefix}valid_to_epoch IS NULL OR {prefix}valid_to_epoch > ?{epoch_param_idx})")
+    }
+}
+
 pub fn insert_temporal_fact(conn: &mut Connection, input: &TemporalFactInput<'_>) -> Result<i64> {
     validate_input(input)?;
     let now = chrono::Utc::now().timestamp();
@@ -230,16 +262,7 @@ fn query_facts(
         conditions.push(format!(
             "(valid_from_epoch IS NULL OR valid_from_epoch <= ?{idx})"
         ));
-        if has_invalidated_at_epoch {
-            conditions.push(format!(
-                "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx} \
-                  OR (invalidated_at_epoch IS NOT NULL AND invalidated_at_epoch > ?{idx}))"
-            ));
-        } else {
-            conditions.push(format!(
-                "(valid_to_epoch IS NULL OR valid_to_epoch > ?{idx})"
-            ));
-        }
+        conditions.push(as_of_validity_filter_sql("", idx, has_invalidated_at_epoch));
         conditions.push(format!("learned_at_epoch <= ?{idx}"));
         if has_invalidated_at_epoch {
             conditions.push(format!(

--- a/src/memory/facts/tests.rs
+++ b/src/memory/facts/tests.rs
@@ -144,6 +144,32 @@ fn backdated_supersession_preserves_prior_belief_until_invalidation_time() -> Re
 }
 
 #[test]
+fn as_of_known_replacement_does_not_return_superseded_fact() -> Result<()> {
+    let conn = setup_fact_conn()?;
+    let project = "test-temporal-known-replacement";
+    let old_id = insert_temporal_fact_in_current_tx(&conn, &input(project, "staging", 100), 150)?;
+    let mut replacement = input(project, "production", 200);
+    replacement.supersedes_fact_id = Some(old_id);
+    let new_id = insert_temporal_fact_in_current_tx(&conn, &replacement, 250)?;
+
+    let as_of = list_facts_as_of(
+        &conn,
+        project,
+        225,
+        Some("deploy-target"),
+        Some(FactPredicate::AffectsProject),
+    )?;
+    assert_eq!(
+        as_of
+            .iter()
+            .map(|fact| (fact.id, fact.object.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(new_id, "production")]
+    );
+    Ok(())
+}
+
+#[test]
 fn current_queries_exclude_invalidated_active_rows() -> Result<()> {
     let mut conn = setup_fact_conn()?;
     let project = "test-temporal-current-invalidated";


### PR DESCRIPTION
## Summary
- keep backdated superseded facts visible only when no replacement was learned by the as-of epoch
- share the as-of validity SQL predicate between facts and current_state fact loading
- add regression coverage for known replacement and future-learned replacement cases
- bump release metadata to 0.5.69

## Why
This addresses late review feedback on #483: the previous predicate could return both the superseded and replacement fact when the replacement was already learned at the requested as_of epoch.

## Verification
- cargo fmt --check
- git diff --check
- python3 scripts/ci/check_plugin_version_sync.py --expected-version 0.5.69
- python3 scripts/ci/check_version_bump.py origin/main WORKTREE
- cargo test as_of_known_replacement_does_not_return_superseded_fact -- --nocapture
- cargo test as_of_facts_use_known_replacement_without_returning_superseded_fact -- --nocapture
- cargo test backdated_supersession_preserves_prior_belief_until_invalidation_time -- --nocapture
- cargo test as_of_facts_keep_backdated_superseded_fact_until_invalidation_time -- --nocapture
- cargo test memory::facts::tests -- --nocapture
- cargo test memory::current_state::tests -- --nocapture
- cargo check
- cargo clippy -- -D warnings
- cargo test

## Review
Independent read-only thread reviewer `019ec6a4-ba3b-7b63-b65d-46a0df2cb2a4` found no blocking issues.