### PR TITLE
Handle unresolved memory conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.70"
+version = "0.5.71"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.70",
+  "version": "0.5.71",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.70",
+  "version": "0.5.71",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.70": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.70",
+    "0.5.71": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.71",
       "assets": {}
     }
   }

--- a/prompts/dream.txt
+++ b/prompts/dream.txt
@@ -1,8 +1,8 @@
 You are a memory consolidation assistant. Given multiple related memory entries from the same project, merge them into a single accurate, non-redundant memory.
 
 Rules:
-1. Keep the MOST RECENT factual information when there are contradictions.
-2. Note important historical changes with "Previously: ..." in the content if it adds useful context.
+1. Do not silently choose a winner when entries contradict each other.
+2. Note important historical changes with "Previously: ..." in the content if it adds useful context and the evidence clearly supports the change.
 3. Output exactly ONE merged memory in this XML format:
 
 <memory>
@@ -15,5 +15,8 @@ Rules:
 
 4. If the entries are NOT actually related and should remain separate, output:
 <no_merge reason="brief explanation"/>
+
+5. If the entries are related but contain an unresolved contradiction, output:
+<conflict ids="space-separated input IDs" reason="brief explanation"/>
 
 Do NOT add any text outside the XML tags.

--- a/src/dream.rs
+++ b/src/dream.rs
@@ -589,6 +589,46 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(conflict_edge_count, 2);
+
+        let operation_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memory_operation_log WHERE operation = 'conflict'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(operation_count, 1);
+
+        let plan = decisions::load_cluster_plan(
+            &conn,
+            project,
+            vec![Cluster {
+                members: clusters[0].members.clone(),
+            }],
+        )?;
+        assert_eq!(plan.eligible.len(), 1);
+        assert_eq!(plan.suppressed, 0);
+
+        process_clusters(project, &mut conn, &clusters, |_cluster, _project| {
+            Box::pin(async move {
+                Ok(MergeDecision::Conflict {
+                    conflicting_ids: vec![third_id, first_id],
+                    reason: Some("provider choice is unresolved".to_string()),
+                })
+            })
+        })
+        .await?;
+
+        let conflict_edge_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memory_edges WHERE edge_type = 'conflicts'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(conflict_edge_count, 2);
+        let operation_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memory_operation_log WHERE operation = 'conflict'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(operation_count, 1);
         Ok(())
     }
 

--- a/src/dream.rs
+++ b/src/dream.rs
@@ -477,7 +477,7 @@ mod tests {
             [],
             |row| row.get(0),
         )?;
-        assert_eq!(conflict_edge_count, 1);
+        assert_eq!(conflict_edge_count, 2);
         let merged_edge_count: i64 = conn.query_row(
             "SELECT COUNT(*) FROM memory_edges WHERE edge_type = 'merged_into'",
             [],
@@ -495,6 +495,100 @@ mod tests {
         assert_eq!(decision, "defer");
         assert_eq!(reason, "embedding provider is unresolved");
         assert!(operation_id.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn process_clusters_defer_records_only_conflicting_subset() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        setup_memory_schema(&conn);
+        let project = "test-dream-conflict-subset";
+        let first_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            project,
+            Some("conflict-a"),
+            "Use provider A",
+            "Use provider A for embeddings.",
+            "decision",
+            None,
+        )?;
+        let second_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            project,
+            Some("conflict-b"),
+            "Keep provider B as backup",
+            "Keep provider B as a backup option.",
+            "decision",
+            None,
+        )?;
+        let third_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            project,
+            Some("conflict-c"),
+            "Use provider C",
+            "Use provider C for embeddings.",
+            "decision",
+            None,
+        )?;
+        let clusters = vec![Cluster {
+            members: vec![
+                candidates::MemoryCandidate {
+                    id: first_id,
+                    topic_key: Some("conflict-a".to_string()),
+                    title: "Use provider A".to_string(),
+                    content: "Use provider A for embeddings.".to_string(),
+                    memory_type: "decision".to_string(),
+                    updated_at_epoch: 1,
+                },
+                candidates::MemoryCandidate {
+                    id: second_id,
+                    topic_key: Some("conflict-b".to_string()),
+                    title: "Keep provider B as backup".to_string(),
+                    content: "Keep provider B as a backup option.".to_string(),
+                    memory_type: "decision".to_string(),
+                    updated_at_epoch: 2,
+                },
+                candidates::MemoryCandidate {
+                    id: third_id,
+                    topic_key: Some("conflict-c".to_string()),
+                    title: "Use provider C".to_string(),
+                    content: "Use provider C for embeddings.".to_string(),
+                    memory_type: "decision".to_string(),
+                    updated_at_epoch: 3,
+                },
+            ],
+        }];
+
+        process_clusters(project, &mut conn, &clusters, |_cluster, _project| {
+            Box::pin(async move {
+                Ok(MergeDecision::Conflict {
+                    conflicting_ids: vec![third_id, first_id],
+                    reason: Some("provider choice is unresolved".to_string()),
+                })
+            })
+        })
+        .await?;
+
+        let (member_ids_json, cluster_size): (String, i64) = conn.query_row(
+            "SELECT member_ids_json, cluster_size
+             FROM dream_cluster_decisions
+             WHERE project = ?1",
+            params![project],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let member_ids: Vec<i64> = serde_json::from_str(&member_ids_json)?;
+        assert_eq!(member_ids, vec![first_id, third_id]);
+        assert_eq!(cluster_size, 2);
+
+        let conflict_edge_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memory_edges WHERE edge_type = 'conflicts'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(conflict_edge_count, 2);
         Ok(())
     }
 

--- a/src/dream.rs
+++ b/src/dream.rs
@@ -1,5 +1,6 @@
 mod apply;
 mod candidates;
+mod conflict;
 mod constants;
 mod decisions;
 mod merge;
@@ -175,6 +176,47 @@ async fn process_clusters(
                 record_no_merge(conn, project, cluster, reason.as_deref())?;
                 skipped += 1;
             }
+            MergeDecision::Conflict {
+                conflicting_ids,
+                reason,
+            } => match conflict::record_conflict(
+                conn,
+                project,
+                cluster,
+                &conflicting_ids,
+                reason.as_deref(),
+            ) {
+                Ok(outcome) => {
+                    skipped += 1;
+                    crate::log::info(
+                        "dream",
+                        &format!(
+                            "deferred conflict ids={:?} operation_id={} edge_count={}",
+                            conflicting_ids, outcome.operation_id, outcome.edge_count
+                        ),
+                    );
+                }
+                Err(error) => {
+                    record_failed(
+                        conn,
+                        project,
+                        cluster,
+                        &format!(
+                            "conflict record failed: {}",
+                            crate::db::truncate_str(&error.to_string(), 500)
+                        ),
+                    )?;
+                    apply_failures += 1;
+                    crate::log::warn(
+                        "dream",
+                        &format!(
+                            "project={} cluster_size={} cluster_first_id={:?} conflict record failed: {}",
+                            project, cluster_size, cluster_first_id, error
+                        ),
+                    );
+                    continue;
+                }
+            },
         }
     }
 
@@ -341,6 +383,119 @@ mod tests {
         assert_eq!(row.0, "no_merge");
         assert_eq!(row.1, "entries cover different decisions");
         assert_eq!(row.2, "[101,102]");
+    }
+
+    #[tokio::test]
+    async fn process_clusters_persists_conflict_defer_without_merging() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        setup_memory_schema(&conn);
+        let project = "test-dream-conflict";
+        let first_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            project,
+            Some("conflict-a"),
+            "Use provider A",
+            "Use provider A for embeddings.",
+            "decision",
+            None,
+        )?;
+        let second_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            project,
+            Some("conflict-b"),
+            "Use provider B",
+            "Use provider B for embeddings.",
+            "decision",
+            None,
+        )?;
+        let clusters = vec![Cluster {
+            members: vec![
+                candidates::MemoryCandidate {
+                    id: first_id,
+                    topic_key: Some("conflict-a".to_string()),
+                    title: "Use provider A".to_string(),
+                    content: "Use provider A for embeddings.".to_string(),
+                    memory_type: "decision".to_string(),
+                    updated_at_epoch: 1,
+                },
+                candidates::MemoryCandidate {
+                    id: second_id,
+                    topic_key: Some("conflict-b".to_string()),
+                    title: "Use provider B".to_string(),
+                    content: "Use provider B for embeddings.".to_string(),
+                    memory_type: "decision".to_string(),
+                    updated_at_epoch: 2,
+                },
+            ],
+        }];
+
+        process_clusters(project, &mut conn, &clusters, |_cluster, _project| {
+            Box::pin(async move {
+                Ok(MergeDecision::Conflict {
+                    conflicting_ids: vec![second_id, first_id],
+                    reason: Some("embedding provider is unresolved".to_string()),
+                })
+            })
+        })
+        .await?;
+
+        let active_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memories
+             WHERE id IN (?1, ?2) AND status = 'active'",
+            params![first_id, second_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(active_count, 2);
+        let memory_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memories WHERE project = ?1",
+            params![project],
+            |row| row.get(0),
+        )?;
+        assert_eq!(memory_count, 2);
+
+        let (operation, conflicting_json, defer_reason): (String, String, Option<String>) = conn
+            .query_row(
+                "SELECT operation, conflicting_ids, defer_reason
+                 FROM memory_operation_log
+                 ORDER BY id DESC
+                 LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
+        assert_eq!(operation, "conflict");
+        let conflicting_ids: Vec<i64> = serde_json::from_str(&conflicting_json)?;
+        assert_eq!(conflicting_ids, vec![first_id, second_id]);
+        assert_eq!(
+            defer_reason.as_deref(),
+            Some("embedding provider is unresolved")
+        );
+
+        let conflict_edge_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memory_edges WHERE edge_type = 'conflicts'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(conflict_edge_count, 1);
+        let merged_edge_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memory_edges WHERE edge_type = 'merged_into'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(merged_edge_count, 0);
+
+        let (decision, reason, operation_id): (String, String, Option<i64>) = conn.query_row(
+            "SELECT decision, reason, source_operation_id
+             FROM dream_cluster_decisions
+             WHERE project = ?1",
+            params![project],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(decision, "defer");
+        assert_eq!(reason, "embedding provider is unresolved");
+        assert!(operation_id.is_some());
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/dream.rs
+++ b/src/dream.rs
@@ -499,6 +499,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn process_clusters_records_failed_for_invalid_conflict_ids() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        setup_memory_schema(&conn);
+        let project = "test-dream-invalid-conflict";
+        let clusters = vec![make_cluster([101, 102], ["topic-a", "topic-b"])];
+
+        let Err(error) = process_clusters(project, &mut conn, &clusters, |_cluster, _project| {
+            Box::pin(async move {
+                Ok(MergeDecision::Conflict {
+                    conflicting_ids: vec![101],
+                    reason: Some("invalid conflict ids".to_string()),
+                })
+            })
+        })
+        .await
+        else {
+            panic!("invalid conflict should fail the only cluster attempt");
+        };
+        assert!(
+            error.to_string().contains("all 1 cluster attempts failed"),
+            "unexpected error: {error}"
+        );
+        let (decision, reason): (String, String) = conn.query_row(
+            "SELECT decision, reason
+             FROM dream_cluster_decisions
+             WHERE project = ?1",
+            params![project],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(decision, "failed");
+        assert!(
+            reason.contains("dream conflict requires at least two memory ids"),
+            "unexpected failed reason: {reason}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn process_clusters_continues_after_apply_failure() {
         let mut conn = Connection::open_in_memory().expect("in-memory db");
         setup_memory_schema(&conn);

--- a/src/dream/conflict.rs
+++ b/src/dream/conflict.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use super::candidates::Cluster;
 use super::decisions;
@@ -23,6 +23,15 @@ pub(super) fn record_conflict(
 ) -> Result<ConflictOutcome> {
     let tx = conn.transaction()?;
     let metadata = validate_conflicting_ids(&tx, project, cluster, conflicting_ids)?;
+    let decision_cluster = cluster_for_conflicting_ids(cluster, &metadata.ids);
+    if let Some(operation_id) = existing_conflict_operation_id(&tx, &metadata.ids)? {
+        decisions::record_defer(&tx, project, &decision_cluster, reason, operation_id)?;
+        tx.commit()?;
+        return Ok(ConflictOutcome {
+            operation_id,
+            edge_count: 0,
+        });
+    }
     let operation_input = MemoryOperationInput {
         source: "dream".to_string(),
         actor: "dream".to_string(),
@@ -56,7 +65,6 @@ pub(super) fn record_conflict(
             reason: Some(defer_reason),
         },
     )?;
-    let decision_cluster = cluster_for_conflicting_ids(cluster, &metadata.ids);
     decisions::record_defer(&tx, project, &decision_cluster, reason, operation_id)?;
     tx.commit()?;
     Ok(ConflictOutcome {
@@ -133,6 +141,37 @@ fn validate_conflicting_ids(
         state_key: common_optional_string(rows.iter().map(|row| row.state_key.as_deref())),
         state_key_id: common_optional_i64(rows.iter().map(|row| row.state_key_id)),
     })
+}
+
+fn existing_conflict_operation_id(conn: &Connection, ids: &[i64]) -> Result<Option<i64>> {
+    let mut operation_id = None;
+    for (idx, from_memory_id) in ids.iter().copied().enumerate() {
+        for to_memory_id in ids.iter().copied().skip(idx + 1) {
+            let pair_operation_id = conn
+                .query_row(
+                    "SELECT source_operation_id
+                     FROM memory_edges
+                     WHERE edge_type = 'conflicts'
+                       AND (
+                            (from_memory_id = ?1 AND to_memory_id = ?2)
+                            OR (from_memory_id = ?2 AND to_memory_id = ?1)
+                       )
+                       AND source_operation_id IS NOT NULL
+                     ORDER BY created_at_epoch DESC, id DESC
+                     LIMIT 1",
+                    params![from_memory_id, to_memory_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()?;
+            let Some(pair_operation_id) = pair_operation_id else {
+                return Ok(None);
+            };
+            operation_id = Some(operation_id.map_or(pair_operation_id, |current: i64| {
+                current.max(pair_operation_id)
+            }));
+        }
+    }
+    Ok(operation_id)
 }
 
 #[derive(Debug)]

--- a/src/dream/conflict.rs
+++ b/src/dream/conflict.rs
@@ -186,47 +186,146 @@ struct MemoryRow {
 
 fn load_memory_rows(conn: &Connection, project: &str, ids: &[i64]) -> Result<Vec<MemoryRow>> {
     let mut rows = Vec::with_capacity(ids.len());
+    let current_filter =
+        crate::memory::memory_current_filter_sql("m.status", "m.expires_at_epoch", false);
     for id in ids {
-        rows.push(conn.query_row(
-            "SELECT
-                 COALESCE(
-                     m.owner_scope,
-                     CASE WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
-                 ) AS owner_scope,
-                 COALESCE(
-                     m.owner_key,
-                     CASE WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user:default' ELSE m.project END
-                 ) AS owner_key,
-                 m.memory_type,
-                 m.topic_key,
-                 sk.state_key,
-                 m.state_key_id
-             FROM memories m
-             LEFT JOIN memory_state_keys sk ON sk.id = m.state_key_id
-             WHERE m.id = ?1
-               AND m.status = 'active'
-               AND (
-                    (m.owner_scope = 'repo' AND m.owner_key = ?2)
-                    OR m.target_project = ?2
-                    OR (
-                        m.owner_scope IS NULL
-                        AND m.project = ?2
-                        AND COALESCE(m.scope, 'project') != 'global'
-                    )
-               )
-             LIMIT 1",
-            params![id, project],
-            |row| {
-                Ok(MemoryRow {
-                    owner_scope: row.get(0)?,
-                    owner_key: row.get(1)?,
-                    memory_type: row.get(2)?,
-                    topic_key: row.get(3)?,
-                    state_key: row.get(4)?,
-                    state_key_id: row.get(5)?,
-                })
-            },
-        )?);
+        if let Some(row) = conn
+            .query_row(
+                &format!(
+                    "SELECT
+                     COALESCE(
+                         m.owner_scope,
+                         CASE WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
+                     ) AS owner_scope,
+                     COALESCE(
+                         m.owner_key,
+                         CASE WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user:default' ELSE m.project END
+                     ) AS owner_key,
+                     m.memory_type,
+                     m.topic_key,
+                     sk.state_key,
+                     m.state_key_id
+                 FROM memories m
+                 LEFT JOIN memory_state_keys sk ON sk.id = m.state_key_id
+                 WHERE m.id = ?1
+                   AND {current_filter}
+                   AND (
+                        (m.owner_scope = 'repo' AND m.owner_key = ?2)
+                        OR m.target_project = ?2
+                        OR (
+                            m.owner_scope IS NULL
+                            AND m.project = ?2
+                            AND COALESCE(m.scope, 'project') != 'global'
+                        )
+                   )
+                 LIMIT 1"
+                ),
+                params![id, project],
+                |row| {
+                    Ok(MemoryRow {
+                        owner_scope: row.get(0)?,
+                        owner_key: row.get(1)?,
+                        memory_type: row.get(2)?,
+                        topic_key: row.get(3)?,
+                        state_key: row.get(4)?,
+                        state_key_id: row.get(5)?,
+                    })
+                },
+            )
+            .optional()?
+        {
+            rows.push(row);
+        }
     }
     Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dream::candidates::MemoryCandidate;
+    use crate::memory::insert_memory;
+    use crate::memory::tests_helper::setup_memory_schema;
+
+    fn cluster_for_ids(first_id: i64, second_id: i64) -> Cluster {
+        Cluster {
+            members: vec![
+                MemoryCandidate {
+                    id: first_id,
+                    topic_key: Some("conflict-a".to_string()),
+                    title: "Use provider A".to_string(),
+                    content: "Use provider A for embeddings.".to_string(),
+                    memory_type: "decision".to_string(),
+                    updated_at_epoch: 1,
+                },
+                MemoryCandidate {
+                    id: second_id,
+                    topic_key: Some("conflict-b".to_string()),
+                    title: "Use provider B".to_string(),
+                    content: "Use provider B for embeddings.".to_string(),
+                    memory_type: "decision".to_string(),
+                    updated_at_epoch: 2,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn record_conflict_rejects_expired_memory() -> Result<()> {
+        let mut conn = Connection::open_in_memory()?;
+        setup_memory_schema(&conn);
+        let project = "test-dream-expired-conflict";
+        let first_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            project,
+            Some("conflict-a"),
+            "Use provider A",
+            "Use provider A for embeddings.",
+            "decision",
+            None,
+        )?;
+        let second_id = insert_memory(
+            &conn,
+            Some("sess-1"),
+            project,
+            Some("conflict-b"),
+            "Use provider B",
+            "Use provider B for embeddings.",
+            "decision",
+            None,
+        )?;
+        conn.execute(
+            "UPDATE memories SET expires_at_epoch = 1 WHERE id = ?1",
+            params![second_id],
+        )?;
+        let cluster = cluster_for_ids(first_id, second_id);
+
+        let Err(error) = record_conflict(
+            &mut conn,
+            project,
+            &cluster,
+            &[first_id, second_id],
+            Some("expired provider conflict"),
+        ) else {
+            panic!("expired conflict memory should be rejected");
+        };
+        assert!(
+            error.to_string().contains("active repo memories"),
+            "unexpected error: {error}"
+        );
+        let conflict_edge_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memory_edges WHERE edge_type = 'conflicts'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(conflict_edge_count, 0);
+        let operation_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memory_operation_log WHERE operation = 'conflict'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(operation_count, 0);
+        Ok(())
+    }
 }

--- a/src/dream/conflict.rs
+++ b/src/dream/conflict.rs
@@ -1,0 +1,177 @@
+use anyhow::{bail, Result};
+use rusqlite::{params, Connection};
+
+use super::candidates::Cluster;
+use super::decisions;
+use crate::memory::conflict_common::{common_optional_i64, common_optional_string, common_string};
+use crate::memory::edge::{insert_pairwise_conflict_edges, MemoryEdgeWriteContext};
+use crate::memory::lifecycle::MemoryLifecycleOp;
+use crate::memory::operation::{insert_operation_log, MemoryOperationInput, MemoryOperationPlan};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ConflictOutcome {
+    pub operation_id: i64,
+    pub edge_count: usize,
+}
+
+pub(super) fn record_conflict(
+    conn: &mut Connection,
+    project: &str,
+    cluster: &Cluster,
+    conflicting_ids: &[i64],
+    reason: Option<&str>,
+) -> Result<ConflictOutcome> {
+    let tx = conn.transaction()?;
+    let metadata = validate_conflicting_ids(&tx, project, cluster, conflicting_ids)?;
+    let operation_input = MemoryOperationInput {
+        source: "dream".to_string(),
+        actor: "dream".to_string(),
+        source_project: project.to_string(),
+        owner_scope: metadata.owner_scope,
+        owner_key: metadata.owner_key,
+        memory_type: metadata.memory_type,
+        topic_key: metadata.topic_key,
+        state_key: metadata.state_key.clone(),
+        source_candidate_id: None,
+        confidence: None,
+    };
+    let defer_reason = reason.unwrap_or("dream consolidation deferred unresolved conflict");
+    let plan = MemoryOperationPlan::new(
+        MemoryLifecycleOp::Conflict,
+        metadata.state_key,
+        "dream consolidation detected unresolved memory conflict",
+    )
+    .with_conflicting_ids(metadata.ids.clone())
+    .with_defer_reason(defer_reason);
+    let operation_id = insert_operation_log(&tx, &operation_input, &plan, None)?;
+    let edge_count = insert_pairwise_conflict_edges(
+        &tx,
+        &metadata.ids,
+        MemoryEdgeWriteContext {
+            state_key_id: metadata.state_key_id,
+            source_candidate_id: None,
+            evidence_event_ids: &[],
+            source_operation_id: Some(operation_id),
+            confidence: None,
+            reason: Some(defer_reason),
+        },
+    )?;
+    decisions::record_defer(&tx, project, cluster, reason, operation_id)?;
+    tx.commit()?;
+    Ok(ConflictOutcome {
+        operation_id,
+        edge_count,
+    })
+}
+
+#[derive(Debug)]
+struct ConflictMetadata {
+    ids: Vec<i64>,
+    owner_scope: String,
+    owner_key: String,
+    memory_type: String,
+    topic_key: Option<String>,
+    state_key: Option<String>,
+    state_key_id: Option<i64>,
+}
+
+fn validate_conflicting_ids(
+    conn: &Connection,
+    project: &str,
+    cluster: &Cluster,
+    conflicting_ids: &[i64],
+) -> Result<ConflictMetadata> {
+    let member_ids = cluster
+        .members
+        .iter()
+        .map(|member| member.id)
+        .collect::<std::collections::HashSet<_>>();
+    let mut ids = conflicting_ids.to_vec();
+    ids.sort_unstable();
+    ids.dedup();
+    if ids.len() < 2 {
+        bail!("dream conflict requires at least two memory ids");
+    }
+    if ids.iter().any(|id| !member_ids.contains(id)) {
+        bail!("dream conflict ids must be members of the cluster");
+    }
+    let rows = load_memory_rows(conn, project, &ids)?;
+    if rows.len() != ids.len() {
+        bail!("dream conflict ids must resolve to active repo memories in the project");
+    }
+    Ok(ConflictMetadata {
+        ids,
+        owner_scope: common_string(rows.iter().map(|row| row.owner_scope.as_str()))
+            .unwrap_or_else(|| "repo".to_string()),
+        owner_key: common_string(rows.iter().map(|row| row.owner_key.as_str()))
+            .unwrap_or_else(|| project.to_string()),
+        memory_type: common_string(rows.iter().map(|row| row.memory_type.as_str()))
+            .or_else(|| {
+                cluster
+                    .members
+                    .first()
+                    .map(|member| member.memory_type.clone())
+            })
+            .unwrap_or_else(|| "memory".to_string()),
+        topic_key: common_optional_string(rows.iter().map(|row| row.topic_key.as_deref())),
+        state_key: common_optional_string(rows.iter().map(|row| row.state_key.as_deref())),
+        state_key_id: common_optional_i64(rows.iter().map(|row| row.state_key_id)),
+    })
+}
+
+#[derive(Debug)]
+struct MemoryRow {
+    owner_scope: String,
+    owner_key: String,
+    memory_type: String,
+    topic_key: Option<String>,
+    state_key: Option<String>,
+    state_key_id: Option<i64>,
+}
+
+fn load_memory_rows(conn: &Connection, project: &str, ids: &[i64]) -> Result<Vec<MemoryRow>> {
+    let mut rows = Vec::with_capacity(ids.len());
+    for id in ids {
+        rows.push(conn.query_row(
+            "SELECT
+                 COALESCE(
+                     m.owner_scope,
+                     CASE WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
+                 ) AS owner_scope,
+                 COALESCE(
+                     m.owner_key,
+                     CASE WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user:default' ELSE m.project END
+                 ) AS owner_key,
+                 m.memory_type,
+                 m.topic_key,
+                 sk.state_key,
+                 m.state_key_id
+             FROM memories m
+             LEFT JOIN memory_state_keys sk ON sk.id = m.state_key_id
+             WHERE m.id = ?1
+               AND m.status = 'active'
+               AND (
+                    (m.owner_scope = 'repo' AND m.owner_key = ?2)
+                    OR m.target_project = ?2
+                    OR (
+                        m.owner_scope IS NULL
+                        AND m.project = ?2
+                        AND COALESCE(m.scope, 'project') != 'global'
+                    )
+               )
+             LIMIT 1",
+            params![id, project],
+            |row| {
+                Ok(MemoryRow {
+                    owner_scope: row.get(0)?,
+                    owner_key: row.get(1)?,
+                    memory_type: row.get(2)?,
+                    topic_key: row.get(3)?,
+                    state_key: row.get(4)?,
+                    state_key_id: row.get(5)?,
+                })
+            },
+        )?);
+    }
+    Ok(rows)
+}

--- a/src/dream/conflict.rs
+++ b/src/dream/conflict.rs
@@ -56,12 +56,28 @@ pub(super) fn record_conflict(
             reason: Some(defer_reason),
         },
     )?;
-    decisions::record_defer(&tx, project, cluster, reason, operation_id)?;
+    let decision_cluster = cluster_for_conflicting_ids(cluster, &metadata.ids);
+    decisions::record_defer(&tx, project, &decision_cluster, reason, operation_id)?;
     tx.commit()?;
     Ok(ConflictOutcome {
         operation_id,
         edge_count,
     })
+}
+
+fn cluster_for_conflicting_ids(cluster: &Cluster, ids: &[i64]) -> Cluster {
+    let ids = ids
+        .iter()
+        .copied()
+        .collect::<std::collections::HashSet<_>>();
+    let mut members = cluster
+        .members
+        .iter()
+        .filter(|member| ids.contains(&member.id))
+        .cloned()
+        .collect::<Vec<_>>();
+    members.sort_by_key(|member| member.id);
+    Cluster { members }
 }
 
 #[derive(Debug)]

--- a/src/dream/decisions.rs
+++ b/src/dream/decisions.rs
@@ -47,6 +47,7 @@ pub(super) fn record_no_merge(
         reason.unwrap_or("no merge returned by dream"),
         Some(now + DREAM_NO_MERGE_REVIEW_SECS),
         None,
+        None,
     )
 }
 
@@ -56,7 +57,7 @@ pub(super) fn record_failed(
     cluster: &Cluster,
     reason: &str,
 ) -> Result<()> {
-    upsert_decision(conn, project, cluster, "failed", reason, None, None)
+    upsert_decision(conn, project, cluster, "failed", reason, None, None, None)
 }
 
 pub(super) fn record_merged(
@@ -72,7 +73,27 @@ pub(super) fn record_merged(
         "merged",
         "dream consolidation merged cluster",
         None,
-        Some(outcome),
+        Some(outcome.merged_id),
+        Some(outcome.operation_id),
+    )
+}
+
+pub(super) fn record_defer(
+    conn: &Connection,
+    project: &str,
+    cluster: &Cluster,
+    reason: Option<&str>,
+    source_operation_id: i64,
+) -> Result<()> {
+    upsert_decision(
+        conn,
+        project,
+        cluster,
+        "defer",
+        reason.unwrap_or("dream consolidation deferred unresolved conflict"),
+        None,
+        None,
+        Some(source_operation_id),
     )
 }
 
@@ -106,7 +127,8 @@ fn upsert_decision(
     decision: &str,
     reason: &str,
     next_review_epoch: Option<i64>,
-    outcome: Option<ApplyOutcome>,
+    source_memory_id: Option<i64>,
+    source_operation_id: Option<i64>,
 ) -> Result<()> {
     let now = chrono::Utc::now().timestamp();
     let Some(memory_type) = cluster_memory_type(cluster) else {
@@ -140,8 +162,8 @@ fn upsert_decision(
             member_ids_json,
             cluster.members.len() as i64,
             next_review_epoch,
-            outcome.map(|value| value.merged_id),
-            outcome.map(|value| value.operation_id),
+            source_memory_id,
+            source_operation_id,
             now
         ],
     )?;

--- a/src/dream/merge.rs
+++ b/src/dream/merge.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 
 use super::candidates::{Cluster, MemoryCandidate};
 use super::constants::DREAM_PROMPT;
@@ -44,10 +44,10 @@ pub(super) async fn merge_cluster(
     )
     .await?;
 
-    Ok(filter_superseded_ids(parse_response(&response)?, cluster))
+    filter_superseded_ids(parse_response(&response)?, cluster)
 }
 
-fn filter_superseded_ids(decision: MergeDecision, cluster: &Cluster) -> MergeDecision {
+fn filter_superseded_ids(decision: MergeDecision, cluster: &Cluster) -> Result<MergeDecision> {
     let member_ids: std::collections::HashSet<i64> = cluster.members.iter().map(|m| m.id).collect();
     match decision {
         MergeDecision::Merge(mut result) => {
@@ -68,11 +68,11 @@ fn filter_superseded_ids(decision: MergeDecision, cluster: &Cluster) -> MergeDec
                     "dream",
                     "rejecting merge with no valid superseded_id(s) after filtering",
                 );
-                return MergeDecision::NoMerge {
+                return Ok(MergeDecision::NoMerge {
                     reason: Some("no valid superseded ids after filtering".to_string()),
-                };
+                });
             }
-            MergeDecision::Merge(result)
+            Ok(MergeDecision::Merge(result))
         }
         MergeDecision::Conflict {
             mut conflicting_ids,
@@ -80,8 +80,6 @@ fn filter_superseded_ids(decision: MergeDecision, cluster: &Cluster) -> MergeDec
         } => {
             let before = conflicting_ids.len();
             conflicting_ids.retain(|id| member_ids.contains(id));
-            conflicting_ids.sort_unstable();
-            conflicting_ids.dedup();
             let dropped = before - conflicting_ids.len();
             if dropped > 0 {
                 crate::log::warn(
@@ -91,22 +89,23 @@ fn filter_superseded_ids(decision: MergeDecision, cluster: &Cluster) -> MergeDec
                         dropped
                     ),
                 );
+                bail!("dream conflict referenced memory id outside cluster");
             }
+            conflicting_ids.sort_unstable();
+            conflicting_ids.dedup();
             if conflicting_ids.len() < 2 {
                 crate::log::warn(
                     "dream",
                     "rejecting conflict with fewer than two valid conflicting id(s) after filtering",
                 );
-                return MergeDecision::NoMerge {
-                    reason: Some("no valid conflict pair after filtering".to_string()),
-                };
+                bail!("dream conflict requires at least two valid cluster ids");
             }
-            MergeDecision::Conflict {
+            Ok(MergeDecision::Conflict {
                 conflicting_ids,
                 reason,
-            }
+            })
         }
-        MergeDecision::NoMerge { .. } => decision,
+        MergeDecision::NoMerge { .. } => Ok(decision),
     }
 }
 
@@ -128,7 +127,7 @@ fn build_user_message(members: &[MemoryCandidate]) -> String {
 fn parse_response(response: &str) -> Result<MergeDecision> {
     if response.contains("<conflict") {
         return Ok(MergeDecision::Conflict {
-            conflicting_ids: extract_conflict_ids(response),
+            conflicting_ids: extract_conflict_ids(response)?,
             reason: extract_conflict_reason(response),
         });
     }
@@ -200,19 +199,29 @@ fn extract_no_merge_reason(text: &str) -> Option<String> {
         .filter(|reason| !reason.is_empty())
 }
 
-fn extract_conflict_ids(text: &str) -> Vec<i64> {
+fn extract_conflict_ids(text: &str) -> Result<Vec<i64>> {
     let Some(start) = text.find("<conflict") else {
-        return Vec::new();
+        bail!("conflict response missing <conflict> tag");
     };
     let tag = &text[start..];
     let Some(end) = tag.find('>') else {
-        return Vec::new();
+        bail!("conflict response missing closing tag bracket");
     };
-    extract_attr(&tag[..=end], "ids")
-        .unwrap_or_default()
-        .split_whitespace()
-        .filter_map(|id| id.parse::<i64>().ok())
-        .collect()
+    let ids_raw = extract_attr(&tag[..=end], "ids")
+        .map(|ids| ids.trim().to_string())
+        .filter(|ids| !ids.is_empty())
+        .ok_or_else(|| anyhow!("conflict response missing ids attribute"))?;
+    let mut ids = Vec::new();
+    for token in ids_raw.split_whitespace() {
+        let id = token
+            .parse::<i64>()
+            .map_err(|_| anyhow!("conflict response contains invalid memory id '{token}'"))?;
+        ids.push(id);
+    }
+    if ids.len() < 2 {
+        bail!("conflict response requires at least two memory ids");
+    }
+    Ok(ids)
 }
 
 fn extract_conflict_reason(text: &str) -> Option<String> {
@@ -368,6 +377,18 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_conflict_invalid_id_errors() {
+        let response = r#"<conflict ids="20 not-a-number" reason="bad id"/>"#;
+        let Err(err) = parse_response(response) else {
+            panic!("invalid conflict id must fail");
+        };
+        assert!(
+            err.to_string().contains("invalid memory id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn test_parse_missing_required_tag_errors() {
         let response = "<memory><topic_key>k</topic_key></memory>";
         let err = parse_response(response).expect_err("expected Err");
@@ -429,7 +450,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_superseded_ids_drops_hallucinated() {
+    fn test_filter_superseded_ids_drops_hallucinated() -> Result<()> {
         let cluster = Cluster {
             members: vec![
                 MemoryCandidate {
@@ -458,15 +479,16 @@ mod tests {
             // 99999 is hallucinated; 10 and 20 are valid cluster members
             superseded_ids: vec![10, 99999, 20],
         });
-        match filter_superseded_ids(decision, &cluster) {
+        match filter_superseded_ids(decision, &cluster)? {
             MergeDecision::Merge(r) => assert_eq!(r.superseded_ids, vec![10, 20]),
             MergeDecision::NoMerge { .. } => panic!("expected Merge"),
             MergeDecision::Conflict { .. } => panic!("expected Merge"),
         }
+        Ok(())
     }
 
     #[test]
-    fn test_filter_conflict_ids_drops_hallucinated_and_sorts() {
+    fn test_filter_conflict_ids_dedupes_and_sorts() -> Result<()> {
         let cluster = Cluster {
             members: vec![
                 MemoryCandidate {
@@ -488,10 +510,10 @@ mod tests {
             ],
         };
         let decision = MergeDecision::Conflict {
-            conflicting_ids: vec![20, 99999, 10, 20],
+            conflicting_ids: vec![20, 10, 20],
             reason: Some("same state differs".into()),
         };
-        match filter_superseded_ids(decision, &cluster) {
+        match filter_superseded_ids(decision, &cluster)? {
             MergeDecision::Conflict {
                 conflicting_ids,
                 reason,
@@ -501,10 +523,46 @@ mod tests {
             }
             MergeDecision::Merge(_) | MergeDecision::NoMerge { .. } => panic!("expected conflict"),
         }
+        Ok(())
     }
 
     #[test]
-    fn test_filter_superseded_ids_rejects_empty_after_filter() {
+    fn test_filter_conflict_ids_rejects_hallucinated() {
+        let cluster = Cluster {
+            members: vec![
+                MemoryCandidate {
+                    id: 10,
+                    topic_key: Some("k".into()),
+                    title: "t".into(),
+                    content: "c".into(),
+                    memory_type: "decision".into(),
+                    updated_at_epoch: 0,
+                },
+                MemoryCandidate {
+                    id: 20,
+                    topic_key: Some("k".into()),
+                    title: "t".into(),
+                    content: "c".into(),
+                    memory_type: "decision".into(),
+                    updated_at_epoch: 0,
+                },
+            ],
+        };
+        let decision = MergeDecision::Conflict {
+            conflicting_ids: vec![20, 99999, 10],
+            reason: Some("same state differs".into()),
+        };
+        let Err(err) = filter_superseded_ids(decision, &cluster) else {
+            panic!("hallucinated conflict id must fail");
+        };
+        assert!(
+            err.to_string().contains("outside cluster"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_filter_superseded_ids_rejects_empty_after_filter() -> Result<()> {
         let cluster = Cluster {
             members: vec![MemoryCandidate {
                 id: 10,
@@ -523,18 +581,20 @@ mod tests {
             superseded_ids: vec![99999],
         });
         assert!(matches!(
-            filter_superseded_ids(decision, &cluster),
+            filter_superseded_ids(decision, &cluster)?,
             MergeDecision::NoMerge { .. }
         ));
+        Ok(())
     }
 
     #[test]
-    fn test_filter_superseded_ids_no_merge_passthrough() {
+    fn test_filter_superseded_ids_no_merge_passthrough() -> Result<()> {
         let cluster = Cluster { members: vec![] };
         assert!(matches!(
-            filter_superseded_ids(MergeDecision::NoMerge { reason: None }, &cluster),
+            filter_superseded_ids(MergeDecision::NoMerge { reason: None }, &cluster)?,
             MergeDecision::NoMerge { .. }
         ));
+        Ok(())
     }
 
     #[test]

--- a/src/dream/merge.rs
+++ b/src/dream/merge.rs
@@ -24,6 +24,13 @@ pub(super) struct MergeResult {
     pub superseded_ids: Vec<i64>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DecisionTag {
+    Conflict,
+    NoMerge,
+    Memory,
+}
+
 pub(super) async fn merge_cluster(
     cluster: &Cluster,
     project: &str,
@@ -125,17 +132,19 @@ fn build_user_message(members: &[MemoryCandidate]) -> String {
 }
 
 fn parse_response(response: &str) -> Result<MergeDecision> {
-    if response.contains("<conflict") {
-        return Ok(MergeDecision::Conflict {
-            conflicting_ids: extract_conflict_ids(response)?,
-            reason: extract_conflict_reason(response),
-        });
-    }
-
-    if response.contains("<no_merge") {
-        return Ok(MergeDecision::NoMerge {
-            reason: extract_no_merge_reason(response),
-        });
+    match first_decision_tag(response) {
+        Some(DecisionTag::Conflict) => {
+            return Ok(MergeDecision::Conflict {
+                conflicting_ids: extract_conflict_ids(response)?,
+                reason: extract_conflict_reason(response),
+            });
+        }
+        Some(DecisionTag::NoMerge) => {
+            return Ok(MergeDecision::NoMerge {
+                reason: extract_no_merge_reason(response),
+            });
+        }
+        Some(DecisionTag::Memory) | None => {}
     }
 
     let topic_key = require_tag(response, "topic_key")?;
@@ -164,6 +173,18 @@ fn parse_response(response: &str) -> Result<MergeDecision> {
         content,
         superseded_ids,
     }))
+}
+
+fn first_decision_tag(response: &str) -> Option<DecisionTag> {
+    [
+        ("<conflict", DecisionTag::Conflict),
+        ("<no_merge", DecisionTag::NoMerge),
+        ("<memory", DecisionTag::Memory),
+    ]
+    .into_iter()
+    .filter_map(|(marker, tag)| response.find(marker).map(|index| (index, tag)))
+    .min_by_key(|(index, _)| *index)
+    .map(|(_, tag)| tag)
 }
 
 fn require_tag(response: &str, tag: &str) -> Result<String> {
@@ -334,6 +355,27 @@ mod tests {
             MergeDecision::NoMerge { .. } => panic!("expected Merge"),
             MergeDecision::Conflict { .. } => panic!("expected Merge"),
         }
+    }
+
+    #[test]
+    fn test_parse_merge_content_with_literal_conflict_tag() -> Result<()> {
+        let response = r#"<memory>
+<topic_key>dream-contract</topic_key>
+<type>decision</type>
+<title>Dream conflict contract</title>
+<content>The prompt may return <conflict ids="10 20" reason="values differ"/> when facts disagree.</content>
+<supersedes>10 20</supersedes>
+</memory>"#;
+        match parse_response(response)? {
+            MergeDecision::Merge(r) => {
+                assert_eq!(r.topic_key, "dream-contract");
+                assert_eq!(r.superseded_ids, vec![10, 20]);
+                assert!(r.content.contains("<conflict ids="));
+            }
+            MergeDecision::NoMerge { .. } => panic!("expected Merge"),
+            MergeDecision::Conflict { .. } => panic!("expected Merge"),
+        }
+        Ok(())
     }
 
     #[test]

--- a/src/dream/merge.rs
+++ b/src/dream/merge.rs
@@ -6,7 +6,13 @@ use super::constants::DREAM_PROMPT;
 #[derive(Debug)]
 pub(super) enum MergeDecision {
     Merge(MergeResult),
-    NoMerge { reason: Option<String> },
+    NoMerge {
+        reason: Option<String>,
+    },
+    Conflict {
+        conflicting_ids: Vec<i64>,
+        reason: Option<String>,
+    },
 }
 
 #[derive(Debug)]
@@ -42,32 +48,66 @@ pub(super) async fn merge_cluster(
 }
 
 fn filter_superseded_ids(decision: MergeDecision, cluster: &Cluster) -> MergeDecision {
-    let MergeDecision::Merge(mut result) = decision else {
-        return decision;
-    };
     let member_ids: std::collections::HashSet<i64> = cluster.members.iter().map(|m| m.id).collect();
-    let before = result.superseded_ids.len();
-    result.superseded_ids.retain(|id| member_ids.contains(id));
-    let dropped = before - result.superseded_ids.len();
-    if dropped > 0 {
-        crate::log::warn(
-            "dream",
-            &format!(
-                "dropped {} hallucinated superseded_id(s) not in cluster",
-                dropped
-            ),
-        );
+    match decision {
+        MergeDecision::Merge(mut result) => {
+            let before = result.superseded_ids.len();
+            result.superseded_ids.retain(|id| member_ids.contains(id));
+            let dropped = before - result.superseded_ids.len();
+            if dropped > 0 {
+                crate::log::warn(
+                    "dream",
+                    &format!(
+                        "dropped {} hallucinated superseded_id(s) not in cluster",
+                        dropped
+                    ),
+                );
+            }
+            if result.superseded_ids.is_empty() {
+                crate::log::warn(
+                    "dream",
+                    "rejecting merge with no valid superseded_id(s) after filtering",
+                );
+                return MergeDecision::NoMerge {
+                    reason: Some("no valid superseded ids after filtering".to_string()),
+                };
+            }
+            MergeDecision::Merge(result)
+        }
+        MergeDecision::Conflict {
+            mut conflicting_ids,
+            reason,
+        } => {
+            let before = conflicting_ids.len();
+            conflicting_ids.retain(|id| member_ids.contains(id));
+            conflicting_ids.sort_unstable();
+            conflicting_ids.dedup();
+            let dropped = before - conflicting_ids.len();
+            if dropped > 0 {
+                crate::log::warn(
+                    "dream",
+                    &format!(
+                        "dropped {} hallucinated conflicting_id(s) not in cluster",
+                        dropped
+                    ),
+                );
+            }
+            if conflicting_ids.len() < 2 {
+                crate::log::warn(
+                    "dream",
+                    "rejecting conflict with fewer than two valid conflicting id(s) after filtering",
+                );
+                return MergeDecision::NoMerge {
+                    reason: Some("no valid conflict pair after filtering".to_string()),
+                };
+            }
+            MergeDecision::Conflict {
+                conflicting_ids,
+                reason,
+            }
+        }
+        MergeDecision::NoMerge { .. } => decision,
     }
-    if result.superseded_ids.is_empty() {
-        crate::log::warn(
-            "dream",
-            "rejecting merge with no valid superseded_id(s) after filtering",
-        );
-        return MergeDecision::NoMerge {
-            reason: Some("no valid superseded ids after filtering".to_string()),
-        };
-    }
-    MergeDecision::Merge(result)
 }
 
 fn build_user_message(members: &[MemoryCandidate]) -> String {
@@ -86,6 +126,13 @@ fn build_user_message(members: &[MemoryCandidate]) -> String {
 }
 
 fn parse_response(response: &str) -> Result<MergeDecision> {
+    if response.contains("<conflict") {
+        return Ok(MergeDecision::Conflict {
+            conflicting_ids: extract_conflict_ids(response),
+            reason: extract_conflict_reason(response),
+        });
+    }
+
     if response.contains("<no_merge") {
         return Ok(MergeDecision::NoMerge {
             reason: extract_no_merge_reason(response),
@@ -146,6 +193,30 @@ fn extract_tag(text: &str, tag: &str) -> Option<String> {
 
 fn extract_no_merge_reason(text: &str) -> Option<String> {
     let start = text.find("<no_merge")?;
+    let tag = &text[start..];
+    let end = tag.find('>')?;
+    extract_attr(&tag[..=end], "reason")
+        .map(|reason| reason.trim().to_string())
+        .filter(|reason| !reason.is_empty())
+}
+
+fn extract_conflict_ids(text: &str) -> Vec<i64> {
+    let Some(start) = text.find("<conflict") else {
+        return Vec::new();
+    };
+    let tag = &text[start..];
+    let Some(end) = tag.find('>') else {
+        return Vec::new();
+    };
+    extract_attr(&tag[..=end], "ids")
+        .unwrap_or_default()
+        .split_whitespace()
+        .filter_map(|id| id.parse::<i64>().ok())
+        .collect()
+}
+
+fn extract_conflict_reason(text: &str) -> Option<String> {
+    let start = text.find("<conflict")?;
     let tag = &text[start..];
     let end = tag.find('>')?;
     extract_attr(&tag[..=end], "reason")
@@ -252,6 +323,7 @@ mod tests {
                 assert_eq!(r.superseded_ids, vec![42, 17]);
             }
             MergeDecision::NoMerge { .. } => panic!("expected Merge"),
+            MergeDecision::Conflict { .. } => panic!("expected Merge"),
         }
     }
 
@@ -272,7 +344,27 @@ mod tests {
                 assert_eq!(reason.as_deref(), Some("entries cover different topics"));
             }
             MergeDecision::Merge(_) => panic!("expected no merge"),
+            MergeDecision::Conflict { .. } => panic!("expected no merge"),
         }
+    }
+
+    #[test]
+    fn test_parse_conflict_reason_and_ids() -> Result<()> {
+        let response = r#"<conflict ids="20 10" reason="same setting has incompatible values"/>"#;
+        match parse_response(response)? {
+            MergeDecision::Conflict {
+                conflicting_ids,
+                reason,
+            } => {
+                assert_eq!(conflicting_ids, vec![20, 10]);
+                assert_eq!(
+                    reason.as_deref(),
+                    Some("same setting has incompatible values")
+                );
+            }
+            MergeDecision::Merge(_) | MergeDecision::NoMerge { .. } => panic!("expected conflict"),
+        }
+        Ok(())
     }
 
     #[test]
@@ -332,6 +424,7 @@ mod tests {
         match parse_response(response).expect("expected Ok") {
             MergeDecision::Merge(r) => assert_eq!(r.memory_type, "discovery"),
             MergeDecision::NoMerge { .. } => panic!("expected Merge"),
+            MergeDecision::Conflict { .. } => panic!("expected Merge"),
         }
     }
 
@@ -368,6 +461,45 @@ mod tests {
         match filter_superseded_ids(decision, &cluster) {
             MergeDecision::Merge(r) => assert_eq!(r.superseded_ids, vec![10, 20]),
             MergeDecision::NoMerge { .. } => panic!("expected Merge"),
+            MergeDecision::Conflict { .. } => panic!("expected Merge"),
+        }
+    }
+
+    #[test]
+    fn test_filter_conflict_ids_drops_hallucinated_and_sorts() {
+        let cluster = Cluster {
+            members: vec![
+                MemoryCandidate {
+                    id: 10,
+                    topic_key: Some("k".into()),
+                    title: "t".into(),
+                    content: "c".into(),
+                    memory_type: "decision".into(),
+                    updated_at_epoch: 0,
+                },
+                MemoryCandidate {
+                    id: 20,
+                    topic_key: Some("k".into()),
+                    title: "t".into(),
+                    content: "c".into(),
+                    memory_type: "decision".into(),
+                    updated_at_epoch: 0,
+                },
+            ],
+        };
+        let decision = MergeDecision::Conflict {
+            conflicting_ids: vec![20, 99999, 10, 20],
+            reason: Some("same state differs".into()),
+        };
+        match filter_superseded_ids(decision, &cluster) {
+            MergeDecision::Conflict {
+                conflicting_ids,
+                reason,
+            } => {
+                assert_eq!(conflicting_ids, vec![10, 20]);
+                assert_eq!(reason.as_deref(), Some("same state differs"));
+            }
+            MergeDecision::Merge(_) | MergeDecision::NoMerge { .. } => panic!("expected conflict"),
         }
     }
 

--- a/src/eval/governance/fixture.rs
+++ b/src/eval/governance/fixture.rs
@@ -534,6 +534,7 @@ fn count_lifecycle(counts: &mut LifecycleCounts, op: memory::lifecycle::MemoryLi
         memory::lifecycle::MemoryLifecycleOp::Invalidate => counts.invalidate += 1,
         memory::lifecycle::MemoryLifecycleOp::Noop => counts.noop += 1,
         memory::lifecycle::MemoryLifecycleOp::Defer => counts.defer += 1,
+        memory::lifecycle::MemoryLifecycleOp::Conflict => counts.conflict += 1,
     }
 }
 

--- a/src/eval/governance/run.rs
+++ b/src/eval/governance/run.rs
@@ -82,6 +82,7 @@ fn run_sandbox_eval_inner(
         invalidate: 1,
         noop: 1,
         defer: 1,
+        conflict: 0,
     };
     if lifecycle_counts != expected_lifecycle_counts {
         failing_examples.push(format!(
@@ -501,12 +502,13 @@ impl Display for GovernanceEvalReport {
         )?;
         writeln!(
             f,
-            "lifecycle: add={} update={} invalidate={} noop={} defer={}",
+            "lifecycle: add={} update={} invalidate={} noop={} defer={} conflict={}",
             self.lifecycle_counts.add,
             self.lifecycle_counts.update,
             self.lifecycle_counts.invalidate,
             self.lifecycle_counts.noop,
-            self.lifecycle_counts.defer
+            self.lifecycle_counts.defer,
+            self.lifecycle_counts.conflict
         )?;
         writeln!(
             f,

--- a/src/eval/governance/tests.rs
+++ b/src/eval/governance/tests.rs
@@ -23,7 +23,8 @@ fn governance_eval_sandbox_reports_all_required_metrics() -> Result<()> {
             update: 1,
             invalidate: 1,
             noop: 1,
-            defer: 1
+            defer: 1,
+            conflict: 0
         }
     );
     assert_eq!(report.summary_candidates.total, 7);

--- a/src/eval/governance/types.rs
+++ b/src/eval/governance/types.rs
@@ -76,6 +76,7 @@ pub struct LifecycleCounts {
     pub invalidate: usize,
     pub noop: usize,
     pub defer: usize,
+    pub conflict: usize,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/graph_candidate/conflict_bridge.rs
+++ b/src/graph_candidate/conflict_bridge.rs
@@ -1,0 +1,160 @@
+use anyhow::{bail, Result};
+use rusqlite::{params, Connection};
+
+use super::{parse_memory_ref_id, ParsedGraphCandidate};
+use crate::memory::conflict_common::{common_optional_i64, common_optional_string, common_string};
+use crate::memory::edge::{insert_pairwise_conflict_edges, MemoryEdgeWriteContext};
+use crate::memory::operation::MemoryOperationInput;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MemoryConflictBridge {
+    pub(super) ids: Vec<i64>,
+    pub(super) owner_scope: String,
+    pub(super) owner_key: String,
+    pub(super) memory_type: String,
+    pub(super) topic_key: Option<String>,
+    pub(super) state_key: Option<String>,
+    pub(super) state_key_id: Option<i64>,
+}
+
+impl MemoryConflictBridge {
+    pub(super) fn operation_input(
+        &self,
+        source_project: &str,
+        candidate_id: i64,
+        candidate: &ParsedGraphCandidate,
+        actor: &str,
+    ) -> MemoryOperationInput {
+        MemoryOperationInput {
+            source: "graph_candidate".to_string(),
+            actor: actor.to_string(),
+            source_project: source_project.to_string(),
+            owner_scope: self.owner_scope.clone(),
+            owner_key: self.owner_key.clone(),
+            memory_type: self.memory_type.clone(),
+            topic_key: self.topic_key.clone().or(Some(candidate.edge_type.clone())),
+            state_key: self.state_key.clone(),
+            source_candidate_id: Some(candidate_id),
+            confidence: Some(candidate.confidence),
+        }
+    }
+
+    pub(super) fn insert_memory_edges(
+        &self,
+        conn: &Connection,
+        operation_id: i64,
+        candidate: &ParsedGraphCandidate,
+    ) -> Result<usize> {
+        insert_pairwise_conflict_edges(
+            conn,
+            &self.ids,
+            MemoryEdgeWriteContext {
+                state_key_id: self.state_key_id,
+                source_candidate_id: None,
+                evidence_event_ids: &candidate.evidence_event_ids,
+                source_operation_id: Some(operation_id),
+                confidence: Some(candidate.confidence),
+                reason: Some(candidate.reason.as_str()),
+            },
+        )
+    }
+}
+
+pub(super) fn build_memory_conflict_bridge(
+    conn: &Connection,
+    source_project: &str,
+    candidate: &ParsedGraphCandidate,
+) -> Result<Option<MemoryConflictBridge>> {
+    if candidate.edge_type != "conflicts" {
+        return Ok(None);
+    }
+    let Some(from_id) = parse_memory_ref_id(&candidate.from_ref)? else {
+        return Ok(None);
+    };
+    let Some(to_id) = parse_memory_ref_id(&candidate.to_ref)? else {
+        return Ok(None);
+    };
+    if from_id == to_id {
+        bail!("graph conflict candidate cannot point to the same memory twice");
+    }
+    let mut ids = vec![from_id, to_id];
+    ids.sort_unstable();
+    ids.dedup();
+    let rows = load_memory_ref_rows(conn, source_project, &ids)?;
+    if rows.len() != ids.len() {
+        bail!("graph conflict candidate references memory outside the active repo scope");
+    }
+    Ok(Some(MemoryConflictBridge {
+        ids,
+        owner_scope: common_string(rows.iter().map(|row| row.owner_scope.as_str()))
+            .unwrap_or_else(|| "repo".to_string()),
+        owner_key: common_string(rows.iter().map(|row| row.owner_key.as_str()))
+            .unwrap_or_else(|| source_project.to_string()),
+        memory_type: common_string(rows.iter().map(|row| row.memory_type.as_str()))
+            .unwrap_or_else(|| "memory".to_string()),
+        topic_key: common_optional_string(rows.iter().map(|row| row.topic_key.as_deref())),
+        state_key: common_optional_string(rows.iter().map(|row| row.state_key.as_deref())),
+        state_key_id: common_optional_i64(rows.iter().map(|row| row.state_key_id)),
+    }))
+}
+
+#[derive(Debug)]
+struct MemoryRefRow {
+    owner_scope: String,
+    owner_key: String,
+    memory_type: String,
+    topic_key: Option<String>,
+    state_key: Option<String>,
+    state_key_id: Option<i64>,
+}
+
+fn load_memory_ref_rows(
+    conn: &Connection,
+    source_project: &str,
+    memory_ids: &[i64],
+) -> Result<Vec<MemoryRefRow>> {
+    let mut rows = Vec::with_capacity(memory_ids.len());
+    for memory_id in memory_ids {
+        rows.push(conn.query_row(
+            "SELECT
+                 COALESCE(
+                     m.owner_scope,
+                     CASE WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
+                 ) AS owner_scope,
+                 COALESCE(
+                     m.owner_key,
+                     CASE WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user:default' ELSE m.project END
+                 ) AS owner_key,
+                 m.memory_type,
+                 m.topic_key,
+                 sk.state_key,
+                 m.state_key_id
+             FROM memories m
+             LEFT JOIN memory_state_keys sk ON sk.id = m.state_key_id
+             WHERE m.id = ?1
+               AND m.status = 'active'
+               AND (
+                    (m.owner_scope = 'repo' AND m.owner_key = ?2)
+                    OR m.target_project = ?2
+                    OR (
+                        m.owner_scope IS NULL
+                        AND m.project = ?2
+                        AND COALESCE(m.scope, 'project') != 'global'
+                    )
+               )
+             LIMIT 1",
+            params![memory_id, source_project],
+            |row| {
+                Ok(MemoryRefRow {
+                    owner_scope: row.get(0)?,
+                    owner_key: row.get(1)?,
+                    memory_type: row.get(2)?,
+                    topic_key: row.get(3)?,
+                    state_key: row.get(4)?,
+                    state_key_id: row.get(5)?,
+                })
+            },
+        )?);
+    }
+    Ok(rows)
+}

--- a/src/graph_candidate/conflict_bridge.rs
+++ b/src/graph_candidate/conflict_bridge.rs
@@ -124,9 +124,12 @@ fn load_memory_ref_rows(
     memory_ids: &[i64],
 ) -> Result<Vec<MemoryRefRow>> {
     let mut rows = Vec::with_capacity(memory_ids.len());
+    let current_filter =
+        crate::memory::memory_current_filter_sql("m.status", "m.expires_at_epoch", false);
     for memory_id in memory_ids {
         rows.push(conn.query_row(
-            "SELECT
+            &format!(
+                "SELECT
                  COALESCE(
                      m.owner_scope,
                      CASE WHEN COALESCE(m.scope, 'project') = 'global' THEN 'user' ELSE 'repo' END
@@ -142,7 +145,7 @@ fn load_memory_ref_rows(
              FROM memories m
              LEFT JOIN memory_state_keys sk ON sk.id = m.state_key_id
              WHERE m.id = ?1
-               AND m.status = 'active'
+               AND {current_filter}
                AND (
                     (m.owner_scope = 'repo' AND m.owner_key = ?2)
                     OR m.target_project = ?2
@@ -152,7 +155,8 @@ fn load_memory_ref_rows(
                         AND COALESCE(m.scope, 'project') != 'global'
                     )
                )
-             LIMIT 1",
+             LIMIT 1"
+            ),
             params![memory_id, source_project],
             |row| {
                 Ok(MemoryRefRow {

--- a/src/graph_candidate/conflict_bridge.rs
+++ b/src/graph_candidate/conflict_bridge.rs
@@ -64,6 +64,7 @@ pub(super) fn build_memory_conflict_bridge(
     conn: &Connection,
     source_project: &str,
     candidate: &ParsedGraphCandidate,
+    prompt_memory_ref_ids: Option<&[i64]>,
 ) -> Result<Option<MemoryConflictBridge>> {
     if candidate.edge_type != "conflicts" {
         return Ok(None);
@@ -80,6 +81,15 @@ pub(super) fn build_memory_conflict_bridge(
     let mut ids = vec![from_id, to_id];
     ids.sort_unstable();
     ids.dedup();
+    let Some(prompt_memory_ref_ids) = prompt_memory_ref_ids else {
+        bail!("graph conflict candidates require persisted prompt memory_refs");
+    };
+    if !ids
+        .iter()
+        .all(|memory_id| prompt_memory_ref_ids.contains(memory_id))
+    {
+        bail!("graph conflict candidate references memory outside provided memory_refs");
+    }
     let rows = load_memory_ref_rows(conn, source_project, &ids)?;
     if rows.len() != ids.len() {
         bail!("graph conflict candidate references memory outside the active repo scope");

--- a/src/graph_candidate/conflict_bridge.rs
+++ b/src/graph_candidate/conflict_bridge.rs
@@ -69,10 +69,10 @@ pub(super) fn build_memory_conflict_bridge(
         return Ok(None);
     }
     let Some(from_id) = parse_memory_ref_id(&candidate.from_ref)? else {
-        return Ok(None);
+        bail!("graph conflict candidates must use memory:* endpoints");
     };
     let Some(to_id) = parse_memory_ref_id(&candidate.to_ref)? else {
-        return Ok(None);
+        bail!("graph conflict candidates must use memory:* endpoints");
     };
     if from_id == to_id {
         bail!("graph conflict candidate cannot point to the same memory twice");

--- a/src/graph_candidate/mod.rs
+++ b/src/graph_candidate/mod.rs
@@ -172,11 +172,12 @@ fn persist_graph_candidates(
     let tx = conn.transaction()?;
     let mut summary = GraphCandidatePersistSummary::default();
     for candidate in candidates {
-        ensure_candidate_evidence(candidate, &allowed_evidence)?;
-        ensure_graph_conflict_prompt_refs(candidate, Some(&prompt_memory_ref_ids))?;
+        let candidate = canonicalize_graph_candidate(candidate)?;
+        ensure_candidate_evidence(&candidate, &allowed_evidence)?;
+        ensure_graph_conflict_prompt_refs(&candidate, Some(&prompt_memory_ref_ids))?;
         let evidence_json = serde_json::to_string(&candidate.evidence_event_ids)?;
         if let Some(existing_id) =
-            find_graph_candidate(&tx, task.project_id, candidate, &evidence_json)?
+            find_graph_candidate(&tx, task.project_id, &candidate, &evidence_json)?
         {
             update_graph_candidate_prompt_memory_refs(
                 &tx,
@@ -212,16 +213,16 @@ fn persist_graph_candidates(
         let candidate_id = tx.last_insert_rowid();
         summary.candidates += 1;
 
-        let source_supported = graph_candidate_has_source_support(candidate, batch);
+        let source_supported = graph_candidate_has_source_support(&candidate, batch);
         let trusted_refs_valid =
-            graph_candidate_has_trusted_refs(&tx, &task.project, task.project_id, candidate)?;
-        if graph_should_auto_promote(candidate) && source_supported && trusted_refs_valid {
+            graph_candidate_has_trusted_refs(&tx, &task.project, task.project_id, &candidate)?;
+        if graph_should_auto_promote(&candidate) && source_supported && trusted_refs_valid {
             let outcome = insert_trusted_graph_edge(
                 &tx,
                 &task.project,
                 task.project_id,
                 candidate_id,
-                candidate,
+                &candidate,
                 Some(&prompt_memory_ref_ids),
                 "graph_candidate",
             )?;
@@ -237,7 +238,7 @@ fn persist_graph_candidates(
                     candidate.edge_type,
                     candidate.risk_class,
                     candidate.confidence,
-                    graph_auto_promote_block_reason(candidate, source_supported, trusted_refs_valid)
+                    graph_auto_promote_block_reason(&candidate, source_supported, trusted_refs_valid)
                 ),
             );
             summary.pending_review += 1;
@@ -245,6 +246,27 @@ fn persist_graph_candidates(
     }
     tx.commit()?;
     Ok(summary)
+}
+
+fn canonicalize_graph_candidate(candidate: &ParsedGraphCandidate) -> Result<ParsedGraphCandidate> {
+    let mut candidate = candidate.clone();
+    if candidate.edge_type != "conflicts" {
+        return Ok(candidate);
+    }
+    let Some(from_id) = parse_memory_ref_id(&candidate.from_ref)? else {
+        return Ok(candidate);
+    };
+    let Some(to_id) = parse_memory_ref_id(&candidate.to_ref)? else {
+        return Ok(candidate);
+    };
+    let (from_id, to_id) = if from_id <= to_id {
+        (from_id, to_id)
+    } else {
+        (to_id, from_id)
+    };
+    candidate.from_ref = format!("memory:{from_id}");
+    candidate.to_ref = format!("memory:{to_id}");
+    Ok(candidate)
 }
 
 fn ensure_candidate_evidence(

--- a/src/graph_candidate/mod.rs
+++ b/src/graph_candidate/mod.rs
@@ -699,11 +699,14 @@ fn active_repo_memory_exists(
     source_project: &str,
     memory_id: i64,
 ) -> Result<bool> {
+    let current_filter =
+        crate::memory::memory_current_filter_sql("status", "expires_at_epoch", false);
     conn.query_row(
-        "SELECT 1
+        &format!(
+            "SELECT 1
          FROM memories
          WHERE id = ?1
-           AND status = 'active'
+           AND {current_filter}
            AND (
                 (owner_scope = 'repo' AND owner_key = ?2)
                 OR target_project = ?2
@@ -713,7 +716,8 @@ fn active_repo_memory_exists(
                     AND COALESCE(scope, 'project') != 'global'
                 )
            )
-         LIMIT 1",
+         LIMIT 1"
+        ),
         params![memory_id, source_project],
         |_| Ok(()),
     )

--- a/src/graph_candidate/mod.rs
+++ b/src/graph_candidate/mod.rs
@@ -12,6 +12,7 @@ use crate::memory::graph_contract::{
 use crate::memory::lifecycle::MemoryLifecycleOp;
 use crate::memory::operation::{insert_operation_log, MemoryOperationInput, MemoryOperationPlan};
 
+mod conflict_bridge;
 mod parser;
 pub(crate) mod review;
 mod source;
@@ -288,23 +289,36 @@ pub(crate) fn insert_trusted_graph_edge(
 ) -> Result<TrustedGraphEdgeOutcome> {
     ensure_review_threshold(candidate)?;
     ensure_trusted_graph_refs(conn, source_project, project_id, candidate)?;
-    let operation_input = MemoryOperationInput {
-        source: "graph_candidate".to_string(),
-        actor: actor.to_string(),
-        source_project: source_project.to_string(),
-        owner_scope: "repo".to_string(),
-        owner_key: source_project.to_string(),
-        memory_type: "graph_edge".to_string(),
-        topic_key: Some(candidate.edge_type.clone()),
-        state_key: None,
-        source_candidate_id: Some(candidate_id),
-        confidence: Some(candidate.confidence),
-    };
-    let operation_plan = MemoryOperationPlan::new(
-        MemoryLifecycleOp::Add,
-        None,
-        "graph candidate promoted to trusted graph edge",
+    let conflict_bridge =
+        conflict_bridge::build_memory_conflict_bridge(conn, source_project, candidate)?;
+    let operation_input = conflict_bridge.as_ref().map_or_else(
+        || MemoryOperationInput {
+            source: "graph_candidate".to_string(),
+            actor: actor.to_string(),
+            source_project: source_project.to_string(),
+            owner_scope: "repo".to_string(),
+            owner_key: source_project.to_string(),
+            memory_type: "graph_edge".to_string(),
+            topic_key: Some(candidate.edge_type.clone()),
+            state_key: None,
+            source_candidate_id: Some(candidate_id),
+            confidence: Some(candidate.confidence),
+        },
+        |bridge| bridge.operation_input(source_project, candidate_id, candidate, actor),
     );
+    let operation_plan = match &conflict_bridge {
+        Some(bridge) => MemoryOperationPlan::new(
+            MemoryLifecycleOp::Conflict,
+            bridge.state_key.clone(),
+            "graph conflict candidate promoted to trusted memory conflict edge",
+        )
+        .with_conflicting_ids(bridge.ids.clone()),
+        None => MemoryOperationPlan::new(
+            MemoryLifecycleOp::Add,
+            None,
+            "graph candidate promoted to trusted graph edge",
+        ),
+    };
     let operation_id = insert_operation_log(conn, &operation_input, &operation_plan, None)?;
     let edge_input = trusted_graph_edge_input(
         conn,
@@ -315,6 +329,9 @@ pub(crate) fn insert_trusted_graph_edge(
         candidate,
     )?;
     let edge_id = insert_graph_edge(conn, &edge_input)?;
+    if let Some(bridge) = conflict_bridge {
+        bridge.insert_memory_edges(conn, operation_id, candidate)?;
+    }
     Ok(TrustedGraphEdgeOutcome {
         edge_id,
         operation_id,

--- a/src/graph_candidate/mod.rs
+++ b/src/graph_candidate/mod.rs
@@ -167,12 +167,22 @@ fn persist_graph_candidates(
         .iter()
         .copied()
         .collect::<BTreeSet<_>>();
+    let prompt_memory_ref_ids = batch.prompt_memory_ref_ids();
+    let prompt_memory_ref_ids_json = serde_json::to_string(&prompt_memory_ref_ids)?;
     let tx = conn.transaction()?;
     let mut summary = GraphCandidatePersistSummary::default();
     for candidate in candidates {
         ensure_candidate_evidence(candidate, &allowed_evidence)?;
+        ensure_graph_conflict_prompt_refs(candidate, Some(&prompt_memory_ref_ids))?;
         let evidence_json = serde_json::to_string(&candidate.evidence_event_ids)?;
-        if graph_candidate_exists(&tx, task.project_id, candidate, &evidence_json)? {
+        if let Some(existing_id) =
+            find_graph_candidate(&tx, task.project_id, candidate, &evidence_json)?
+        {
+            update_graph_candidate_prompt_memory_refs(
+                &tx,
+                existing_id,
+                &prompt_memory_ref_ids_json,
+            )?;
             continue;
         }
 
@@ -180,10 +190,10 @@ fn persist_graph_candidates(
         tx.execute(
             "INSERT INTO graph_candidates
              (project_id, source_project, candidate_type, edge_type, from_ref, to_ref,
-              evidence_event_ids, confidence, risk_class, reason, review_status,
+              evidence_event_ids, prompt_memory_ref_ids, confidence, risk_class, reason, review_status,
               created_at_epoch, updated_at_epoch)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-                     'pending_review', ?11, ?11)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+                     'pending_review', ?12, ?12)",
             params![
                 task.project_id,
                 task.project,
@@ -192,6 +202,7 @@ fn persist_graph_candidates(
                 candidate.from_ref,
                 candidate.to_ref,
                 evidence_json,
+                prompt_memory_ref_ids_json,
                 candidate.confidence,
                 candidate.risk_class,
                 candidate.reason,
@@ -211,6 +222,7 @@ fn persist_graph_candidates(
                 task.project_id,
                 candidate_id,
                 candidate,
+                Some(&prompt_memory_ref_ids),
                 "graph_candidate",
             )?;
             mark_candidate_promoted(&tx, candidate_id, "auto_promoted", &outcome)?;
@@ -250,15 +262,14 @@ fn ensure_candidate_evidence(
     Ok(())
 }
 
-fn graph_candidate_exists(
+fn find_graph_candidate(
     conn: &Connection,
     project_id: i64,
     candidate: &ParsedGraphCandidate,
     evidence_json: &str,
-) -> Result<bool> {
-    let existing: Option<i64> = conn
-        .query_row(
-            "SELECT id FROM graph_candidates
+) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT id FROM graph_candidates
              WHERE project_id = ?1
                AND candidate_type = ?2
                AND edge_type = ?3
@@ -266,18 +277,35 @@ fn graph_candidate_exists(
                AND to_ref = ?5
                AND evidence_event_ids = ?6
              LIMIT 1",
-            params![
-                project_id,
-                candidate.candidate_type,
-                candidate.edge_type,
-                candidate.from_ref,
-                candidate.to_ref,
-                evidence_json
-            ],
-            |row| row.get(0),
-        )
-        .optional()?;
-    Ok(existing.is_some())
+        params![
+            project_id,
+            candidate.candidate_type,
+            candidate.edge_type,
+            candidate.from_ref,
+            candidate.to_ref,
+            evidence_json
+        ],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn update_graph_candidate_prompt_memory_refs(
+    conn: &Connection,
+    candidate_id: i64,
+    prompt_memory_ref_ids_json: &str,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    conn.execute(
+        "UPDATE graph_candidates
+         SET prompt_memory_ref_ids = ?1,
+             updated_at_epoch = ?2
+         WHERE id = ?3
+           AND prompt_memory_ref_ids IS NULL",
+        params![prompt_memory_ref_ids_json, now, candidate_id],
+    )?;
+    Ok(())
 }
 
 pub(crate) fn insert_trusted_graph_edge(
@@ -286,12 +314,18 @@ pub(crate) fn insert_trusted_graph_edge(
     project_id: i64,
     candidate_id: i64,
     candidate: &ParsedGraphCandidate,
+    prompt_memory_ref_ids: Option<&[i64]>,
     actor: &str,
 ) -> Result<TrustedGraphEdgeOutcome> {
     ensure_review_threshold(candidate)?;
+    ensure_graph_conflict_prompt_refs(candidate, prompt_memory_ref_ids)?;
     ensure_trusted_graph_refs(conn, source_project, project_id, candidate)?;
-    let conflict_bridge =
-        conflict_bridge::build_memory_conflict_bridge(conn, source_project, candidate)?;
+    let conflict_bridge = conflict_bridge::build_memory_conflict_bridge(
+        conn,
+        source_project,
+        candidate,
+        prompt_memory_ref_ids,
+    )?;
     let operation_input = conflict_bridge.as_ref().map_or_else(
         || MemoryOperationInput {
             source: "graph_candidate".to_string(),
@@ -389,6 +423,28 @@ fn ensure_review_threshold(candidate: &ParsedGraphCandidate) -> Result<()> {
             candidate.confidence,
             REVIEW_APPROVAL_MIN_CONFIDENCE
         );
+    }
+    Ok(())
+}
+
+fn ensure_graph_conflict_prompt_refs(
+    candidate: &ParsedGraphCandidate,
+    prompt_memory_ref_ids: Option<&[i64]>,
+) -> Result<()> {
+    if candidate.edge_type != "conflicts" {
+        return Ok(());
+    }
+    let Some(from_id) = parse_memory_ref_id(&candidate.from_ref)? else {
+        bail!("graph conflict candidates must use memory:* endpoints");
+    };
+    let Some(to_id) = parse_memory_ref_id(&candidate.to_ref)? else {
+        bail!("graph conflict candidates must use memory:* endpoints");
+    };
+    let Some(prompt_memory_ref_ids) = prompt_memory_ref_ids else {
+        bail!("graph conflict candidates require persisted prompt memory_refs");
+    };
+    if !prompt_memory_ref_ids.contains(&from_id) || !prompt_memory_ref_ids.contains(&to_id) {
+        bail!("graph conflict candidate references memory outside provided memory_refs");
     }
     Ok(())
 }

--- a/src/graph_candidate/mod.rs
+++ b/src/graph_candidate/mod.rs
@@ -30,6 +30,7 @@ Each block must include <type>edge</type>, <edge_type>, <from_ref>, <to_ref>,
 <evidence_event_ids>, <risk_class>, <confidence>, and <reason>.
 Use only edge candidates with edge_type mentions, touches_file, or conflicts.
 Use only provided observations and evidence ids.
+For conflicts, use only memory:<id> endpoints from provided memory_refs.
 If there is no durable graph candidate, return exactly <no_graph_candidates reason=\"...\"/>.
 If evidence is ambiguous or contradictory, return exactly <defer reason=\"...\"/>.
 Do not invent files, entities, memories, evidence ids, or relationships.";

--- a/src/graph_candidate/review.rs
+++ b/src/graph_candidate/review.rs
@@ -35,6 +35,7 @@ struct GraphCandidateRow {
     from_ref: String,
     to_ref: String,
     evidence_event_ids: String,
+    prompt_memory_ref_ids: Option<String>,
     confidence: f64,
     risk_class: String,
     reason: String,
@@ -67,6 +68,7 @@ pub(crate) fn approve_candidate(conn: &mut Connection, id: i64) -> Result<Option
     };
     ensure_reviewable(&row)?;
     let candidate = row.as_candidate()?;
+    let prompt_memory_ref_ids = row.prompt_memory_ref_ids()?;
     let project_id = row
         .project_id
         .with_context(|| format!("graph candidate {} is missing project_id", row.id))?;
@@ -76,6 +78,7 @@ pub(crate) fn approve_candidate(conn: &mut Connection, id: i64) -> Result<Option
         project_id,
         row.id,
         &candidate,
+        prompt_memory_ref_ids.as_deref(),
         "graph_review",
     )?;
     mark_candidate_promoted(&tx, row.id, "approved", &outcome)?;
@@ -94,7 +97,8 @@ pub(crate) fn defer_candidate(conn: &Connection, id: i64, reason: &str) -> Resul
 fn load_row(conn: &Connection, id: i64) -> Result<Option<GraphCandidateRow>> {
     conn.query_row(
         "SELECT c.id, c.project_id, p.project_path, c.source_project, c.candidate_type, c.edge_type,
-                c.from_ref, c.to_ref, c.evidence_event_ids, c.confidence, c.risk_class,
+                c.from_ref, c.to_ref, c.evidence_event_ids, c.prompt_memory_ref_ids,
+                c.confidence, c.risk_class,
                 c.reason, c.review_status, c.promoted_edge_id, c.created_at_epoch
          FROM graph_candidates c
          LEFT JOIN projects p ON p.id = c.project_id
@@ -144,7 +148,8 @@ fn load_reviewable_rows(
     let limit = limit.clamp(1, 200);
     let mut sql = String::from(
         "SELECT c.id, c.project_id, p.project_path, c.source_project, c.candidate_type, c.edge_type,
-                c.from_ref, c.to_ref, c.evidence_event_ids, c.confidence, c.risk_class,
+                c.from_ref, c.to_ref, c.evidence_event_ids, c.prompt_memory_ref_ids,
+                c.confidence, c.risk_class,
                 c.reason, c.review_status, c.promoted_edge_id, c.created_at_epoch
          FROM graph_candidates c
          LEFT JOIN projects p ON p.id = c.project_id
@@ -180,12 +185,13 @@ impl GraphCandidateRow {
             from_ref: row.get(6)?,
             to_ref: row.get(7)?,
             evidence_event_ids: row.get(8)?,
-            confidence: row.get(9)?,
-            risk_class: row.get(10)?,
-            reason: row.get(11)?,
-            review_status: row.get(12)?,
-            promoted_edge_id: row.get(13)?,
-            created_at_epoch: row.get(14)?,
+            prompt_memory_ref_ids: row.get(9)?,
+            confidence: row.get(10)?,
+            risk_class: row.get(11)?,
+            reason: row.get(12)?,
+            review_status: row.get(13)?,
+            promoted_edge_id: row.get(14)?,
+            created_at_epoch: row.get(15)?,
         })
     }
 
@@ -201,6 +207,20 @@ impl GraphCandidateRow {
             risk_class: self.risk_class.clone(),
             reason: self.reason.clone(),
         })
+    }
+
+    fn prompt_memory_ref_ids(&self) -> Result<Option<Vec<i64>>> {
+        self.prompt_memory_ref_ids
+            .as_deref()
+            .map(|raw| {
+                serde_json::from_str(raw).with_context(|| {
+                    format!(
+                        "graph candidate {} has malformed prompt_memory_ref_ids",
+                        self.id
+                    )
+                })
+            })
+            .transpose()
     }
 
     fn into_review(self, conn: &Connection) -> Result<ReviewGraphCandidate> {

--- a/src/graph_candidate/source.rs
+++ b/src/graph_candidate/source.rs
@@ -24,12 +24,23 @@ struct GraphSourceEvent {
     text: String,
 }
 
+#[derive(Debug, Clone)]
+struct GraphSourceMemory {
+    id: i64,
+    memory_type: String,
+    topic_key: Option<String>,
+    title: String,
+    content: String,
+    evidence_event_ids: Vec<i64>,
+}
+
 pub(super) struct GraphObservationBatch {
     pub(super) from_event_id: i64,
     pub(super) to_event_id: i64,
     pub(super) evidence_event_ids: Vec<i64>,
     source_events: Vec<GraphSourceEvent>,
     observations: Vec<GraphSourceObservation>,
+    source_memories: Vec<GraphSourceMemory>,
 }
 
 pub(super) fn load_graph_observation_batch(
@@ -116,12 +127,14 @@ pub(super) fn load_graph_observation_batch(
     let to_event_id = *evidence_set.iter().next_back().unwrap_or(&0);
     let evidence_event_ids = evidence_set.into_iter().collect::<Vec<_>>();
     let source_events = load_graph_source_events(conn, &evidence_event_ids)?;
+    let source_memories = load_graph_source_memories(conn, &task.project, &evidence_event_ids)?;
     Ok(Some(GraphObservationBatch {
         from_event_id,
         to_event_id,
         evidence_event_ids,
         source_events,
         observations,
+        source_memories,
     }))
 }
 
@@ -155,6 +168,70 @@ fn load_graph_source_events(
         }
     }
     Ok(events)
+}
+
+fn load_graph_source_memories(
+    conn: &Connection,
+    source_project: &str,
+    evidence_event_ids: &[i64],
+) -> Result<Vec<GraphSourceMemory>> {
+    let evidence_event_ids = evidence_event_ids.iter().copied().collect::<BTreeSet<_>>();
+    let mut stmt = conn.prepare(
+        "SELECT m.id,
+                m.memory_type,
+                m.topic_key,
+                m.title,
+                m.content,
+                COALESCE(m.evidence_event_ids, c.evidence_event_ids) AS evidence_event_ids
+         FROM memories m
+         LEFT JOIN memory_candidates c ON c.id = m.source_candidate_id
+         WHERE m.status = 'active'
+           AND COALESCE(m.evidence_event_ids, c.evidence_event_ids) IS NOT NULL
+           AND (
+                (m.owner_scope = 'repo' AND m.owner_key = ?1)
+                OR m.target_project = ?1
+                OR (
+                    m.owner_scope IS NULL
+                    AND m.project = ?1
+                    AND COALESCE(m.scope, 'project') != 'global'
+                )
+           )
+         ORDER BY m.updated_at_epoch DESC, m.id DESC
+         LIMIT 200",
+    )?;
+    let rows = stmt
+        .query_map(params![source_project], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut memories = Vec::new();
+    for (id, memory_type, topic_key, title, content, evidence_json) in rows {
+        let memory_event_ids = serde_json::from_str::<Vec<i64>>(&evidence_json)
+            .with_context(|| format!("memory {id} has malformed evidence_event_ids"))?;
+        if memory_event_ids
+            .iter()
+            .any(|event_id| evidence_event_ids.contains(event_id))
+        {
+            memories.push(GraphSourceMemory {
+                id,
+                memory_type,
+                topic_key,
+                title,
+                content,
+                evidence_event_ids: memory_event_ids,
+            });
+        }
+    }
+    memories.sort_by_key(|memory| memory.id);
+    Ok(memories)
 }
 
 fn parse_observation_file_list(
@@ -495,6 +572,36 @@ pub(super) fn build_graph_candidate_prompt(
         batch.from_event_id,
         batch.to_event_id
     );
+    if !batch.source_memories.is_empty() {
+        prompt.push_str("<memory_refs>\n");
+        for memory in &batch.source_memories {
+            let evidence = memory
+                .evidence_event_ids
+                .iter()
+                .map(i64::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            prompt.push_str(&format!(
+                "<memory_ref ref=\"memory:{}\" type=\"{}\" topic_key=\"{}\" evidence_event_ids=\"{}\">\n",
+                memory.id,
+                xml_escape_attr(&memory.memory_type),
+                xml_escape_attr(memory.topic_key.as_deref().unwrap_or("")),
+                xml_escape_attr(&evidence)
+            ));
+            prompt.push_str("<title>");
+            prompt.push_str(&xml_escape_text(&crate::db::truncate_str(
+                &memory.title,
+                200,
+            )));
+            prompt.push_str("</title>\n<content>");
+            prompt.push_str(&xml_escape_text(&crate::db::truncate_str(
+                &memory.content,
+                500,
+            )));
+            prompt.push_str("</content>\n</memory_ref>\n");
+        }
+        prompt.push_str("</memory_refs>\n\n");
+    }
     for observation in &batch.observations {
         let evidence = observation
             .evidence_event_ids

--- a/src/graph_candidate/source.rs
+++ b/src/graph_candidate/source.rs
@@ -25,8 +25,8 @@ struct GraphSourceEvent {
 }
 
 #[derive(Debug, Clone)]
-struct GraphSourceMemory {
-    id: i64,
+pub(super) struct GraphSourceMemory {
+    pub(super) id: i64,
     memory_type: String,
     topic_key: Option<String>,
     title: String,
@@ -41,6 +41,15 @@ pub(super) struct GraphObservationBatch {
     source_events: Vec<GraphSourceEvent>,
     observations: Vec<GraphSourceObservation>,
     source_memories: Vec<GraphSourceMemory>,
+}
+
+impl GraphObservationBatch {
+    pub(super) fn prompt_memory_ref_ids(&self) -> Vec<i64> {
+        self.source_memories
+            .iter()
+            .map(|memory| memory.id)
+            .collect()
+    }
 }
 
 pub(super) fn load_graph_observation_batch(

--- a/src/graph_candidate/source.rs
+++ b/src/graph_candidate/source.rs
@@ -589,12 +589,12 @@ pub(super) fn build_graph_candidate_prompt(
                 xml_escape_attr(&evidence)
             ));
             prompt.push_str("<title>");
-            prompt.push_str(&xml_escape_text(&crate::db::truncate_str(
+            prompt.push_str(&xml_escape_text(crate::db::truncate_str(
                 &memory.title,
                 200,
             )));
             prompt.push_str("</title>\n<content>");
-            prompt.push_str(&xml_escape_text(&crate::db::truncate_str(
+            prompt.push_str(&xml_escape_text(crate::db::truncate_str(
                 &memory.content,
                 500,
             )));

--- a/src/graph_candidate/source.rs
+++ b/src/graph_candidate/source.rs
@@ -207,7 +207,6 @@ fn load_graph_source_memories(
          FROM memories m
          LEFT JOIN memory_candidates c ON c.id = m.source_candidate_id
          WHERE {current_filter}
-           AND COALESCE(m.evidence_event_ids, c.evidence_event_ids) IS NOT NULL
            AND (
                 (m.owner_scope = 'repo' AND m.owner_key = ?1)
                 OR m.target_project = ?1
@@ -227,7 +226,7 @@ fn load_graph_source_memories(
                 row.get::<_, Option<String>>(2)?,
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
-                row.get::<_, String>(5)?,
+                row.get::<_, Option<String>>(5)?,
                 row.get::<_, Option<i64>>(6)?,
                 row.get::<_, i64>(7)?,
             ))
@@ -248,8 +247,14 @@ fn load_graph_source_memories(
         updated_at_epoch,
     ) in rows
     {
-        let memory_event_ids = serde_json::from_str::<Vec<i64>>(&evidence_json)
-            .with_context(|| format!("memory {id} has malformed evidence_event_ids"))?;
+        let memory_event_ids = evidence_json
+            .as_deref()
+            .map(|raw| {
+                serde_json::from_str::<Vec<i64>>(raw)
+                    .with_context(|| format!("memory {id} has malformed evidence_event_ids"))
+            })
+            .transpose()?
+            .unwrap_or_default();
         let evidence_overlap = memory_event_ids
             .iter()
             .any(|event_id| evidence_event_ids.contains(event_id));

--- a/src/graph_candidate/source.rs
+++ b/src/graph_candidate/source.rs
@@ -34,6 +34,14 @@ pub(super) struct GraphSourceMemory {
     evidence_event_ids: Vec<i64>,
 }
 
+#[derive(Debug, Clone)]
+struct GraphSourceMemoryRow {
+    memory: GraphSourceMemory,
+    state_key_id: Option<i64>,
+    updated_at_epoch: i64,
+    evidence_overlap: bool,
+}
+
 pub(super) struct GraphObservationBatch {
     pub(super) from_event_id: i64,
     pub(super) to_event_id: i64,
@@ -185,16 +193,20 @@ fn load_graph_source_memories(
     evidence_event_ids: &[i64],
 ) -> Result<Vec<GraphSourceMemory>> {
     let evidence_event_ids = evidence_event_ids.iter().copied().collect::<BTreeSet<_>>();
-    let mut stmt = conn.prepare(
+    let current_filter =
+        crate::memory::memory_current_filter_sql("m.status", "m.expires_at_epoch", false);
+    let mut stmt = conn.prepare(&format!(
         "SELECT m.id,
                 m.memory_type,
                 m.topic_key,
                 m.title,
                 m.content,
-                COALESCE(m.evidence_event_ids, c.evidence_event_ids) AS evidence_event_ids
+                COALESCE(m.evidence_event_ids, c.evidence_event_ids) AS evidence_event_ids,
+                m.state_key_id,
+                m.updated_at_epoch
          FROM memories m
          LEFT JOIN memory_candidates c ON c.id = m.source_candidate_id
-         WHERE m.status = 'active'
+         WHERE {current_filter}
            AND COALESCE(m.evidence_event_ids, c.evidence_event_ids) IS NOT NULL
            AND (
                 (m.owner_scope = 'repo' AND m.owner_key = ?1)
@@ -205,9 +217,8 @@ fn load_graph_source_memories(
                     AND COALESCE(m.scope, 'project') != 'global'
                 )
            )
-         ORDER BY m.updated_at_epoch DESC, m.id DESC
-         LIMIT 200",
-    )?;
+         ORDER BY m.updated_at_epoch DESC, m.id DESC"
+    ))?;
     let rows = stmt
         .query_map(params![source_project], |row| {
             Ok((
@@ -217,30 +228,90 @@ fn load_graph_source_memories(
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
                 row.get::<_, String>(5)?,
+                row.get::<_, Option<i64>>(6)?,
+                row.get::<_, i64>(7)?,
             ))
         })?
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut memories = Vec::new();
-    for (id, memory_type, topic_key, title, content, evidence_json) in rows {
+    let mut memory_rows = Vec::new();
+    let mut overlapping_state_key_ids = BTreeSet::new();
+    let mut overlapping_topic_keys = BTreeSet::new();
+    for (
+        id,
+        memory_type,
+        topic_key,
+        title,
+        content,
+        evidence_json,
+        state_key_id,
+        updated_at_epoch,
+    ) in rows
+    {
         let memory_event_ids = serde_json::from_str::<Vec<i64>>(&evidence_json)
             .with_context(|| format!("memory {id} has malformed evidence_event_ids"))?;
-        if memory_event_ids
+        let evidence_overlap = memory_event_ids
             .iter()
-            .any(|event_id| evidence_event_ids.contains(event_id))
-        {
-            memories.push(GraphSourceMemory {
+            .any(|event_id| evidence_event_ids.contains(event_id));
+        if evidence_overlap {
+            if let Some(state_key_id) = state_key_id {
+                overlapping_state_key_ids.insert(state_key_id);
+            }
+            if let Some(topic_key) = topic_key.as_deref().and_then(non_empty) {
+                overlapping_topic_keys.insert((memory_type.clone(), topic_key.to_string()));
+            }
+        }
+        memory_rows.push(GraphSourceMemoryRow {
+            memory: GraphSourceMemory {
                 id,
                 memory_type,
                 topic_key,
                 title,
                 content,
                 evidence_event_ids: memory_event_ids,
-            });
-        }
+            },
+            state_key_id,
+            updated_at_epoch,
+            evidence_overlap,
+        });
     }
+    let mut memories = memory_rows
+        .into_iter()
+        .filter(|row| {
+            row.evidence_overlap
+                || row
+                    .state_key_id
+                    .is_some_and(|state_key_id| overlapping_state_key_ids.contains(&state_key_id))
+                || row
+                    .memory
+                    .topic_key
+                    .as_deref()
+                    .and_then(non_empty)
+                    .is_some_and(|topic_key| {
+                        overlapping_topic_keys
+                            .contains(&(row.memory.memory_type.clone(), topic_key.to_string()))
+                    })
+        })
+        .collect::<Vec<_>>();
+    memories.sort_by(|left, right| {
+        right
+            .evidence_overlap
+            .cmp(&left.evidence_overlap)
+            .then_with(|| right.updated_at_epoch.cmp(&left.updated_at_epoch))
+            .then_with(|| left.memory.id.cmp(&right.memory.id))
+    });
+    memories.truncate(200);
+    let mut memories = memories
+        .into_iter()
+        .map(|row| row.memory)
+        .collect::<Vec<_>>();
     memories.sort_by_key(|memory| memory.id);
     Ok(memories)
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
 }
 
 fn parse_observation_file_list(

--- a/src/graph_candidate/tests.rs
+++ b/src/graph_candidate/tests.rs
@@ -173,11 +173,20 @@ fn insert_graph_source_observation_with_files(
 }
 
 fn graph_candidate_xml(edge_type: &str, to_ref: &str, evidence_id: i64) -> String {
+    graph_candidate_xml_from(edge_type, "memory:1", to_ref, evidence_id)
+}
+
+fn graph_candidate_xml_from(
+    edge_type: &str,
+    from_ref: &str,
+    to_ref: &str,
+    evidence_id: i64,
+) -> String {
     format!(
         "<graph_candidate>\
             <type>edge</type>\
             <edge_type>{edge_type}</edge_type>\
-            <from_ref>memory:1</from_ref>\
+            <from_ref>{from_ref}</from_ref>\
             <to_ref>{to_ref}</to_ref>\
             <evidence_event_ids>{evidence_id}</evidence_event_ids>\
             <risk_class>low</risk_class>\
@@ -399,6 +408,48 @@ async fn graph_candidate_prompt_includes_evidence_backed_memory_refs_for_conflic
         |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
     )?;
     assert_eq!(edge_type, "conflicts");
+    assert_eq!(from_ref, "memory:1");
+    assert_eq!(to_ref, "memory:2");
+    Ok(())
+}
+
+#[tokio::test]
+async fn graph_candidate_canonicalizes_symmetric_conflict_refs_for_dedupe() -> Result<()> {
+    let mut conn = graph_test_conn();
+    let task = graph_test_task(&mut conn, "sess-graph-conflict-canonical")?;
+    insert_graph_memory(&conn, &task.project, 1)?;
+    insert_graph_memory(&conn, &task.project, 2)?;
+    let event_id = insert_graph_source_observation(
+        &conn,
+        &task,
+        "Memory 1 and memory 2 conflict regardless of output order.",
+    )?;
+    set_graph_memory_evidence(&conn, &[1, 2], &[event_id])?;
+
+    let result = process_with_graph_generator(&mut conn, &task, |_prompt| async move {
+        Ok(format!(
+            "{}{}{}",
+            graph_candidate_xml_from("conflicts", "memory:2", "memory:1", event_id),
+            graph_candidate_xml_from("conflicts", "memory:1", "memory:2", event_id),
+            graph_candidate_xml_from("conflicts", "memory:02", "memory:1", event_id)
+        ))
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        GraphCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1
+        }
+    );
+    let (candidate_count, from_ref, to_ref): (i64, String, String) = conn.query_row(
+        "SELECT COUNT(*), from_ref, to_ref FROM graph_candidates",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    assert_eq!(candidate_count, 1);
     assert_eq!(from_ref, "memory:1");
     assert_eq!(to_ref, "memory:2");
     Ok(())

--- a/src/graph_candidate/tests.rs
+++ b/src/graph_candidate/tests.rs
@@ -569,7 +569,7 @@ async fn graph_candidate_memory_refs_include_same_topic_older_conflicts() -> Res
         &mut conn,
         "sess-graph-memory-ref-old-topic-conflict",
         &[
-            "Older memory 1 said provider A is required.",
+            "Older imported memory 1 said provider A is required.",
             "New memory 2 says provider B is required.",
         ],
     )?;
@@ -584,7 +584,6 @@ async fn graph_candidate_memory_refs_include_same_topic_older_conflicts() -> Res
         "UPDATE memories SET memory_type = 'lesson' WHERE id = 3",
         [],
     )?;
-    set_graph_memory_evidence(&conn, &[1], &[event_ids[0]])?;
     set_graph_memory_evidence(&conn, &[2], &[event_ids[1]])?;
     set_graph_memory_evidence(&conn, &[3], &[event_ids[0]])?;
     insert_graph_source_observation_with_evidence(
@@ -597,7 +596,11 @@ async fn graph_candidate_memory_refs_include_same_topic_older_conflicts() -> Res
     let result = process_with_graph_generator(&mut conn, &task, |prompt| async move {
         assert!(
             prompt.contains("ref=\"memory:1\""),
-            "same-topic older memory should be included: {prompt}"
+            "same-topic older memory without evidence should be included: {prompt}"
+        );
+        assert!(
+            prompt.contains("ref=\"memory:1\" type=\"decision\" topic_key=\"provider-choice\" evidence_event_ids=\"\""),
+            "evidence-less memory should render with empty evidence list: {prompt}"
         );
         assert!(
             prompt.contains("ref=\"memory:2\""),

--- a/src/graph_candidate/tests.rs
+++ b/src/graph_candidate/tests.rs
@@ -741,6 +741,26 @@ async fn graph_review_approve_reject_and_defer() -> Result<()> {
     let edge_id =
         review::approve_candidate(&mut conn, pending[0].id)?.expect("candidate should approve");
     assert!(edge_id > 0);
+    let (memory_edge_count, source_candidate_id, operation, conflicting_json): (
+        i64,
+        Option<i64>,
+        String,
+        String,
+    ) = conn.query_row(
+        "SELECT COUNT(*), me.source_candidate_id, mol.operation, mol.conflicting_ids
+         FROM memory_edges me
+         JOIN memory_operation_log mol ON mol.id = me.source_operation_id
+        WHERE me.edge_type = 'conflicts'
+           AND me.from_memory_id = 1
+           AND me.to_memory_id = 2",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    assert_eq!(memory_edge_count, 1);
+    assert_eq!(source_candidate_id, None);
+    assert_eq!(operation, "conflict");
+    let conflicting_ids: Vec<i64> = serde_json::from_str(&conflicting_json)?;
+    assert_eq!(conflicting_ids, vec![1, 2]);
     assert!(review::reject_candidate(
         &conn,
         pending[1].id,

--- a/src/graph_candidate/tests.rs
+++ b/src/graph_candidate/tests.rs
@@ -712,6 +712,55 @@ fn graph_review_approval_rejects_foreign_memory_ref() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn graph_review_approval_rejects_non_memory_conflict_refs() -> Result<()> {
+    let mut conn = graph_test_conn();
+    let (task, event_ids) = graph_test_task_with_events(
+        &mut conn,
+        "sess-graph-non-memory-conflict",
+        &["Worker conflicts with Other."],
+    )?;
+    insert_graph_entity(&conn, "Worker")?;
+    insert_graph_entity(&conn, "Other")?;
+    conn.execute(
+        "INSERT INTO graph_candidates
+         (project_id, source_project, candidate_type, edge_type, from_ref, to_ref,
+          evidence_event_ids, confidence, risk_class, reason, review_status,
+          created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, 'edge', 'conflicts', 'entity:Worker', 'entity:Other',
+                 ?3, 0.91, 'low', 'non-memory conflict ref', 'pending_review', 1, 1)",
+        params![
+            task.project_id,
+            task.project,
+            serde_json::to_string(&vec![event_ids[0]])?
+        ],
+    )?;
+
+    let err = review::approve_candidate(&mut conn, 1)
+        .expect_err("non-memory conflict refs must not approve");
+    assert!(
+        err.to_string().contains("memory:* endpoints"),
+        "unexpected error: {err}"
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM graph_candidates", [], |row| {
+            row.get(0)
+        })?;
+    let graph_edge_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM graph_edges", [], |row| row.get(0))?;
+    let memory_edge_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_edges", [], |row| row.get(0))?;
+    let operation_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_operation_log", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(review_status, "pending_review");
+    assert_eq!(graph_edge_count, 0);
+    assert_eq!(memory_edge_count, 0);
+    assert_eq!(operation_count, 0);
+    Ok(())
+}
+
 #[tokio::test]
 async fn graph_review_approve_reject_and_defer() -> Result<()> {
     let mut conn = graph_test_conn();

--- a/src/graph_candidate/tests.rs
+++ b/src/graph_candidate/tests.rs
@@ -444,6 +444,134 @@ async fn graph_candidate_rejects_conflict_ref_outside_prompt_memory_refs() -> Re
 }
 
 #[tokio::test]
+async fn graph_candidate_memory_ref_cap_applies_after_evidence_filtering() -> Result<()> {
+    let mut conn = graph_test_conn();
+    let task = graph_test_task(&mut conn, "sess-graph-memory-ref-cap-after-filter")?;
+    insert_graph_memory(&conn, &task.project, 1)?;
+    insert_graph_memory(&conn, &task.project, 2)?;
+    let event_id =
+        insert_graph_source_observation(&conn, &task, "Memory 1 conflicts with memory 2.")?;
+    set_graph_memory_evidence(&conn, &[1, 2], &[event_id])?;
+    for memory_id in 1_000..1_250 {
+        insert_graph_memory(&conn, &task.project, memory_id)?;
+        conn.execute(
+            "UPDATE memories
+             SET evidence_event_ids = ?1,
+                 updated_at_epoch = ?2
+             WHERE id = ?3",
+            params![
+                serde_json::to_string(&vec![memory_id + 10_000])?,
+                memory_id,
+                memory_id
+            ],
+        )?;
+    }
+
+    let result = process_with_graph_generator(&mut conn, &task, |prompt| async move {
+        assert!(prompt.contains("ref=\"memory:1\""), "prompt: {prompt}");
+        assert!(prompt.contains("ref=\"memory:2\""), "prompt: {prompt}");
+        Ok(graph_candidate_xml("conflicts", "memory:2", event_id))
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        GraphCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1
+        }
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn graph_candidate_memory_refs_exclude_expired_active_memories() -> Result<()> {
+    let mut conn = graph_test_conn();
+    let task = graph_test_task(&mut conn, "sess-graph-memory-ref-expired")?;
+    insert_graph_memory(&conn, &task.project, 1)?;
+    let event_id = insert_graph_source_observation(
+        &conn,
+        &task,
+        "Expired memory 1 should not be offered as a conflict endpoint.",
+    )?;
+    set_graph_memory_evidence(&conn, &[1], &[event_id])?;
+    conn.execute("UPDATE memories SET expires_at_epoch = 1 WHERE id = 1", [])?;
+
+    let result = process_with_graph_generator(&mut conn, &task, |prompt| async move {
+        assert!(
+            !prompt.contains("ref=\"memory:1\""),
+            "expired memory must not be exposed: {prompt}"
+        );
+        Ok("<no_graph_candidates reason=\"no current memory refs\"/>".to_string())
+    })
+    .await?;
+
+    assert_eq!(result, GraphCandidateResult::NoCandidates);
+    Ok(())
+}
+
+#[tokio::test]
+async fn graph_candidate_memory_refs_include_same_topic_older_conflicts() -> Result<()> {
+    let mut conn = graph_test_conn();
+    let (task, event_ids) = graph_test_task_with_events(
+        &mut conn,
+        "sess-graph-memory-ref-old-topic-conflict",
+        &[
+            "Older memory 1 said provider A is required.",
+            "New memory 2 says provider B is required.",
+        ],
+    )?;
+    insert_graph_memory(&conn, &task.project, 1)?;
+    insert_graph_memory(&conn, &task.project, 2)?;
+    insert_graph_memory(&conn, &task.project, 3)?;
+    conn.execute(
+        "UPDATE memories SET topic_key = 'provider-choice' WHERE id IN (1, 2, 3)",
+        [],
+    )?;
+    conn.execute(
+        "UPDATE memories SET memory_type = 'lesson' WHERE id = 3",
+        [],
+    )?;
+    set_graph_memory_evidence(&conn, &[1], &[event_ids[0]])?;
+    set_graph_memory_evidence(&conn, &[2], &[event_ids[1]])?;
+    set_graph_memory_evidence(&conn, &[3], &[event_ids[0]])?;
+    insert_graph_source_observation_with_evidence(
+        &conn,
+        &task,
+        "Memory 2 contradicts the existing provider-choice memory.",
+        &[event_ids[1]],
+    )?;
+
+    let result = process_with_graph_generator(&mut conn, &task, |prompt| async move {
+        assert!(
+            prompt.contains("ref=\"memory:1\""),
+            "same-topic older memory should be included: {prompt}"
+        );
+        assert!(
+            prompt.contains("ref=\"memory:2\""),
+            "direct evidence memory should be included: {prompt}"
+        );
+        assert!(
+            !prompt.contains("ref=\"memory:3\""),
+            "same-topic memory with a different memory_type should not be included: {prompt}"
+        );
+        Ok(graph_candidate_xml("conflicts", "memory:2", event_ids[1]))
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        GraphCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1
+        }
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn graph_candidate_routes_unsupported_auto_edge_to_review() -> Result<()> {
     let mut conn = graph_test_conn();
     let task = graph_test_task(&mut conn, "sess-graph-unsupported-file")?;
@@ -907,6 +1035,49 @@ fn graph_review_approval_rejects_conflict_without_prompt_memory_refs() -> Result
     assert_eq!(review_status, "pending_review");
     assert_eq!(graph_edge_count, 0);
     assert_eq!(memory_edge_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn graph_review_approval_rejects_expired_prompt_memory_ref() -> Result<()> {
+    let mut conn = graph_test_conn();
+    let task = graph_test_task(&mut conn, "sess-graph-conflict-expired-after-prompt")?;
+    insert_graph_memory(&conn, &task.project, 1)?;
+    insert_graph_memory(&conn, &task.project, 2)?;
+    let event_id =
+        insert_graph_source_observation(&conn, &task, "Memory 1 now conflicts with memory 2.")?;
+    set_graph_memory_evidence(&conn, &[1, 2], &[event_id])?;
+    process_with_graph_generator(&mut conn, &task, |_prompt| async move {
+        Ok(graph_candidate_xml("conflicts", "memory:2", event_id))
+    })
+    .await?;
+    conn.execute("UPDATE memories SET expires_at_epoch = 1 WHERE id = 2", [])?;
+
+    let pending = review::list_pending(&conn, None, 10)?;
+    assert_eq!(pending.len(), 1);
+    let err = review::approve_candidate(&mut conn, pending[0].id)
+        .expect_err("expired memory refs must fail closed at approval time");
+    assert!(
+        err.to_string()
+            .contains("does not resolve to an active memory"),
+        "unexpected error: {err}"
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM graph_candidates", [], |row| {
+            row.get(0)
+        })?;
+    let graph_edge_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM graph_edges", [], |row| row.get(0))?;
+    let memory_edge_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_edges", [], |row| row.get(0))?;
+    let operation_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_operation_log", [], |row| {
+            row.get(0)
+        })?;
+    assert_eq!(review_status, "pending_review");
+    assert_eq!(graph_edge_count, 0);
+    assert_eq!(memory_edge_count, 0);
+    assert_eq!(operation_count, 0);
     Ok(())
 }
 

--- a/src/graph_candidate/tests.rs
+++ b/src/graph_candidate/tests.rs
@@ -341,6 +341,59 @@ async fn graph_candidate_uses_structured_files_for_touch_support() -> Result<()>
 }
 
 #[tokio::test]
+async fn graph_candidate_prompt_includes_evidence_backed_memory_refs_for_conflicts() -> Result<()> {
+    let mut conn = graph_test_conn();
+    let task = graph_test_task(&mut conn, "sess-graph-conflict-memory-refs")?;
+    insert_graph_memory(&conn, &task.project, 1)?;
+    insert_graph_memory(&conn, &task.project, 2)?;
+    let event_id = insert_graph_source_observation(
+        &conn,
+        &task,
+        "Provider A and provider B are contradictory active memories.",
+    )?;
+    let evidence_json = serde_json::to_string(&vec![event_id])?;
+    conn.execute(
+        "UPDATE memories SET evidence_event_ids = ?1 WHERE id IN (1, 2)",
+        params![evidence_json],
+    )?;
+
+    let result = process_with_graph_generator(&mut conn, &task, |prompt| async move {
+        assert!(
+            prompt.contains("<memory_refs>"),
+            "prompt should include memory refs: {prompt}"
+        );
+        assert!(
+            prompt.contains("ref=\"memory:1\""),
+            "prompt should expose memory:1: {prompt}"
+        );
+        assert!(
+            prompt.contains("ref=\"memory:2\""),
+            "prompt should expose memory:2: {prompt}"
+        );
+        Ok(graph_candidate_xml("conflicts", "memory:2", event_id))
+    })
+    .await?;
+
+    assert_eq!(
+        result,
+        GraphCandidateResult::Written {
+            candidates: 1,
+            promoted: 0,
+            pending_review: 1
+        }
+    );
+    let (edge_type, from_ref, to_ref): (String, String, String) = conn.query_row(
+        "SELECT edge_type, from_ref, to_ref FROM graph_candidates",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    assert_eq!(edge_type, "conflicts");
+    assert_eq!(from_ref, "memory:1");
+    assert_eq!(to_ref, "memory:2");
+    Ok(())
+}
+
+#[tokio::test]
 async fn graph_candidate_routes_unsupported_auto_edge_to_review() -> Result<()> {
     let mut conn = graph_test_conn();
     let task = graph_test_task(&mut conn, "sess-graph-unsupported-file")?;

--- a/src/graph_candidate/tests.rs
+++ b/src/graph_candidate/tests.rs
@@ -72,6 +72,21 @@ fn insert_graph_memory(conn: &Connection, project: &str, id: i64) -> Result<()> 
     Ok(())
 }
 
+fn set_graph_memory_evidence(
+    conn: &Connection,
+    memory_ids: &[i64],
+    event_ids: &[i64],
+) -> Result<()> {
+    let evidence_json = serde_json::to_string(event_ids)?;
+    for memory_id in memory_ids {
+        conn.execute(
+            "UPDATE memories SET evidence_event_ids = ?1 WHERE id = ?2",
+            params![evidence_json, memory_id],
+        )?;
+    }
+    Ok(())
+}
+
 fn insert_graph_entity(conn: &Connection, name: &str) -> Result<i64> {
     conn.execute(
         "INSERT INTO entities(canonical_name, entity_type, mention_count, created_at_epoch)
@@ -351,11 +366,7 @@ async fn graph_candidate_prompt_includes_evidence_backed_memory_refs_for_conflic
         &task,
         "Provider A and provider B are contradictory active memories.",
     )?;
-    let evidence_json = serde_json::to_string(&vec![event_id])?;
-    conn.execute(
-        "UPDATE memories SET evidence_event_ids = ?1 WHERE id IN (1, 2)",
-        params![evidence_json],
-    )?;
+    set_graph_memory_evidence(&conn, &[1, 2], &[event_id])?;
 
     let result = process_with_graph_generator(&mut conn, &task, |prompt| async move {
         assert!(
@@ -390,6 +401,45 @@ async fn graph_candidate_prompt_includes_evidence_backed_memory_refs_for_conflic
     assert_eq!(edge_type, "conflicts");
     assert_eq!(from_ref, "memory:1");
     assert_eq!(to_ref, "memory:2");
+    Ok(())
+}
+
+#[tokio::test]
+async fn graph_candidate_rejects_conflict_ref_outside_prompt_memory_refs() -> Result<()> {
+    let mut conn = graph_test_conn();
+    let task = graph_test_task(&mut conn, "sess-graph-conflict-outside-memory-refs")?;
+    insert_graph_memory(&conn, &task.project, 1)?;
+    insert_graph_memory(&conn, &task.project, 2)?;
+    let event_id = insert_graph_source_observation(
+        &conn,
+        &task,
+        "Memory 1 conflicts with a stale provider claim.",
+    )?;
+    set_graph_memory_evidence(&conn, &[1], &[event_id])?;
+
+    let err = process_with_graph_generator(&mut conn, &task, |prompt| async move {
+        assert!(prompt.contains("ref=\"memory:1\""), "prompt: {prompt}");
+        assert!(
+            !prompt.contains("ref=\"memory:2\""),
+            "memory:2 must not be available to conflict output: {prompt}"
+        );
+        Ok(graph_candidate_xml("conflicts", "memory:2", event_id))
+    })
+    .await
+    .expect_err("conflict refs outside prompt memory_refs must fail closed");
+
+    assert!(
+        err.to_string().contains("provided memory_refs"),
+        "unexpected error: {err}"
+    );
+    let candidate_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM graph_candidates", [], |row| {
+            row.get(0)
+        })?;
+    let edge_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM graph_edges", [], |row| row.get(0))?;
+    assert_eq!(candidate_count, 0);
+    assert_eq!(edge_count, 0);
     Ok(())
 }
 
@@ -711,6 +761,7 @@ fn graph_review_promotion_guard_rolls_back_stale_approval() -> Result<()> {
         task.project_id,
         1,
         &candidate,
+        None,
         "graph_review",
     )?;
     let err = mark_candidate_promoted(&tx, 1, "approved", &outcome)
@@ -814,6 +865,51 @@ fn graph_review_approval_rejects_non_memory_conflict_refs() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn graph_review_approval_rejects_conflict_without_prompt_memory_refs() -> Result<()> {
+    let mut conn = graph_test_conn();
+    let (task, event_ids) = graph_test_task_with_events(
+        &mut conn,
+        "sess-graph-conflict-no-prompt-refs",
+        &["Memory 1 conflicts with memory 2."],
+    )?;
+    insert_graph_memory(&conn, &task.project, 1)?;
+    insert_graph_memory(&conn, &task.project, 2)?;
+    conn.execute(
+        "INSERT INTO graph_candidates
+         (project_id, source_project, candidate_type, edge_type, from_ref, to_ref,
+          evidence_event_ids, confidence, risk_class, reason, review_status,
+          created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, 'edge', 'conflicts', 'memory:1', 'memory:2',
+                 ?3, 0.91, 'low', 'legacy conflict without prompt refs',
+                 'pending_review', 1, 1)",
+        params![
+            task.project_id,
+            task.project,
+            serde_json::to_string(&vec![event_ids[0]])?
+        ],
+    )?;
+
+    let err = review::approve_candidate(&mut conn, 1)
+        .expect_err("conflict approval without persisted prompt refs must fail closed");
+    assert!(
+        err.to_string().contains("persisted prompt memory_refs"),
+        "unexpected error: {err}"
+    );
+    let review_status: String =
+        conn.query_row("SELECT review_status FROM graph_candidates", [], |row| {
+            row.get(0)
+        })?;
+    let graph_edge_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM graph_edges", [], |row| row.get(0))?;
+    let memory_edge_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM memory_edges", [], |row| row.get(0))?;
+    assert_eq!(review_status, "pending_review");
+    assert_eq!(graph_edge_count, 0);
+    assert_eq!(memory_edge_count, 0);
+    Ok(())
+}
+
 #[tokio::test]
 async fn graph_review_approve_reject_and_defer() -> Result<()> {
     let mut conn = graph_test_conn();
@@ -827,6 +923,7 @@ async fn graph_review_approve_reject_and_defer() -> Result<()> {
         &task,
         "Memory 1 conflicts with memory 2, memory 3, and memory 4.",
     )?;
+    set_graph_memory_evidence(&conn, &[1, 2, 3, 4], &[event_id])?;
     process_with_graph_generator(&mut conn, &task, |_prompt| async move {
         Ok(format!(
             "{}{}{}",

--- a/src/graph_candidate/tests/review_regressions.rs
+++ b/src/graph_candidate/tests/review_regressions.rs
@@ -198,6 +198,7 @@ async fn graph_candidate_rejects_unpromotable_candidate_type() -> Result<()> {
 #[test]
 fn graph_candidate_system_prompt_only_requests_promotable_edge_candidates() {
     assert!(GRAPH_CANDIDATE_SYSTEM.contains("Use only edge candidates"));
+    assert!(GRAPH_CANDIDATE_SYSTEM.contains("For conflicts, use only memory:<id> endpoints"));
     assert!(!GRAPH_CANDIDATE_SYSTEM.contains("entity_alias"));
     assert!(!GRAPH_CANDIDATE_SYSTEM.contains("state_relation"));
     assert!(!GRAPH_CANDIDATE_SYSTEM.contains("type=claim"));

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,4 +1,5 @@
 pub mod claims;
+pub(crate) mod conflict_common;
 pub mod current_state;
 pub mod dedup;
 pub mod edge;

--- a/src/memory/conflict_common.rs
+++ b/src/memory/conflict_common.rs
@@ -1,0 +1,20 @@
+pub(crate) fn common_string<'a>(mut values: impl Iterator<Item = &'a str>) -> Option<String> {
+    let first = values.next()?.to_string();
+    values.all(|value| value == first).then_some(first)
+}
+
+pub(crate) fn common_optional_string<'a>(
+    mut values: impl Iterator<Item = Option<&'a str>>,
+) -> Option<String> {
+    let first = values.next()??.to_string();
+    values
+        .all(|value| value.is_some_and(|value| value == first))
+        .then_some(first)
+}
+
+pub(crate) fn common_optional_i64(mut values: impl Iterator<Item = Option<i64>>) -> Option<i64> {
+    let first = values.next()??;
+    values
+        .all(|value| value.is_some_and(|value| value == first))
+        .then_some(first)
+}

--- a/src/memory/current_state/tests/review_regressions.rs
+++ b/src/memory/current_state/tests/review_regressions.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use rusqlite::params;
 
+use crate::memory::edge::{insert_pairwise_conflict_edges, MemoryEdgeWriteContext};
+
 use super::super::{current_state, CurrentStateRequest};
 use super::support::{
     current_state_test_conn, insert_current_state_memory_at, insert_state_key, set_current_memory,
@@ -488,5 +490,120 @@ fn current_conflict_refs_include_edge_evidence() -> Result<()> {
     assert_eq!(result.conflicts[0].evidence_event_ids, vec![21, 22]);
     assert_eq!(result.conflicts[0].source_candidate_id, Some(30));
     assert_eq!(result.conflicts[0].source_operation_id, Some(40));
+    Ok(())
+}
+
+#[test]
+fn cross_state_conflicts_have_per_side_why_scope() -> Result<()> {
+    let conn = current_state_test_conn()?;
+    conn.execute(
+        "INSERT INTO memory_state_keys
+         (id, owner_scope, owner_key, memory_type, state_key, state_label,
+          state_status, current_memory_id, created_at_epoch, updated_at_epoch)
+         VALUES
+             (10, 'repo', '/repo', 'decision', 'deploy-target',
+              'deploy target', 'active', NULL, 1, 10),
+             (11, 'repo', '/repo', 'decision', 'runtime-target',
+              'runtime target', 'active', NULL, 1, 10)",
+        [],
+    )?;
+    insert_current_state_memory_at(
+        &conn,
+        1,
+        "/repo",
+        "Deploy target",
+        "Use production.",
+        "active",
+        10,
+        100,
+        Some(100),
+        None,
+    )?;
+    insert_current_state_memory_at(
+        &conn,
+        2,
+        "/repo",
+        "Runtime target",
+        "Use staging.",
+        "active",
+        11,
+        110,
+        Some(110),
+        None,
+    )?;
+    conn.execute(
+        "UPDATE memory_state_keys
+         SET current_memory_id = CASE id WHEN 10 THEN 1 WHEN 11 THEN 2 END
+         WHERE id IN (10, 11)",
+        [],
+    )?;
+
+    let inserted = insert_pairwise_conflict_edges(
+        &conn,
+        &[1, 2],
+        MemoryEdgeWriteContext {
+            evidence_event_ids: &[7, 8],
+            reason: Some("cross-state conflict"),
+            ..Default::default()
+        },
+    )?;
+    assert_eq!(inserted, 2);
+
+    let deploy_edge_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_edges
+         WHERE edge_type = 'conflicts' AND state_key_id = 10",
+        [],
+        |row| row.get(0),
+    )?;
+    let runtime_edge_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memory_edges
+         WHERE edge_type = 'conflicts' AND state_key_id = 11",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(deploy_edge_count, 1);
+    assert_eq!(runtime_edge_count, 1);
+
+    let deploy = current_state(
+        &conn,
+        &CurrentStateRequest {
+            state_key: "deploy-target".to_string(),
+            project: Some("/repo".to_string()),
+            memory_type: Some("decision".to_string()),
+            include_history: true,
+            ..Default::default()
+        },
+    )?;
+    assert_eq!(deploy.status, "current");
+    assert!(deploy.conflicts.is_empty());
+    assert_eq!(
+        deploy
+            .why
+            .iter()
+            .filter(|why| why.edge_type == "conflicts")
+            .count(),
+        1
+    );
+
+    let runtime = current_state(
+        &conn,
+        &CurrentStateRequest {
+            state_key: "runtime-target".to_string(),
+            project: Some("/repo".to_string()),
+            memory_type: Some("decision".to_string()),
+            include_history: true,
+            ..Default::default()
+        },
+    )?;
+    assert_eq!(runtime.status, "current");
+    assert!(runtime.conflicts.is_empty());
+    assert_eq!(
+        runtime
+            .why
+            .iter()
+            .filter(|why| why.edge_type == "conflicts")
+            .count(),
+        1
+    );
     Ok(())
 }

--- a/src/memory/edge.rs
+++ b/src/memory/edge.rs
@@ -173,27 +173,55 @@ pub fn insert_pairwise_conflict_edges(
     let mut inserted = 0usize;
     for (idx, from_memory_id) in ids.iter().copied().enumerate() {
         for to_memory_id in ids.iter().copied().skip(idx + 1) {
-            insert_memory_edge(
-                conn,
-                &MemoryEdgeInput {
-                    edge_type: MemoryEdgeType::Conflicts,
-                    from_memory_id: Some(from_memory_id),
-                    to_memory_id: Some(to_memory_id),
-                    state_key_id: context
-                        .state_key_id
-                        .or(memory_state_key_id(conn, to_memory_id)?)
-                        .or(memory_state_key_id(conn, from_memory_id)?),
-                    source_candidate_id: context.source_candidate_id,
-                    evidence_event_ids: context.evidence_event_ids,
-                    source_operation_id: context.source_operation_id,
-                    confidence: context.confidence,
-                    reason: context.reason,
-                },
-            )?;
-            inserted += 1;
+            for state_key_id in
+                conflict_edge_state_keys(conn, from_memory_id, to_memory_id, context.state_key_id)?
+            {
+                insert_memory_edge(
+                    conn,
+                    &MemoryEdgeInput {
+                        edge_type: MemoryEdgeType::Conflicts,
+                        from_memory_id: Some(from_memory_id),
+                        to_memory_id: Some(to_memory_id),
+                        state_key_id,
+                        source_candidate_id: context.source_candidate_id,
+                        evidence_event_ids: context.evidence_event_ids,
+                        source_operation_id: context.source_operation_id,
+                        confidence: context.confidence,
+                        reason: context.reason,
+                    },
+                )?;
+                inserted += 1;
+            }
         }
     }
     Ok(inserted)
+}
+
+fn conflict_edge_state_keys(
+    conn: &Connection,
+    from_memory_id: i64,
+    to_memory_id: i64,
+    explicit_state_key_id: Option<i64>,
+) -> Result<Vec<Option<i64>>> {
+    if explicit_state_key_id.is_some() {
+        return Ok(vec![explicit_state_key_id]);
+    }
+    let from_state_key_id = memory_state_key_id(conn, from_memory_id)?;
+    let to_state_key_id = memory_state_key_id(conn, to_memory_id)?;
+    if from_state_key_id == to_state_key_id {
+        return Ok(vec![from_state_key_id]);
+    }
+    let mut state_key_ids = Vec::new();
+    if from_state_key_id.is_some() {
+        state_key_ids.push(from_state_key_id);
+    }
+    if to_state_key_id.is_some() {
+        state_key_ids.push(to_state_key_id);
+    }
+    if state_key_ids.is_empty() {
+        state_key_ids.push(None);
+    }
+    Ok(state_key_ids)
 }
 
 fn memory_state_key_id(conn: &Connection, memory_id: i64) -> Result<Option<i64>> {

--- a/src/memory/edge.rs
+++ b/src/memory/edge.rs
@@ -146,6 +146,56 @@ pub fn insert_merged_into_edges(
     )
 }
 
+pub fn insert_conflicts_edges(
+    conn: &Connection,
+    from_memory_ids: &[i64],
+    to_memory_id: i64,
+    context: MemoryEdgeWriteContext<'_>,
+) -> Result<usize> {
+    insert_replacement_edges(
+        conn,
+        MemoryEdgeType::Conflicts,
+        from_memory_ids,
+        to_memory_id,
+        context,
+    )
+}
+
+pub fn insert_pairwise_conflict_edges(
+    conn: &Connection,
+    memory_ids: &[i64],
+    context: MemoryEdgeWriteContext<'_>,
+) -> Result<usize> {
+    let mut ids = memory_ids.to_vec();
+    ids.sort_unstable();
+    ids.dedup();
+
+    let mut inserted = 0usize;
+    for (idx, from_memory_id) in ids.iter().copied().enumerate() {
+        for to_memory_id in ids.iter().copied().skip(idx + 1) {
+            insert_memory_edge(
+                conn,
+                &MemoryEdgeInput {
+                    edge_type: MemoryEdgeType::Conflicts,
+                    from_memory_id: Some(from_memory_id),
+                    to_memory_id: Some(to_memory_id),
+                    state_key_id: context
+                        .state_key_id
+                        .or(memory_state_key_id(conn, to_memory_id)?)
+                        .or(memory_state_key_id(conn, from_memory_id)?),
+                    source_candidate_id: context.source_candidate_id,
+                    evidence_event_ids: context.evidence_event_ids,
+                    source_operation_id: context.source_operation_id,
+                    confidence: context.confidence,
+                    reason: context.reason,
+                },
+            )?;
+            inserted += 1;
+        }
+    }
+    Ok(inserted)
+}
+
 fn memory_state_key_id(conn: &Connection, memory_id: i64) -> Result<Option<i64>> {
     Ok(conn
         .query_row(

--- a/src/memory/lifecycle.rs
+++ b/src/memory/lifecycle.rs
@@ -13,6 +13,7 @@ pub enum MemoryLifecycleOp {
     Invalidate,
     Noop,
     Defer,
+    Conflict,
 }
 
 impl MemoryLifecycleOp {
@@ -23,6 +24,7 @@ impl MemoryLifecycleOp {
             Self::Invalidate => "invalidate",
             Self::Noop => "noop",
             Self::Defer => "defer",
+            Self::Conflict => "conflict",
         }
     }
 }

--- a/src/memory/operation.rs
+++ b/src/memory/operation.rs
@@ -61,6 +61,11 @@ impl MemoryOperationPlan {
         self
     }
 
+    pub fn with_conflicting_ids(mut self, conflicting_ids: Vec<i64>) -> Self {
+        self.conflicting_ids = conflicting_ids;
+        self
+    }
+
     pub fn with_noop_reason(mut self, reason: impl Into<String>) -> Self {
         self.noop_reason = Some(reason.into());
         self

--- a/src/migrate/types.rs
+++ b/src/migrate/types.rs
@@ -215,6 +215,11 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "reference_time_epoch",
         sql: include_str!("../migrations/v042_reference_time_epoch.sql"),
     },
+    Migration {
+        version: 43,
+        name: "graph_candidate_prompt_memory_refs",
+        sql: include_str!("../migrations/v043_graph_candidate_prompt_memory_refs.sql"),
+    },
 ];
 
 pub(crate) const OLD_BASELINE_VERSION: i64 = 13;

--- a/src/migrations/v043_graph_candidate_prompt_memory_refs.sql
+++ b/src/migrations/v043_graph_candidate_prompt_memory_refs.sql
@@ -1,0 +1,5 @@
+-- v043_graph_candidate_prompt_memory_refs: persist the exact memory refs
+-- shown to graph candidate extraction so conflict approvals can fail closed.
+
+ALTER TABLE graph_candidates
+ADD COLUMN prompt_memory_ref_ids TEXT;


### PR DESCRIPTION
Fixes #480.

## Summary
- bridge approved graph `conflicts` candidates into `memory_edges.conflicts` and `memory_operation_log.conflicting_ids`
- add dream `<conflict>` output handling that records defer decisions without merging or staling memories
- surface conflict as a distinct lifecycle count in governance eval reports

## Verification
- cargo check
- cargo test dream --lib
- cargo test graph_candidate::tests --lib
- cargo test memory::current_state::tests --lib
- cargo test
