### PR TITLE
Add git-anchored staleness labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.72"
+version = "0.5.73"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.72"
+version = "0.5.73"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/eval/gates/issue381-git-staleness-report.json
+++ b/eval/gates/issue381-git-staleness-report.json
@@ -1,0 +1,2121 @@
+{
+  "version": "2026-06-12",
+  "baseline_version": "2026-06-12",
+  "thresholds_version": "2026-06-12",
+  "summary": {
+    "metrics_checked": 47,
+    "passed": true
+  },
+  "deltas": [
+    {
+      "metric": "extraction.all_checks",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "extraction.candidate_precision",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "extraction.candidate_recall",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "extraction.forbidden_candidate_exclusion",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "extraction.forbidden_observation_exclusion",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "extraction.observation_precision",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "extraction.observation_recall",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "extraction.over_save_quality",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.overall.evidence_recall_at_k",
+      "baseline": 0.75,
+      "current": 0.75,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.overall.hit_at_k",
+      "baseline": 0.75,
+      "current": 0.75,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.overall.mrr_at_10",
+      "baseline": 0.6708333333333333,
+      "current": 0.75,
+      "delta": 0.07916666666666672,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.overall.ndcg_at_10",
+      "baseline": 0.6569288667454157,
+      "current": 0.7479930197287047,
+      "delta": 0.09106415298328896,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.overall.precision_at_k",
+      "baseline": 0.2250000000000001,
+      "current": 0.6916666666666667,
+      "delta": 0.46666666666666656,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.overall.recall_at_k",
+      "baseline": 0.75,
+      "current": 0.75,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.scored_queries",
+      "baseline": 40.0,
+      "current": 40.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.abstention.abstention_pass_rate",
+      "baseline": 0.0,
+      "current": 1.0,
+      "delta": 1.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.knowledge_update.evidence_recall_at_k",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.knowledge_update.hit_at_k",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.knowledge_update.mrr_at_10",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.knowledge_update.ndcg_at_10",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.knowledge_update.precision_at_k",
+      "baseline": 0.25,
+      "current": 0.8,
+      "delta": 0.55,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.knowledge_update.recall_at_k",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.multi_hop.evidence_recall_at_k",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.multi_hop.hit_at_k",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.multi_hop.mrr_at_10",
+      "baseline": 0.95,
+      "current": 1.0,
+      "delta": 0.050000000000000044,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.multi_hop.ndcg_at_10",
+      "baseline": 0.827715466981663,
+      "current": 0.9919720789148186,
+      "delta": 0.16425661193315566,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.multi_hop.precision_at_k",
+      "baseline": 0.4,
+      "current": 0.9666666666666666,
+      "delta": 0.5666666666666665,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.multi_hop.recall_at_k",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.paraphrase.evidence_recall_at_k",
+      "baseline": 0.0,
+      "current": 0.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.paraphrase.hit_at_k",
+      "baseline": 0.0,
+      "current": 0.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.paraphrase.mrr_at_10",
+      "baseline": 0.0,
+      "current": 0.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.paraphrase.ndcg_at_10",
+      "baseline": 0.0,
+      "current": 0.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.paraphrase.precision_at_k",
+      "baseline": 0.0,
+      "current": 0.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.paraphrase.recall_at_k",
+      "baseline": 0.0,
+      "current": 0.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.temporal.evidence_recall_at_k",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.temporal.hit_at_k",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.temporal.mrr_at_10",
+      "baseline": 0.7333333333333333,
+      "current": 1.0,
+      "delta": 0.2666666666666667,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.temporal.ndcg_at_10",
+      "baseline": 0.8,
+      "current": 1.0,
+      "delta": 0.19999999999999996,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.temporal.precision_at_k",
+      "baseline": 0.25,
+      "current": 1.0,
+      "delta": 0.75,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.slice.temporal.recall_at_k",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "golden.total_queries",
+      "baseline": 50.0,
+      "current": 50.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "injection.abstention_false_positive_bound",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "injection.all_checks",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "injection.expected_memory_recall",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "injection.forbidden_memory_exclusion",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "injection.user_prompt_submit_abstention_false_positive_bound",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    },
+    {
+      "metric": "injection.user_prompt_submit_memory_recall",
+      "baseline": 1.0,
+      "current": 1.0,
+      "delta": 0.0,
+      "max_drop": 0.0,
+      "status": "pass"
+    }
+  ],
+  "failures": [],
+  "source_reports": {
+    "golden": {
+      "abstention_passed": 10,
+      "abstention_queries": 10,
+      "by_category": {
+        "abstention": {
+          "abstention_passed": 10,
+          "abstention_queries": 10,
+          "metrics": null,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 9.582459,
+          "retrieval_latency_p95_ms": 10.263875,
+          "scored_queries": 0,
+          "total_queries": 10
+        },
+        "knowledge_update": {
+          "abstention_passed": 0,
+          "abstention_queries": 0,
+          "metrics": {
+            "count": 10,
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 0.8,
+            "recall_at_k": 1.0
+          },
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 10.079792000000001,
+          "retrieval_latency_p95_ms": 10.522916,
+          "scored_queries": 10,
+          "total_queries": 10
+        },
+        "multi_hop": {
+          "abstention_passed": 0,
+          "abstention_queries": 0,
+          "metrics": {
+            "count": 10,
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 0.9919720789148186,
+            "precision_at_k": 0.9666666666666666,
+            "recall_at_k": 1.0
+          },
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 10.588625,
+          "retrieval_latency_p95_ms": 11.365375,
+          "scored_queries": 10,
+          "total_queries": 10
+        },
+        "retrieval": {
+          "abstention_passed": 0,
+          "abstention_queries": 0,
+          "metrics": {
+            "count": 10,
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 9.653625,
+          "retrieval_latency_p95_ms": 10.900416,
+          "scored_queries": 10,
+          "total_queries": 10
+        },
+        "temporal": {
+          "abstention_passed": 0,
+          "abstention_queries": 0,
+          "metrics": {
+            "count": 10,
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 9.812083,
+          "retrieval_latency_p95_ms": 10.111958000000001,
+          "scored_queries": 10,
+          "total_queries": 10
+        }
+      },
+      "by_slice": {
+        "abstention": {
+          "abstention_passed": 10,
+          "abstention_queries": 10,
+          "metrics": null,
+          "query_tokens_per_query": 12.0,
+          "retrieval_latency_p50_ms": 9.582459,
+          "retrieval_latency_p95_ms": 10.263875,
+          "scored_queries": 0,
+          "total_queries": 10
+        },
+        "knowledge_update": {
+          "abstention_passed": 0,
+          "abstention_queries": 0,
+          "metrics": {
+            "count": 10,
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 0.8,
+            "recall_at_k": 1.0
+          },
+          "query_tokens_per_query": 12.8,
+          "retrieval_latency_p50_ms": 10.079792000000001,
+          "retrieval_latency_p95_ms": 10.522916,
+          "scored_queries": 10,
+          "total_queries": 10
+        },
+        "multi_hop": {
+          "abstention_passed": 0,
+          "abstention_queries": 0,
+          "metrics": {
+            "count": 10,
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 0.9919720789148186,
+            "precision_at_k": 0.9666666666666666,
+            "recall_at_k": 1.0
+          },
+          "query_tokens_per_query": 19.6,
+          "retrieval_latency_p50_ms": 10.588625,
+          "retrieval_latency_p95_ms": 11.365375,
+          "scored_queries": 10,
+          "total_queries": 10
+        },
+        "paraphrase": {
+          "abstention_passed": 0,
+          "abstention_queries": 0,
+          "metrics": {
+            "count": 10,
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "query_tokens_per_query": 7.4,
+          "retrieval_latency_p50_ms": 9.653625,
+          "retrieval_latency_p95_ms": 10.900416,
+          "scored_queries": 10,
+          "total_queries": 10
+        },
+        "temporal": {
+          "abstention_passed": 0,
+          "abstention_queries": 0,
+          "metrics": {
+            "count": 10,
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "query_tokens_per_query": 12.6,
+          "retrieval_latency_p50_ms": 9.812083,
+          "retrieval_latency_p95_ms": 10.111958000000001,
+          "scored_queries": 10,
+          "total_queries": 10
+        }
+      },
+      "description": "Synthetic golden retrieval dataset for remem. Fictional project/entity names prevent pretraining leakage; slice labels drive per-slice metrics.",
+      "evaluation_layers": {
+        "answer_generation": {
+          "description": "answer generation is intentionally excluded from golden retrieval eval",
+          "status": "not_run"
+        },
+        "llm_judge": {
+          "description": "LLM judging is intentionally excluded from deterministic golden eval",
+          "status": "not_run"
+        },
+        "retrieval": {
+          "description": "fixed golden retrieval metrics: Hit@K, Recall@K, MRR, nDCG, evidence recall",
+          "status": "deterministic"
+        }
+      },
+      "k": 5,
+      "overall": {
+        "count": 40,
+        "evidence_recall_at_k": 0.75,
+        "hit_at_k": 0.75,
+        "mrr_at_10": 0.75,
+        "ndcg_at_10": 0.7479930197287047,
+        "precision_at_k": 0.6916666666666667,
+        "recall_at_k": 0.75
+      },
+      "queries": [
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-01",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Mira Vale controls violet rail allowance for Project KestrelNook.",
+              "title_contains": null,
+              "topic_key": "kestrelnook-violet-rail-allowance"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "owner mauve locomotive ration",
+          "query_tokens": 8,
+          "result_count": 0,
+          "retrieval_latency_ms": 10.900416,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-02",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Toma Reed owns orange dock shutdown window for Project LumenQuay.",
+              "title_contains": null,
+              "topic_key": "lumenquay-orange-dock-window"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "keeper amber harbor curfew",
+          "query_tokens": 7,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.637500000000001,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-03",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Nia Sol runs gray grove pruning protocol for Project CinderBloom.",
+              "title_contains": null,
+              "topic_key": "cinderbloom-gray-grove-pruning"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "executor silver orchard cleanse",
+          "query_tokens": 8,
+          "result_count": 0,
+          "retrieval_latency_ms": 10.046583,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-04",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Oren Pike stores blue kiln inspection notes in Project BrindleForge.",
+              "title_contains": null,
+              "topic_key": "brindleforge-blue-kiln-inspection"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "where azure furnace audit",
+          "query_tokens": 7,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.499749999999999,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-05",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Ivo Lane manages red archive allowance for Project VellumSpire.",
+              "title_contains": null,
+              "topic_key": "vellumspire-red-archive-allowance"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "holder crimson library quota",
+          "query_tokens": 7,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.653625,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-06",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Sana Holt guards green span revert plan for Project HollowSpan.",
+              "title_contains": null,
+              "topic_key": "hollowspan-green-span-revert"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "custodian emerald bridge rollback",
+          "query_tokens": 9,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.880708,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-07",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Pax Rune coordinates white ravine handoff for Project PaleRavine.",
+              "title_contains": null,
+              "topic_key": "paleravine-white-ravine-handoff"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "lead ivory canyon relay",
+          "query_tokens": 6,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.641167000000001,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-08",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Lina Moss controls copper oven alert for Project CopperOven.",
+              "title_contains": null,
+              "topic_key": "copperoven-copper-oven-alert"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "owner bronze bakery alarm",
+          "query_tokens": 7,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.620458,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-09",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Miko Ash maintains cyan ward schedule for Project CyanWard.",
+              "title_contains": null,
+              "topic_key": "cyanward-cyan-ward-schedule"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "keeper teal clinic roster",
+          "query_tokens": 7,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.464458,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "retrieval",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "paraphrase-10",
+          "matched_refs": 0,
+          "metrics": {
+            "evidence_recall_at_k": 0.0,
+            "hit_at_k": 0.0,
+            "mrr_at_10": 0.0,
+            "ndcg_at_10": 0.0,
+            "precision_at_k": 0.0,
+            "recall_at_k": 0.0
+          },
+          "missing_evidence_refs": [
+            {
+              "branch": null,
+              "memory_id": null,
+              "memory_type": "decision",
+              "project": null,
+              "scope": null,
+              "text_contains": "Vera Knox owns purple observatory authorization for Project VioletDome.",
+              "title_contains": null,
+              "topic_key": "violetdome-purple-observatory-authorization"
+            }
+          ],
+          "missing_relevant_ids": [],
+          "query": "handler plum telescope permit",
+          "query_tokens": 8,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.972417,
+          "retrieved_ids": [],
+          "slice": "paraphrase",
+          "status": "MISS"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-01",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 0.5,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current NebulaLatch quorum for Project kestrelnook?",
+          "query_tokens": 13,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.491541999999999,
+          "retrieved_ids": [
+            11,
+            21
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-02",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current HarborMint signer for Project lumenquay?",
+          "query_tokens": 12,
+          "result_count": 1,
+          "retrieval_latency_ms": 10.133042,
+          "retrieved_ids": [
+            12
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-03",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current GroveCache shard for Project cinderbloom?",
+          "query_tokens": 13,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.913917,
+          "retrieved_ids": [
+            13
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-04",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current KilnGuard threshold for Project brindleforge?",
+          "query_tokens": 14,
+          "result_count": 1,
+          "retrieval_latency_ms": 10.017834,
+          "retrieved_ids": [
+            14
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-05",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current ArchiveFox retention for Project vellumspire?",
+          "query_tokens": 14,
+          "result_count": 1,
+          "retrieval_latency_ms": 10.079792000000001,
+          "retrieved_ids": [
+            15
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-06",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 0.5,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current SpanDrift owner for Project hollowspan?",
+          "query_tokens": 12,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.076458,
+          "retrieved_ids": [
+            16,
+            41
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-07",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current RavineRelay region for Project paleravine?",
+          "query_tokens": 13,
+          "result_count": 1,
+          "retrieval_latency_ms": 10.522916,
+          "retrieved_ids": [
+            17
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-08",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 0.5,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current OvenBell route for Project copperoven?",
+          "query_tokens": 12,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.0205,
+          "retrieved_ids": [
+            18,
+            28
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-09",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 0.5,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current WardRoster source for Project cyanward?",
+          "query_tokens": 12,
+          "result_count": 2,
+          "retrieval_latency_ms": 9.854333,
+          "retrieved_ids": [
+            19,
+            29
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "knowledge_update",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "knowledge-update-10",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Current DomePermit approver for Project violetdome?",
+          "query_tokens": 13,
+          "result_count": 1,
+          "retrieval_latency_ms": 10.225542,
+          "retrieved_ids": [
+            20
+          ],
+          "slice": "knowledge_update",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-01",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "latest NightJar deployment for Project kestrelnook",
+          "query_tokens": 13,
+          "result_count": 1,
+          "retrieval_latency_ms": 10.111958000000001,
+          "retrieved_ids": [
+            21
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-02",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "before HarborMint freeze for Project lumenquay",
+          "query_tokens": 12,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.652249999999999,
+          "retrieved_ids": [
+            22
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-03",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "after GroveCache rotation for Project cinderbloom",
+          "query_tokens": 13,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.812083,
+          "retrieved_ids": [
+            23
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-04",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "during KilnGuard audit week for Project brindleforge",
+          "query_tokens": 13,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.768416,
+          "retrieved_ids": [
+            24
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-05",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "latest ArchiveFox cleanup for Project vellumspire",
+          "query_tokens": 13,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.877666999999999,
+          "retrieved_ids": [
+            25
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-06",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "before SpanDrift cutover for Project hollowspan",
+          "query_tokens": 12,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.603708000000001,
+          "retrieved_ids": [
+            26
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-07",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "after RavineRelay incident for Project paleravine",
+          "query_tokens": 13,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.742125000000001,
+          "retrieved_ids": [
+            27
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-08",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "during OvenBell maintenance for Project copperoven",
+          "query_tokens": 13,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.978000000000002,
+          "retrieved_ids": [
+            28
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-09",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "latest WardRoster import for Project cyanward",
+          "query_tokens": 12,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.89825,
+          "retrieved_ids": [
+            29
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "temporal",
+          "expected_refs": 1,
+          "expected_relevant_ids": [],
+          "id": "temporal-10",
+          "matched_refs": 1,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "after DomePermit review for Project violetdome",
+          "query_tokens": 12,
+          "result_count": 1,
+          "retrieval_latency_ms": 9.784584,
+          "retrieved_ids": [
+            30
+          ],
+          "slice": "temporal",
+          "status": "HIT"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-01",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Has Project KestrelNook migrated NebulaLatch to Oracle Cloud?",
+          "query_tokens": 16,
+          "result_count": 0,
+          "retrieval_latency_ms": 10.006457999999999,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-02",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "What is the HarborMint password rotation secret?",
+          "query_tokens": 12,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.659915999999999,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-03",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which production customer paid for GroveCache premium?",
+          "query_tokens": 14,
+          "result_count": 0,
+          "retrieval_latency_ms": 10.263875,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-04",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Show the KilnGuard private signing key.",
+          "query_tokens": 10,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.582459,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-05",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Did ArchiveFox replace remem with Cassandra?",
+          "query_tokens": 11,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.631458,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-06",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "What is the SpanDrift payroll token?",
+          "query_tokens": 9,
+          "result_count": 0,
+          "retrieval_latency_ms": 8.868667,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-07",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which RavineRelay medical record was exported?",
+          "query_tokens": 12,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.211208000000001,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-08",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Has OvenBell switched to MongoDB-only storage?",
+          "query_tokens": 12,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.045333,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-09",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "What is the WardRoster user credit card number?",
+          "query_tokens": 12,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.097959,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "abstention",
+          "expected_refs": 0,
+          "expected_relevant_ids": [],
+          "id": "abstention-10",
+          "matched_refs": 0,
+          "metrics": null,
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Did DomePermit delete all audit logs yesterday?",
+          "query_tokens": 12,
+          "result_count": 0,
+          "retrieval_latency_ms": 9.561250000000001,
+          "retrieved_ids": [],
+          "slice": "abstention",
+          "status": "PASS"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-01",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 0.9197207891481876,
+            "precision_at_k": 0.6666666666666666,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles NebulaLatch through its owning team in Project kestrelnook?",
+          "query_tokens": 20,
+          "result_count": 3,
+          "retrieval_latency_ms": 11.365375,
+          "retrieved_ids": [
+            31,
+            21,
+            32
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-02",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles HarborMint through its owning team in Project lumenquay?",
+          "query_tokens": 19,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.7375,
+          "retrieved_ids": [
+            33,
+            34
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-03",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles GroveCache through its owning team in Project cinderbloom?",
+          "query_tokens": 20,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.72625,
+          "retrieved_ids": [
+            35,
+            36
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-04",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles KilnGuard through its owning team in Project brindleforge?",
+          "query_tokens": 20,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.602667,
+          "retrieved_ids": [
+            37,
+            38
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-05",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles ArchiveFox through its owning team in Project vellumspire?",
+          "query_tokens": 20,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.511958,
+          "retrieved_ids": [
+            39,
+            40
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-06",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles SpanDrift through its owning team in Project hollowspan?",
+          "query_tokens": 19,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.435958000000001,
+          "retrieved_ids": [
+            41,
+            42
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-07",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles RavineRelay through its owning team in Project paleravine?",
+          "query_tokens": 20,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.397917,
+          "retrieved_ids": [
+            43,
+            44
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-08",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles OvenBell through its owning team in Project copperoven?",
+          "query_tokens": 19,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.588625,
+          "retrieved_ids": [
+            45,
+            46
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-09",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles WardRoster through its owning team in Project cyanward?",
+          "query_tokens": 19,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.470917,
+          "retrieved_ids": [
+            47,
+            48
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        },
+        {
+          "category": "multi_hop",
+          "expected_refs": 2,
+          "expected_relevant_ids": [],
+          "id": "multi-hop-10",
+          "matched_refs": 2,
+          "metrics": {
+            "evidence_recall_at_k": 1.0,
+            "hit_at_k": 1.0,
+            "mrr_at_10": 1.0,
+            "ndcg_at_10": 1.0,
+            "precision_at_k": 1.0,
+            "recall_at_k": 1.0
+          },
+          "missing_evidence_refs": [],
+          "missing_relevant_ids": [],
+          "query": "Which pager handles DomePermit through its owning team in Project violetdome?",
+          "query_tokens": 20,
+          "result_count": 2,
+          "retrieval_latency_ms": 10.486749999999999,
+          "retrieved_ids": [
+            49,
+            50
+          ],
+          "slice": "multi_hop",
+          "status": "HIT"
+        }
+      ],
+      "rank_k": 10,
+      "scored_queries": 40,
+      "skipped_queries": 0,
+      "total_queries": 50,
+      "version": "2.0"
+    },
+    "injection": {
+      "cases": [
+        {
+          "expectation": "expected",
+          "id": "1",
+          "matched": true,
+          "title": "Migration locking fix",
+          "topic_key": "inject-migration-locking"
+        },
+        {
+          "expectation": "expected",
+          "id": "2",
+          "matched": true,
+          "title": "API token handling decision",
+          "topic_key": "inject-api-token-handling"
+        },
+        {
+          "expectation": "expected",
+          "id": "8",
+          "matched": true,
+          "title": "Stale source anchor decision",
+          "topic_key": "inject-stale-source-anchor"
+        },
+        {
+          "expectation": "forbidden",
+          "id": "3",
+          "matched": true,
+          "title": "Feature branch wasm snapshot",
+          "topic_key": "inject-branch-mismatch"
+        },
+        {
+          "expectation": "forbidden",
+          "id": "4",
+          "matched": true,
+          "title": "Other project migration shortcut",
+          "topic_key": "inject-cross-project"
+        },
+        {
+          "expectation": "forbidden",
+          "id": "5",
+          "matched": true,
+          "title": "Deleted project advice",
+          "topic_key": "inject-deleted-advice"
+        }
+      ],
+      "failing_examples": [],
+      "metadata": {
+        "boundary": "context::render_context_output",
+        "branch": "main",
+        "core_count": 4,
+        "corpus": "builtin-context-injection-v2",
+        "data_dir": "/var/folders/h2/29bv07g91nqd40ybjj_vb6nm0000gn/T/remem-injection-eval-36706-1781475063649015000",
+        "data_dir_kept": false,
+        "host": "codex-cli",
+        "index_count": 0,
+        "lesson_count": 0,
+        "memories_loaded": 4,
+        "output_chars": 1372,
+        "preference_count": 0,
+        "project": "/tmp/remem-injection-eval/repo",
+        "real_db_touched": false,
+        "session_count": 0,
+        "storage": "temporary sqlite",
+        "truncated": false,
+        "workstream_count": 0
+      },
+      "metrics": {
+        "abstention_false_positive_bound": {
+          "passed": 1,
+          "rate": 1.0,
+          "total": 1
+        },
+        "all_checks_passed": true,
+        "expected_memory_recall": {
+          "passed": 3,
+          "rate": 1.0,
+          "total": 3
+        },
+        "forbidden_memory_exclusion": {
+          "passed": 3,
+          "rate": 1.0,
+          "total": 3
+        },
+        "stale_anchor_labeling": {
+          "passed": 1,
+          "rate": 1.0,
+          "total": 1
+        },
+        "user_prompt_submit_abstention_false_positive_bound": {
+          "passed": 1,
+          "rate": 1.0,
+          "total": 1
+        },
+        "user_prompt_submit_memory_recall": {
+          "passed": 1,
+          "rate": 1.0,
+          "total": 1
+        }
+      }
+    },
+    "extraction": {
+      "cases": [
+        {
+          "candidate_request_sha256": "a21e45990a9f9a11b49107714b0e2b0f644e6709eb617ddbca7837a503c76f3d",
+          "forbidden_candidates": [],
+          "forbidden_observations": [],
+          "id": "build-fix-loop-guard",
+          "missing_expected_candidates": [],
+          "missing_expected_observations": [],
+          "observation_request_sha256": "ded254888675feba15e8cc2fda35d5a29a81f8f4b248d4ce257e84cb02834c9f",
+          "over_saved_predictions": 0,
+          "pass": true,
+          "predicted_candidates": [
+            {
+              "index": 0,
+              "memory_type": "lesson",
+              "risk_class": "medium",
+              "scope": "project",
+              "text": "After three consecutive failed build fixes on the same problem, stop and challenge the hypothesis before editing again.",
+              "topic_key": "build-fix-loop-guard"
+            }
+          ],
+          "predicted_observations": [
+            {
+              "confidence": 0.91,
+              "index": 0,
+              "observation_type": "decision",
+              "text": "After three consecutive failed build fixes on the same problem, stop and challenge the hypothesis before editing again."
+            }
+          ],
+          "transcript_events": 3,
+          "unexpected_candidates": [],
+          "unexpected_observations": []
+        },
+        {
+          "candidate_request_sha256": "c885dc5134cd6e9cf944bcb6cc341432b925c2a1a3a6101b36d2fe78721e28ee",
+          "forbidden_candidates": [],
+          "forbidden_observations": [],
+          "id": "automatic-capture-primary",
+          "missing_expected_candidates": [],
+          "missing_expected_observations": [],
+          "observation_request_sha256": "024b14719614bda0fed7abba0096cadfd171ee52c2c54d8bc89c80b48da7e552",
+          "over_saved_predictions": 0,
+          "pass": true,
+          "predicted_candidates": [
+            {
+              "index": 0,
+              "memory_type": "architecture",
+              "risk_class": "medium",
+              "scope": "project",
+              "text": "Memory capture must not depend on Codex voluntarily calling save_memory; automatic extraction is the primary channel and manual saves are supplemental.",
+              "topic_key": "automatic-capture-primary"
+            }
+          ],
+          "predicted_observations": [
+            {
+              "confidence": 0.95,
+              "index": 0,
+              "observation_type": "decision",
+              "text": "Memory capture must not depend on Codex voluntarily calling save_memory; automatic extraction is the primary channel and manual saves are only supplemental."
+            }
+          ],
+          "transcript_events": 2,
+          "unexpected_candidates": [],
+          "unexpected_observations": []
+        }
+      ],
+      "failing_examples": [],
+      "metadata": {
+        "cases": 2,
+        "corpus": "eval/extraction/corpus.json",
+        "corpus_version": "2026-06-12",
+        "description": "Deterministic extraction-quality corpus for observation and memory-candidate parser outputs.",
+        "transcript_events": 5
+      },
+      "metrics": {
+        "all_checks_passed": true,
+        "candidate_precision": {
+          "passed": 2,
+          "rate": 1.0,
+          "total": 2
+        },
+        "candidate_recall": {
+          "passed": 2,
+          "rate": 1.0,
+          "total": 2
+        },
+        "forbidden_candidate_exclusion": {
+          "passed": 2,
+          "rate": 1.0,
+          "total": 2
+        },
+        "forbidden_observation_exclusion": {
+          "passed": 2,
+          "rate": 1.0,
+          "total": 2
+        },
+        "observation_precision": {
+          "passed": 2,
+          "rate": 1.0,
+          "total": 2
+        },
+        "observation_recall": {
+          "passed": 2,
+          "rate": 1.0,
+          "total": 2
+        },
+        "over_save_penalty": 0.0,
+        "over_saved_predictions": 0,
+        "total_predictions": 4
+      }
+    }
+  }
+}

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.72",
+  "version": "0.5.73",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.72",
+  "version": "0.5.73",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.72": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.72",
+    "0.5.73": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.73",
       "assets": {}
     }
   }

--- a/src/api/handlers/search.rs
+++ b/src/api/handlers/search.rs
@@ -7,7 +7,7 @@ use axum::{
 
 use crate::memory::service;
 
-use super::super::helpers::{error_response, memory_to_item, open_request_db};
+use super::super::helpers::{error_response, memory_to_item_with_conn, open_request_db};
 use super::super::types::{
     DbState, MemoryItem, Meta, MultiHopInfo, RawHitItem, SearchParams, SearchResponse,
 };
@@ -71,7 +71,11 @@ pub(in crate::api) async fn handle_search(
     match service::search_memories(&conn, &req) {
         Ok(results) => {
             let count = results.memories.len();
-            let items: Vec<MemoryItem> = results.memories.iter().map(memory_to_item).collect();
+            let items: Vec<MemoryItem> = results
+                .memories
+                .iter()
+                .map(|memory| memory_to_item_with_conn(&conn, memory))
+                .collect();
             let raw_hits: Vec<RawHitItem> = results
                 .raw_hits
                 .into_iter()

--- a/src/api/handlers/show.rs
+++ b/src/api/handlers/show.rs
@@ -7,7 +7,7 @@ use axum::{
 
 use crate::memory;
 
-use super::super::helpers::{error_response, memory_to_item, open_request_db};
+use super::super::helpers::{error_response, memory_to_item_with_conn, open_request_db};
 use super::super::types::{DbState, ShowParams};
 
 pub(in crate::api) async fn handle_get_memory(
@@ -20,7 +20,9 @@ pub(in crate::api) async fn handle_get_memory(
     };
 
     match memory::get_memories_by_ids(&conn, &[params.id], None) {
-        Ok(results) if !results.is_empty() => Json(memory_to_item(&results[0])).into_response(),
+        Ok(results) if !results.is_empty() => {
+            Json(memory_to_item_with_conn(&conn, &results[0])).into_response()
+        }
         Ok(_) => {
             error_response(StatusCode::NOT_FOUND, "not_found", "Memory not found").into_response()
         }

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -8,7 +8,31 @@ use crate::{db, memory};
 
 use super::types::{ErrorDetail, ErrorResponse, MemoryItem};
 
-pub(super) fn memory_to_item(memory: &memory::Memory) -> MemoryItem {
+pub(super) fn memory_to_item_with_conn(
+    conn: &rusqlite::Connection,
+    memory: &memory::Memory,
+) -> MemoryItem {
+    let now_epoch = chrono::Utc::now().timestamp();
+    let staleness = match memory::memory_staleness_label_with_conn(conn, memory, now_epoch) {
+        Ok(label) => label,
+        Err(err) => {
+            crate::log::warn(
+                "api",
+                &format!(
+                    "memory {} staleness source-anchor lookup failed: {}",
+                    memory.id, err
+                ),
+            );
+            memory::memory_staleness_label(memory, now_epoch)
+        }
+    };
+    memory_to_item_with_staleness(memory, staleness)
+}
+
+fn memory_to_item_with_staleness(
+    memory: &memory::Memory,
+    staleness: memory::MemoryStalenessLabel,
+) -> MemoryItem {
     MemoryItem {
         id: memory.id,
         title: memory.title.clone(),
@@ -17,7 +41,7 @@ pub(super) fn memory_to_item(memory: &memory::Memory) -> MemoryItem {
         project: memory.project.clone(),
         scope: memory.scope.clone(),
         status: memory.status.clone(),
-        staleness: memory::memory_staleness_label(memory, chrono::Utc::now().timestamp()),
+        staleness,
         topic_key: memory.topic_key.clone(),
         branch: memory.branch.clone(),
         created_at_epoch: memory.created_at_epoch,

--- a/src/cli/actions/query/tests.rs
+++ b/src/cli/actions/query/tests.rs
@@ -96,7 +96,7 @@ fn sample_explain() -> SearchExplain {
             staleness: crate::memory::MemoryStalenessLabel {
                 status: "active".to_string(),
                 age: "fresh",
-                source_anchor: "untracked",
+                source_anchor: "untracked".to_string(),
                 label: "status=active; staleness=fresh; source_anchor=untracked".to_string(),
             },
             contributions: vec![ChannelContribution {

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,6 +12,7 @@ mod hybrid_context;
 mod implicit_query;
 mod injection_gate;
 mod invocation;
+mod memory_selection;
 mod memory_traits;
 mod ownership;
 mod policy;

--- a/src/context/audit.rs
+++ b/src/context/audit.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
 use rusqlite::params;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use crate::memory::{age_staleness_label, memory_staleness as shared_memory_staleness, Memory};
+use crate::memory::{
+    age_staleness_label, memory_staleness as shared_memory_staleness, Memory, MemoryStalenessLabel,
+};
 
 use super::injection_gate::{ContextGateAction, ContextGateDecision};
 use super::invocation::ContextInvocation;
@@ -114,10 +116,18 @@ impl ContextAuditItem {
 }
 
 pub(in crate::context) fn memory_render_metadata(memory: &Memory, now_epoch: i64) -> String {
+    memory_render_metadata_with_labels(memory, now_epoch, &HashMap::new())
+}
+
+pub(in crate::context) fn memory_render_metadata_with_labels(
+    memory: &Memory,
+    now_epoch: i64,
+    staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
+) -> String {
     format!(
-        "src=memory:#{}; {}",
+        "src=memory:#{};{}",
         memory.id,
-        memory_staleness(memory, now_epoch)
+        memory_staleness_with_labels(memory, now_epoch, staleness_labels).replace("; ", ";")
     )
 }
 
@@ -136,6 +146,17 @@ pub(in crate::context) fn memory_provenance(memory: &Memory) -> String {
 
 pub(in crate::context) fn memory_staleness(memory: &Memory, now_epoch: i64) -> String {
     shared_memory_staleness(memory, now_epoch)
+}
+
+fn memory_staleness_with_labels(
+    memory: &Memory,
+    now_epoch: i64,
+    staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
+) -> String {
+    staleness_labels
+        .get(&memory.id)
+        .map(|label| label.label.clone())
+        .unwrap_or_else(|| memory_staleness(memory, now_epoch))
 }
 
 pub(in crate::context) fn record_context_injection_items(

--- a/src/context/audit.rs
+++ b/src/context/audit.rs
@@ -30,6 +30,18 @@ impl ContextAuditItem {
         Self::memory_item(memory, channel, Some(render_order), "injected", None)
     }
 
+    pub fn injected_memory_with_labels(
+        memory: &Memory,
+        channel: &'static str,
+        render_order: i64,
+        staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
+    ) -> Self {
+        let mut item = Self::injected_memory(memory, channel, render_order);
+        item.staleness =
+            memory_staleness_with_labels(memory, chrono::Utc::now().timestamp(), staleness_labels);
+        item
+    }
+
     pub fn dropped_memory(memory: &Memory, channel: &'static str, reason: &'static str) -> Self {
         Self::memory_item(memory, channel, None, "dropped", Some(reason))
     }
@@ -234,20 +246,22 @@ pub(in crate::context) fn build_context_audit_items(
     let index = index_ids.iter().copied().collect::<HashSet<_>>();
     for id in core_ids {
         if let Some(memory) = loaded.memories.iter().find(|memory| memory.id == *id) {
-            items.push(ContextAuditItem::injected_memory(
+            items.push(ContextAuditItem::injected_memory_with_labels(
                 memory,
                 "core",
                 render_order,
+                &loaded.staleness_labels,
             ));
             render_order += 1;
         }
     }
     for id in index_ids {
         if let Some(memory) = loaded.memories.iter().find(|memory| memory.id == *id) {
-            items.push(ContextAuditItem::injected_memory(
+            items.push(ContextAuditItem::injected_memory_with_labels(
                 memory,
                 "index",
                 render_order,
+                &loaded.staleness_labels,
             ));
             render_order += 1;
         }
@@ -264,10 +278,11 @@ pub(in crate::context) fn build_context_audit_items(
     let lesson = lesson_ids.iter().copied().collect::<HashSet<_>>();
     for id in lesson_ids {
         if let Some(lesson_memory) = loaded.lessons.iter().find(|lesson| lesson.memory.id == *id) {
-            items.push(ContextAuditItem::injected_memory(
+            items.push(ContextAuditItem::injected_memory_with_labels(
                 &lesson_memory.memory,
                 "lessons",
                 render_order,
+                &loaded.staleness_labels,
             ));
             render_order += 1;
         }

--- a/src/context/audit.rs
+++ b/src/context/audit.rs
@@ -115,10 +115,6 @@ impl ContextAuditItem {
     }
 }
 
-pub(in crate::context) fn memory_render_metadata(memory: &Memory, now_epoch: i64) -> String {
-    memory_render_metadata_with_labels(memory, now_epoch, &HashMap::new())
-}
-
 pub(in crate::context) fn memory_render_metadata_with_labels(
     memory: &Memory,
     now_epoch: i64,

--- a/src/context/memory_selection.rs
+++ b/src/context/memory_selection.rs
@@ -1,0 +1,229 @@
+use std::collections::HashMap;
+
+use crate::memory::Memory;
+
+use super::memory_traits::is_memory_self_diagnostic;
+use super::types::HiddenDuplicateGroup;
+
+pub(super) fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {
+    let Some(branch) = current_branch else {
+        return;
+    };
+
+    memories.sort_by(|left, right| {
+        branch_sort_score(left, branch).cmp(&branch_sort_score(right, branch))
+    });
+}
+
+fn branch_sort_score(memory: &Memory, current_branch: &str) -> u8 {
+    match memory.branch.as_deref() {
+        Some(branch) if branch == current_branch => 0,
+        None => 1,
+        Some("main") | Some("master") => 2,
+        _ => 3,
+    }
+}
+
+struct ClusterRepresentative {
+    first_index: usize,
+    cluster_key: String,
+    memory: Memory,
+    hidden_ids: Vec<i64>,
+}
+
+pub(super) fn deduplicate_memory_clusters(
+    memories: Vec<Memory>,
+    current_branch: Option<&str>,
+) -> (Vec<Memory>, Vec<HiddenDuplicateGroup>) {
+    let mut representatives: HashMap<String, ClusterRepresentative> = HashMap::new();
+
+    for (index, memory) in memories.into_iter().enumerate() {
+        let cluster_key = memory_cluster_key(&memory);
+        match representatives.get_mut(&cluster_key) {
+            Some(representative) => {
+                if is_better_cluster_representative(&memory, &representative.memory, current_branch)
+                {
+                    representative.hidden_ids.push(representative.memory.id);
+                    representative.memory = memory;
+                } else {
+                    representative.hidden_ids.push(memory.id);
+                }
+            }
+            None => {
+                representatives.insert(
+                    cluster_key.clone(),
+                    ClusterRepresentative {
+                        first_index: index,
+                        cluster_key,
+                        memory,
+                        hidden_ids: Vec::new(),
+                    },
+                );
+            }
+        }
+    }
+
+    let mut deduped: Vec<ClusterRepresentative> = representatives.into_values().collect();
+    deduped.sort_by_key(|representative| representative.first_index);
+    let hidden_groups = deduped
+        .iter()
+        .filter(|representative| !representative.hidden_ids.is_empty())
+        .map(|representative| HiddenDuplicateGroup {
+            cluster_key: representative.cluster_key.clone(),
+            chosen_id: representative.memory.id,
+            hidden_ids: representative.hidden_ids.clone(),
+        })
+        .collect();
+    let memories = deduped
+        .into_iter()
+        .map(|representative| representative.memory)
+        .collect();
+    (memories, hidden_groups)
+}
+
+fn is_better_cluster_representative(
+    candidate: &Memory,
+    incumbent: &Memory,
+    current_branch: Option<&str>,
+) -> bool {
+    let candidate_branch_score = current_branch
+        .map(|branch| branch_sort_score(candidate, branch))
+        .unwrap_or(0);
+    let incumbent_branch_score = current_branch
+        .map(|branch| branch_sort_score(incumbent, branch))
+        .unwrap_or(0);
+
+    candidate_branch_score < incumbent_branch_score
+        || (candidate_branch_score == incumbent_branch_score
+            && candidate.updated_at_epoch > incumbent.updated_at_epoch)
+}
+
+pub(super) fn limit_self_diagnostic_memories(memories: Vec<Memory>, limit: usize) -> Vec<Memory> {
+    let mut retained = Vec::new();
+    let mut self_diagnostic_count = 0;
+
+    for memory in memories {
+        if is_memory_self_diagnostic(&memory) {
+            if self_diagnostic_count >= limit {
+                continue;
+            }
+            self_diagnostic_count += 1;
+        }
+        retained.push(memory);
+    }
+
+    retained
+}
+
+fn memory_cluster_key(memory: &Memory) -> String {
+    if let Some(topic_key) = stable_topic_key(memory.topic_key.as_deref(), &memory.memory_type) {
+        return format!("topic:{topic_key}");
+    }
+
+    if let Some(context) = context_prefix(&memory.text) {
+        return format!(
+            "context:{}:{}",
+            memory.memory_type,
+            context_cluster_suffix(&normalize_cluster_text(&context))
+        );
+    }
+
+    format!(
+        "title:{}:{}",
+        memory.memory_type,
+        normalize_cluster_text(&memory.title)
+    )
+}
+
+fn stable_topic_key<'a>(topic_key: Option<&'a str>, memory_type: &str) -> Option<&'a str> {
+    let key = topic_key?.trim();
+    if key.is_empty() || looks_generated_topic_key(key, memory_type) {
+        return None;
+    }
+    Some(key)
+}
+
+fn looks_generated_topic_key(key: &str, memory_type: &str) -> bool {
+    let Some(suffix) = key.strip_prefix(&format!("{memory_type}-")) else {
+        return false;
+    };
+    suffix.len() >= 12 && suffix.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn context_prefix(text: &str) -> Option<String> {
+    let trimmed = text.trim_start();
+    let rest = trimmed.strip_prefix("[Context:")?;
+    let end = rest.find(']')?;
+    Some(rest[..end].trim().to_string())
+}
+
+pub(super) fn normalize_cluster_text(text: &str) -> String {
+    let mut folded = String::new();
+    for ch in text.chars() {
+        if ch.is_alphanumeric() {
+            folded.extend(ch.to_lowercase());
+        } else {
+            folded.push(' ');
+        }
+    }
+
+    let normalized = folded.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    normalized.chars().take(96).collect()
+}
+
+pub(super) fn context_cluster_suffix(normalized_context: &str) -> String {
+    let tokens: Vec<&str> = normalized_context.split_whitespace().collect();
+    if let Some(reference_key) = reference_cluster_key(&tokens) {
+        return reference_key;
+    }
+
+    let ascii_tokens: Vec<&str> = tokens
+        .iter()
+        .copied()
+        .filter(|token| token.chars().all(|ch| ch.is_ascii_alphanumeric()))
+        .filter(|token| !is_context_stop_token(token))
+        .take(5)
+        .collect();
+    if ascii_tokens.len() >= 2 {
+        return format!("tokens:{}", ascii_tokens.join("-"));
+    }
+
+    normalized_context.chars().take(96).collect()
+}
+
+pub(super) fn reference_cluster_key(tokens: &[&str]) -> Option<String> {
+    for window in tokens.windows(2) {
+        let label = window[0];
+        let value = window[1];
+        if matches!(label, "pr" | "pull" | "pullrequest")
+            && value.chars().all(|ch| ch.is_ascii_digit())
+        {
+            return Some(format!("pr:{value}"));
+        }
+        if matches!(label, "issue" | "issues") && value.chars().all(|ch| ch.is_ascii_digit()) {
+            return Some(format!("issue:{value}"));
+        }
+    }
+    None
+}
+
+fn is_context_stop_token(token: &str) -> bool {
+    matches!(
+        token,
+        "a" | "an"
+            | "and"
+            | "by"
+            | "for"
+            | "from"
+            | "in"
+            | "of"
+            | "on"
+            | "the"
+            | "to"
+            | "with"
+            | "context"
+            | "skills"
+            | "skill"
+    )
+}

--- a/src/context/prompt_submit.rs
+++ b/src/context/prompt_submit.rs
@@ -1,11 +1,13 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use rusqlite::params;
 
 use crate::memory::Memory;
 
-use super::audit::{memory_render_metadata, record_context_injection_items, ContextAuditItem};
+use super::audit::{
+    memory_render_metadata_with_labels, record_context_injection_items, ContextAuditItem,
+};
 use super::fact_labels::annotate_memories_with_temporal_facts_for_query;
 use super::format::{char_len, format_epoch_short, truncate_chars_with_ellipsis};
 use super::host::resolve_host_kind;
@@ -101,7 +103,12 @@ pub(crate) fn prompt_submit_additional_context(
     audit_items.extend(rendered.iter().enumerate().map(|(index, memory)| {
         ContextAuditItem::injected_memory(memory, "prompt_submit", index as i64 + 1)
     }));
-    let output = render_prompt_submit_context(&rendered);
+    let staleness_labels = crate::memory::memory_staleness_labels_for_memories(
+        conn,
+        &rendered,
+        chrono::Utc::now().timestamp(),
+    )?;
+    let output = render_prompt_submit_context(&rendered, &staleness_labels);
     let decision = prompt_submit_decision(output);
     record_context_injection_items(conn, &invocation, &decision, &audit_items)?;
     Ok(Some(decision.output))
@@ -148,7 +155,10 @@ fn prompt_relevance_passes(prompt: &str, memory: &Memory) -> bool {
         .any(|token| memory_text.contains(token))
 }
 
-fn render_prompt_submit_context(memories: &[Memory]) -> String {
+fn render_prompt_submit_context(
+    memories: &[Memory],
+    staleness_labels: &HashMap<i64, crate::memory::MemoryStalenessLabel>,
+) -> String {
     let mut output = String::from("# remem prompt context\n\n## Relevant Memories\n");
     let now = chrono::Utc::now().timestamp();
     for memory in memories {
@@ -158,7 +168,7 @@ fn render_prompt_submit_context(memories: &[Memory]) -> String {
             memory.title,
             memory.memory_type,
             format_epoch_short(memory.updated_at_epoch),
-            memory_render_metadata(memory, now)
+            memory_render_metadata_with_labels(memory, now, staleness_labels)
         );
         if char_len(&output) + char_len(&header) >= PROMPT_SUBMIT_CHAR_LIMIT {
             break;

--- a/src/context/prompt_submit.rs
+++ b/src/context/prompt_submit.rs
@@ -103,11 +103,7 @@ pub(crate) fn prompt_submit_additional_context(
     audit_items.extend(rendered.iter().enumerate().map(|(index, memory)| {
         ContextAuditItem::injected_memory(memory, "prompt_submit", index as i64 + 1)
     }));
-    let staleness_labels = crate::memory::memory_staleness_labels_for_memories(
-        conn,
-        &rendered,
-        chrono::Utc::now().timestamp(),
-    )?;
+    let staleness_labels = prompt_submit_staleness_labels(conn, &rendered);
     let output = render_prompt_submit_context(&rendered, &staleness_labels);
     let decision = prompt_submit_decision(output);
     record_context_injection_items(conn, &invocation, &decision, &audit_items)?;
@@ -183,6 +179,30 @@ fn render_prompt_submit_context(
         }
     }
     output
+}
+
+fn prompt_submit_staleness_labels(
+    conn: &rusqlite::Connection,
+    memories: &[Memory],
+) -> HashMap<i64, crate::memory::MemoryStalenessLabel> {
+    let now_epoch = chrono::Utc::now().timestamp();
+    memories
+        .iter()
+        .map(|memory| {
+            let label = crate::memory::memory_staleness_label_with_conn(conn, memory, now_epoch)
+                .unwrap_or_else(|error| {
+                    crate::log::warn(
+                        "context",
+                        &format!(
+                            "prompt-submit source-anchor label fallback for memory {}: {error}",
+                            memory.id
+                        ),
+                    );
+                    crate::memory::memory_staleness_label(memory, now_epoch)
+                });
+            (memory.id, label)
+        })
+        .collect()
 }
 
 fn empty_prompt_submit_decision() -> ContextGateDecision {
@@ -359,6 +379,36 @@ mod tests {
             output.contains("HarborMint verified_by Toma Reed"),
             "{output}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn prompt_submit_falls_back_when_source_anchor_label_fails() -> Result<()> {
+        let conn = setup_prompt_submit_conn()?;
+        let project = "/tmp/remem-prompt-submit-staleness-fallback";
+        let memory_id = insert_prompt_submit_memory(
+            &conn,
+            project,
+            "SQLCipher storage decision",
+            "Persist private data with SQLCipher encryption at rest.",
+        )?;
+        conn.execute(
+            "UPDATE memories SET files = '[not-json' WHERE id = ?1",
+            [memory_id],
+        )?;
+
+        let output = prompt_submit_additional_context(
+            &conn,
+            project,
+            project,
+            "sess-prompt-staleness-fallback",
+            "How should SQLCipher protect private persisted data?",
+            Some("claude-code"),
+        )?
+        .ok_or_else(|| anyhow::anyhow!("prompt should still inject context"))?;
+
+        assert!(output.contains("SQLCipher storage decision"), "{output}");
+        assert!(output.contains("source_anchor=untracked"), "{output}");
         Ok(())
     }
 

--- a/src/context/prompt_submit.rs
+++ b/src/context/prompt_submit.rs
@@ -100,10 +100,15 @@ pub(crate) fn prompt_submit_additional_context(
         return Ok(None);
     }
 
-    audit_items.extend(rendered.iter().enumerate().map(|(index, memory)| {
-        ContextAuditItem::injected_memory(memory, "prompt_submit", index as i64 + 1)
-    }));
     let staleness_labels = prompt_submit_staleness_labels(conn, &rendered);
+    audit_items.extend(rendered.iter().enumerate().map(|(index, memory)| {
+        ContextAuditItem::injected_memory_with_labels(
+            memory,
+            "prompt_submit",
+            index as i64 + 1,
+            &staleness_labels,
+        )
+    }));
     let output = render_prompt_submit_context(&rendered, &staleness_labels);
     let decision = prompt_submit_decision(output);
     record_context_injection_items(conn, &invocation, &decision, &audit_items)?;

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -87,7 +87,6 @@ pub(super) fn load_context_data_with_policy(
         crate::log::error("context", &message);
         errors.push(ContextLoadError::new("memories", message));
     }
-    let staleness_labels = load_staleness_labels(conn, project, &mut errors, &memories);
     let lessons = memory::lesson::list_lessons_for_context(
         conn,
         project,
@@ -100,6 +99,12 @@ pub(super) fn load_context_data_with_policy(
         errors.push(ContextLoadError::new("lessons", message));
         Vec::new()
     });
+    let staleness_memories = memories
+        .iter()
+        .chain(lessons.iter().map(|lesson| &lesson.memory))
+        .cloned()
+        .collect::<Vec<_>>();
+    let staleness_labels = load_staleness_labels(conn, &staleness_memories);
 
     LoadedContext {
         memories,
@@ -117,24 +122,26 @@ pub(super) fn load_context_data_with_policy(
 
 fn load_staleness_labels(
     conn: &Connection,
-    project: &str,
-    errors: &mut Vec<ContextLoadError>,
     memories: &[Memory],
 ) -> std::collections::HashMap<i64, memory::MemoryStalenessLabel> {
     let now_epoch = chrono::Utc::now().timestamp();
-    match memory::memory_staleness_labels_for_memories(conn, memories, now_epoch) {
-        Ok(labels) => labels,
-        Err(e) => {
-            let message =
-                format!("failed to load source-anchor staleness labels for {project}: {e}");
-            crate::log::error("context", &message);
-            errors.push(ContextLoadError::new("memories", message));
-            memories
-                .iter()
-                .map(|memory| (memory.id, memory::memory_staleness_label(memory, now_epoch)))
-                .collect()
-        }
-    }
+    memories
+        .iter()
+        .map(|memory| {
+            let label = memory::memory_staleness_label_with_conn(conn, memory, now_epoch)
+                .unwrap_or_else(|error| {
+                    crate::log::warn(
+                        "context",
+                        &format!(
+                            "source-anchor staleness label fallback for memory {}: {error}",
+                            memory.id
+                        ),
+                    );
+                    memory::memory_staleness_label(memory, now_epoch)
+                });
+            (memory.id, label)
+        })
+        .collect()
 }
 
 struct ContextMemorySelection {

--- a/src/context/query.rs
+++ b/src/context/query.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use anyhow::Result;
 use rusqlite::Connection;
@@ -11,10 +11,14 @@ use super::filters::{
 };
 use super::hybrid_context::query_hybrid_context_memories;
 use super::implicit_query::build_implicit_context_query;
-use super::memory_traits::{is_memory_self_diagnostic, is_self_diagnostic_text};
+use super::memory_selection::{
+    context_cluster_suffix, deduplicate_memory_clusters, limit_self_diagnostic_memories,
+    normalize_cluster_text, reference_cluster_key, sort_memories_by_branch,
+};
+use super::memory_traits::is_self_diagnostic_text;
 use super::ownership::{startup_memory_owner_decision, OwnerCounts, OwnerMetadata, OwnerTrace};
 use super::policy::{ContextPolicy, SectionKind};
-use super::types::{ContextLoadError, HiddenDuplicateGroup, LoadedContext, SessionSummaryBrief};
+use super::types::{ContextLoadError, LoadedContext, SessionSummaryBrief};
 use crate::memory::{self, Memory};
 
 const SUMMARY_FETCH_BATCH_SIZE: usize = 25;
@@ -83,6 +87,7 @@ pub(super) fn load_context_data_with_policy(
         crate::log::error("context", &message);
         errors.push(ContextLoadError::new("memories", message));
     }
+    let staleness_labels = load_staleness_labels(conn, project, &mut errors, &memories);
     let lessons = memory::lesson::list_lessons_for_context(
         conn,
         project,
@@ -98,6 +103,7 @@ pub(super) fn load_context_data_with_policy(
 
     LoadedContext {
         memories,
+        staleness_labels,
         lessons,
         summaries,
         workstreams,
@@ -106,6 +112,28 @@ pub(super) fn load_context_data_with_policy(
         owner_traces: memory_selection.owner_traces,
         owner_counts: memory_selection.owner_counts,
         diagnostics: memory_selection.diagnostics,
+    }
+}
+
+fn load_staleness_labels(
+    conn: &Connection,
+    project: &str,
+    errors: &mut Vec<ContextLoadError>,
+    memories: &[Memory],
+) -> std::collections::HashMap<i64, memory::MemoryStalenessLabel> {
+    let now_epoch = chrono::Utc::now().timestamp();
+    match memory::memory_staleness_labels_for_memories(conn, memories, now_epoch) {
+        Ok(labels) => labels,
+        Err(e) => {
+            let message =
+                format!("failed to load source-anchor staleness labels for {project}: {e}");
+            crate::log::error("context", &message);
+            errors.push(ContextLoadError::new("memories", message));
+            memories
+                .iter()
+                .map(|memory| (memory.id, memory::memory_staleness_label(memory, now_epoch)))
+                .collect()
+        }
     }
 }
 
@@ -447,229 +475,6 @@ fn map_context_memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ContextMe
         memory: memory::map_memory_row_pub(row)?,
         owner: OwnerMetadata::from_memory_row(row, 13)?,
     })
-}
-
-fn sort_memories_by_branch(memories: &mut [Memory], current_branch: Option<&str>) {
-    let Some(branch) = current_branch else {
-        return;
-    };
-
-    memories.sort_by(|left, right| {
-        branch_sort_score(left, branch).cmp(&branch_sort_score(right, branch))
-    });
-}
-
-fn branch_sort_score(memory: &Memory, current_branch: &str) -> u8 {
-    match memory.branch.as_deref() {
-        Some(branch) if branch == current_branch => 0,
-        None => 1,
-        Some("main") | Some("master") => 2,
-        _ => 3,
-    }
-}
-
-struct ClusterRepresentative {
-    first_index: usize,
-    cluster_key: String,
-    memory: Memory,
-    hidden_ids: Vec<i64>,
-}
-
-fn deduplicate_memory_clusters(
-    memories: Vec<Memory>,
-    current_branch: Option<&str>,
-) -> (Vec<Memory>, Vec<HiddenDuplicateGroup>) {
-    let mut representatives: HashMap<String, ClusterRepresentative> = HashMap::new();
-
-    for (index, memory) in memories.into_iter().enumerate() {
-        let cluster_key = memory_cluster_key(&memory);
-        match representatives.get_mut(&cluster_key) {
-            Some(representative) => {
-                if is_better_cluster_representative(&memory, &representative.memory, current_branch)
-                {
-                    representative.hidden_ids.push(representative.memory.id);
-                    representative.memory = memory;
-                } else {
-                    representative.hidden_ids.push(memory.id);
-                }
-            }
-            None => {
-                representatives.insert(
-                    cluster_key.clone(),
-                    ClusterRepresentative {
-                        first_index: index,
-                        cluster_key,
-                        memory,
-                        hidden_ids: Vec::new(),
-                    },
-                );
-            }
-        }
-    }
-
-    let mut deduped: Vec<ClusterRepresentative> = representatives.into_values().collect();
-    deduped.sort_by_key(|representative| representative.first_index);
-    let hidden_groups = deduped
-        .iter()
-        .filter(|representative| !representative.hidden_ids.is_empty())
-        .map(|representative| HiddenDuplicateGroup {
-            cluster_key: representative.cluster_key.clone(),
-            chosen_id: representative.memory.id,
-            hidden_ids: representative.hidden_ids.clone(),
-        })
-        .collect();
-    let memories = deduped
-        .into_iter()
-        .map(|representative| representative.memory)
-        .collect();
-    (memories, hidden_groups)
-}
-
-fn is_better_cluster_representative(
-    candidate: &Memory,
-    incumbent: &Memory,
-    current_branch: Option<&str>,
-) -> bool {
-    let candidate_branch_score = current_branch
-        .map(|branch| branch_sort_score(candidate, branch))
-        .unwrap_or(0);
-    let incumbent_branch_score = current_branch
-        .map(|branch| branch_sort_score(incumbent, branch))
-        .unwrap_or(0);
-
-    candidate_branch_score < incumbent_branch_score
-        || (candidate_branch_score == incumbent_branch_score
-            && candidate.updated_at_epoch > incumbent.updated_at_epoch)
-}
-
-fn limit_self_diagnostic_memories(memories: Vec<Memory>, limit: usize) -> Vec<Memory> {
-    let mut retained = Vec::new();
-    let mut self_diagnostic_count = 0;
-
-    for memory in memories {
-        if is_memory_self_diagnostic(&memory) {
-            if self_diagnostic_count >= limit {
-                continue;
-            }
-            self_diagnostic_count += 1;
-        }
-        retained.push(memory);
-    }
-
-    retained
-}
-
-fn memory_cluster_key(memory: &Memory) -> String {
-    if let Some(topic_key) = stable_topic_key(memory.topic_key.as_deref(), &memory.memory_type) {
-        return format!("topic:{topic_key}");
-    }
-
-    if let Some(context) = context_prefix(&memory.text) {
-        return format!(
-            "context:{}:{}",
-            memory.memory_type,
-            context_cluster_suffix(&normalize_cluster_text(&context))
-        );
-    }
-
-    format!(
-        "title:{}:{}",
-        memory.memory_type,
-        normalize_cluster_text(&memory.title)
-    )
-}
-
-fn stable_topic_key<'a>(topic_key: Option<&'a str>, memory_type: &str) -> Option<&'a str> {
-    let key = topic_key?.trim();
-    if key.is_empty() || looks_generated_topic_key(key, memory_type) {
-        return None;
-    }
-    Some(key)
-}
-
-fn looks_generated_topic_key(key: &str, memory_type: &str) -> bool {
-    let Some(suffix) = key.strip_prefix(&format!("{memory_type}-")) else {
-        return false;
-    };
-    suffix.len() >= 12 && suffix.chars().all(|ch| ch.is_ascii_hexdigit())
-}
-
-fn context_prefix(text: &str) -> Option<String> {
-    let trimmed = text.trim_start();
-    let rest = trimmed.strip_prefix("[Context:")?;
-    let end = rest.find(']')?;
-    Some(rest[..end].trim().to_string())
-}
-
-fn normalize_cluster_text(text: &str) -> String {
-    let mut folded = String::new();
-    for ch in text.chars() {
-        if ch.is_alphanumeric() {
-            folded.extend(ch.to_lowercase());
-        } else {
-            folded.push(' ');
-        }
-    }
-
-    let normalized = folded.split_whitespace().collect::<Vec<_>>().join(" ");
-
-    normalized.chars().take(96).collect()
-}
-
-fn context_cluster_suffix(normalized_context: &str) -> String {
-    let tokens: Vec<&str> = normalized_context.split_whitespace().collect();
-    if let Some(reference_key) = reference_cluster_key(&tokens) {
-        return reference_key;
-    }
-
-    let ascii_tokens: Vec<&str> = tokens
-        .iter()
-        .copied()
-        .filter(|token| token.chars().all(|ch| ch.is_ascii_alphanumeric()))
-        .filter(|token| !is_context_stop_token(token))
-        .take(5)
-        .collect();
-    if ascii_tokens.len() >= 2 {
-        return format!("tokens:{}", ascii_tokens.join("-"));
-    }
-
-    normalized_context.chars().take(96).collect()
-}
-
-fn reference_cluster_key(tokens: &[&str]) -> Option<String> {
-    for window in tokens.windows(2) {
-        let label = window[0];
-        let value = window[1];
-        if matches!(label, "pr" | "pull" | "pullrequest")
-            && value.chars().all(|ch| ch.is_ascii_digit())
-        {
-            return Some(format!("pr:{value}"));
-        }
-        if matches!(label, "issue" | "issues") && value.chars().all(|ch| ch.is_ascii_digit()) {
-            return Some(format!("issue:{value}"));
-        }
-    }
-    None
-}
-
-fn is_context_stop_token(token: &str) -> bool {
-    matches!(
-        token,
-        "a" | "an"
-            | "and"
-            | "by"
-            | "for"
-            | "from"
-            | "in"
-            | "of"
-            | "on"
-            | "the"
-            | "to"
-            | "with"
-            | "context"
-            | "skills"
-            | "skill"
-    )
 }
 
 pub(super) fn query_recent_summaries(

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -17,9 +17,9 @@ use super::invocation::{
 use super::policy::{ContextLimits, ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
-    empty_state_output, render_core_memory_with_limits, render_lessons_with_limit,
-    render_lessons_with_summary, render_memory_index_with_limits_excluding,
-    render_memory_index_with_summary, render_recent_sessions_with_limit,
+    empty_state_output, render_core_memory_with_limits_and_staleness, render_lessons_with_limit,
+    render_lessons_with_summary, render_memory_index_with_limits_excluding_and_staleness,
+    render_memory_index_with_summary_and_staleness, render_recent_sessions_with_limit,
     render_workstreams_with_limits, render_workstreams_with_summary,
 };
 use super::types::{ContextLoadError, ContextRequest};
@@ -161,14 +161,19 @@ fn render_loaded_context_for_eval(
     }
     if !loaded.memories.is_empty() {
         let render_limits = section_render_limits(policy);
-        let core_summary =
-            render_core_memory_with_limits(&mut output, &loaded.memories, &render_limits);
+        let core_summary = render_core_memory_with_limits_and_staleness(
+            &mut output,
+            &loaded.memories,
+            &render_limits,
+            &loaded.staleness_labels,
+        );
         let core_ids: HashSet<i64> = core_summary.ids.into_iter().collect();
-        render_memory_index_with_limits_excluding(
+        render_memory_index_with_limits_excluding_and_staleness(
             &mut output,
             &loaded.memories,
             &render_limits,
             &core_ids,
+            &loaded.staleness_labels,
         );
     }
     if !loaded.workstreams.is_empty() {
@@ -498,8 +503,12 @@ fn render_context_output_with_policy(
     if !loaded.memories.is_empty() {
         let render_limits = section_render_limits(&policy);
         let before = char_len(&output);
-        let core_summary =
-            render_core_memory_with_limits(&mut output, &loaded.memories, &render_limits);
+        let core_summary = render_core_memory_with_limits_and_staleness(
+            &mut output,
+            &loaded.memories,
+            &render_limits,
+            &loaded.staleness_labels,
+        );
         let core_count = core_summary.count;
         stats.core_ids = core_summary.ids.clone();
         stats.core = SectionRenderStats {
@@ -508,11 +517,12 @@ fn render_context_output_with_policy(
         };
         let before = char_len(&output);
         let core_ids = core_summary.ids.into_iter().collect();
-        let index_summary = render_memory_index_with_summary(
+        let index_summary = render_memory_index_with_summary_and_staleness(
             &mut output,
             &loaded.memories,
             &render_limits,
             &core_ids,
+            &loaded.staleness_labels,
         );
         index_ids = index_summary.ids;
         stats.index = SectionRenderStats {

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -17,8 +17,9 @@ use super::invocation::{
 use super::policy::{ContextLimits, ContextPolicy, SectionKind};
 use super::query::load_context_data_with_policy;
 use super::sections::{
-    empty_state_output, render_core_memory_with_limits_and_staleness, render_lessons_with_limit,
-    render_lessons_with_summary, render_memory_index_with_limits_excluding_and_staleness,
+    empty_state_output, render_core_memory_with_limits_and_staleness,
+    render_lessons_with_limit_and_staleness, render_lessons_with_summary_and_staleness,
+    render_memory_index_with_limits_excluding_and_staleness,
     render_memory_index_with_summary_and_staleness, render_recent_sessions_with_limit,
     render_workstreams_with_limits, render_workstreams_with_summary,
 };
@@ -152,11 +153,12 @@ fn render_loaded_context_for_eval(
 
     render_context_load_errors(&mut output, &loaded.errors);
     if !loaded.lessons.is_empty() {
-        render_lessons_with_limit(
+        render_lessons_with_limit_and_staleness(
             &mut output,
             &loaded.lessons,
             policy.section_item_limit(SectionKind::Lessons, policy.limits.lesson_limit),
             policy.section_char_limit(SectionKind::Lessons, policy.limits.lesson_char_limit),
+            &loaded.staleness_labels,
         );
     }
     if !loaded.memories.is_empty() {
@@ -488,11 +490,12 @@ fn render_context_output_with_policy(
 
     if !loaded.lessons.is_empty() {
         let before = char_len(&output);
-        let lesson_summary = render_lessons_with_summary(
+        let lesson_summary = render_lessons_with_summary_and_staleness(
             &mut output,
             &loaded.lessons,
             policy.section_item_limit(SectionKind::Lessons, policy.limits.lesson_limit),
             policy.section_char_limit(SectionKind::Lessons, policy.limits.lesson_char_limit),
+            &loaded.staleness_labels,
         );
         lesson_ids = lesson_summary.ids;
         stats.lessons = SectionRenderStats {

--- a/src/context/sections.rs
+++ b/src/context/sections.rs
@@ -19,8 +19,10 @@ pub(super) use index::render_memory_index_with_limits;
 pub(super) use index::render_memory_index_with_limits_excluding;
 pub(super) use index::render_memory_index_with_limits_excluding_and_staleness;
 pub(super) use index::render_memory_index_with_summary_and_staleness;
+#[cfg(test)]
 pub(super) use lessons::render_lessons_with_limit;
-pub(super) use lessons::render_lessons_with_summary;
+pub(super) use lessons::render_lessons_with_limit_and_staleness;
+pub(super) use lessons::render_lessons_with_summary_and_staleness;
 #[cfg(test)]
 pub(super) use sessions::render_recent_sessions;
 pub(super) use sessions::render_recent_sessions_with_limit;

--- a/src/context/sections.rs
+++ b/src/context/sections.rs
@@ -7,14 +7,18 @@ mod workstreams;
 
 #[cfg(test)]
 pub(super) use core::render_core_memory;
+#[cfg(test)]
 pub(super) use core::render_core_memory_with_limits;
+pub(super) use core::render_core_memory_with_limits_and_staleness;
 pub(super) use empty::empty_state_output;
 #[cfg(test)]
 pub(super) use index::render_memory_index;
 #[cfg(test)]
 pub(super) use index::render_memory_index_with_limits;
+#[cfg(test)]
 pub(super) use index::render_memory_index_with_limits_excluding;
-pub(super) use index::render_memory_index_with_summary;
+pub(super) use index::render_memory_index_with_limits_excluding_and_staleness;
+pub(super) use index::render_memory_index_with_summary_and_staleness;
 pub(super) use lessons::render_lessons_with_limit;
 pub(super) use lessons::render_lessons_with_summary;
 #[cfg(test)]

--- a/src/context/sections/core.rs
+++ b/src/context/sections/core.rs
@@ -1,7 +1,7 @@
-use crate::memory::{Memory, MemoryType};
+use crate::memory::{Memory, MemoryStalenessLabel, MemoryType};
 use std::collections::HashMap;
 
-use super::super::audit::memory_render_metadata;
+use super::super::audit::memory_render_metadata_with_labels;
 use super::super::format::{char_len, format_epoch_short, truncate_chars_with_ellipsis};
 use super::super::memory_traits::is_memory_self_diagnostic;
 use super::super::policy::ContextLimits;
@@ -21,10 +21,20 @@ pub(in crate::context) fn render_core_memory(output: &mut String, memories: &[Me
     render_core_memory_with_limits(output, memories, &ContextLimits::default());
 }
 
+#[cfg(test)]
 pub(in crate::context) fn render_core_memory_with_limits(
     output: &mut String,
     memories: &[Memory],
     limits: &ContextLimits,
+) -> CoreRenderSummary {
+    render_core_memory_with_limits_and_staleness(output, memories, limits, &HashMap::new())
+}
+
+pub(in crate::context) fn render_core_memory_with_limits_and_staleness(
+    output: &mut String,
+    memories: &[Memory],
+    limits: &ContextLimits,
+    staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
 ) -> CoreRenderSummary {
     if limits.core_item_limit == 0 || limits.core_char_limit == 0 {
         return CoreRenderSummary::default();
@@ -78,6 +88,7 @@ pub(in crate::context) fn render_core_memory_with_limits(
             memory,
             limits.core_char_limit,
             now,
+            staleness_labels,
         ) {
             selected_ids.insert(memory.id);
             *type_counts.entry(memory.memory_type.as_str()).or_default() += 1;
@@ -100,6 +111,7 @@ pub(in crate::context) fn render_core_memory_with_limits(
             memory,
             limits.core_char_limit,
             now,
+            staleness_labels,
         );
     }
 
@@ -121,7 +133,7 @@ pub(in crate::context) fn render_core_memory_with_limits(
             memory.title,
             memory.memory_type,
             date,
-            memory_render_metadata(memory, now)
+            memory_render_metadata_with_labels(memory, now, staleness_labels)
         ));
         output.push_str(&preview);
         output.push('\n');
@@ -139,6 +151,7 @@ fn push_selected_memory<'a>(
     memory: &'a Memory,
     max_chars: usize,
     now_epoch: i64,
+    staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
 ) -> bool {
     let header = format!(
         "**#{} {}** ({}, {}; {})\n",
@@ -146,7 +159,7 @@ fn push_selected_memory<'a>(
         memory.title,
         memory.memory_type,
         format_epoch_short(memory.updated_at_epoch),
-        memory_render_metadata(memory, now_epoch)
+        memory_render_metadata_with_labels(memory, now_epoch, staleness_labels)
     );
     let fixed_chars = char_len(&header) + 1;
     if *total_chars + fixed_chars >= max_chars {

--- a/src/context/sections/index.rs
+++ b/src/context/sections/index.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::memory::{Memory, MemoryType};
+use crate::memory::{Memory, MemoryStalenessLabel, MemoryType};
 
-use super::super::audit::memory_render_metadata;
+use super::super::audit::memory_render_metadata_with_labels;
 use super::super::format::{
     char_len, format_epoch_short, truncate_chars_with_ellipsis, type_label,
 };
@@ -23,6 +23,7 @@ pub(in crate::context) fn render_memory_index_with_limits(
     render_memory_index_with_limits_excluding(output, memories, limits, &excluded_ids)
 }
 
+#[cfg(test)]
 pub(in crate::context) fn render_memory_index_with_limits_excluding(
     output: &mut String,
     memories: &[Memory],
@@ -32,17 +33,51 @@ pub(in crate::context) fn render_memory_index_with_limits_excluding(
     render_memory_index_with_summary(output, memories, limits, excluded_ids).count
 }
 
+pub(in crate::context) fn render_memory_index_with_limits_excluding_and_staleness(
+    output: &mut String,
+    memories: &[Memory],
+    limits: &ContextLimits,
+    excluded_ids: &HashSet<i64>,
+    staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
+) -> usize {
+    render_memory_index_with_summary_and_staleness(
+        output,
+        memories,
+        limits,
+        excluded_ids,
+        staleness_labels,
+    )
+    .count
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(in crate::context) struct IndexRenderSummary {
     pub count: usize,
     pub ids: Vec<i64>,
 }
 
+#[cfg(test)]
 pub(in crate::context) fn render_memory_index_with_summary(
     output: &mut String,
     memories: &[Memory],
     limits: &ContextLimits,
     excluded_ids: &HashSet<i64>,
+) -> IndexRenderSummary {
+    render_memory_index_with_summary_and_staleness(
+        output,
+        memories,
+        limits,
+        excluded_ids,
+        &HashMap::new(),
+    )
+}
+
+pub(in crate::context) fn render_memory_index_with_summary_and_staleness(
+    output: &mut String,
+    memories: &[Memory],
+    limits: &ContextLimits,
+    excluded_ids: &HashSet<i64>,
+    staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
 ) -> IndexRenderSummary {
     if limits.memory_index_limit == 0 || limits.memory_index_char_limit == 0 {
         return IndexRenderSummary::default();
@@ -93,6 +128,7 @@ pub(in crate::context) fn render_memory_index_with_summary(
                 &mut total_chars,
                 &mut rendered_ids,
                 now,
+                staleness_labels,
             );
         }
     }
@@ -115,6 +151,7 @@ pub(in crate::context) fn render_memory_index_with_summary(
                     &mut total_chars,
                     &mut rendered_ids,
                     now,
+                    staleness_labels,
                 );
             }
         }
@@ -140,6 +177,7 @@ fn push_memory_index_line(
     total_chars: &mut usize,
     rendered_ids: &mut Vec<i64>,
     now_epoch: i64,
+    staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
 ) -> usize {
     let section_label = if label == memory_type {
         memory_type.to_string()
@@ -163,7 +201,7 @@ fn push_memory_index_line(
             memory.id,
             memory.title,
             date,
-            memory_render_metadata(memory, now_epoch)
+            memory_render_metadata_with_labels(memory, now_epoch, staleness_labels)
         );
         let separator = if first { "" } else { " | " };
         let next_len = char_len(separator) + char_len(&item);

--- a/src/context/sections/lessons.rs
+++ b/src/context/sections/lessons.rs
@@ -1,6 +1,8 @@
 use crate::memory::lesson::LessonMemory;
+use crate::memory::MemoryStalenessLabel;
+use std::collections::HashMap;
 
-use super::super::audit::memory_render_metadata;
+use super::super::audit::memory_render_metadata_with_labels;
 use super::super::format::{char_len, format_epoch_short, truncate_chars_with_ellipsis};
 
 const PREVIEW_LEN: usize = 180;
@@ -11,6 +13,7 @@ pub(in crate::context) struct LessonRenderSummary {
     pub ids: Vec<i64>,
 }
 
+#[cfg(test)]
 pub(in crate::context) fn render_lessons_with_limit(
     output: &mut String,
     lessons: &[LessonMemory],
@@ -20,11 +23,45 @@ pub(in crate::context) fn render_lessons_with_limit(
     render_lessons_with_summary(output, lessons, item_limit, char_limit).count
 }
 
+pub(in crate::context) fn render_lessons_with_limit_and_staleness(
+    output: &mut String,
+    lessons: &[LessonMemory],
+    item_limit: usize,
+    char_limit: usize,
+    staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
+) -> usize {
+    render_lessons_with_summary_and_staleness(
+        output,
+        lessons,
+        item_limit,
+        char_limit,
+        staleness_labels,
+    )
+    .count
+}
+
+#[cfg(test)]
 pub(in crate::context) fn render_lessons_with_summary(
     output: &mut String,
     lessons: &[LessonMemory],
     item_limit: usize,
     char_limit: usize,
+) -> LessonRenderSummary {
+    render_lessons_with_summary_and_staleness(
+        output,
+        lessons,
+        item_limit,
+        char_limit,
+        &HashMap::new(),
+    )
+}
+
+pub(in crate::context) fn render_lessons_with_summary_and_staleness(
+    output: &mut String,
+    lessons: &[LessonMemory],
+    item_limit: usize,
+    char_limit: usize,
+    staleness_labels: &HashMap<i64, MemoryStalenessLabel>,
 ) -> LessonRenderSummary {
     if lessons.is_empty() || item_limit == 0 || char_limit == 0 {
         return LessonRenderSummary::default();
@@ -50,7 +87,7 @@ pub(in crate::context) fn render_lessons_with_summary(
             metadata.confidence,
             metadata.reinforcement_count,
             format_epoch_short(metadata.last_reinforced_at_epoch),
-            memory_render_metadata(memory, now)
+            memory_render_metadata_with_labels(memory, now, staleness_labels)
         );
         let fixed_chars = char_len(&title) + 1;
         if total_chars + fixed_chars >= char_limit {

--- a/src/context/tests/mod.rs
+++ b/src/context/tests/mod.rs
@@ -8,6 +8,7 @@ mod ownership;
 mod render;
 mod retrieval;
 mod sessions;
+mod staleness;
 
 pub(super) fn sample_memory(id: i64, memory_type: &str, title: &str) -> Memory {
     sample_memory_with_epoch(id, memory_type, title, 1_710_000_000)

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -1,7 +1,5 @@
 use crate::memory::lesson::{LessonMemory, LessonMetadata};
-use crate::memory::memory_staleness_label_for_anchor;
 use crate::workstream::{WorkStream, WorkStreamStatus};
-use std::collections::HashMap;
 
 use super::super::host::HostKind;
 use super::super::injection_gate::{ContextGateAction, ContextGateDecision};
@@ -13,7 +11,7 @@ use super::super::render::{
 };
 use super::super::sections::{
     render_core_memory, render_core_memory_with_limits, render_lessons_with_limit,
-    render_lessons_with_limit_and_staleness, render_memory_index, render_memory_index_with_limits,
+    render_memory_index, render_memory_index_with_limits,
     render_memory_index_with_limits_excluding, render_recent_sessions,
     render_recent_sessions_with_limit, render_workstreams, render_workstreams_with_limits,
 };
@@ -207,27 +205,6 @@ fn render_lessons_respects_item_and_char_limits() {
     assert!(output.contains("reinforced 3"));
     assert!(!output.contains("Second lesson"));
     assert!(output.chars().count() <= 240);
-}
-
-#[test]
-fn render_lessons_includes_source_anchor_staleness_labels() {
-    let mut output = String::new();
-    let lessons = vec![sample_lesson(1, "Stale lesson", 0.9, 2)];
-    let mut labels = HashMap::new();
-    labels.insert(
-        1,
-        memory_staleness_label_for_anchor(
-            &lessons[0].memory,
-            chrono::Utc::now().timestamp(),
-            "verify-before-trust",
-        ),
-    );
-
-    let rendered = render_lessons_with_limit_and_staleness(&mut output, &lessons, 1, 240, &labels);
-
-    assert_eq!(rendered, 1);
-    assert!(output.contains("Stale lesson"));
-    assert!(output.contains("source_anchor=verify-before-trust"));
 }
 
 #[test]

--- a/src/context/tests/render.rs
+++ b/src/context/tests/render.rs
@@ -1,5 +1,7 @@
 use crate::memory::lesson::{LessonMemory, LessonMetadata};
+use crate::memory::memory_staleness_label_for_anchor;
 use crate::workstream::{WorkStream, WorkStreamStatus};
+use std::collections::HashMap;
 
 use super::super::host::HostKind;
 use super::super::injection_gate::{ContextGateAction, ContextGateDecision};
@@ -11,7 +13,7 @@ use super::super::render::{
 };
 use super::super::sections::{
     render_core_memory, render_core_memory_with_limits, render_lessons_with_limit,
-    render_memory_index, render_memory_index_with_limits,
+    render_lessons_with_limit_and_staleness, render_memory_index, render_memory_index_with_limits,
     render_memory_index_with_limits_excluding, render_recent_sessions,
     render_recent_sessions_with_limit, render_workstreams, render_workstreams_with_limits,
 };
@@ -205,6 +207,27 @@ fn render_lessons_respects_item_and_char_limits() {
     assert!(output.contains("reinforced 3"));
     assert!(!output.contains("Second lesson"));
     assert!(output.chars().count() <= 240);
+}
+
+#[test]
+fn render_lessons_includes_source_anchor_staleness_labels() {
+    let mut output = String::new();
+    let lessons = vec![sample_lesson(1, "Stale lesson", 0.9, 2)];
+    let mut labels = HashMap::new();
+    labels.insert(
+        1,
+        memory_staleness_label_for_anchor(
+            &lessons[0].memory,
+            chrono::Utc::now().timestamp(),
+            "verify-before-trust",
+        ),
+    );
+
+    let rendered = render_lessons_with_limit_and_staleness(&mut output, &lessons, 1, 240, &labels);
+
+    assert_eq!(rendered, 1);
+    assert!(output.contains("Stale lesson"));
+    assert!(output.contains("source_anchor=verify-before-trust"));
 }
 
 #[test]

--- a/src/context/tests/staleness.rs
+++ b/src/context/tests/staleness.rs
@@ -1,7 +1,9 @@
 use crate::memory::lesson::{save_lesson, SaveLessonRequest};
 use rusqlite::{params, Connection};
 
+use super::super::audit::build_context_audit_items;
 use super::super::query::load_context_data;
+use super::super::types::ContextDiagnostics;
 use super::{insert_memory, setup_context_schema};
 
 #[test]
@@ -143,6 +145,65 @@ fn load_context_data_includes_lesson_memories_in_staleness_labels() {
             .map(|label| label.source_anchor.as_str()),
         Some("verify-before-trust")
     );
+}
+
+#[test]
+fn context_audit_uses_rendered_source_anchor_labels() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_context_schema(&conn);
+    setup_context_git_trace_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory(
+        &conn,
+        201,
+        project,
+        Some("audit-source-anchor"),
+        "decision",
+        "Audit source anchor",
+        "Audit items should store the rendered source-anchor label.",
+        now,
+    );
+    conn.execute(
+        "UPDATE memories
+         SET session_id = 'audit-session', files = ?1, branch = 'main'
+         WHERE id = 201",
+        [r#"["src/audit.rs"]"#],
+    )
+    .unwrap();
+    link_context_commit(
+        &conn,
+        1,
+        project,
+        "source-audit",
+        100,
+        &["src/audit.rs"],
+        "audit-session",
+    );
+    insert_context_commit(
+        &conn,
+        2,
+        project,
+        "later-audit",
+        200,
+        &["src/audit.rs"],
+        Some("main"),
+    );
+
+    let mut loaded = load_context_data(&conn, project, Some("main"));
+    loaded.memories.retain(|memory| memory.id == 201);
+    loaded.lessons.clear();
+    loaded.workstreams.clear();
+    loaded.summaries.clear();
+    loaded.diagnostics = ContextDiagnostics::default();
+    let audit_items = build_context_audit_items(&loaded, &[201], &[], &[], &[]);
+
+    assert_eq!(audit_items.len(), 1);
+    assert_eq!(audit_items[0].status, "injected");
+    assert!(audit_items[0]
+        .staleness
+        .contains("source_anchor=verify-before-trust"));
 }
 
 fn setup_context_git_trace_schema(conn: &Connection) {

--- a/src/context/tests/staleness.rs
+++ b/src/context/tests/staleness.rs
@@ -1,8 +1,11 @@
-use crate::memory::lesson::{save_lesson, SaveLessonRequest};
+use crate::memory::lesson::{save_lesson, LessonMemory, LessonMetadata, SaveLessonRequest};
+use crate::memory::memory_staleness_label_for_anchor;
 use rusqlite::{params, Connection};
+use std::collections::HashMap;
 
 use super::super::audit::build_context_audit_items;
 use super::super::query::load_context_data;
+use super::super::sections::render_lessons_with_limit_and_staleness;
 use super::super::types::ContextDiagnostics;
 use super::{insert_memory, setup_context_schema};
 
@@ -148,6 +151,27 @@ fn load_context_data_includes_lesson_memories_in_staleness_labels() {
 }
 
 #[test]
+fn render_lessons_includes_source_anchor_staleness_labels() {
+    let mut output = String::new();
+    let lessons = vec![sample_lesson(1, "Stale lesson", 0.9, 2)];
+    let mut labels = HashMap::new();
+    labels.insert(
+        1,
+        memory_staleness_label_for_anchor(
+            &lessons[0].memory,
+            chrono::Utc::now().timestamp(),
+            "verify-before-trust",
+        ),
+    );
+
+    let rendered = render_lessons_with_limit_and_staleness(&mut output, &lessons, 1, 240, &labels);
+
+    assert_eq!(rendered, 1);
+    assert!(output.contains("Stale lesson"));
+    assert!(output.contains("source_anchor=verify-before-trust"));
+}
+
+#[test]
 fn context_audit_uses_rendered_source_anchor_labels() {
     let conn = Connection::open_in_memory().unwrap();
     setup_context_schema(&conn);
@@ -204,6 +228,21 @@ fn context_audit_uses_rendered_source_anchor_labels() {
     assert!(audit_items[0]
         .staleness
         .contains("source_anchor=verify-before-trust"));
+}
+
+fn sample_lesson(id: i64, title: &str, confidence: f64, reinforcement_count: i64) -> LessonMemory {
+    let memory = super::sample_memory(id, "lesson", title);
+    LessonMemory {
+        memory,
+        metadata: LessonMetadata {
+            memory_id: id,
+            confidence,
+            reinforcement_count,
+            source_evidence: None,
+            last_reinforced_at_epoch: 1_710_000_000,
+            stale_after_epoch: None,
+        },
+    }
 }
 
 fn setup_context_git_trace_schema(conn: &Connection) {

--- a/src/context/tests/staleness.rs
+++ b/src/context/tests/staleness.rs
@@ -1,0 +1,212 @@
+use crate::memory::lesson::{save_lesson, SaveLessonRequest};
+use rusqlite::{params, Connection};
+
+use super::super::query::load_context_data;
+use super::{insert_memory, setup_context_schema};
+
+#[test]
+fn load_context_data_preserves_good_staleness_labels_when_one_memory_fails() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_context_schema(&conn);
+    setup_context_git_trace_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    insert_memory(
+        &conn,
+        101,
+        project,
+        Some("legacy-bad-files"),
+        "decision",
+        "Legacy bad files",
+        "Malformed legacy files should only affect this memory.",
+        now,
+    );
+    conn.execute(
+        "UPDATE memories
+         SET session_id = 'bad-session', files = '[not-json', branch = 'main'
+         WHERE id = 101",
+        [],
+    )
+    .unwrap();
+    insert_memory(
+        &conn,
+        102,
+        project,
+        Some("stale-source-anchor"),
+        "decision",
+        "Stale source anchor",
+        "This memory should keep its verify-before-trust warning.",
+        now - 1,
+    );
+    conn.execute(
+        "UPDATE memories
+         SET session_id = 'stale-session', files = ?1, branch = 'main'
+         WHERE id = 102",
+        [r#"["src/stale.rs"]"#],
+    )
+    .unwrap();
+    link_context_commit(
+        &conn,
+        1,
+        project,
+        "source-stale",
+        100,
+        &["src/stale.rs"],
+        "stale-session",
+    );
+    insert_context_commit(
+        &conn,
+        2,
+        project,
+        "later-stale",
+        200,
+        &["src/stale.rs"],
+        Some("main"),
+    );
+
+    let loaded = load_context_data(&conn, project, Some("main"));
+
+    assert_eq!(
+        loaded
+            .staleness_labels
+            .get(&101)
+            .map(|label| label.source_anchor.as_str()),
+        Some("untracked")
+    );
+    assert_eq!(
+        loaded
+            .staleness_labels
+            .get(&102)
+            .map(|label| label.source_anchor.as_str()),
+        Some("verify-before-trust")
+    );
+    assert!(loaded
+        .errors
+        .iter()
+        .all(|error| !error.message.contains("source-anchor staleness labels")));
+}
+
+#[test]
+fn load_context_data_includes_lesson_memories_in_staleness_labels() {
+    let conn = Connection::open_in_memory().unwrap();
+    setup_context_schema(&conn);
+    setup_context_git_trace_schema(&conn);
+    let project = "/tmp/remem";
+    let now = chrono::Utc::now().timestamp();
+
+    let lesson_id = save_lesson(
+        &conn,
+        &SaveLessonRequest {
+            session_id: Some("lesson-session"),
+            project,
+            topic_key: Some("lesson-source-anchor"),
+            title: "Check lesson anchors",
+            content: "Lesson: lesson memories should render source-anchor warnings too.",
+            confidence: 0.9,
+            source_evidence: Some("lesson evidence"),
+            files: Some(r#"["src/lesson.rs"]"#),
+            branch: Some("main"),
+            scope: "project",
+            created_at_epoch: Some(now),
+            stale_after_epoch: None,
+        },
+    )
+    .unwrap();
+    link_context_commit(
+        &conn,
+        1,
+        project,
+        "source-lesson",
+        100,
+        &["src/lesson.rs"],
+        "lesson-session",
+    );
+    insert_context_commit(
+        &conn,
+        2,
+        project,
+        "later-lesson",
+        200,
+        &["src/lesson.rs"],
+        Some("main"),
+    );
+
+    let loaded = load_context_data(&conn, project, Some("main"));
+
+    assert_eq!(loaded.lessons.len(), 1);
+    assert_eq!(loaded.lessons[0].memory.id, lesson_id);
+    assert_eq!(
+        loaded
+            .staleness_labels
+            .get(&lesson_id)
+            .map(|label| label.source_anchor.as_str()),
+        Some("verify-before-trust")
+    );
+}
+
+fn setup_context_git_trace_schema(conn: &Connection) {
+    conn.execute_batch(
+        "CREATE TABLE git_commits (
+            id INTEGER PRIMARY KEY,
+            project TEXT NOT NULL,
+            repo_path TEXT NOT NULL,
+            sha TEXT NOT NULL,
+            short_sha TEXT NOT NULL,
+            branch TEXT,
+            message TEXT,
+            authored_at_epoch INTEGER,
+            changed_files TEXT NOT NULL DEFAULT '[]',
+            created_at_epoch INTEGER NOT NULL,
+            updated_at_epoch INTEGER NOT NULL
+        );
+        CREATE TABLE git_commit_sessions (
+            commit_id INTEGER NOT NULL,
+            session_id TEXT NOT NULL,
+            memory_session_id TEXT,
+            source TEXT NOT NULL,
+            linked_at_epoch INTEGER NOT NULL,
+            PRIMARY KEY(commit_id, session_id)
+        );",
+    )
+    .unwrap();
+}
+
+fn link_context_commit(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+    memory_session_id: &str,
+) {
+    insert_context_commit(conn, id, project, sha, epoch, changed_files, Some("main"));
+    conn.execute(
+        "INSERT INTO git_commit_sessions
+         (commit_id, session_id, memory_session_id, source, linked_at_epoch)
+         VALUES (?1, ?2, ?3, 'test', ?4)",
+        params![id, format!("content-{id}"), memory_session_id, epoch],
+    )
+    .unwrap();
+}
+
+fn insert_context_commit(
+    conn: &Connection,
+    id: i64,
+    project: &str,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+    branch: Option<&str>,
+) {
+    let changed_files = serde_json::to_string(changed_files).unwrap();
+    conn.execute(
+        "INSERT INTO git_commits
+         (id, project, repo_path, sha, short_sha, branch, message,
+          authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch)
+         VALUES (?1, ?2, ?2, ?3, ?3, ?4, NULL, ?5, ?6, ?5, ?5)",
+        params![id, project, sha, branch, epoch, changed_files],
+    )
+    .unwrap();
+}

--- a/src/context/types.rs
+++ b/src/context/types.rs
@@ -1,6 +1,7 @@
 use crate::memory::lesson::LessonMemory;
-use crate::memory::Memory;
+use crate::memory::{Memory, MemoryStalenessLabel};
 use crate::workstream::WorkStream;
+use std::collections::HashMap;
 use std::fmt;
 
 use super::host::HostKind;
@@ -27,6 +28,7 @@ pub(super) struct SessionSummaryBrief {
 #[derive(Debug)]
 pub(super) struct LoadedContext {
     pub memories: Vec<Memory>,
+    pub staleness_labels: HashMap<i64, MemoryStalenessLabel>,
     pub lessons: Vec<LessonMemory>,
     pub summaries: Vec<SessionSummaryBrief>,
     pub workstreams: Vec<WorkStream>,

--- a/src/eval/injection/run.rs
+++ b/src/eval/injection/run.rs
@@ -16,6 +16,7 @@ const HOST: &str = "codex-cli";
 const USER_PROMPT_HOST: &str = "claude-code";
 const CURRENT_BRANCH: &str = "main";
 const ABSTENTION_FORBIDDEN_TITLE: &str = "Unrelated recent deployment note";
+const STALE_ANCHOR_TITLE: &str = "Stale source anchor decision";
 const USER_PROMPT_SESSION: &str = "eval-user-prompt-submit";
 
 #[derive(Clone, Copy)]
@@ -124,6 +125,18 @@ const FIXTURE_MEMORIES: &[FixtureMemory] = &[
         updated_offset: 40,
         expected: InjectionExpectation::Filler,
     },
+    FixtureMemory {
+        id: 8,
+        project: PROJECT,
+        topic_key: "inject-stale-source-anchor",
+        title: STALE_ANCHOR_TITLE,
+        content: "The legacy source anchor references src/stale_anchor.rs and must be verified before trust after later code changes.",
+        memory_type: "decision",
+        branch: Some(CURRENT_BRANCH),
+        status: "active",
+        updated_offset: -3,
+        expected: InjectionExpectation::Expected,
+    },
 ];
 
 pub fn run_sandbox_eval(options: InjectionEvalOptions) -> Result<InjectionEvalReport> {
@@ -188,6 +201,12 @@ fn run_sandbox_eval_inner(
         .contains(ABSTENTION_FORBIDDEN_TITLE);
     let abstention_false_positive_bound =
         InjectionRateMetric::new(usize::from(abstention_passed), 1);
+    let stale_anchor_labeling_passed = snapshot.rendered_output.contains(STALE_ANCHOR_TITLE)
+        && snapshot
+            .rendered_output
+            .contains("source_anchor=verify-before-trust");
+    let stale_anchor_labeling =
+        InjectionRateMetric::new(usize::from(stale_anchor_labeling_passed), 1);
     let user_prompt_submit_passed = user_prompt_context
         .as_deref()
         .is_some_and(|output| output.contains("Migration locking fix"));
@@ -199,6 +218,7 @@ fn run_sandbox_eval_inner(
     let all_checks_passed = expected_memory_recall.is_perfect()
         && forbidden_memory_exclusion.is_perfect()
         && abstention_false_positive_bound.is_perfect()
+        && stale_anchor_labeling.is_perfect()
         && user_prompt_submit_memory_recall.is_perfect()
         && user_prompt_submit_abstention_false_positive_bound.is_perfect();
     let mut failing_examples = Vec::new();
@@ -212,6 +232,10 @@ fn run_sandbox_eval_inner(
         failing_examples.push(format!(
             "abstention rendered unrelated memory: {ABSTENTION_FORBIDDEN_TITLE}"
         ));
+    }
+    if !stale_anchor_labeling_passed {
+        failing_examples
+            .push("stale source-anchor memory missing verify-before-trust label".to_string());
     }
     if !user_prompt_submit_passed {
         failing_examples
@@ -248,6 +272,7 @@ fn run_sandbox_eval_inner(
             expected_memory_recall,
             forbidden_memory_exclusion,
             abstention_false_positive_bound,
+            stale_anchor_labeling,
             user_prompt_submit_memory_recall,
             user_prompt_submit_abstention_false_positive_bound,
             all_checks_passed,
@@ -297,20 +322,23 @@ fn seed_fixture(conn: &mut Connection) -> Result<()> {
             "INSERT INTO memories
              (id, session_id, project, topic_key, title, content, memory_type, files,
               created_at_epoch, updated_at_epoch, status, branch, scope)
-             VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?7, ?8, ?9, 'project')",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9, ?10, ?11, 'project')",
             params![
                 memory.id,
+                fixture_session_id(memory),
                 memory.project,
                 memory.topic_key,
                 memory.title,
                 memory.content,
                 memory.memory_type,
+                fixture_files(memory),
                 now + memory.updated_offset,
                 memory.status,
                 memory.branch,
             ],
         )?;
     }
+    seed_stale_anchor_commits(&tx, now)?;
     tx.execute(
         "INSERT INTO workstreams
          (id, project, title, description, status, progress, next_action, blockers,
@@ -320,6 +348,51 @@ fn seed_fixture(conn: &mut Connection) -> Result<()> {
         params![ABSTENTION_PROJECT, now],
     )?;
     tx.commit()?;
+    Ok(())
+}
+
+fn fixture_session_id(memory: &FixtureMemory) -> Option<&'static str> {
+    (memory.id == 8).then_some("inject-stale-source-anchor-session")
+}
+
+fn fixture_files(memory: &FixtureMemory) -> Option<&'static str> {
+    (memory.id == 8).then_some(r#"["src/stale_anchor.rs"]"#)
+}
+
+fn seed_stale_anchor_commits(tx: &rusqlite::Transaction<'_>, now: i64) -> Result<()> {
+    let source_epoch = now - 20;
+    let later_epoch = now - 10;
+    tx.execute(
+        "INSERT INTO git_commits
+         (id, project, repo_path, sha, short_sha, branch, message, authored_at_epoch,
+          changed_files, created_at_epoch, updated_at_epoch)
+         VALUES (1, ?1, ?1, 'source-anchor-sha', 'source-', 'main',
+                 'Capture stale anchor source', ?2, ?3, ?2, ?2)",
+        params![
+            PROJECT,
+            source_epoch,
+            serde_json::to_string(&["src/stale_anchor.rs"])?
+        ],
+    )?;
+    tx.execute(
+        "INSERT INTO git_commit_sessions
+         (commit_id, session_id, memory_session_id, source, linked_at_epoch)
+         VALUES (1, 'content-stale-anchor', 'inject-stale-source-anchor-session',
+                 'test', ?1)",
+        params![source_epoch],
+    )?;
+    tx.execute(
+        "INSERT INTO git_commits
+         (id, project, repo_path, sha, short_sha, branch, message, authored_at_epoch,
+          changed_files, created_at_epoch, updated_at_epoch)
+         VALUES (2, ?1, ?1, 'later-anchor-sha', 'later-a', 'main',
+                 'Change stale anchor file', ?2, ?3, ?2, ?2)",
+        params![
+            PROJECT,
+            later_epoch,
+            serde_json::to_string(&["src/stale_anchor.rs"])?
+        ],
+    )?;
     Ok(())
 }
 

--- a/src/eval/injection/run.rs
+++ b/src/eval/injection/run.rs
@@ -201,10 +201,12 @@ fn run_sandbox_eval_inner(
         .contains(ABSTENTION_FORBIDDEN_TITLE);
     let abstention_false_positive_bound =
         InjectionRateMetric::new(usize::from(abstention_passed), 1);
-    let stale_anchor_labeling_passed = snapshot.rendered_output.contains(STALE_ANCHOR_TITLE)
-        && snapshot
-            .rendered_output
-            .contains("source_anchor=verify-before-trust");
+    let stale_anchor_labeling_passed = rendered_line_contains_title_and_label(
+        &snapshot.rendered_output,
+        8,
+        STALE_ANCHOR_TITLE,
+        "source_anchor=verify-before-trust",
+    );
     let stale_anchor_labeling =
         InjectionRateMetric::new(usize::from(stale_anchor_labeling_passed), 1);
     let user_prompt_submit_passed = user_prompt_context
@@ -302,6 +304,25 @@ fn evaluate_cases(output: &str, expectation: InjectionExpectation) -> Vec<Inject
             }
         })
         .collect()
+}
+
+pub(super) fn rendered_line_contains_title_and_label(
+    output: &str,
+    memory_id: i64,
+    title: &str,
+    label: &str,
+) -> bool {
+    let id_marker = format!("#{memory_id} ");
+    let provenance_marker = format!("src=memory:#{memory_id}");
+    output
+        .lines()
+        .flat_map(|line| line.split(" | "))
+        .any(|segment| {
+            segment.contains(&id_marker)
+                && segment.contains(title)
+                && segment.contains(&provenance_marker)
+                && segment.contains(label)
+        })
 }
 
 impl InjectionExpectation {

--- a/src/eval/injection/tests.rs
+++ b/src/eval/injection/tests.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 
 use super::types::CORPUS_NAME;
 use super::{
-    run_sandbox_eval, InjectionEvalMetadata, InjectionEvalOptions, InjectionEvalReport,
-    InjectionMetricSummary, InjectionRateMetric,
+    run::rendered_line_contains_title_and_label, run_sandbox_eval, InjectionEvalMetadata,
+    InjectionEvalOptions, InjectionEvalReport, InjectionMetricSummary, InjectionRateMetric,
 };
 
 #[test]
@@ -101,4 +101,24 @@ fn injection_eval_display_includes_metrics() {
     assert!(rendered.contains("user_prompt_submit_memory_recall: 1/1"));
     assert!(rendered.contains("user_prompt_submit_abstention_false_positive_bound: 1/1"));
     assert!(rendered.contains("all_checks_passed: true"));
+}
+
+#[test]
+fn stale_anchor_eval_requires_label_on_target_memory_line() {
+    let output = "\
+**#8 Stale source anchor decision** (src=memory:#8;status=active;staleness=fresh;source_anchor=tracked) | **#9 Other memory** (src=memory:#9;status=active;staleness=fresh;source_anchor=verify-before-trust)
+";
+
+    assert!(!rendered_line_contains_title_and_label(
+        output,
+        8,
+        "Stale source anchor decision",
+        "source_anchor=verify-before-trust"
+    ));
+    assert!(rendered_line_contains_title_and_label(
+        "**#8 Stale source anchor decision** (src=memory:#8;source_anchor=verify-before-trust)",
+        8,
+        "Stale source anchor decision",
+        "source_anchor=verify-before-trust"
+    ));
 }

--- a/src/eval/injection/tests.rs
+++ b/src/eval/injection/tests.rs
@@ -30,6 +30,11 @@ fn injection_eval_exercises_session_start_render_path() -> Result<()> {
         report
     );
     assert!(
+        report.metrics.stale_anchor_labeling.is_perfect(),
+        "{:#?}",
+        report
+    );
+    assert!(
         report.metrics.user_prompt_submit_memory_recall.is_perfect(),
         "{:#?}",
         report
@@ -77,6 +82,7 @@ fn injection_eval_display_includes_metrics() {
             expected_memory_recall: InjectionRateMetric::new(2, 2),
             forbidden_memory_exclusion: InjectionRateMetric::new(3, 3),
             abstention_false_positive_bound: InjectionRateMetric::new(1, 1),
+            stale_anchor_labeling: InjectionRateMetric::new(1, 1),
             user_prompt_submit_memory_recall: InjectionRateMetric::new(1, 1),
             user_prompt_submit_abstention_false_positive_bound: InjectionRateMetric::new(1, 1),
             all_checks_passed: true,
@@ -91,6 +97,7 @@ fn injection_eval_display_includes_metrics() {
     assert!(rendered.contains("expected_memory_recall: 2/2"));
     assert!(rendered.contains("forbidden_memory_exclusion: 3/3"));
     assert!(rendered.contains("abstention_false_positive_bound: 1/1"));
+    assert!(rendered.contains("stale_anchor_labeling: 1/1"));
     assert!(rendered.contains("user_prompt_submit_memory_recall: 1/1"));
     assert!(rendered.contains("user_prompt_submit_abstention_false_positive_bound: 1/1"));
     assert!(rendered.contains("all_checks_passed: true"));

--- a/src/eval/injection/types.rs
+++ b/src/eval/injection/types.rs
@@ -46,6 +46,7 @@ pub struct InjectionMetricSummary {
     pub expected_memory_recall: InjectionRateMetric,
     pub forbidden_memory_exclusion: InjectionRateMetric,
     pub abstention_false_positive_bound: InjectionRateMetric,
+    pub stale_anchor_labeling: InjectionRateMetric,
     pub user_prompt_submit_memory_recall: InjectionRateMetric,
     pub user_prompt_submit_abstention_false_positive_bound: InjectionRateMetric,
     pub all_checks_passed: bool,
@@ -89,6 +90,13 @@ impl Display for InjectionEvalReport {
             self.metrics.abstention_false_positive_bound.passed,
             self.metrics.abstention_false_positive_bound.total,
             self.metrics.abstention_false_positive_bound.rate * 100.0
+        )?;
+        writeln!(
+            f,
+            "stale_anchor_labeling: {}/{} ({:.1}%)",
+            self.metrics.stale_anchor_labeling.passed,
+            self.metrics.stale_anchor_labeling.total,
+            self.metrics.stale_anchor_labeling.rate * 100.0
         )?;
         writeln!(
             f,

--- a/src/mcp/server/search_tools.rs
+++ b/src/mcp/server/search_tools.rs
@@ -112,10 +112,22 @@ impl MemoryServer {
                 .into_iter()
                 .map(|memory| {
                     let staleness = requested_explain.then(|| {
-                        crate::memory::memory_staleness_label(
-                            &memory,
-                            chrono::Utc::now().timestamp(),
-                        )
+                        let now_epoch = chrono::Utc::now().timestamp();
+                        match crate::memory::memory_staleness_label_with_conn(
+                            conn, &memory, now_epoch,
+                        ) {
+                            Ok(label) => label,
+                            Err(err) => {
+                                crate::log::warn(
+                                    "mcp",
+                                    &format!(
+                                        "memory {} staleness source-anchor lookup failed: {}",
+                                        memory.id, err
+                                    ),
+                                );
+                                crate::memory::memory_staleness_label(&memory, now_epoch)
+                            }
+                        }
                     });
                     let updated = chrono::DateTime::from_timestamp(memory.updated_at_epoch, 0)
                         .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())

--- a/src/memory/staleness.rs
+++ b/src/memory/staleness.rs
@@ -121,7 +121,7 @@ fn source_anchor_for_memory(conn: &Connection, memory: &Memory) -> Result<&'stat
     }
     let mut file_epochs = file_epoch_map(
         parse_file_list(memory.files.as_deref(), &project)?,
-        memory.created_at_epoch,
+        memory.updated_at_epoch,
     );
     if session_ids.is_empty() || file_epochs.is_empty() {
         let evidence = evidence_anchor_for_memory(conn, memory, &project)?;
@@ -325,12 +325,20 @@ fn evidence_anchor_for_memory(
     let captured_refs = captured_event_refs(conn, &anchor.project, &anchor.event_ids)?;
     anchor.session_ids = captured_refs.session_ids;
     anchor.session_row_ids = captured_refs.session_row_ids;
-    add_legacy_event_files(
-        conn,
-        &anchor.project,
-        &anchor.event_ids,
-        &mut anchor.file_epochs,
-    )?;
+    let legacy_event_ids: Vec<i64> = anchor
+        .event_ids
+        .iter()
+        .copied()
+        .filter(|event_id| !captured_refs.event_epochs.contains_key(event_id))
+        .collect();
+    if !legacy_event_ids.is_empty() {
+        add_legacy_event_files(
+            conn,
+            &anchor.project,
+            &legacy_event_ids,
+            &mut anchor.file_epochs,
+        )?;
+    }
     add_observation_files(
         conn,
         &anchor.project,

--- a/src/memory/staleness.rs
+++ b/src/memory/staleness.rs
@@ -1,3 +1,7 @@
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
 
 use super::Memory;
@@ -6,17 +10,25 @@ use super::Memory;
 pub struct MemoryStalenessLabel {
     pub status: String,
     pub age: &'static str,
-    pub source_anchor: &'static str,
+    pub source_anchor: String,
     pub label: String,
 }
 
 pub fn memory_staleness_label(memory: &Memory, now_epoch: i64) -> MemoryStalenessLabel {
+    memory_staleness_label_for_anchor(memory, now_epoch, "untracked")
+}
+
+pub fn memory_staleness_label_for_anchor(
+    memory: &Memory,
+    now_epoch: i64,
+    source_anchor: impl Into<String>,
+) -> MemoryStalenessLabel {
     let age = age_staleness(memory.updated_at_epoch, now_epoch);
-    let source_anchor = "untracked";
+    let source_anchor = source_anchor.into();
     MemoryStalenessLabel {
         status: memory.status.clone(),
         age,
-        source_anchor,
+        source_anchor: source_anchor.clone(),
         label: format!(
             "status={}; staleness={age}; source_anchor={source_anchor}",
             memory.status
@@ -24,12 +36,36 @@ pub fn memory_staleness_label(memory: &Memory, now_epoch: i64) -> MemoryStalenes
     }
 }
 
+pub fn memory_staleness_label_with_conn(
+    conn: &Connection,
+    memory: &Memory,
+    now_epoch: i64,
+) -> Result<MemoryStalenessLabel> {
+    let source_anchor = source_anchor_for_memory(conn, memory)?;
+    Ok(memory_staleness_label_for_anchor(
+        memory,
+        now_epoch,
+        source_anchor,
+    ))
+}
+
+pub fn memory_staleness_labels_for_memories(
+    conn: &Connection,
+    memories: &[Memory],
+    now_epoch: i64,
+) -> Result<HashMap<i64, MemoryStalenessLabel>> {
+    let mut labels = HashMap::new();
+    for memory in memories {
+        labels.insert(
+            memory.id,
+            memory_staleness_label_with_conn(conn, memory, now_epoch)?,
+        );
+    }
+    Ok(labels)
+}
+
 pub fn memory_staleness(memory: &Memory, now_epoch: i64) -> String {
-    format!(
-        "status={}; staleness={}",
-        memory.status,
-        age_staleness(memory.updated_at_epoch, now_epoch)
-    )
+    memory_staleness_label(memory, now_epoch).label
 }
 
 pub fn age_staleness_label(updated_at_epoch: i64, now_epoch: i64) -> String {
@@ -45,6 +81,142 @@ pub fn age_staleness(updated_at_epoch: i64, now_epoch: i64) -> &'static str {
     } else {
         "old"
     }
+}
+
+fn source_anchor_for_memory(conn: &Connection, memory: &Memory) -> Result<&'static str> {
+    let Some(session_id) = memory
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok("untracked");
+    };
+    let touched_files = parse_file_list(memory.files.as_deref())?;
+    if touched_files.is_empty() || !git_trace_tables_exist(conn)? {
+        return Ok("untracked");
+    }
+    let Some(anchor) = source_commit_anchor(conn, &memory.project, session_id)? else {
+        return Ok("untracked");
+    };
+    if later_commit_touches_any_file(conn, &memory.project, anchor, &touched_files)? {
+        Ok("verify-before-trust")
+    } else {
+        Ok("tracked")
+    }
+}
+
+fn git_trace_tables_exist(conn: &Connection) -> Result<bool> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*)
+         FROM sqlite_master
+         WHERE type = 'table'
+           AND name IN ('git_commits', 'git_commit_sessions')",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(count == 2)
+}
+
+fn source_commit_anchor(
+    conn: &Connection,
+    project: &str,
+    session_id: &str,
+) -> Result<Option<(i64, i64)>> {
+    conn.query_row(
+        "SELECT c.id, COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch)
+         FROM git_commits c
+         JOIN git_commit_sessions l ON l.commit_id = c.id
+         WHERE c.project = ?1
+           AND (l.memory_session_id = ?2 OR l.session_id = ?2)
+         ORDER BY COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch) DESC,
+                  c.id DESC
+         LIMIT 1",
+        params![project, session_id],
+        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn later_commit_touches_any_file(
+    conn: &Connection,
+    project: &str,
+    anchor: (i64, i64),
+    touched_files: &HashSet<String>,
+) -> Result<bool> {
+    let (anchor_id, anchor_epoch) = anchor;
+    let mut stmt = conn.prepare(
+        "SELECT changed_files
+         FROM git_commits
+         WHERE project = ?1
+           AND (
+             COALESCE(authored_at_epoch, updated_at_epoch, created_at_epoch) > ?2
+             OR (
+               COALESCE(authored_at_epoch, updated_at_epoch, created_at_epoch) = ?2
+               AND id > ?3
+             )
+           )",
+    )?;
+    let mut rows = stmt.query(params![project, anchor_epoch, anchor_id])?;
+    while let Some(row) = rows.next()? {
+        let raw: String = row.get(0)?;
+        let changed_files = parse_json_file_array(&raw)
+            .with_context(|| "parse git commit changed_files for source-anchor staleness")?;
+        if changed_files
+            .iter()
+            .any(|changed_file| paths_overlap(changed_file, touched_files))
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn parse_file_list(raw: Option<&str>) -> Result<HashSet<String>> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(HashSet::new());
+    };
+    let files = if raw.starts_with('[') {
+        parse_json_file_array(raw)
+            .with_context(|| "parse memory files for source-anchor staleness")?
+    } else {
+        raw.split([',', '\n'])
+            .map(str::trim)
+            .map(|value| value.trim_matches('"'))
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect()
+    };
+    Ok(files
+        .into_iter()
+        .filter_map(|file| normalize_file_path(&file))
+        .collect())
+}
+
+fn parse_json_file_array(raw: &str) -> Result<Vec<String>> {
+    let files = serde_json::from_str::<Vec<String>>(raw)?;
+    Ok(files)
+}
+
+fn paths_overlap(changed_file: &str, touched_files: &HashSet<String>) -> bool {
+    let Some(changed_file) = normalize_file_path(changed_file) else {
+        return false;
+    };
+    touched_files.iter().any(|memory_file| {
+        changed_file == *memory_file
+            || changed_file
+                .strip_prefix(memory_file)
+                .is_some_and(|tail| tail.starts_with('/'))
+            || memory_file
+                .strip_prefix(&changed_file)
+                .is_some_and(|tail| tail.starts_with('/'))
+    })
+}
+
+fn normalize_file_path(path: &str) -> Option<String> {
+    let trimmed = path.trim().trim_start_matches("./").trim_matches('/');
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 #[cfg(test)]
@@ -82,7 +254,7 @@ mod tests {
         );
         assert_eq!(
             memory_staleness(&memory(1_700_000_000, "active"), 1_700_000_000),
-            "status=active; staleness=fresh"
+            "status=active; staleness=fresh; source_anchor=untracked"
         );
     }
 
@@ -93,5 +265,129 @@ mod tests {
         assert_eq!(age_staleness(now - 30 * 86_400, now), "fresh");
         assert_eq!(age_staleness(now - 31 * 86_400, now), "aging");
         assert_eq!(age_staleness(now - 91 * 86_400, now), "old");
+    }
+
+    #[test]
+    fn source_anchor_marks_untracked_without_files_or_commit_link() -> Result<()> {
+        let conn = migrated_db()?;
+        let mut memory = memory(1_700_000_000, "active");
+        memory.session_id = Some("mem-session-1".to_string());
+
+        let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+        assert_eq!(label.source_anchor, "untracked");
+        Ok(())
+    }
+
+    #[test]
+    fn source_anchor_tracks_commit_without_later_file_change() -> Result<()> {
+        let conn = migrated_db()?;
+        let memory = tracked_memory(Some(r#"["src/lib.rs"]"#));
+        link_commit(
+            &conn,
+            1,
+            "source-sha",
+            100,
+            &["src/lib.rs"],
+            "mem-session-1",
+        )?;
+        insert_commit(&conn, 2, "later-sha", 200, &["README.md"])?;
+
+        let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+        assert_eq!(label.source_anchor, "tracked");
+        assert!(label.label.contains("source_anchor=tracked"));
+        Ok(())
+    }
+
+    #[test]
+    fn source_anchor_requires_verification_after_later_file_change() -> Result<()> {
+        let conn = migrated_db()?;
+        let memory = tracked_memory(Some(r#"["src/lib.rs"]"#));
+        link_commit(
+            &conn,
+            1,
+            "source-sha",
+            100,
+            &["src/lib.rs"],
+            "mem-session-1",
+        )?;
+        insert_commit(&conn, 2, "later-sha", 200, &["src/lib.rs"])?;
+
+        let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+        assert_eq!(label.source_anchor, "verify-before-trust");
+        assert!(label.label.contains("source_anchor=verify-before-trust"));
+        Ok(())
+    }
+
+    #[test]
+    fn source_anchor_matches_directory_overlap() -> Result<()> {
+        let conn = migrated_db()?;
+        let memory = tracked_memory(Some(r#"["src/context"]"#));
+        link_commit(
+            &conn,
+            1,
+            "source-sha",
+            100,
+            &["src/context/query.rs"],
+            "mem-session-1",
+        )?;
+        insert_commit(&conn, 2, "later-sha", 200, &["src/context/render.rs"])?;
+
+        let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+        assert_eq!(label.source_anchor, "verify-before-trust");
+        Ok(())
+    }
+
+    fn migrated_db() -> Result<Connection> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        Ok(conn)
+    }
+
+    fn tracked_memory(files: Option<&str>) -> Memory {
+        let mut memory = memory(1_700_000_000, "active");
+        memory.session_id = Some("mem-session-1".to_string());
+        memory.project = "proj".to_string();
+        memory.files = files.map(str::to_string);
+        memory
+    }
+
+    fn link_commit(
+        conn: &Connection,
+        id: i64,
+        sha: &str,
+        epoch: i64,
+        changed_files: &[&str],
+        memory_session_id: &str,
+    ) -> Result<()> {
+        insert_commit(conn, id, sha, epoch, changed_files)?;
+        conn.execute(
+            "INSERT INTO git_commit_sessions
+             (commit_id, session_id, memory_session_id, source, linked_at_epoch)
+             VALUES (?1, ?2, ?3, 'test', ?4)",
+            params![id, format!("content-{id}"), memory_session_id, epoch],
+        )?;
+        Ok(())
+    }
+
+    fn insert_commit(
+        conn: &Connection,
+        id: i64,
+        sha: &str,
+        epoch: i64,
+        changed_files: &[&str],
+    ) -> Result<()> {
+        let changed_files = serde_json::to_string(changed_files)?;
+        conn.execute(
+            "INSERT INTO git_commits
+             (id, project, repo_path, sha, short_sha, branch, message,
+              authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch)
+             VALUES (?1, 'proj', '/repo', ?2, ?2, 'main', NULL, ?3, ?4, ?3, ?3)",
+            params![id, sha, epoch, changed_files],
+        )?;
+        Ok(())
     }
 }

--- a/src/memory/staleness.rs
+++ b/src/memory/staleness.rs
@@ -25,7 +25,15 @@ struct SourceAnchor {
 struct EvidenceAnchor {
     project: String,
     session_ids: Vec<String>,
+    session_row_ids: Vec<i64>,
+    event_ids: Vec<i64>,
     touched_files: HashSet<String>,
+}
+
+#[derive(Debug, Default)]
+struct CapturedEventRefs {
+    session_ids: Vec<String>,
+    session_row_ids: Vec<i64>,
 }
 
 pub fn memory_staleness_label(memory: &Memory, now_epoch: i64) -> MemoryStalenessLabel {
@@ -121,8 +129,14 @@ fn source_anchor_for_memory(conn: &Connection, memory: &Memory) -> Result<&'stat
     }
 
     let memory_branch = non_empty_trimmed(memory.branch.as_deref()).map(str::to_string);
-    let Some(anchor) =
-        source_commit_anchor_for_sessions(conn, &project, &session_ids, memory_branch.as_deref())?
+    let Some(anchor) = source_commit_anchor_for_sessions(
+        conn,
+        &project,
+        &session_ids,
+        memory_branch.as_deref(),
+        memory.created_at_epoch,
+        &touched_files,
+    )?
     else {
         return Ok("untracked");
     };
@@ -157,11 +171,19 @@ fn source_commit_anchor_for_sessions(
     project: &str,
     session_ids: &[String],
     branch_filter: Option<&str>,
+    max_epoch: i64,
+    touched_files: &HashSet<String>,
 ) -> Result<Option<SourceAnchor>> {
     let mut latest = None;
     for session_id in session_ids {
-        let Some(anchor) =
-            source_commit_anchor_for_session(conn, project, session_id, branch_filter)?
+        let Some(anchor) = source_commit_anchor_for_session(
+            conn,
+            project,
+            session_id,
+            branch_filter,
+            max_epoch,
+            touched_files,
+        )?
         else {
             continue;
         };
@@ -179,28 +201,49 @@ fn source_commit_anchor_for_session(
     project: &str,
     session_id: &str,
     branch_filter: Option<&str>,
+    max_epoch: i64,
+    touched_files: &HashSet<String>,
 ) -> Result<Option<SourceAnchor>> {
-    conn.query_row(
-        "SELECT c.id, COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch), c.branch
+    let mut stmt = conn.prepare(
+        "SELECT c.id,
+                COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch),
+                c.branch,
+                c.changed_files
          FROM git_commits c
          JOIN git_commit_sessions l ON l.commit_id = c.id
          WHERE c.project = ?1
            AND (l.memory_session_id = ?2 OR l.session_id = ?2)
            AND (?3 IS NULL OR c.branch = ?3)
+           AND COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch) <= ?4
          ORDER BY COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch) DESC,
                   c.id DESC
-         LIMIT 1",
-        params![project, session_id, branch_filter],
+         ",
+    )?;
+    let rows = stmt.query_map(
+        params![project, session_id, branch_filter, max_epoch],
         |row| {
-            Ok(SourceAnchor {
-                id: row.get(0)?,
-                epoch: row.get(1)?,
-                branch: row.get(2)?,
-            })
+            Ok((
+                SourceAnchor {
+                    id: row.get(0)?,
+                    epoch: row.get(1)?,
+                    branch: row.get(2)?,
+                },
+                row.get::<_, String>(3)?,
+            ))
         },
-    )
-    .optional()
-    .map_err(Into::into)
+    )?;
+    for row in rows {
+        let (anchor, raw_changed_files) = row?;
+        let changed_files = parse_json_file_array(&raw_changed_files)
+            .with_context(|| "parse git commit changed_files for source-anchor staleness")?;
+        if changed_files
+            .iter()
+            .any(|changed_file| paths_overlap(changed_file, touched_files))
+        {
+            return Ok(Some(anchor));
+        }
+    }
+    Ok(None)
 }
 
 fn later_commit_touches_any_file(
@@ -268,16 +311,21 @@ fn evidence_anchor_for_memory(
         project,
         ..Default::default()
     };
-    anchor.session_ids = captured_event_sessions(conn, &anchor.project, &event_ids)?;
+    anchor.event_ids = event_ids;
+    let captured_refs = captured_event_refs(conn, &anchor.project, &anchor.event_ids)?;
+    anchor.session_ids = captured_refs.session_ids;
+    anchor.session_row_ids = captured_refs.session_row_ids;
     add_legacy_event_files(
         conn,
         &anchor.project,
-        &anchor.session_ids,
+        &anchor.event_ids,
         &mut anchor.touched_files,
     )?;
     add_observation_files(
         conn,
         &anchor.project,
+        &anchor.event_ids,
+        &anchor.session_row_ids,
         &anchor.session_ids,
         &mut anchor.touched_files,
     )?;
@@ -409,20 +457,20 @@ fn candidate_evidence_reference(
     Ok((project, event_ids))
 }
 
-fn captured_event_sessions(
+fn captured_event_refs(
     conn: &Connection,
     project: &str,
     event_ids: &[i64],
-) -> Result<Vec<String>> {
+) -> Result<CapturedEventRefs> {
     if event_ids.is_empty()
         || !table_exists(conn, "captured_events")?
         || !table_exists(conn, "projects")?
     {
-        return Ok(Vec::new());
+        return Ok(CapturedEventRefs::default());
     }
     let placeholders = placeholders(2, event_ids.len());
     let sql = format!(
-        "SELECT DISTINCT e.session_id
+        "SELECT e.session_id, e.session_row_id
          FROM captured_events e
          JOIN projects p ON p.id = e.project_id
          WHERE p.project_path = ?1
@@ -435,34 +483,38 @@ fn captured_event_sessions(
     }
     let refs = crate::db::to_sql_refs(&values);
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(0))?;
-    let mut session_ids = Vec::new();
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    let mut refs = CapturedEventRefs::default();
     for row in rows {
-        push_unique(&mut session_ids, row?);
+        let (session_id, session_row_id) = row?;
+        push_unique(&mut refs.session_ids, session_id);
+        push_unique_i64(&mut refs.session_row_ids, session_row_id);
     }
-    Ok(session_ids)
+    Ok(refs)
 }
 
 fn add_legacy_event_files(
     conn: &Connection,
     project: &str,
-    session_ids: &[String],
+    event_ids: &[i64],
     touched_files: &mut HashSet<String>,
 ) -> Result<()> {
-    if session_ids.is_empty() || !table_exists(conn, "events")? {
+    if event_ids.is_empty() || !table_exists(conn, "events")? {
         return Ok(());
     }
-    let placeholders = placeholders(2, session_ids.len());
+    let placeholders = placeholders(2, event_ids.len());
     let sql = format!(
         "SELECT files
          FROM events
          WHERE project = ?1
-           AND session_id IN ({placeholders})
+           AND id IN ({placeholders})
            AND files IS NOT NULL"
     );
     let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(project.to_string())];
-    for session_id in session_ids {
-        values.push(Box::new(session_id.clone()));
+    for event_id in event_ids {
+        values.push(Box::new(*event_id));
     }
     let refs = crate::db::to_sql_refs(&values);
     let mut stmt = conn.prepare(&sql)?;
@@ -476,10 +528,86 @@ fn add_legacy_event_files(
 fn add_observation_files(
     conn: &Connection,
     project: &str,
+    event_ids: &[i64],
+    session_row_ids: &[i64],
     session_ids: &[String],
     touched_files: &mut HashSet<String>,
 ) -> Result<()> {
-    if session_ids.is_empty() || !table_exists(conn, "observations")? {
+    if event_ids.is_empty() || !table_exists(conn, "observations")? {
+        return Ok(());
+    }
+    if column_exists(conn, "observations", "session_row_id")?
+        && column_exists(conn, "observations", "evidence_event_ids")?
+    {
+        return add_observation_files_by_evidence_events(
+            conn,
+            project,
+            event_ids,
+            session_row_ids,
+            touched_files,
+        );
+    }
+    add_legacy_observation_files(conn, project, session_ids, touched_files)
+}
+
+fn add_observation_files_by_evidence_events(
+    conn: &Connection,
+    project: &str,
+    event_ids: &[i64],
+    session_row_ids: &[i64],
+    touched_files: &mut HashSet<String>,
+) -> Result<()> {
+    if session_row_ids.is_empty() {
+        return Ok(());
+    }
+    let wanted = event_ids.iter().copied().collect::<HashSet<_>>();
+    let placeholders = placeholders(2, session_row_ids.len());
+    let sql = format!(
+        "SELECT files_read, files_modified, evidence_event_ids
+         FROM observations
+         WHERE project = ?1
+           AND session_row_id IN ({placeholders})
+           AND evidence_event_ids IS NOT NULL
+           AND (
+             files_read IS NOT NULL
+             OR files_modified IS NOT NULL
+           )"
+    );
+    let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(project.to_string())];
+    for session_row_id in session_row_ids {
+        values.push(Box::new(*session_row_id));
+    }
+    let refs = crate::db::to_sql_refs(&values);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok((
+            row.get::<_, Option<String>>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+        ))
+    })?;
+    for row in rows {
+        let (files_read, files_modified, evidence_json) = row?;
+        let observation_event_ids =
+            parse_evidence_event_ids(evidence_json.as_deref(), "observation evidence_event_ids")?;
+        if observation_event_ids
+            .iter()
+            .any(|event_id| wanted.contains(event_id))
+        {
+            touched_files.extend(parse_file_list(files_read.as_deref())?);
+            touched_files.extend(parse_file_list(files_modified.as_deref())?);
+        }
+    }
+    Ok(())
+}
+
+fn add_legacy_observation_files(
+    conn: &Connection,
+    project: &str,
+    session_ids: &[String],
+    touched_files: &mut HashSet<String>,
+) -> Result<()> {
+    if session_ids.is_empty() {
         return Ok(());
     }
     let placeholders = placeholders(2, session_ids.len());
@@ -562,6 +690,12 @@ fn non_empty_trimmed(value: Option<&str>) -> Option<&str> {
 
 fn push_unique(values: &mut Vec<String>, value: String) {
     if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn push_unique_i64(values: &mut Vec<i64>, value: i64) {
+    if !values.contains(&value) {
         values.push(value);
     }
 }

--- a/src/memory/staleness.rs
+++ b/src/memory/staleness.rs
@@ -115,7 +115,7 @@ fn source_anchor_for_memory(conn: &Connection, memory: &Memory) -> Result<&'stat
     if let Some(session_id) = non_empty_trimmed(memory.session_id.as_deref()) {
         push_unique(&mut session_ids, session_id.to_string());
     }
-    let mut touched_files = parse_file_list(memory.files.as_deref())?;
+    let mut touched_files = parse_file_list(memory.files.as_deref(), &project)?;
     if session_ids.is_empty() || touched_files.is_empty() {
         let evidence = evidence_anchor_for_memory(conn, memory, &project)?;
         project = evidence.project;
@@ -213,7 +213,7 @@ fn source_commit_anchor_for_session(
          JOIN git_commit_sessions l ON l.commit_id = c.id
          WHERE c.project = ?1
            AND (l.memory_session_id = ?2 OR l.session_id = ?2)
-           AND (?3 IS NULL OR c.branch = ?3)
+           AND (?3 IS NULL OR c.branch = ?3 OR c.branch IS NULL)
            AND COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch) <= ?4
          ORDER BY COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch) DESC,
                   c.id DESC
@@ -238,7 +238,7 @@ fn source_commit_anchor_for_session(
             .with_context(|| "parse git commit changed_files for source-anchor staleness")?;
         if changed_files
             .iter()
-            .any(|changed_file| paths_overlap(changed_file, touched_files))
+            .any(|changed_file| paths_overlap(changed_file, touched_files, project))
         {
             return Ok(Some(anchor));
         }
@@ -264,7 +264,7 @@ fn later_commit_touches_any_file(
                AND id > ?3
              )
            )
-           AND (?4 IS NULL OR branch = ?4)",
+           AND (?4 IS NULL OR branch = ?4 OR branch IS NULL)",
     )?;
     let mut rows = stmt.query(params![project, anchor.epoch, anchor.id, branch_filter])?;
     while let Some(row) = rows.next()? {
@@ -273,7 +273,7 @@ fn later_commit_touches_any_file(
             .with_context(|| "parse git commit changed_files for source-anchor staleness")?;
         if changed_files
             .iter()
-            .any(|changed_file| paths_overlap(changed_file, touched_files))
+            .any(|changed_file| paths_overlap(changed_file, touched_files, project))
         {
             return Ok(true);
         }
@@ -520,7 +520,7 @@ fn add_legacy_event_files(
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(0))?;
     for row in rows {
-        touched_files.extend(parse_file_list(Some(&row?))?);
+        touched_files.extend(parse_file_list(Some(&row?), project)?);
     }
     Ok(())
 }
@@ -594,8 +594,8 @@ fn add_observation_files_by_evidence_events(
             .iter()
             .any(|event_id| wanted.contains(event_id))
         {
-            touched_files.extend(parse_file_list(files_read.as_deref())?);
-            touched_files.extend(parse_file_list(files_modified.as_deref())?);
+            touched_files.extend(parse_file_list(files_read.as_deref(), project)?);
+            touched_files.extend(parse_file_list(files_modified.as_deref(), project)?);
         }
     }
     Ok(())
@@ -635,8 +635,8 @@ fn add_legacy_observation_files(
     })?;
     for row in rows {
         let (files_read, files_modified) = row?;
-        touched_files.extend(parse_file_list(files_read.as_deref())?);
-        touched_files.extend(parse_file_list(files_modified.as_deref())?);
+        touched_files.extend(parse_file_list(files_read.as_deref(), project)?);
+        touched_files.extend(parse_file_list(files_modified.as_deref(), project)?);
     }
     Ok(())
 }
@@ -700,7 +700,7 @@ fn push_unique_i64(values: &mut Vec<i64>, value: i64) {
     }
 }
 
-fn parse_file_list(raw: Option<&str>) -> Result<HashSet<String>> {
+fn parse_file_list(raw: Option<&str>, project: &str) -> Result<HashSet<String>> {
     let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok(HashSet::new());
     };
@@ -717,7 +717,7 @@ fn parse_file_list(raw: Option<&str>) -> Result<HashSet<String>> {
     };
     Ok(files
         .into_iter()
-        .filter_map(|file| normalize_file_path(&file))
+        .filter_map(|file| normalize_file_path_for_project(&file, project))
         .collect())
 }
 
@@ -726,8 +726,8 @@ fn parse_json_file_array(raw: &str) -> Result<Vec<String>> {
     Ok(files)
 }
 
-fn paths_overlap(changed_file: &str, touched_files: &HashSet<String>) -> bool {
-    let Some(changed_file) = normalize_file_path(changed_file) else {
+fn paths_overlap(changed_file: &str, touched_files: &HashSet<String>, project: &str) -> bool {
+    let Some(changed_file) = normalize_file_path_for_project(changed_file, project) else {
         return false;
     };
     touched_files.iter().any(|memory_file| {
@@ -744,6 +744,21 @@ fn paths_overlap(changed_file: &str, touched_files: &HashSet<String>) -> bool {
 fn normalize_file_path(path: &str) -> Option<String> {
     let trimmed = path.trim().trim_start_matches("./").trim_matches('/');
     (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn normalize_file_path_for_project(path: &str, project: &str) -> Option<String> {
+    let normalized = normalize_file_path(path)?;
+    let Some(project) = normalize_file_path(project) else {
+        return Some(normalized);
+    };
+    if normalized == project {
+        return None;
+    }
+    normalized
+        .strip_prefix(&format!("{project}/"))
+        .map(str::to_string)
+        .filter(|value| !value.is_empty())
+        .or(Some(normalized))
 }
 
 #[cfg(test)]

--- a/src/memory/staleness.rs
+++ b/src/memory/staleness.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, types::ToSql, Connection, OptionalExtension};
 use serde::Serialize;
 
 use super::Memory;
@@ -12,6 +12,20 @@ pub struct MemoryStalenessLabel {
     pub age: &'static str,
     pub source_anchor: String,
     pub label: String,
+}
+
+#[derive(Debug, Clone)]
+struct SourceAnchor {
+    id: i64,
+    epoch: i64,
+    branch: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct EvidenceAnchor {
+    project: String,
+    session_ids: Vec<String>,
+    touched_files: HashSet<String>,
 }
 
 pub fn memory_staleness_label(memory: &Memory, now_epoch: i64) -> MemoryStalenessLabel {
@@ -84,22 +98,42 @@ pub fn age_staleness(updated_at_epoch: i64, now_epoch: i64) -> &'static str {
 }
 
 fn source_anchor_for_memory(conn: &Connection, memory: &Memory) -> Result<&'static str> {
-    let Some(session_id) = memory
-        .session_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
+    if !git_trace_tables_exist(conn)? {
+        return Ok("untracked");
+    }
+
+    let mut project = source_project_for_memory(conn, memory)?;
+    let mut session_ids = Vec::new();
+    if let Some(session_id) = non_empty_trimmed(memory.session_id.as_deref()) {
+        push_unique(&mut session_ids, session_id.to_string());
+    }
+    let mut touched_files = parse_file_list(memory.files.as_deref())?;
+    if session_ids.is_empty() || touched_files.is_empty() {
+        let evidence = evidence_anchor_for_memory(conn, memory, &project)?;
+        project = evidence.project;
+        for session_id in evidence.session_ids {
+            push_unique(&mut session_ids, session_id);
+        }
+        touched_files.extend(evidence.touched_files);
+    }
+    if session_ids.is_empty() || touched_files.is_empty() {
+        return Ok("untracked");
+    }
+
+    let memory_branch = non_empty_trimmed(memory.branch.as_deref()).map(str::to_string);
+    let Some(anchor) =
+        source_commit_anchor_for_sessions(conn, &project, &session_ids, memory_branch.as_deref())?
     else {
         return Ok("untracked");
     };
-    let touched_files = parse_file_list(memory.files.as_deref())?;
-    if touched_files.is_empty() || !git_trace_tables_exist(conn)? {
-        return Ok("untracked");
-    }
-    let Some(anchor) = source_commit_anchor(conn, &memory.project, session_id)? else {
-        return Ok("untracked");
-    };
-    if later_commit_touches_any_file(conn, &memory.project, anchor, &touched_files)? {
+    let branch_filter = memory_branch.or_else(|| anchor.branch.clone());
+    if later_commit_touches_any_file(
+        conn,
+        &project,
+        &anchor,
+        branch_filter.as_deref(),
+        &touched_files,
+    )? {
         Ok("verify-before-trust")
     } else {
         Ok("tracked")
@@ -118,22 +152,52 @@ fn git_trace_tables_exist(conn: &Connection) -> Result<bool> {
     Ok(count == 2)
 }
 
-fn source_commit_anchor(
+fn source_commit_anchor_for_sessions(
+    conn: &Connection,
+    project: &str,
+    session_ids: &[String],
+    branch_filter: Option<&str>,
+) -> Result<Option<SourceAnchor>> {
+    let mut latest = None;
+    for session_id in session_ids {
+        let Some(anchor) =
+            source_commit_anchor_for_session(conn, project, session_id, branch_filter)?
+        else {
+            continue;
+        };
+        if latest.as_ref().is_none_or(|current: &SourceAnchor| {
+            (anchor.epoch, anchor.id) > (current.epoch, current.id)
+        }) {
+            latest = Some(anchor);
+        }
+    }
+    Ok(latest)
+}
+
+fn source_commit_anchor_for_session(
     conn: &Connection,
     project: &str,
     session_id: &str,
-) -> Result<Option<(i64, i64)>> {
+    branch_filter: Option<&str>,
+) -> Result<Option<SourceAnchor>> {
     conn.query_row(
-        "SELECT c.id, COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch)
+        "SELECT c.id, COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch), c.branch
          FROM git_commits c
          JOIN git_commit_sessions l ON l.commit_id = c.id
          WHERE c.project = ?1
            AND (l.memory_session_id = ?2 OR l.session_id = ?2)
+           AND (?3 IS NULL OR c.branch = ?3)
          ORDER BY COALESCE(c.authored_at_epoch, c.updated_at_epoch, c.created_at_epoch) DESC,
                   c.id DESC
          LIMIT 1",
-        params![project, session_id],
-        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        params![project, session_id, branch_filter],
+        |row| {
+            Ok(SourceAnchor {
+                id: row.get(0)?,
+                epoch: row.get(1)?,
+                branch: row.get(2)?,
+            })
+        },
     )
     .optional()
     .map_err(Into::into)
@@ -142,10 +206,10 @@ fn source_commit_anchor(
 fn later_commit_touches_any_file(
     conn: &Connection,
     project: &str,
-    anchor: (i64, i64),
+    anchor: &SourceAnchor,
+    branch_filter: Option<&str>,
     touched_files: &HashSet<String>,
 ) -> Result<bool> {
-    let (anchor_id, anchor_epoch) = anchor;
     let mut stmt = conn.prepare(
         "SELECT changed_files
          FROM git_commits
@@ -156,9 +220,10 @@ fn later_commit_touches_any_file(
                COALESCE(authored_at_epoch, updated_at_epoch, created_at_epoch) = ?2
                AND id > ?3
              )
-           )",
+           )
+           AND (?4 IS NULL OR branch = ?4)",
     )?;
-    let mut rows = stmt.query(params![project, anchor_epoch, anchor_id])?;
+    let mut rows = stmt.query(params![project, anchor.epoch, anchor.id, branch_filter])?;
     while let Some(row) = rows.next()? {
         let raw: String = row.get(0)?;
         let changed_files = parse_json_file_array(&raw)
@@ -171,6 +236,334 @@ fn later_commit_touches_any_file(
         }
     }
     Ok(false)
+}
+
+fn source_project_for_memory(conn: &Connection, memory: &Memory) -> Result<String> {
+    if !column_exists(conn, "memories", "source_project")? {
+        return Ok(memory.project.clone());
+    }
+    Ok(conn
+        .query_row(
+            "SELECT COALESCE(source_project, project) FROM memories WHERE id = ?1",
+            [memory.id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .unwrap_or_else(|| memory.project.clone()))
+}
+
+fn evidence_anchor_for_memory(
+    conn: &Connection,
+    memory: &Memory,
+    default_project: &str,
+) -> Result<EvidenceAnchor> {
+    let (project, event_ids) = memory_evidence_reference(conn, memory, default_project)?;
+    if event_ids.is_empty() {
+        return Ok(EvidenceAnchor {
+            project,
+            ..Default::default()
+        });
+    }
+    let mut anchor = EvidenceAnchor {
+        project,
+        ..Default::default()
+    };
+    anchor.session_ids = captured_event_sessions(conn, &anchor.project, &event_ids)?;
+    add_legacy_event_files(
+        conn,
+        &anchor.project,
+        &anchor.session_ids,
+        &mut anchor.touched_files,
+    )?;
+    add_observation_files(
+        conn,
+        &anchor.project,
+        &anchor.session_ids,
+        &mut anchor.touched_files,
+    )?;
+    Ok(anchor)
+}
+
+fn memory_evidence_reference(
+    conn: &Connection,
+    memory: &Memory,
+    default_project: &str,
+) -> Result<(String, Vec<i64>)> {
+    if !table_exists(conn, "memories")? || !column_exists(conn, "memories", "evidence_event_ids")? {
+        return Ok((default_project.to_string(), Vec::new()));
+    }
+    let has_source_candidate = column_exists(conn, "memories", "source_candidate_id")?;
+    let has_source_project = column_exists(conn, "memories", "source_project")?;
+    let (project, memory_evidence_json, source_candidate_id) = match (
+        has_source_candidate,
+        has_source_project,
+    ) {
+        (true, true) => conn
+            .query_row(
+                "SELECT COALESCE(source_project, project), evidence_event_ids, source_candidate_id
+             FROM memories WHERE id = ?1",
+                [memory.id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                    ))
+                },
+            )
+            .optional()?
+            .unwrap_or_else(|| (default_project.to_string(), None, None)),
+        (true, false) => conn
+            .query_row(
+                "SELECT project, evidence_event_ids, source_candidate_id
+                 FROM memories WHERE id = ?1",
+                [memory.id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                    ))
+                },
+            )
+            .optional()?
+            .unwrap_or_else(|| (default_project.to_string(), None, None)),
+        (false, true) => conn
+            .query_row(
+                "SELECT COALESCE(source_project, project), evidence_event_ids
+                 FROM memories WHERE id = ?1",
+                [memory.id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        None,
+                    ))
+                },
+            )
+            .optional()?
+            .unwrap_or_else(|| (default_project.to_string(), None, None)),
+        (false, false) => {
+            let evidence_json = conn
+                .query_row(
+                    "SELECT evidence_event_ids FROM memories WHERE id = ?1",
+                    [memory.id],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+                .optional()?
+                .flatten();
+            (default_project.to_string(), evidence_json, None)
+        }
+    };
+
+    let memory_event_ids = parse_evidence_event_ids(
+        memory_evidence_json.as_deref(),
+        &format!("memory {} evidence_event_ids", memory.id),
+    )?;
+    if !memory_event_ids.is_empty() {
+        return Ok((project, memory_event_ids));
+    }
+    let Some(source_candidate_id) = source_candidate_id else {
+        return Ok((project, Vec::new()));
+    };
+    candidate_evidence_reference(conn, source_candidate_id, &project)
+}
+
+fn candidate_evidence_reference(
+    conn: &Connection,
+    candidate_id: i64,
+    default_project: &str,
+) -> Result<(String, Vec<i64>)> {
+    if !table_exists(conn, "memory_candidates")?
+        || !column_exists(conn, "memory_candidates", "evidence_event_ids")?
+    {
+        return Ok((default_project.to_string(), Vec::new()));
+    }
+    let row = if table_exists(conn, "projects")? {
+        conn.query_row(
+            "SELECT COALESCE(p.project_path, ?2), c.evidence_event_ids
+             FROM memory_candidates c
+             LEFT JOIN projects p ON p.id = c.project_id
+             WHERE c.id = ?1",
+            params![candidate_id, default_project],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?
+    } else {
+        conn.query_row(
+            "SELECT ?2, evidence_event_ids
+             FROM memory_candidates
+             WHERE id = ?1",
+            params![candidate_id, default_project],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?
+    };
+    let Some((project, evidence_json)) = row else {
+        return Ok((default_project.to_string(), Vec::new()));
+    };
+    let event_ids = parse_evidence_event_ids(
+        Some(&evidence_json),
+        &format!("memory candidate {candidate_id} evidence_event_ids"),
+    )?;
+    Ok((project, event_ids))
+}
+
+fn captured_event_sessions(
+    conn: &Connection,
+    project: &str,
+    event_ids: &[i64],
+) -> Result<Vec<String>> {
+    if event_ids.is_empty()
+        || !table_exists(conn, "captured_events")?
+        || !table_exists(conn, "projects")?
+    {
+        return Ok(Vec::new());
+    }
+    let placeholders = placeholders(2, event_ids.len());
+    let sql = format!(
+        "SELECT DISTINCT e.session_id
+         FROM captured_events e
+         JOIN projects p ON p.id = e.project_id
+         WHERE p.project_path = ?1
+           AND e.id IN ({placeholders})
+         ORDER BY e.id ASC"
+    );
+    let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(project.to_string())];
+    for event_id in event_ids {
+        values.push(Box::new(*event_id));
+    }
+    let refs = crate::db::to_sql_refs(&values);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(0))?;
+    let mut session_ids = Vec::new();
+    for row in rows {
+        push_unique(&mut session_ids, row?);
+    }
+    Ok(session_ids)
+}
+
+fn add_legacy_event_files(
+    conn: &Connection,
+    project: &str,
+    session_ids: &[String],
+    touched_files: &mut HashSet<String>,
+) -> Result<()> {
+    if session_ids.is_empty() || !table_exists(conn, "events")? {
+        return Ok(());
+    }
+    let placeholders = placeholders(2, session_ids.len());
+    let sql = format!(
+        "SELECT files
+         FROM events
+         WHERE project = ?1
+           AND session_id IN ({placeholders})
+           AND files IS NOT NULL"
+    );
+    let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(project.to_string())];
+    for session_id in session_ids {
+        values.push(Box::new(session_id.clone()));
+    }
+    let refs = crate::db::to_sql_refs(&values);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(0))?;
+    for row in rows {
+        touched_files.extend(parse_file_list(Some(&row?))?);
+    }
+    Ok(())
+}
+
+fn add_observation_files(
+    conn: &Connection,
+    project: &str,
+    session_ids: &[String],
+    touched_files: &mut HashSet<String>,
+) -> Result<()> {
+    if session_ids.is_empty() || !table_exists(conn, "observations")? {
+        return Ok(());
+    }
+    let placeholders = placeholders(2, session_ids.len());
+    let sql = format!(
+        "SELECT files_read, files_modified
+         FROM observations
+         WHERE project = ?1
+           AND memory_session_id IN ({placeholders})
+           AND (
+             files_read IS NOT NULL
+             OR files_modified IS NOT NULL
+           )"
+    );
+    let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(project.to_string())];
+    for session_id in session_ids {
+        values.push(Box::new(session_id.clone()));
+    }
+    let refs = crate::db::to_sql_refs(&values);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok((
+            row.get::<_, Option<String>>(0)?,
+            row.get::<_, Option<String>>(1)?,
+        ))
+    })?;
+    for row in rows {
+        let (files_read, files_modified) = row?;
+        touched_files.extend(parse_file_list(files_read.as_deref())?);
+        touched_files.extend(parse_file_list(files_modified.as_deref())?);
+    }
+    Ok(())
+}
+
+fn parse_evidence_event_ids(raw: Option<&str>, context: &str) -> Result<Vec<i64>> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(Vec::new());
+    };
+    let mut ids = serde_json::from_str::<Vec<i64>>(raw)
+        .with_context(|| format!("parse {context} for source-anchor staleness"))?;
+    ids.retain(|id| *id > 0);
+    ids.sort_unstable();
+    ids.dedup();
+    Ok(ids)
+}
+
+fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
+    let exists = conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM sqlite_master
+             WHERE type = 'table' AND name = ?1
+         )",
+        [table],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(exists != 0)
+}
+
+fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
+    let sql = format!("PRAGMA table_info({table})");
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for row in rows {
+        if row? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn placeholders(start: usize, count: usize) -> String {
+    (start..start + count)
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn non_empty_trimmed(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
 }
 
 fn parse_file_list(raw: Option<&str>) -> Result<HashSet<String>> {
@@ -220,174 +613,4 @@ fn normalize_file_path(path: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn memory(updated_at_epoch: i64, status: &str) -> Memory {
-        Memory {
-            id: 1,
-            session_id: None,
-            project: "/repo".to_string(),
-            topic_key: None,
-            title: "Staleness fixture".to_string(),
-            text: "body".to_string(),
-            memory_type: "decision".to_string(),
-            files: None,
-            created_at_epoch: updated_at_epoch,
-            updated_at_epoch,
-            status: status.to_string(),
-            branch: None,
-            scope: "project".to_string(),
-        }
-    }
-
-    #[test]
-    fn labels_memory_status_age_and_untracked_source_anchor() {
-        let label = memory_staleness_label(&memory(1_700_000_000, "active"), 1_700_000_000);
-
-        assert_eq!(label.status, "active");
-        assert_eq!(label.age, "fresh");
-        assert_eq!(label.source_anchor, "untracked");
-        assert_eq!(
-            label.label,
-            "status=active; staleness=fresh; source_anchor=untracked"
-        );
-        assert_eq!(
-            memory_staleness(&memory(1_700_000_000, "active"), 1_700_000_000),
-            "status=active; staleness=fresh; source_anchor=untracked"
-        );
-    }
-
-    #[test]
-    fn classifies_age_buckets() {
-        let now = 1_700_000_000;
-
-        assert_eq!(age_staleness(now - 30 * 86_400, now), "fresh");
-        assert_eq!(age_staleness(now - 31 * 86_400, now), "aging");
-        assert_eq!(age_staleness(now - 91 * 86_400, now), "old");
-    }
-
-    #[test]
-    fn source_anchor_marks_untracked_without_files_or_commit_link() -> Result<()> {
-        let conn = migrated_db()?;
-        let mut memory = memory(1_700_000_000, "active");
-        memory.session_id = Some("mem-session-1".to_string());
-
-        let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
-
-        assert_eq!(label.source_anchor, "untracked");
-        Ok(())
-    }
-
-    #[test]
-    fn source_anchor_tracks_commit_without_later_file_change() -> Result<()> {
-        let conn = migrated_db()?;
-        let memory = tracked_memory(Some(r#"["src/lib.rs"]"#));
-        link_commit(
-            &conn,
-            1,
-            "source-sha",
-            100,
-            &["src/lib.rs"],
-            "mem-session-1",
-        )?;
-        insert_commit(&conn, 2, "later-sha", 200, &["README.md"])?;
-
-        let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
-
-        assert_eq!(label.source_anchor, "tracked");
-        assert!(label.label.contains("source_anchor=tracked"));
-        Ok(())
-    }
-
-    #[test]
-    fn source_anchor_requires_verification_after_later_file_change() -> Result<()> {
-        let conn = migrated_db()?;
-        let memory = tracked_memory(Some(r#"["src/lib.rs"]"#));
-        link_commit(
-            &conn,
-            1,
-            "source-sha",
-            100,
-            &["src/lib.rs"],
-            "mem-session-1",
-        )?;
-        insert_commit(&conn, 2, "later-sha", 200, &["src/lib.rs"])?;
-
-        let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
-
-        assert_eq!(label.source_anchor, "verify-before-trust");
-        assert!(label.label.contains("source_anchor=verify-before-trust"));
-        Ok(())
-    }
-
-    #[test]
-    fn source_anchor_matches_directory_overlap() -> Result<()> {
-        let conn = migrated_db()?;
-        let memory = tracked_memory(Some(r#"["src/context"]"#));
-        link_commit(
-            &conn,
-            1,
-            "source-sha",
-            100,
-            &["src/context/query.rs"],
-            "mem-session-1",
-        )?;
-        insert_commit(&conn, 2, "later-sha", 200, &["src/context/render.rs"])?;
-
-        let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
-
-        assert_eq!(label.source_anchor, "verify-before-trust");
-        Ok(())
-    }
-
-    fn migrated_db() -> Result<Connection> {
-        let conn = Connection::open_in_memory()?;
-        crate::migrate::run_migrations(&conn)?;
-        Ok(conn)
-    }
-
-    fn tracked_memory(files: Option<&str>) -> Memory {
-        let mut memory = memory(1_700_000_000, "active");
-        memory.session_id = Some("mem-session-1".to_string());
-        memory.project = "proj".to_string();
-        memory.files = files.map(str::to_string);
-        memory
-    }
-
-    fn link_commit(
-        conn: &Connection,
-        id: i64,
-        sha: &str,
-        epoch: i64,
-        changed_files: &[&str],
-        memory_session_id: &str,
-    ) -> Result<()> {
-        insert_commit(conn, id, sha, epoch, changed_files)?;
-        conn.execute(
-            "INSERT INTO git_commit_sessions
-             (commit_id, session_id, memory_session_id, source, linked_at_epoch)
-             VALUES (?1, ?2, ?3, 'test', ?4)",
-            params![id, format!("content-{id}"), memory_session_id, epoch],
-        )?;
-        Ok(())
-    }
-
-    fn insert_commit(
-        conn: &Connection,
-        id: i64,
-        sha: &str,
-        epoch: i64,
-        changed_files: &[&str],
-    ) -> Result<()> {
-        let changed_files = serde_json::to_string(changed_files)?;
-        conn.execute(
-            "INSERT INTO git_commits
-             (id, project, repo_path, sha, short_sha, branch, message,
-              authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch)
-             VALUES (?1, 'proj', '/repo', ?2, ?2, 'main', NULL, ?3, ?4, ?3, ?3)",
-            params![id, sha, epoch, changed_files],
-        )?;
-        Ok(())
-    }
-}
+mod tests;

--- a/src/memory/staleness.rs
+++ b/src/memory/staleness.rs
@@ -5,6 +5,9 @@ use rusqlite::{params, types::ToSql, Connection, OptionalExtension};
 use serde::Serialize;
 
 use super::Memory;
+use path::{file_path_overlaps, parse_file_list, parse_json_file_array};
+
+mod path;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct MemoryStalenessLabel {
@@ -27,13 +30,14 @@ struct EvidenceAnchor {
     session_ids: Vec<String>,
     session_row_ids: Vec<i64>,
     event_ids: Vec<i64>,
-    touched_files: HashSet<String>,
+    file_epochs: HashMap<String, i64>,
 }
 
 #[derive(Debug, Default)]
 struct CapturedEventRefs {
     session_ids: Vec<String>,
     session_row_ids: Vec<i64>,
+    event_epochs: HashMap<i64, i64>,
 }
 
 pub fn memory_staleness_label(memory: &Memory, now_epoch: i64) -> MemoryStalenessLabel {
@@ -115,42 +119,48 @@ fn source_anchor_for_memory(conn: &Connection, memory: &Memory) -> Result<&'stat
     if let Some(session_id) = non_empty_trimmed(memory.session_id.as_deref()) {
         push_unique(&mut session_ids, session_id.to_string());
     }
-    let mut touched_files = parse_file_list(memory.files.as_deref(), &project)?;
-    if session_ids.is_empty() || touched_files.is_empty() {
+    let mut file_epochs = file_epoch_map(
+        parse_file_list(memory.files.as_deref(), &project)?,
+        memory.created_at_epoch,
+    );
+    if session_ids.is_empty() || file_epochs.is_empty() {
         let evidence = evidence_anchor_for_memory(conn, memory, &project)?;
         project = evidence.project;
         for session_id in evidence.session_ids {
             push_unique(&mut session_ids, session_id);
         }
-        touched_files.extend(evidence.touched_files);
+        for (file, epoch) in evidence.file_epochs {
+            file_epochs.insert(file, epoch);
+        }
     }
-    if session_ids.is_empty() || touched_files.is_empty() {
+    if session_ids.is_empty() || file_epochs.is_empty() {
         return Ok("untracked");
     }
 
     let memory_branch = non_empty_trimmed(memory.branch.as_deref()).map(str::to_string);
-    let Some(anchor) = source_commit_anchor_for_sessions(
-        conn,
-        &project,
-        &session_ids,
-        memory_branch.as_deref(),
-        memory.created_at_epoch,
-        &touched_files,
-    )?
-    else {
-        return Ok("untracked");
-    };
-    let branch_filter = memory_branch.or_else(|| anchor.branch.clone());
-    if later_commit_touches_any_file(
-        conn,
-        &project,
-        &anchor,
-        branch_filter.as_deref(),
-        &touched_files,
-    )? {
-        Ok("verify-before-trust")
-    } else {
+    let mut anchored_any = false;
+    for (file, max_epoch) in &file_epochs {
+        let Some(anchor) = source_commit_anchor_for_file_sessions(
+            conn,
+            &project,
+            &session_ids,
+            memory_branch.as_deref(),
+            *max_epoch,
+            file,
+        )?
+        else {
+            continue;
+        };
+        anchored_any = true;
+        let branch_filter = memory_branch.as_deref().or(anchor.branch.as_deref());
+        if later_commit_touches_file(conn, &project, &anchor, branch_filter, file)? {
+            return Ok("verify-before-trust");
+        }
+    }
+    if anchored_any {
         Ok("tracked")
+    } else {
+        Ok("untracked")
     }
 }
 
@@ -166,13 +176,13 @@ fn git_trace_tables_exist(conn: &Connection) -> Result<bool> {
     Ok(count == 2)
 }
 
-fn source_commit_anchor_for_sessions(
+fn source_commit_anchor_for_file_sessions(
     conn: &Connection,
     project: &str,
     session_ids: &[String],
     branch_filter: Option<&str>,
     max_epoch: i64,
-    touched_files: &HashSet<String>,
+    touched_file: &str,
 ) -> Result<Option<SourceAnchor>> {
     let mut latest = None;
     for session_id in session_ids {
@@ -182,7 +192,7 @@ fn source_commit_anchor_for_sessions(
             session_id,
             branch_filter,
             max_epoch,
-            touched_files,
+            touched_file,
         )?
         else {
             continue;
@@ -202,7 +212,7 @@ fn source_commit_anchor_for_session(
     session_id: &str,
     branch_filter: Option<&str>,
     max_epoch: i64,
-    touched_files: &HashSet<String>,
+    touched_file: &str,
 ) -> Result<Option<SourceAnchor>> {
     let mut stmt = conn.prepare(
         "SELECT c.id,
@@ -238,7 +248,7 @@ fn source_commit_anchor_for_session(
             .with_context(|| "parse git commit changed_files for source-anchor staleness")?;
         if changed_files
             .iter()
-            .any(|changed_file| paths_overlap(changed_file, touched_files, project))
+            .any(|changed_file| file_path_overlaps(changed_file, touched_file, project))
         {
             return Ok(Some(anchor));
         }
@@ -246,12 +256,12 @@ fn source_commit_anchor_for_session(
     Ok(None)
 }
 
-fn later_commit_touches_any_file(
+fn later_commit_touches_file(
     conn: &Connection,
     project: &str,
     anchor: &SourceAnchor,
     branch_filter: Option<&str>,
-    touched_files: &HashSet<String>,
+    touched_file: &str,
 ) -> Result<bool> {
     let mut stmt = conn.prepare(
         "SELECT changed_files
@@ -273,7 +283,7 @@ fn later_commit_touches_any_file(
             .with_context(|| "parse git commit changed_files for source-anchor staleness")?;
         if changed_files
             .iter()
-            .any(|changed_file| paths_overlap(changed_file, touched_files, project))
+            .any(|changed_file| file_path_overlaps(changed_file, touched_file, project))
         {
             return Ok(true);
         }
@@ -319,7 +329,7 @@ fn evidence_anchor_for_memory(
         conn,
         &anchor.project,
         &anchor.event_ids,
-        &mut anchor.touched_files,
+        &mut anchor.file_epochs,
     )?;
     add_observation_files(
         conn,
@@ -327,7 +337,8 @@ fn evidence_anchor_for_memory(
         &anchor.event_ids,
         &anchor.session_row_ids,
         &anchor.session_ids,
-        &mut anchor.touched_files,
+        &captured_refs.event_epochs,
+        &mut anchor.file_epochs,
     )?;
     Ok(anchor)
 }
@@ -469,8 +480,13 @@ fn captured_event_refs(
         return Ok(CapturedEventRefs::default());
     }
     let placeholders = placeholders(2, event_ids.len());
+    let event_time_expr = if column_exists(conn, "captured_events", "reference_time_epoch")? {
+        "COALESCE(e.reference_time_epoch, e.created_at_epoch)"
+    } else {
+        "e.created_at_epoch"
+    };
     let sql = format!(
-        "SELECT e.session_id, e.session_row_id
+        "SELECT e.id, e.session_id, e.session_row_id, {event_time_expr}
          FROM captured_events e
          JOIN projects p ON p.id = e.project_id
          WHERE p.project_path = ?1
@@ -484,13 +500,19 @@ fn captured_event_refs(
     let refs = crate::db::to_sql_refs(&values);
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(refs.as_slice(), |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, i64>(3)?,
+        ))
     })?;
     let mut refs = CapturedEventRefs::default();
     for row in rows {
-        let (session_id, session_row_id) = row?;
+        let (event_id, session_id, session_row_id, created_at_epoch) = row?;
         push_unique(&mut refs.session_ids, session_id);
         push_unique_i64(&mut refs.session_row_ids, session_row_id);
+        refs.event_epochs.insert(event_id, created_at_epoch);
     }
     Ok(refs)
 }
@@ -499,14 +521,14 @@ fn add_legacy_event_files(
     conn: &Connection,
     project: &str,
     event_ids: &[i64],
-    touched_files: &mut HashSet<String>,
+    file_epochs: &mut HashMap<String, i64>,
 ) -> Result<()> {
     if event_ids.is_empty() || !table_exists(conn, "events")? {
         return Ok(());
     }
     let placeholders = placeholders(2, event_ids.len());
     let sql = format!(
-        "SELECT files
+        "SELECT files, created_at_epoch
          FROM events
          WHERE project = ?1
            AND id IN ({placeholders})
@@ -518,9 +540,12 @@ fn add_legacy_event_files(
     }
     let refs = crate::db::to_sql_refs(&values);
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(refs.as_slice(), |row| row.get::<_, String>(0))?;
+    let rows = stmt.query_map(refs.as_slice(), |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
     for row in rows {
-        touched_files.extend(parse_file_list(Some(&row?), project)?);
+        let (files, created_at_epoch) = row?;
+        add_file_epochs(Some(&files), project, created_at_epoch, file_epochs)?;
     }
     Ok(())
 }
@@ -531,7 +556,8 @@ fn add_observation_files(
     event_ids: &[i64],
     session_row_ids: &[i64],
     session_ids: &[String],
-    touched_files: &mut HashSet<String>,
+    event_epochs: &HashMap<i64, i64>,
+    file_epochs: &mut HashMap<String, i64>,
 ) -> Result<()> {
     if event_ids.is_empty() || !table_exists(conn, "observations")? {
         return Ok(());
@@ -544,10 +570,11 @@ fn add_observation_files(
             project,
             event_ids,
             session_row_ids,
-            touched_files,
+            event_epochs,
+            file_epochs,
         );
     }
-    add_legacy_observation_files(conn, project, session_ids, touched_files)
+    add_legacy_observation_files(conn, project, session_ids, file_epochs)
 }
 
 fn add_observation_files_by_evidence_events(
@@ -555,7 +582,8 @@ fn add_observation_files_by_evidence_events(
     project: &str,
     event_ids: &[i64],
     session_row_ids: &[i64],
-    touched_files: &mut HashSet<String>,
+    event_epochs: &HashMap<i64, i64>,
+    file_epochs: &mut HashMap<String, i64>,
 ) -> Result<()> {
     if session_row_ids.is_empty() {
         return Ok(());
@@ -563,7 +591,7 @@ fn add_observation_files_by_evidence_events(
     let wanted = event_ids.iter().copied().collect::<HashSet<_>>();
     let placeholders = placeholders(2, session_row_ids.len());
     let sql = format!(
-        "SELECT files_read, files_modified, evidence_event_ids
+        "SELECT files_read, files_modified, evidence_event_ids, created_at_epoch
          FROM observations
          WHERE project = ?1
            AND session_row_id IN ({placeholders})
@@ -584,18 +612,31 @@ fn add_observation_files_by_evidence_events(
             row.get::<_, Option<String>>(0)?,
             row.get::<_, Option<String>>(1)?,
             row.get::<_, Option<String>>(2)?,
+            row.get::<_, i64>(3)?,
         ))
     })?;
     for row in rows {
-        let (files_read, files_modified, evidence_json) = row?;
+        let (files_read, files_modified, evidence_json, created_at_epoch) = row?;
         let observation_event_ids =
             parse_evidence_event_ids(evidence_json.as_deref(), "observation evidence_event_ids")?;
         if observation_event_ids
             .iter()
             .any(|event_id| wanted.contains(event_id))
         {
-            touched_files.extend(parse_file_list(files_read.as_deref(), project)?);
-            touched_files.extend(parse_file_list(files_modified.as_deref(), project)?);
+            let source_epoch = observation_event_ids
+                .iter()
+                .filter(|event_id| wanted.contains(event_id))
+                .filter_map(|event_id| event_epochs.get(event_id))
+                .max()
+                .copied()
+                .unwrap_or(created_at_epoch);
+            add_file_epochs(files_read.as_deref(), project, source_epoch, file_epochs)?;
+            add_file_epochs(
+                files_modified.as_deref(),
+                project,
+                source_epoch,
+                file_epochs,
+            )?;
         }
     }
     Ok(())
@@ -605,14 +646,14 @@ fn add_legacy_observation_files(
     conn: &Connection,
     project: &str,
     session_ids: &[String],
-    touched_files: &mut HashSet<String>,
+    file_epochs: &mut HashMap<String, i64>,
 ) -> Result<()> {
     if session_ids.is_empty() {
         return Ok(());
     }
     let placeholders = placeholders(2, session_ids.len());
     let sql = format!(
-        "SELECT files_read, files_modified
+        "SELECT files_read, files_modified, created_at_epoch
          FROM observations
          WHERE project = ?1
            AND memory_session_id IN ({placeholders})
@@ -631,14 +672,51 @@ fn add_legacy_observation_files(
         Ok((
             row.get::<_, Option<String>>(0)?,
             row.get::<_, Option<String>>(1)?,
+            row.get::<_, i64>(2)?,
         ))
     })?;
     for row in rows {
-        let (files_read, files_modified) = row?;
-        touched_files.extend(parse_file_list(files_read.as_deref(), project)?);
-        touched_files.extend(parse_file_list(files_modified.as_deref(), project)?);
+        let (files_read, files_modified, created_at_epoch) = row?;
+        add_file_epochs(
+            files_read.as_deref(),
+            project,
+            created_at_epoch,
+            file_epochs,
+        )?;
+        add_file_epochs(
+            files_modified.as_deref(),
+            project,
+            created_at_epoch,
+            file_epochs,
+        )?;
     }
     Ok(())
+}
+
+fn file_epoch_map(files: HashSet<String>, epoch: i64) -> HashMap<String, i64> {
+    files.into_iter().map(|file| (file, epoch)).collect()
+}
+
+fn add_file_epochs(
+    raw_files: Option<&str>,
+    project: &str,
+    epoch: i64,
+    file_epochs: &mut HashMap<String, i64>,
+) -> Result<()> {
+    merge_file_epochs_max(
+        file_epochs,
+        file_epoch_map(parse_file_list(raw_files, project)?, epoch),
+    );
+    Ok(())
+}
+
+fn merge_file_epochs_max(target: &mut HashMap<String, i64>, source: HashMap<String, i64>) {
+    for (file, epoch) in source {
+        target
+            .entry(file)
+            .and_modify(|existing| *existing = (*existing).max(epoch))
+            .or_insert(epoch);
+    }
 }
 
 fn parse_evidence_event_ids(raw: Option<&str>, context: &str) -> Result<Vec<i64>> {
@@ -698,67 +776,6 @@ fn push_unique_i64(values: &mut Vec<i64>, value: i64) {
     if !values.contains(&value) {
         values.push(value);
     }
-}
-
-fn parse_file_list(raw: Option<&str>, project: &str) -> Result<HashSet<String>> {
-    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
-        return Ok(HashSet::new());
-    };
-    let files = if raw.starts_with('[') {
-        parse_json_file_array(raw)
-            .with_context(|| "parse memory files for source-anchor staleness")?
-    } else {
-        raw.split([',', '\n'])
-            .map(str::trim)
-            .map(|value| value.trim_matches('"'))
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-            .collect()
-    };
-    Ok(files
-        .into_iter()
-        .filter_map(|file| normalize_file_path_for_project(&file, project))
-        .collect())
-}
-
-fn parse_json_file_array(raw: &str) -> Result<Vec<String>> {
-    let files = serde_json::from_str::<Vec<String>>(raw)?;
-    Ok(files)
-}
-
-fn paths_overlap(changed_file: &str, touched_files: &HashSet<String>, project: &str) -> bool {
-    let Some(changed_file) = normalize_file_path_for_project(changed_file, project) else {
-        return false;
-    };
-    touched_files.iter().any(|memory_file| {
-        changed_file == *memory_file
-            || changed_file
-                .strip_prefix(memory_file)
-                .is_some_and(|tail| tail.starts_with('/'))
-            || memory_file
-                .strip_prefix(&changed_file)
-                .is_some_and(|tail| tail.starts_with('/'))
-    })
-}
-
-fn normalize_file_path(path: &str) -> Option<String> {
-    let trimmed = path.trim().trim_start_matches("./").trim_matches('/');
-    (!trimmed.is_empty()).then(|| trimmed.to_string())
-}
-
-fn normalize_file_path_for_project(path: &str, project: &str) -> Option<String> {
-    let normalized = normalize_file_path(path)?;
-    let Some(project) = normalize_file_path(project) else {
-        return Some(normalized);
-    };
-    if normalized == project {
-        return None;
-    }
-    normalized
-        .strip_prefix(&format!("{project}/"))
-        .map(str::to_string)
-        .filter(|value| !value.is_empty())
-        .or(Some(normalized))
 }
 
 #[cfg(test)]

--- a/src/memory/staleness/path.rs
+++ b/src/memory/staleness/path.rs
@@ -1,0 +1,61 @@
+use std::collections::HashSet;
+
+use anyhow::{Context, Result};
+
+pub(super) fn parse_file_list(raw: Option<&str>, project: &str) -> Result<HashSet<String>> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(HashSet::new());
+    };
+    let files = if raw.starts_with('[') {
+        parse_json_file_array(raw)
+            .with_context(|| "parse memory files for source-anchor staleness")?
+    } else {
+        raw.split([',', '\n'])
+            .map(str::trim)
+            .map(|value| value.trim_matches('"'))
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect()
+    };
+    Ok(files
+        .into_iter()
+        .filter_map(|file| normalize_file_path_for_project(&file, project))
+        .collect())
+}
+
+pub(super) fn parse_json_file_array(raw: &str) -> Result<Vec<String>> {
+    Ok(serde_json::from_str::<Vec<String>>(raw)?)
+}
+
+pub(super) fn file_path_overlaps(changed_file: &str, memory_file: &str, project: &str) -> bool {
+    let Some(changed_file) = normalize_file_path_for_project(changed_file, project) else {
+        return false;
+    };
+    changed_file == memory_file
+        || changed_file
+            .strip_prefix(memory_file)
+            .is_some_and(|tail| tail.starts_with('/'))
+        || memory_file
+            .strip_prefix(&changed_file)
+            .is_some_and(|tail| tail.starts_with('/'))
+}
+
+fn normalize_file_path(path: &str) -> Option<String> {
+    let trimmed = path.trim().trim_start_matches("./").trim_matches('/');
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn normalize_file_path_for_project(path: &str, project: &str) -> Option<String> {
+    let normalized = normalize_file_path(path)?;
+    let Some(project) = normalize_file_path(project) else {
+        return Some(normalized);
+    };
+    if normalized == project {
+        return None;
+    }
+    normalized
+        .strip_prefix(&format!("{project}/"))
+        .map(str::to_string)
+        .filter(|value| !value.is_empty())
+        .or(Some(normalized))
+}

--- a/src/memory/staleness/tests.rs
+++ b/src/memory/staleness/tests.rs
@@ -1,0 +1,343 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use super::*;
+use crate::memory::Memory;
+
+fn staleness_memory(updated_at_epoch: i64, status: &str) -> Memory {
+    Memory {
+        id: 1,
+        session_id: None,
+        project: "/repo".to_string(),
+        topic_key: None,
+        title: "Staleness fixture".to_string(),
+        text: "body".to_string(),
+        memory_type: "decision".to_string(),
+        files: None,
+        created_at_epoch: updated_at_epoch,
+        updated_at_epoch,
+        status: status.to_string(),
+        branch: None,
+        scope: "project".to_string(),
+    }
+}
+
+#[test]
+fn labels_memory_status_age_and_untracked_source_anchor() {
+    let label = memory_staleness_label(&staleness_memory(1_700_000_000, "active"), 1_700_000_000);
+
+    assert_eq!(label.status, "active");
+    assert_eq!(label.age, "fresh");
+    assert_eq!(label.source_anchor, "untracked");
+    assert_eq!(
+        label.label,
+        "status=active; staleness=fresh; source_anchor=untracked"
+    );
+    assert_eq!(
+        memory_staleness(&staleness_memory(1_700_000_000, "active"), 1_700_000_000),
+        "status=active; staleness=fresh; source_anchor=untracked"
+    );
+}
+
+#[test]
+fn classifies_age_buckets() {
+    let now = 1_700_000_000;
+
+    assert_eq!(age_staleness(now - 30 * 86_400, now), "fresh");
+    assert_eq!(age_staleness(now - 31 * 86_400, now), "aging");
+    assert_eq!(age_staleness(now - 91 * 86_400, now), "old");
+}
+
+#[test]
+fn source_anchor_marks_untracked_without_files_or_commit_link() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let mut memory = staleness_memory(1_700_000_000, "active");
+    memory.session_id = Some("mem-session-1".to_string());
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "untracked");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_tracks_commit_without_later_file_change() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let memory = tracked_staleness_memory(Some(r#"["src/lib.rs"]"#));
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-sha",
+        100,
+        &["src/lib.rs"],
+        "mem-session-1",
+    )?;
+    insert_staleness_commit(&conn, 2, "later-sha", 200, &["README.md"])?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "tracked");
+    assert!(label.label.contains("source_anchor=tracked"));
+    Ok(())
+}
+
+#[test]
+fn source_anchor_requires_verification_after_later_file_change() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let memory = tracked_staleness_memory(Some(r#"["src/lib.rs"]"#));
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-sha",
+        100,
+        &["src/lib.rs"],
+        "mem-session-1",
+    )?;
+    insert_staleness_commit(&conn, 2, "later-sha", 200, &["src/lib.rs"])?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    assert!(label.label.contains("source_anchor=verify-before-trust"));
+    Ok(())
+}
+
+#[test]
+fn source_anchor_matches_directory_overlap() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let memory = tracked_staleness_memory(Some(r#"["src/context"]"#));
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-sha",
+        100,
+        &["src/context/query.rs"],
+        "mem-session-1",
+    )?;
+    insert_staleness_commit(&conn, 2, "later-sha", 200, &["src/context/render.rs"])?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_uses_candidate_evidence_without_memory_session_or_files() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    seed_project_session(&conn, "auto-session")?;
+    seed_candidate_evidence_memory(&conn, 42, 20, 10, "auto-session", "src/auto.rs")?;
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-auto",
+        100,
+        &["src/auto.rs"],
+        "auto-session",
+    )?;
+    insert_staleness_commit(&conn, 2, "later-auto", 200, &["src/auto.rs"])?;
+
+    let mut memory = staleness_memory(1_700_000_000, "active");
+    memory.id = 42;
+    memory.project = "proj".to_string();
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_ignores_later_commit_on_unrelated_branch() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let mut memory = tracked_staleness_memory(Some(r#"["src/lib.rs"]"#));
+    memory.branch = Some("main".to_string());
+    link_staleness_commit_on_branch(
+        &conn,
+        1,
+        "source-main",
+        100,
+        &["src/lib.rs"],
+        "mem-session-1",
+        "main",
+    )?;
+    insert_staleness_commit_on_branch(&conn, 2, "later-feature", 200, &["src/lib.rs"], "feature")?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "tracked");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_requires_verification_after_same_branch_file_change() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let mut memory = tracked_staleness_memory(Some(r#"["src/lib.rs"]"#));
+    memory.branch = Some("main".to_string());
+    link_staleness_commit_on_branch(
+        &conn,
+        1,
+        "source-main",
+        100,
+        &["src/lib.rs"],
+        "mem-session-1",
+        "main",
+    )?;
+    insert_staleness_commit_on_branch(&conn, 2, "later-main", 200, &["src/lib.rs"], "main")?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
+fn migrated_staleness_db() -> Result<Connection> {
+    let conn = Connection::open_in_memory()?;
+    crate::migrate::run_migrations(&conn)?;
+    Ok(conn)
+}
+
+fn tracked_staleness_memory(files: Option<&str>) -> Memory {
+    let mut memory = staleness_memory(1_700_000_000, "active");
+    memory.session_id = Some("mem-session-1".to_string());
+    memory.project = "proj".to_string();
+    memory.files = files.map(str::to_string);
+    memory
+}
+
+fn seed_project_session(conn: &Connection, session_id: &str) -> Result<()> {
+    conn.execute(
+        "INSERT INTO hosts (id, name, created_at_epoch) VALUES (9001, 'staleness-test-host', 0)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO workspaces (id, root_path, created_at_epoch, updated_at_epoch)
+         VALUES (9001, '/repo/staleness-test', 0, 0)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO projects
+         (id, workspace_id, project_path, project_key, created_at_epoch, updated_at_epoch)
+         VALUES (9001, 9001, 'proj', 'proj', 0, 0)",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO sessions
+         (id, host_id, workspace_id, project_id, session_id, last_seen_at_epoch, status)
+         VALUES (9001, 9001, 9001, 9001, ?1, 0, 'active')",
+        [session_id],
+    )?;
+    Ok(())
+}
+
+fn seed_candidate_evidence_memory(
+    conn: &Connection,
+    memory_id: i64,
+    candidate_id: i64,
+    event_id: i64,
+    session_id: &str,
+    file: &str,
+) -> Result<()> {
+    let evidence_json = serde_json::to_string(&vec![event_id])?;
+    let files_json = serde_json::to_string(&vec![file])?;
+    conn.execute(
+        "INSERT INTO captured_events
+         (id, host_id, workspace_id, project_id, session_row_id, session_id, event_id,
+          event_type, content_hash, retention_class, created_at_epoch, inserted_at_epoch)
+         VALUES (?1, 9001, 9001, 9001, 9001, ?2, 'event-auto', 'tool', 'hash-auto',
+                 'normal', 100, 100)",
+        params![event_id, session_id],
+    )?;
+    conn.execute(
+        "INSERT INTO events
+         (session_id, project, event_type, summary, files, created_at_epoch)
+         VALUES (?1, 'proj', 'file_edit', 'edited source', ?2, 100)",
+        params![session_id, files_json],
+    )?;
+    conn.execute(
+        "INSERT INTO memory_candidates
+         (id, project_id, scope, memory_type, topic_key, text, evidence_event_ids,
+          confidence, risk_class, review_status, created_at_epoch, updated_at_epoch)
+         VALUES (?1, 9001, 'project', 'decision', 'auto-topic', 'auto memory',
+                 ?2, 0.9, 'low', 'auto_promoted', 100, 100)",
+        params![candidate_id, evidence_json],
+    )?;
+    conn.execute(
+        "INSERT INTO memories
+         (id, session_id, project, topic_key, title, content, memory_type, files,
+          created_at_epoch, updated_at_epoch, status, branch, scope,
+          evidence_event_ids, source_candidate_id, source_project)
+         VALUES (?1, NULL, 'proj', 'auto-topic', 'Auto memory', 'auto memory',
+                 'decision', NULL, 100, 100, 'active', NULL, 'project',
+                 NULL, ?2, 'proj')",
+        params![memory_id, candidate_id],
+    )?;
+    Ok(())
+}
+
+fn link_staleness_commit(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+    memory_session_id: &str,
+) -> Result<()> {
+    link_staleness_commit_on_branch(
+        conn,
+        id,
+        sha,
+        epoch,
+        changed_files,
+        memory_session_id,
+        "main",
+    )
+}
+
+fn link_staleness_commit_on_branch(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+    memory_session_id: &str,
+    branch: &str,
+) -> Result<()> {
+    insert_staleness_commit_on_branch(conn, id, sha, epoch, changed_files, branch)?;
+    conn.execute(
+        "INSERT INTO git_commit_sessions
+         (commit_id, session_id, memory_session_id, source, linked_at_epoch)
+         VALUES (?1, ?2, ?3, 'test', ?4)",
+        params![id, format!("content-{id}"), memory_session_id, epoch],
+    )?;
+    Ok(())
+}
+
+fn insert_staleness_commit(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+) -> Result<()> {
+    insert_staleness_commit_on_branch(conn, id, sha, epoch, changed_files, "main")
+}
+
+fn insert_staleness_commit_on_branch(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+    branch: &str,
+) -> Result<()> {
+    let changed_files = serde_json::to_string(changed_files)?;
+    conn.execute(
+        "INSERT INTO git_commits
+         (id, project, repo_path, sha, short_sha, branch, message,
+          authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch)
+         VALUES (?1, 'proj', '/repo', ?2, ?2, ?3, NULL, ?4, ?5, ?4, ?4)",
+        params![id, sha, branch, epoch, changed_files],
+    )?;
+    Ok(())
+}

--- a/src/memory/staleness/tests.rs
+++ b/src/memory/staleness/tests.rs
@@ -126,7 +126,18 @@ fn source_anchor_matches_directory_overlap() -> Result<()> {
 fn source_anchor_uses_candidate_evidence_without_memory_session_or_files() -> Result<()> {
     let conn = migrated_staleness_db()?;
     seed_project_session(&conn, "auto-session")?;
-    seed_candidate_evidence_memory(&conn, 42, 20, 10, "auto-session", "src/auto.rs")?;
+    insert_captured_event(&conn, 10, "auto-session")?;
+    seed_candidate_memory_without_legacy_event(&conn, 42, 20, 10)?;
+    let evidence_json = serde_json::to_string(&vec![10])?;
+    let files_json = serde_json::to_string(&vec!["src/auto.rs"])?;
+    conn.execute(
+        "INSERT INTO observations
+         (memory_session_id, project, type, title, files_modified, created_at_epoch,
+          session_row_id, evidence_event_ids)
+         VALUES ('capture-observation-9001', 'proj', 'discovery', 'Auto files',
+                 ?1, 100, 9001, ?2)",
+        params![files_json, evidence_json],
+    )?;
     link_staleness_commit(
         &conn,
         1,
@@ -151,8 +162,14 @@ fn source_anchor_uses_candidate_evidence_without_memory_session_or_files() -> Re
 fn source_anchor_limits_legacy_files_to_cited_evidence_events() -> Result<()> {
     let conn = migrated_staleness_db()?;
     seed_project_session(&conn, "auto-session")?;
-    seed_candidate_evidence_memory(&conn, 42, 20, 10, "auto-session", "src/cited.rs")?;
-    insert_captured_event(&conn, 11, "auto-session")?;
+    seed_candidate_memory_without_legacy_event(&conn, 42, 20, 10)?;
+    let cited_files = serde_json::to_string(&vec!["src/cited.rs"])?;
+    conn.execute(
+        "INSERT INTO events
+         (id, session_id, project, event_type, summary, files, created_at_epoch)
+         VALUES (10, 'auto-session', 'proj', 'file_edit', 'cited edit', ?1, 100)",
+        [cited_files],
+    )?;
     let unrelated_files = serde_json::to_string(&vec!["src/unrelated.rs"])?;
     conn.execute(
         "INSERT INTO events
@@ -169,6 +186,58 @@ fn source_anchor_limits_legacy_files_to_cited_evidence_events() -> Result<()> {
         "auto-session",
     )?;
     insert_staleness_commit(&conn, 2, "later-unrelated", 200, &["src/unrelated.rs"])?;
+
+    let mut memory = staleness_memory(1_700_000_000, "active");
+    memory.id = 42;
+    memory.project = "proj".to_string();
+    memory.session_id = Some("auto-session".to_string());
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "tracked");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_ignores_colliding_legacy_event_for_captured_evidence() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    seed_project_session(&conn, "auto-session")?;
+    insert_captured_event(&conn, 10, "auto-session")?;
+    seed_candidate_memory_without_legacy_event(&conn, 42, 20, 10)?;
+    let evidence_json = serde_json::to_string(&vec![10])?;
+    let captured_files = serde_json::to_string(&vec!["src/captured.rs"])?;
+    conn.execute(
+        "INSERT INTO observations
+         (memory_session_id, project, type, title, files_modified, created_at_epoch,
+          session_row_id, evidence_event_ids)
+         VALUES ('capture-observation-9001', 'proj', 'discovery', 'Captured files',
+                 ?1, 100, 9001, ?2)",
+        params![captured_files, evidence_json],
+    )?;
+    let legacy_files = serde_json::to_string(&vec!["src/colliding-legacy.rs"])?;
+    conn.execute(
+        "INSERT INTO events
+         (id, session_id, project, event_type, summary, files, created_at_epoch)
+         VALUES (10, 'auto-session', 'proj', 'file_edit', 'legacy collision', ?1, 100)",
+        [legacy_files],
+    )?;
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-captured",
+        100,
+        &["src/captured.rs"],
+        "auto-session",
+    )?;
+    link_staleness_commit(
+        &conn,
+        2,
+        "source-colliding-legacy",
+        100,
+        &["src/colliding-legacy.rs"],
+        "auto-session",
+    )?;
+    insert_staleness_commit(&conn, 3, "later-legacy", 200, &["src/colliding-legacy.rs"])?;
 
     let mut memory = staleness_memory(1_700_000_000, "active");
     memory.id = 42;
@@ -463,6 +532,28 @@ fn source_anchor_bounds_auto_capture_to_cited_evidence_time() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn source_anchor_uses_updated_time_for_direct_file_anchors() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let mut memory = tracked_staleness_memory(Some(r#"["src/upsert.rs"]"#));
+    memory.created_at_epoch = 100;
+    memory.updated_at_epoch = 300;
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-upsert",
+        250,
+        &["src/upsert.rs"],
+        "mem-session-1",
+    )?;
+    insert_staleness_commit(&conn, 2, "later-upsert", 350, &["src/upsert.rs"])?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
 fn migrated_staleness_db() -> Result<Connection> {
     let conn = Connection::open_in_memory()?;
     crate::migrate::run_migrations(&conn)?;
@@ -499,26 +590,6 @@ fn seed_project_session(conn: &Connection, session_id: &str) -> Result<()> {
          VALUES (9001, 9001, 9001, 9001, ?1, 0, 'active')",
         [session_id],
     )?;
-    Ok(())
-}
-
-fn seed_candidate_evidence_memory(
-    conn: &Connection,
-    memory_id: i64,
-    candidate_id: i64,
-    event_id: i64,
-    session_id: &str,
-    file: &str,
-) -> Result<()> {
-    let files_json = serde_json::to_string(&vec![file])?;
-    insert_captured_event(conn, event_id, session_id)?;
-    conn.execute(
-        "INSERT INTO events
-         (id, session_id, project, event_type, summary, files, created_at_epoch)
-         VALUES (?1, ?2, 'proj', 'file_edit', 'edited source', ?3, 100)",
-        params![event_id, session_id, files_json],
-    )?;
-    seed_candidate_memory_without_legacy_event(conn, memory_id, candidate_id, event_id)?;
     Ok(())
 }
 

--- a/src/memory/staleness/tests.rs
+++ b/src/memory/staleness/tests.rs
@@ -148,6 +148,126 @@ fn source_anchor_uses_candidate_evidence_without_memory_session_or_files() -> Re
 }
 
 #[test]
+fn source_anchor_limits_legacy_files_to_cited_evidence_events() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    seed_project_session(&conn, "auto-session")?;
+    seed_candidate_evidence_memory(&conn, 42, 20, 10, "auto-session", "src/cited.rs")?;
+    insert_captured_event(&conn, 11, "auto-session")?;
+    let unrelated_files = serde_json::to_string(&vec!["src/unrelated.rs"])?;
+    conn.execute(
+        "INSERT INTO events
+         (id, session_id, project, event_type, summary, files, created_at_epoch)
+         VALUES (11, 'auto-session', 'proj', 'file_edit', 'unrelated edit', ?1, 110)",
+        [unrelated_files],
+    )?;
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-cited",
+        100,
+        &["src/cited.rs"],
+        "auto-session",
+    )?;
+    insert_staleness_commit(&conn, 2, "later-unrelated", 200, &["src/unrelated.rs"])?;
+
+    let mut memory = staleness_memory(1_700_000_000, "active");
+    memory.id = 42;
+    memory.project = "proj".to_string();
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "tracked");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_uses_observation_evidence_files_by_capture_session_row() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    seed_project_session(&conn, "auto-session")?;
+    insert_captured_event(&conn, 10, "auto-session")?;
+    seed_candidate_memory_without_legacy_event(&conn, 42, 20, 10)?;
+    let evidence_json = serde_json::to_string(&vec![10])?;
+    let files_json = serde_json::to_string(&vec!["src/observed.rs"])?;
+    conn.execute(
+        "INSERT INTO observations
+         (memory_session_id, project, type, title, files_modified, created_at_epoch,
+          session_row_id, evidence_event_ids)
+         VALUES ('capture-observation-9001', 'proj', 'discovery', 'Observed files',
+                 ?1, 100, 9001, ?2)",
+        params![files_json, evidence_json],
+    )?;
+    link_staleness_commit_with_sessions(
+        &conn,
+        1,
+        "source-observed",
+        100,
+        &["src/observed.rs"],
+        "auto-session",
+        "capture-observation-9001",
+    )?;
+    insert_staleness_commit(&conn, 2, "later-observed", 200, &["src/observed.rs"])?;
+
+    let mut memory = staleness_memory(1_700_000_000, "active");
+    memory.id = 42;
+    memory.project = "proj".to_string();
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_ignores_session_commits_created_after_memory() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let mut memory = tracked_staleness_memory(Some(r#"["src/lib.rs"]"#));
+    memory.created_at_epoch = 150;
+    memory.updated_at_epoch = 150;
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-before-memory",
+        100,
+        &["src/lib.rs"],
+        "mem-session-1",
+    )?;
+    link_staleness_commit(
+        &conn,
+        2,
+        "future-same-session",
+        200,
+        &["src/lib.rs"],
+        "mem-session-1",
+    )?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_requires_source_commit_file_overlap() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let mut memory = tracked_staleness_memory(Some(r#"["src/lib.rs"]"#));
+    memory.created_at_epoch = 150;
+    memory.updated_at_epoch = 150;
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-unrelated",
+        100,
+        &["README.md"],
+        "mem-session-1",
+    )?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "untracked");
+    Ok(())
+}
+
+#[test]
 fn source_anchor_ignores_later_commit_on_unrelated_branch() -> Result<()> {
     let conn = migrated_staleness_db()?;
     let mut memory = tracked_staleness_memory(Some(r#"["src/lib.rs"]"#));
@@ -238,22 +358,42 @@ fn seed_candidate_evidence_memory(
     session_id: &str,
     file: &str,
 ) -> Result<()> {
-    let evidence_json = serde_json::to_string(&vec![event_id])?;
     let files_json = serde_json::to_string(&vec![file])?;
+    insert_captured_event(conn, event_id, session_id)?;
+    conn.execute(
+        "INSERT INTO events
+         (id, session_id, project, event_type, summary, files, created_at_epoch)
+         VALUES (?1, ?2, 'proj', 'file_edit', 'edited source', ?3, 100)",
+        params![event_id, session_id, files_json],
+    )?;
+    seed_candidate_memory_without_legacy_event(conn, memory_id, candidate_id, event_id)?;
+    Ok(())
+}
+
+fn insert_captured_event(conn: &Connection, event_id: i64, session_id: &str) -> Result<()> {
     conn.execute(
         "INSERT INTO captured_events
          (id, host_id, workspace_id, project_id, session_row_id, session_id, event_id,
           event_type, content_hash, retention_class, created_at_epoch, inserted_at_epoch)
-         VALUES (?1, 9001, 9001, 9001, 9001, ?2, 'event-auto', 'tool', 'hash-auto',
+         VALUES (?1, 9001, 9001, 9001, 9001, ?2, ?3, 'tool', ?4,
                  'normal', 100, 100)",
-        params![event_id, session_id],
+        params![
+            event_id,
+            session_id,
+            format!("event-{event_id}"),
+            format!("hash-{event_id}")
+        ],
     )?;
-    conn.execute(
-        "INSERT INTO events
-         (session_id, project, event_type, summary, files, created_at_epoch)
-         VALUES (?1, 'proj', 'file_edit', 'edited source', ?2, 100)",
-        params![session_id, files_json],
-    )?;
+    Ok(())
+}
+
+fn seed_candidate_memory_without_legacy_event(
+    conn: &Connection,
+    memory_id: i64,
+    candidate_id: i64,
+    event_id: i64,
+) -> Result<()> {
+    let evidence_json = serde_json::to_string(&vec![event_id])?;
     conn.execute(
         "INSERT INTO memory_candidates
          (id, project_id, scope, memory_type, topic_key, text, evidence_event_ids,
@@ -309,6 +449,25 @@ fn link_staleness_commit_on_branch(
          (commit_id, session_id, memory_session_id, source, linked_at_epoch)
          VALUES (?1, ?2, ?3, 'test', ?4)",
         params![id, format!("content-{id}"), memory_session_id, epoch],
+    )?;
+    Ok(())
+}
+
+fn link_staleness_commit_with_sessions(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+    session_id: &str,
+    memory_session_id: &str,
+) -> Result<()> {
+    insert_staleness_commit_on_branch(conn, id, sha, epoch, changed_files, "main")?;
+    conn.execute(
+        "INSERT INTO git_commit_sessions
+         (commit_id, session_id, memory_session_id, source, linked_at_epoch)
+         VALUES (?1, ?2, ?3, 'test', ?4)",
+        params![id, session_id, memory_session_id, epoch],
     )?;
     Ok(())
 }

--- a/src/memory/staleness/tests.rs
+++ b/src/memory/staleness/tests.rs
@@ -311,6 +311,69 @@ fn source_anchor_requires_verification_after_same_branch_file_change() -> Result
     Ok(())
 }
 
+#[test]
+fn source_anchor_treats_branchless_source_commit_as_branch_neutral() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let mut memory = tracked_staleness_memory(Some(r#"["src/lib.rs"]"#));
+    memory.branch = Some("main".to_string());
+    link_staleness_commit_without_branch(
+        &conn,
+        1,
+        "source-branchless",
+        100,
+        &["src/lib.rs"],
+        "mem-session-1",
+    )?;
+    insert_staleness_commit_on_branch(&conn, 2, "later-main", 200, &["src/lib.rs"], "main")?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_treats_branchless_later_commit_as_branch_neutral() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let mut memory = tracked_staleness_memory(Some(r#"["src/lib.rs"]"#));
+    memory.branch = Some("main".to_string());
+    link_staleness_commit_on_branch(
+        &conn,
+        1,
+        "source-main",
+        100,
+        &["src/lib.rs"],
+        "mem-session-1",
+        "main",
+    )?;
+    insert_staleness_commit_without_branch(&conn, 2, "later-branchless", 200, &["src/lib.rs"])?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_normalizes_absolute_memory_files_against_project() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let memory = tracked_staleness_memory(Some(r#"["/proj/src/lib.rs"]"#));
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-relative",
+        100,
+        &["src/lib.rs"],
+        "mem-session-1",
+    )?;
+    insert_staleness_commit(&conn, 2, "later-relative", 200, &["src/lib.rs"])?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
 fn migrated_staleness_db() -> Result<Connection> {
     let conn = Connection::open_in_memory()?;
     crate::migrate::run_migrations(&conn)?;
@@ -443,7 +506,25 @@ fn link_staleness_commit_on_branch(
     memory_session_id: &str,
     branch: &str,
 ) -> Result<()> {
-    insert_staleness_commit_on_branch(conn, id, sha, epoch, changed_files, branch)?;
+    insert_staleness_commit_with_branch(conn, id, sha, epoch, changed_files, Some(branch))?;
+    conn.execute(
+        "INSERT INTO git_commit_sessions
+         (commit_id, session_id, memory_session_id, source, linked_at_epoch)
+         VALUES (?1, ?2, ?3, 'test', ?4)",
+        params![id, format!("content-{id}"), memory_session_id, epoch],
+    )?;
+    Ok(())
+}
+
+fn link_staleness_commit_without_branch(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+    memory_session_id: &str,
+) -> Result<()> {
+    insert_staleness_commit_with_branch(conn, id, sha, epoch, changed_files, None)?;
     conn.execute(
         "INSERT INTO git_commit_sessions
          (commit_id, session_id, memory_session_id, source, linked_at_epoch)
@@ -462,7 +543,7 @@ fn link_staleness_commit_with_sessions(
     session_id: &str,
     memory_session_id: &str,
 ) -> Result<()> {
-    insert_staleness_commit_on_branch(conn, id, sha, epoch, changed_files, "main")?;
+    insert_staleness_commit_with_branch(conn, id, sha, epoch, changed_files, Some("main"))?;
     conn.execute(
         "INSERT INTO git_commit_sessions
          (commit_id, session_id, memory_session_id, source, linked_at_epoch)
@@ -489,6 +570,27 @@ fn insert_staleness_commit_on_branch(
     epoch: i64,
     changed_files: &[&str],
     branch: &str,
+) -> Result<()> {
+    insert_staleness_commit_with_branch(conn, id, sha, epoch, changed_files, Some(branch))
+}
+
+fn insert_staleness_commit_without_branch(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+) -> Result<()> {
+    insert_staleness_commit_with_branch(conn, id, sha, epoch, changed_files, None)
+}
+
+fn insert_staleness_commit_with_branch(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+    branch: Option<&str>,
 ) -> Result<()> {
     let changed_files = serde_json::to_string(changed_files)?;
     conn.execute(

--- a/src/memory/staleness/tests.rs
+++ b/src/memory/staleness/tests.rs
@@ -374,6 +374,95 @@ fn source_anchor_normalizes_absolute_memory_files_against_project() -> Result<()
     Ok(())
 }
 
+#[test]
+fn source_anchor_checks_each_file_against_its_own_source_commit() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let memory = tracked_staleness_memory(Some(r#"["src/a.rs","src/b.rs"]"#));
+    link_staleness_commit(&conn, 1, "source-a", 100, &["src/a.rs"], "mem-session-1")?;
+    insert_staleness_commit(&conn, 2, "later-a", 200, &["src/a.rs"])?;
+    link_staleness_commit(&conn, 3, "source-b", 300, &["src/b.rs"], "mem-session-1")?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_ignores_later_changes_to_unanchored_files() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    let memory = tracked_staleness_memory(Some(r#"["src/anchored.rs","src/unanchored.rs"]"#));
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-anchored",
+        100,
+        &["src/anchored.rs"],
+        "mem-session-1",
+    )?;
+    insert_staleness_commit(&conn, 2, "later-unanchored", 200, &["src/unanchored.rs"])?;
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "tracked");
+    Ok(())
+}
+
+#[test]
+fn source_anchor_bounds_auto_capture_to_cited_evidence_time() -> Result<()> {
+    let conn = migrated_staleness_db()?;
+    seed_project_session(&conn, "auto-session")?;
+    insert_captured_event(&conn, 10, "auto-session")?;
+    seed_candidate_memory_without_legacy_event(&conn, 42, 20, 10)?;
+    conn.execute(
+        "UPDATE captured_events
+         SET created_at_epoch = 300, reference_time_epoch = 100
+         WHERE id = 10",
+        [],
+    )?;
+    conn.execute(
+        "UPDATE memories
+         SET created_at_epoch = 300, updated_at_epoch = 300
+         WHERE id = 42",
+        [],
+    )?;
+    let evidence_json = serde_json::to_string(&vec![10])?;
+    let files_json = serde_json::to_string(&vec!["src/async.rs"])?;
+    conn.execute(
+        "INSERT INTO observations
+         (memory_session_id, project, type, title, files_modified, created_at_epoch,
+          session_row_id, evidence_event_ids, reference_time_epoch)
+         VALUES ('capture-observation-9001', 'proj', 'discovery', 'Async observed files',
+                 ?1, 300, 9001, ?2, 100)",
+        params![files_json, evidence_json],
+    )?;
+    link_staleness_commit(
+        &conn,
+        1,
+        "source-evidence",
+        100,
+        &["src/async.rs"],
+        "auto-session",
+    )?;
+    link_staleness_commit(
+        &conn,
+        2,
+        "post-evidence-change",
+        200,
+        &["src/async.rs"],
+        "auto-session",
+    )?;
+
+    let mut memory = staleness_memory(300, "active");
+    memory.id = 42;
+    memory.project = "proj".to_string();
+
+    let label = memory_staleness_label_with_conn(&conn, &memory, 1_700_000_000)?;
+
+    assert_eq!(label.source_anchor, "verify-before-trust");
+    Ok(())
+}
+
 fn migrated_staleness_db() -> Result<Connection> {
     let conn = Connection::open_in_memory()?;
     crate::migrate::run_migrations(&conn)?;

--- a/src/retrieval/search.rs
+++ b/src/retrieval/search.rs
@@ -2,9 +2,9 @@ pub(crate) mod common;
 mod memory;
 mod observation;
 
+pub(crate) use memory::{apply_score_demotions, search_with_branch_weights, SearchWeights};
 pub use memory::{
     search, search_with_branch, search_with_branch_explain, ChannelContribution, ChannelHit,
     SearchExplain, SearchExplainChannel, SearchExplainResult,
 };
-pub(crate) use memory::{search_with_branch_weights, SearchWeights};
 pub use observation::search_observations;

--- a/src/retrieval/search/memory.rs
+++ b/src/retrieval/search/memory.rs
@@ -1,6 +1,7 @@
 mod explain;
 mod listing;
 mod runner;
+mod source_anchor;
 #[cfg(test)]
 mod tests;
 mod text;

--- a/src/retrieval/search/memory.rs
+++ b/src/retrieval/search/memory.rs
@@ -12,4 +12,5 @@ pub use explain::{
 };
 pub(crate) use runner::search_with_branch_weights;
 pub use runner::{search, search_with_branch, search_with_branch_explain};
+pub(crate) use source_anchor::apply_score_demotions;
 pub(crate) use weights::SearchWeights;

--- a/src/retrieval/search/memory/source_anchor.rs
+++ b/src/retrieval/search/memory/source_anchor.rs
@@ -7,7 +7,7 @@ use crate::memory::{self, Memory};
 
 const STALE_SCORE_FACTOR: f64 = 0.25;
 
-pub(super) fn apply_score_demotions(
+pub(crate) fn apply_score_demotions(
     conn: &Connection,
     fused: &[(i64, f64)],
     ordered: Vec<Memory>,

--- a/src/retrieval/search/memory/source_anchor.rs
+++ b/src/retrieval/search/memory/source_anchor.rs
@@ -1,0 +1,174 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use crate::memory::{self, Memory};
+
+const STALE_SCORE_FACTOR: f64 = 0.25;
+
+pub(super) fn apply_score_demotions(
+    conn: &Connection,
+    fused: &[(i64, f64)],
+    ordered: Vec<Memory>,
+) -> Result<(Vec<Memory>, Vec<(i64, f64)>)> {
+    if fused.is_empty() || ordered.is_empty() {
+        return Ok((ordered, fused.to_vec()));
+    }
+    let now_epoch = chrono::Utc::now().timestamp();
+    let labels = memory::memory_staleness_labels_for_memories(conn, &ordered, now_epoch)?;
+    let original_rank = fused
+        .iter()
+        .enumerate()
+        .map(|(rank, (id, _))| (*id, rank))
+        .collect::<HashMap<_, _>>();
+    let mut demoted = fused
+        .iter()
+        .map(|(id, score)| {
+            let score = if labels
+                .get(id)
+                .is_some_and(|label| label.source_anchor == "verify-before-trust")
+            {
+                score * STALE_SCORE_FACTOR
+            } else {
+                *score
+            };
+            (*id, score)
+        })
+        .collect::<Vec<_>>();
+    demoted.sort_by(|left, right| {
+        right
+            .1
+            .partial_cmp(&left.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                original_rank
+                    .get(&left.0)
+                    .copied()
+                    .unwrap_or(usize::MAX)
+                    .cmp(&original_rank.get(&right.0).copied().unwrap_or(usize::MAX))
+            })
+    });
+    let id_to_memory = ordered
+        .into_iter()
+        .map(|memory| (memory.id, memory))
+        .collect::<HashMap<_, _>>();
+    let ordered = demoted
+        .iter()
+        .filter_map(|(id, _)| id_to_memory.get(id).cloned())
+        .collect::<Vec<_>>();
+    Ok((ordered, demoted))
+}
+
+pub(super) fn label_for_memory(
+    conn: &Connection,
+    memory: &Memory,
+    now_epoch: i64,
+) -> memory::MemoryStalenessLabel {
+    memory::memory_staleness_label_with_conn(conn, memory, now_epoch)
+        .unwrap_or_else(|_| memory::memory_staleness_label(memory, now_epoch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+
+    #[test]
+    fn apply_score_demotions_ranks_verify_before_trust_lower() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        seed_memory(&conn, 1, "stale-session", r#"["src/stale.rs"]"#)?;
+        seed_memory(&conn, 2, "fresh-session", r#"["src/fresh.rs"]"#)?;
+        link_commit(
+            &conn,
+            1,
+            "source-stale",
+            100,
+            &["src/stale.rs"],
+            "stale-session",
+        )?;
+        insert_commit(&conn, 2, "later-stale", 200, &["src/stale.rs"])?;
+        link_commit(
+            &conn,
+            3,
+            "source-fresh",
+            100,
+            &["src/fresh.rs"],
+            "fresh-session",
+        )?;
+
+        let ordered = memory::get_memories_by_ids(&conn, &[1, 2], None)?;
+        let fused = vec![(1, 1.0), (2, 0.9)];
+
+        let (ordered, demoted) = apply_score_demotions(&conn, &fused, ordered)?;
+
+        assert_eq!(
+            ordered.iter().map(|memory| memory.id).collect::<Vec<_>>(),
+            vec![2, 1]
+        );
+        assert_eq!(demoted[0].0, 2);
+        assert!(demoted[1].1 < demoted[0].1);
+        Ok(())
+    }
+
+    fn seed_memory(
+        conn: &Connection,
+        id: i64,
+        session_id: &str,
+        files: &str,
+    ) -> anyhow::Result<()> {
+        conn.execute(
+            "INSERT INTO memories
+             (id, session_id, project, topic_key, title, content, memory_type, files,
+              created_at_epoch, updated_at_epoch, status, branch, scope)
+             VALUES (?1, ?2, 'proj', ?3, ?4, ?5, 'decision', ?6, 100, 100,
+                     'active', 'main', 'project')",
+            params![
+                id,
+                session_id,
+                format!("topic-{id}"),
+                format!("Memory {id}"),
+                format!("Memory {id} content"),
+                files
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn link_commit(
+        conn: &Connection,
+        id: i64,
+        sha: &str,
+        epoch: i64,
+        changed_files: &[&str],
+        memory_session_id: &str,
+    ) -> anyhow::Result<()> {
+        insert_commit(conn, id, sha, epoch, changed_files)?;
+        conn.execute(
+            "INSERT INTO git_commit_sessions
+             (commit_id, session_id, memory_session_id, source, linked_at_epoch)
+             VALUES (?1, ?2, ?3, 'test', ?4)",
+            params![id, format!("content-{id}"), memory_session_id, epoch],
+        )?;
+        Ok(())
+    }
+
+    fn insert_commit(
+        conn: &Connection,
+        id: i64,
+        sha: &str,
+        epoch: i64,
+        changed_files: &[&str],
+    ) -> anyhow::Result<()> {
+        let changed_files = serde_json::to_string(changed_files)?;
+        conn.execute(
+            "INSERT INTO git_commits
+             (id, project, repo_path, sha, short_sha, branch, message,
+              authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch)
+             VALUES (?1, 'proj', '/repo', ?2, ?2, 'main', NULL, ?3, ?4, ?3, ?3)",
+            params![id, sha, epoch, changed_files],
+        )?;
+        Ok(())
+    }
+}

--- a/src/retrieval/search/memory/source_anchor.rs
+++ b/src/retrieval/search/memory/source_anchor.rs
@@ -16,7 +16,10 @@ pub(super) fn apply_score_demotions(
         return Ok((ordered, fused.to_vec()));
     }
     let now_epoch = chrono::Utc::now().timestamp();
-    let labels = memory::memory_staleness_labels_for_memories(conn, &ordered, now_epoch)?;
+    let labels = ordered
+        .iter()
+        .map(|memory| (memory.id, label_for_memory(conn, memory, now_epoch)))
+        .collect::<HashMap<_, _>>();
     let original_rank = fused
         .iter()
         .enumerate()
@@ -65,8 +68,16 @@ pub(super) fn label_for_memory(
     memory: &Memory,
     now_epoch: i64,
 ) -> memory::MemoryStalenessLabel {
-    memory::memory_staleness_label_with_conn(conn, memory, now_epoch)
-        .unwrap_or_else(|_| memory::memory_staleness_label(memory, now_epoch))
+    memory::memory_staleness_label_with_conn(conn, memory, now_epoch).unwrap_or_else(|error| {
+        crate::log::warn(
+            "retrieval",
+            &format!(
+                "source-anchor label fallback for memory {}: {error}",
+                memory.id
+            ),
+        );
+        memory::memory_staleness_label(memory, now_epoch)
+    })
 }
 
 #[cfg(test)]
@@ -109,6 +120,62 @@ mod tests {
         );
         assert_eq!(demoted[0].0, 2);
         assert!(demoted[1].1 < demoted[0].1);
+        Ok(())
+    }
+
+    #[test]
+    fn apply_score_demotions_keeps_search_results_when_anchor_labels_fail() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        seed_memory(&conn, 1, "malformed-session", "[not-json")?;
+        seed_memory(&conn, 2, "fresh-session", r#"["src/fresh.rs"]"#)?;
+
+        let ordered = memory::get_memories_by_ids(&conn, &[1, 2], None)?;
+        let fused = vec![(1, 1.0), (2, 0.9)];
+
+        let (ordered, demoted) = apply_score_demotions(&conn, &fused, ordered)?;
+
+        assert_eq!(
+            ordered.iter().map(|memory| memory.id).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(demoted, fused);
+        Ok(())
+    }
+
+    #[test]
+    fn apply_score_demotions_keeps_search_results_when_commit_files_fail() -> anyhow::Result<()> {
+        let conn = Connection::open_in_memory()?;
+        crate::migrate::run_migrations(&conn)?;
+        seed_memory(&conn, 1, "malformed-session", r#"["src/stale.rs"]"#)?;
+        seed_memory(&conn, 2, "fresh-session", r#"["src/fresh.rs"]"#)?;
+        link_commit(
+            &conn,
+            1,
+            "source-malformed",
+            100,
+            &["src/stale.rs"],
+            "malformed-session",
+        )?;
+        conn.execute(
+            "INSERT INTO git_commits
+             (id, project, repo_path, sha, short_sha, branch, message,
+              authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch)
+             VALUES (2, 'proj', '/repo', 'later-malformed', 'later-malformed', 'main',
+                     NULL, 200, '[not-json', 200, 200)",
+            [],
+        )?;
+
+        let ordered = memory::get_memories_by_ids(&conn, &[1, 2], None)?;
+        let fused = vec![(1, 1.0), (2, 0.9)];
+
+        let (ordered, demoted) = apply_score_demotions(&conn, &fused, ordered)?;
+
+        assert_eq!(
+            ordered.iter().map(|memory| memory.id).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(demoted, fused);
         Ok(())
     }
 

--- a/src/retrieval/search/memory/text.rs
+++ b/src/retrieval/search/memory/text.rs
@@ -166,6 +166,7 @@ pub(super) fn search_with_query_weights(
     let fused = weighted_ranked_fuse(&channel_inputs, plan.weights.rrf_k);
     let fused_ids: Vec<i64> = fused.iter().map(|(id, _)| *id).collect();
     let ordered = load_ordered_memories(conn, &fused_ids)?;
+    let (ordered, fused) = super::source_anchor::apply_score_demotions(conn, &fused, ordered)?;
     let (ordered, _) =
         gate_and_annotate_memories(conn, query_text, project, &fused, &plan, ordered)?;
     Ok(paginate_memories(ordered, limit, offset))
@@ -225,10 +226,12 @@ pub(super) fn search_with_query_explain(
     let fused = weighted_ranked_fuse(&channel_inputs, plan.weights.rrf_k);
     let fused_ids: Vec<i64> = fused.iter().map(|(id, _)| *id).collect();
     let ordered = load_ordered_memories(conn, &fused_ids)?;
+    let (ordered, fused) = super::source_anchor::apply_score_demotions(conn, &fused, ordered)?;
     let (ordered, gated_fused) =
         gate_and_annotate_memories(conn, query_text, project, &fused, &plan, ordered)?;
     let paged = paginate_memories(ordered, limit, offset);
     let explain = build_explain(
+        conn,
         query_text,
         project,
         memory_type,
@@ -436,6 +439,7 @@ fn build_query_search_plan(
 }
 
 fn build_explain(
+    conn: &Connection,
     query_text: &str,
     project: Option<&str>,
     memory_type: Option<&str>,
@@ -479,7 +483,7 @@ fn build_explain(
             project: memory.project.clone(),
             scope: memory.scope.clone(),
             visibility: visibility_label(memory, project).to_string(),
-            staleness: memory::memory_staleness_label(memory, now_epoch),
+            staleness: super::source_anchor::label_for_memory(conn, memory, now_epoch),
             contributions: contributions_for(memory.id, plan),
         })
         .collect();

--- a/src/retrieval/search_multihop/merge.rs
+++ b/src/retrieval/search_multihop/merge.rs
@@ -3,11 +3,23 @@ use std::collections::HashMap;
 const RRF_K: f64 = 60.0;
 const SECOND_HOP_WEIGHT: f64 = 0.5;
 
+#[cfg(test)]
 pub(crate) fn rank_merged_ids(
     first_hop_ids: &[i64],
     second_hop_ids: &[i64],
     limit: i64,
 ) -> Vec<i64> {
+    rank_merged_scores(first_hop_ids, second_hop_ids, limit)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect()
+}
+
+pub(crate) fn rank_merged_scores(
+    first_hop_ids: &[i64],
+    second_hop_ids: &[i64],
+    limit: i64,
+) -> Vec<(i64, f64)> {
     if limit <= 0 {
         return vec![];
     }
@@ -24,9 +36,5 @@ pub(crate) fn rank_merged_ids(
 
     let mut ranked: Vec<(i64, f64)> = scores.into_iter().collect();
     ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    ranked
-        .into_iter()
-        .take(limit as usize)
-        .map(|(id, _)| id)
-        .collect()
+    ranked.into_iter().take(limit as usize).collect()
 }

--- a/src/retrieval/search_multihop/search.rs
+++ b/src/retrieval/search_multihop/search.rs
@@ -7,7 +7,7 @@ use crate::memory::{self, Memory};
 
 use super::discover::discover_entities;
 use super::expand::collect_second_hop_ids;
-use super::merge::rank_merged_ids;
+use super::merge::rank_merged_scores;
 use super::types::MultiHopResult;
 
 fn paginate_memories(memories: Vec<Memory>, limit: i64, offset: i64) -> Vec<Memory> {
@@ -91,8 +91,15 @@ pub fn search_multi_hop(
         });
     }
 
-    let top_ids = rank_merged_ids(&first_hop_ids, &second_hop_ids, page_target);
-    let memories = paginate_memories(load_ranked_memories(conn, &top_ids)?, limit, offset);
+    let merged = rank_merged_scores(&first_hop_ids, &second_hop_ids, fetch);
+    let merged_ids = merged.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+    let ranked = load_ranked_memories(conn, &merged_ids)?;
+    let (ranked, _) = crate::retrieval::search::apply_score_demotions(conn, &merged, ranked)?;
+    let memories = paginate_memories(
+        ranked.into_iter().take(page_target as usize).collect(),
+        limit,
+        offset,
+    );
     Ok(MultiHopResult {
         memories,
         hops: 2,

--- a/src/retrieval/search_multihop/tests.rs
+++ b/src/retrieval/search_multihop/tests.rs
@@ -1,4 +1,6 @@
 use crate::memory::Memory;
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
 
 use super::discover::discover_entities;
 use super::merge::rank_merged_ids;
@@ -39,4 +41,133 @@ fn rank_merged_ids_boosts_overlap_and_respects_limit() {
 
     let limited = rank_merged_ids(&[1, 2], &[2, 3], 2);
     assert_eq!(limited, vec![2, 1]);
+}
+
+#[test]
+fn search_multi_hop_demotes_verify_before_trust_second_hop() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    crate::migrate::run_migrations(&conn)?;
+    let first_id = crate::memory::insert_memory_full(
+        &conn,
+        Some("first-session"),
+        "proj",
+        Some("multi-hop-first"),
+        "Melanie route",
+        "Melanie mentions Tom in routing notes.",
+        "discovery",
+        None,
+        Some("main"),
+        "project",
+        Some(150),
+    )?;
+    let stale_id = crate::memory::insert_memory_full(
+        &conn,
+        Some("stale-session"),
+        "proj",
+        Some("multi-hop-stale"),
+        "Tom stale source",
+        "Tom stale source-anchor memory.",
+        "decision",
+        Some(r#"["src/stale.rs"]"#),
+        Some("main"),
+        "project",
+        Some(300),
+    )?;
+    let fresh_id = crate::memory::insert_memory_full(
+        &conn,
+        Some("fresh-session"),
+        "proj",
+        Some("multi-hop-fresh"),
+        "Tom fresh source",
+        "Tom fresh source-anchor memory.",
+        "decision",
+        Some(r#"["src/fresh.rs"]"#),
+        Some("main"),
+        "project",
+        Some(150),
+    )?;
+    crate::retrieval::entity::link_entities(&conn, stale_id, &["Tom".to_string()])?;
+    crate::retrieval::entity::link_entities(&conn, fresh_id, &["Tom".to_string()])?;
+    link_commit(
+        &conn,
+        1,
+        "source-stale",
+        100,
+        &["src/stale.rs"],
+        "stale-session",
+    )?;
+    insert_commit(&conn, 2, "later-stale", 200, &["src/stale.rs"])?;
+    link_commit(
+        &conn,
+        3,
+        "source-fresh",
+        100,
+        &["src/fresh.rs"],
+        "fresh-session",
+    )?;
+
+    let result = super::search::search_multi_hop(
+        &conn,
+        "Melanie",
+        Some("proj"),
+        3,
+        0,
+        None,
+        Some("main"),
+        false,
+    )?;
+    let ids = result
+        .memories
+        .iter()
+        .map(|memory| memory.id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(result.hops, 2);
+    assert_eq!(ids.first().copied(), Some(first_id));
+    let fresh_rank = ids
+        .iter()
+        .position(|id| *id == fresh_id)
+        .context("fresh second-hop memory missing")?;
+    let stale_rank = ids
+        .iter()
+        .position(|id| *id == stale_id)
+        .context("stale second-hop memory missing")?;
+    assert!(fresh_rank < stale_rank, "{ids:?}");
+    Ok(())
+}
+
+fn link_commit(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+    memory_session_id: &str,
+) -> Result<()> {
+    insert_commit(conn, id, sha, epoch, changed_files)?;
+    conn.execute(
+        "INSERT INTO git_commit_sessions
+         (commit_id, session_id, memory_session_id, source, linked_at_epoch)
+         VALUES (?1, ?2, ?3, 'test', ?4)",
+        params![id, format!("content-{id}"), memory_session_id, epoch],
+    )?;
+    Ok(())
+}
+
+fn insert_commit(
+    conn: &Connection,
+    id: i64,
+    sha: &str,
+    epoch: i64,
+    changed_files: &[&str],
+) -> Result<()> {
+    let changed_files = serde_json::to_string(changed_files)?;
+    conn.execute(
+        "INSERT INTO git_commits
+         (id, project, repo_path, sha, short_sha, branch, message,
+          authored_at_epoch, changed_files, created_at_epoch, updated_at_epoch)
+         VALUES (?1, 'proj', '/repo', ?2, ?2, 'main', NULL, ?3, ?4, ?3, ?3)",
+        params![id, sha, epoch, changed_files],
+    )?;
+    Ok(())
 }


### PR DESCRIPTION
Refs #381

## Summary
- derive memory source_anchor labels from git commit/session traces
- demote verify-before-trust memories in search ranking and render labels through context/API/MCP
- add injection eval coverage and eval-gates evidence for stale anchor labeling

## Verification
- cargo check
- cargo clippy -- -D warnings
- cargo fmt --check
- git diff --check
- cargo test
- cargo run -- eval-gates --json-out eval/gates/issue381-git-staleness-report.json --json

## Scope
This is a bounded tranche for the git-anchored staleness part of #381. It does not close the umbrella issue.