### PR TITLE
Generalize semantic state keys for hash-like memory topics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.73"
+version = "0.5.74"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.73"
+version = "0.5.74"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.73",
+  "version": "0.5.74",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.73",
+  "version": "0.5.74",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.73": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.73",
+    "0.5.74": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.74",
       "assets": {}
     }
   }

--- a/src/memory/lifecycle/ttl_tests.rs
+++ b/src/memory/lifecycle/ttl_tests.rs
@@ -320,6 +320,69 @@ fn exact_topic_update_still_replaces_legacy_memory_without_state_key() -> Result
 }
 
 #[test]
+fn semantic_state_key_update_supersedes_hash_like_decision_topic() -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+    setup_memory_schema(&conn);
+    let project = "test-lifecycle";
+    let old_id = insert_memory(
+        &conn,
+        Some("s1"),
+        project,
+        Some("decision-11111111"),
+        "Optimize CJK search",
+        "Use FTS5 trigram tokenizer for CJK text search support.",
+        "decision",
+        None,
+    )?;
+
+    let outcome = apply_update(
+        &conn,
+        Some("s2"),
+        project,
+        "decision-22222222",
+        "Refine CJK search",
+        "Switch CJK search to FTS5 trigram tokenization.",
+        "decision",
+        None,
+        None,
+        "project",
+        &[],
+    )?;
+    let new_id = outcome.memory_id.context("replacement memory id")?;
+    assert_ne!(old_id, new_id);
+    assert_eq!(outcome.superseded, 1);
+
+    let old_status: String = conn.query_row(
+        "SELECT status FROM memories WHERE id = ?1",
+        [old_id],
+        |row| row.get(0),
+    )?;
+    let (state_key, current_memory_id): (String, i64) = conn.query_row(
+        "SELECT sk.state_key, sk.current_memory_id
+         FROM memory_state_keys sk
+         JOIN memories m ON m.state_key_id = sk.id
+         WHERE m.id = ?1",
+        [new_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    let supersedes_edges: i64 = conn.query_row(
+        "SELECT COUNT(*)
+         FROM memory_edges
+         WHERE edge_type = 'supersedes'
+           AND from_memory_id = ?1
+           AND to_memory_id = ?2",
+        [old_id, new_id],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(old_status, "stale");
+    assert_eq!(state_key, "decision-cjk-fts5-search-tokenizer-trigram");
+    assert_eq!(current_memory_id, new_id);
+    assert_eq!(supersedes_edges, 1);
+    Ok(())
+}
+
+#[test]
 fn hash_like_topic_update_replaces_same_semantic_state_key_and_moves_current_pointer() -> Result<()>
 {
     let conn = Connection::open_in_memory()?;

--- a/src/memory/operation.rs
+++ b/src/memory/operation.rs
@@ -103,16 +103,22 @@ pub fn plan_direct_save(
 ) -> Result<(MemoryOperationInput, MemoryOperationPlan)> {
     let now = chrono::Utc::now().timestamp();
     let (owner_scope, owner_key) = owner_for_scope(project, scope);
-    let state_key =
-        crate::memory::state_key::derive_state_key(memory_type, topic_key, title, content)
-            .map(|decision| decision.state_key);
+    let state_key_decision =
+        crate::memory::state_key::derive_state_key(memory_type, topic_key, title, content);
+    let state_key = state_key_decision
+        .as_ref()
+        .map(|decision| decision.state_key.clone());
+    let direct_upsert_state_key = state_key_decision
+        .as_ref()
+        .filter(|decision| decision.allows_direct_upsert())
+        .map(|decision| decision.state_key.as_str());
     let existing_match = existing_memory_for_direct_save(
         conn,
         project,
         scope,
         memory_type,
         topic_key,
-        state_key.as_deref(),
+        direct_upsert_state_key,
         title,
         content,
         branch,

--- a/src/memory/promote/summary.rs
+++ b/src/memory/promote/summary.rs
@@ -213,16 +213,13 @@ fn summary_topic_key(
     memory_type: &str,
     topic_prefix: &str,
     title: &str,
-    candidate_text: &str,
+    _candidate_text: &str,
     hash_seed: &str,
 ) -> String {
     let fallback = format!("{}-{}", topic_prefix, content_hash(hash_seed));
-    if let Some(decision) = crate::memory::state_key::derive_state_key(
-        memory_type,
-        Some(&fallback),
-        title,
-        candidate_text,
-    ) {
+    if let Some(decision) =
+        crate::memory::state_key::derive_state_key(memory_type, Some(&fallback), title, hash_seed)
+    {
         return decision.state_key;
     }
     summary_semantic_topic_key(topic_prefix, hash_seed).unwrap_or(fallback)

--- a/src/memory/service/save_tests.rs
+++ b/src/memory/service/save_tests.rs
@@ -61,6 +61,53 @@ fn save_memory_preserves_distinct_created_and_reference_times() -> anyhow::Resul
 }
 
 #[test]
+fn semantic_state_key_direct_save_keeps_distinct_hash_like_topics() -> anyhow::Result<()> {
+    let _dir = ScopedTestDataDir::new("save-semantic-state-key-distinct-direct-rows");
+    let conn = db::open_db()?;
+    let first = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: "Use FTS5 trigram tokenizer for CJK text search support.".to_string(),
+            title: Some("Optimize CJK search".to_string()),
+            project: Some("proj".to_string()),
+            topic_key: Some("decision-11111111".to_string()),
+            memory_type: Some("decision".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+    let second = save_memory(
+        &conn,
+        &SaveMemoryRequest {
+            text: "Switch CJK search to FTS5 trigram tokenization.".to_string(),
+            title: Some("Refine CJK search".to_string()),
+            project: Some("proj".to_string()),
+            topic_key: Some("decision-22222222".to_string()),
+            memory_type: Some("decision".to_string()),
+            local_copy_enabled: Some(false),
+            ..SaveMemoryRequest::default()
+        },
+    )?;
+
+    assert_ne!(first.id, second.id);
+    assert_eq!(first.operation, "add");
+    assert_eq!(second.operation, "add");
+    let active_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories WHERE memory_type = 'decision' AND status = 'active'",
+        [],
+        |row| row.get(0),
+    )?;
+    let operations = conn
+        .prepare("SELECT operation FROM memory_operation_log ORDER BY id ASC")?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    assert_eq!(active_count, 2);
+    assert_eq!(operations, vec!["add".to_string(), "add".to_string()]);
+    Ok(())
+}
+
+#[test]
 fn semantic_preference_duplicate_logs_update() -> anyhow::Result<()> {
     let _dir = ScopedTestDataDir::new("semantic-preference-duplicate-update");
     let conn = db::open_db()?;

--- a/src/memory/state_key.rs
+++ b/src/memory/state_key.rs
@@ -1,5 +1,66 @@
 use anyhow::Result;
 use rusqlite::{params, Connection, OptionalExtension};
+use std::collections::BTreeSet;
+
+const MIN_SEMANTIC_SLOT_TERMS: usize = 4;
+const MAX_SEMANTIC_SLOT_TERMS: usize = 6;
+const CJK_SEMANTIC_SLOT_TERMS: &[(&str, &str)] = &[
+    ("三元组", "trigram"),
+    ("中文", "cjk"),
+    ("全文搜索", "fts5"),
+    ("分词器", "tokenizer"),
+    ("分词", "tokenizer"),
+    ("搜索", "search"),
+    ("检索", "retrieval"),
+    ("查询", "query"),
+    ("数据库", "database"),
+    ("加密", "encryption"),
+    ("接口", "api"),
+    ("钩子", "hook"),
+    ("适配器", "adapter"),
+    ("评测", "eval"),
+    ("基准测试", "benchmark"),
+    ("压缩", "compression"),
+    ("超时", "timeout"),
+    ("工作线程", "worker"),
+    ("记忆", "memory"),
+    ("捕获", "capture"),
+    ("提取", "extraction"),
+    ("事实", "fact"),
+    ("知识图谱", "knowledge-graph"),
+    ("提示词", "prompt"),
+    ("发布", "publish"),
+    ("部署", "deploy"),
+    ("配置", "config"),
+    ("端口", "port"),
+    ("会话", "session"),
+    ("作用域", "scope"),
+    ("全局", "global"),
+    ("摘要", "summary"),
+    ("格式", "format"),
+    ("服务器", "server"),
+    ("服务", "service"),
+    ("性能", "performance"),
+    ("上下文", "context"),
+    ("竞品", "competitive"),
+    ("对比", "comparison"),
+    ("偏好", "preference"),
+    ("共享", "sharing"),
+    ("架构", "architecture"),
+    ("设计", "design"),
+    ("规则", "rule"),
+    ("跨项目", "cross-project"),
+    ("候选", "candidate"),
+    ("声明", "declaration"),
+    ("执行", "execution"),
+    ("验证", "verification"),
+    ("状态", "status"),
+    ("数据", "data"),
+    ("代码", "code"),
+    ("分离", "separation"),
+    ("分开", "separation"),
+    ("隔离", "separation"),
+];
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StateKeyDecision {
@@ -22,11 +83,8 @@ pub fn derive_state_key(
         });
     }
 
-    if memory_type == "preference" {
-        return derive_preference_state_key(title, content);
-    }
-
-    None
+    derive_compat_preference_state_key(memory_type, title, content)
+        .or_else(|| derive_semantic_state_key(memory_type, title, content))
 }
 
 pub fn current_memory_id(
@@ -176,7 +234,14 @@ fn stable_state_topic_key(topic_key: Option<&str>) -> Option<String> {
     }
 }
 
-fn derive_preference_state_key(title: &str, content: &str) -> Option<StateKeyDecision> {
+fn derive_compat_preference_state_key(
+    memory_type: &str,
+    title: &str,
+    content: &str,
+) -> Option<StateKeyDecision> {
+    if memory_type != "preference" {
+        return None;
+    }
     let combined = format!("{title}\n{content}");
     if mentions_verification_status(&combined) && mentions_data_code_separation(&combined) {
         return Some(StateKeyDecision {
@@ -201,6 +266,163 @@ fn derive_preference_state_key(title: &str, content: &str) -> Option<StateKeyDec
     }
 
     None
+}
+
+fn derive_semantic_state_key(
+    memory_type: &str,
+    _title: &str,
+    content: &str,
+) -> Option<StateKeyDecision> {
+    let prefix = semantic_slot_prefix(memory_type)?;
+    let mut terms = semantic_slot_terms(content);
+    if terms.len() < MIN_SEMANTIC_SLOT_TERMS {
+        return None;
+    }
+    terms.truncate(MAX_SEMANTIC_SLOT_TERMS);
+    let raw_key = format!("{prefix}-{}", terms.join("-"));
+    let state_key = crate::memory::promote::slugify_for_topic(&raw_key, 120);
+    if state_key.is_empty() {
+        return None;
+    }
+    Some(StateKeyDecision {
+        state_key,
+        confidence: 0.82,
+        reason: "semantic_slot_terms".to_string(),
+    })
+}
+
+fn semantic_slot_prefix(memory_type: &str) -> Option<&'static str> {
+    match memory_type {
+        "architecture" => Some("architecture"),
+        "bugfix" => Some("bugfix"),
+        "decision" => Some("decision"),
+        "discovery" => Some("discovery"),
+        "lesson" => Some("lesson"),
+        "preference" => Some("preference"),
+        "procedure" => Some("procedure"),
+        _ => None,
+    }
+}
+
+fn semantic_slot_terms(text: &str) -> Vec<String> {
+    let mut terms = BTreeSet::new();
+    for raw in text.split(|ch: char| !ch.is_ascii_alphanumeric()) {
+        let Some(term) = normalize_semantic_slot_term(raw) else {
+            continue;
+        };
+        if !is_semantic_slot_stopword(&term) {
+            terms.insert(term);
+        }
+    }
+    add_cjk_semantic_slot_terms(text, &mut terms);
+    terms.into_iter().collect()
+}
+
+fn add_cjk_semantic_slot_terms(text: &str, terms: &mut BTreeSet<String>) {
+    if !text.chars().any(is_cjk) {
+        return;
+    }
+    for (cjk, canonical) in CJK_SEMANTIC_SLOT_TERMS {
+        if text.contains(cjk) {
+            let Some(term) = normalize_semantic_slot_term(canonical) else {
+                continue;
+            };
+            if !is_semantic_slot_stopword(&term) {
+                terms.insert(term);
+            }
+        }
+    }
+}
+
+fn normalize_semantic_slot_term(raw: &str) -> Option<String> {
+    let mut term = raw.trim().to_ascii_lowercase();
+    if term.is_empty() {
+        return None;
+    }
+    term = match term.as_str() {
+        "tokenization" | "tokenized" | "tokenize" | "tokenizing" => "tokenizer".to_string(),
+        "summaries" => "summary".to_string(),
+        "memories" => "memory".to_string(),
+        "claims" => "claim".to_string(),
+        "candidates" => "candidate".to_string(),
+        "decisions" => "decision".to_string(),
+        "observations" => "observation".to_string(),
+        "indexes" | "indexed" | "indexing" => "index".to_string(),
+        "tests" | "tested" | "testing" => "test".to_string(),
+        "changes" | "changed" | "changing" => "change".to_string(),
+        "updates" | "updated" | "updating" => "update".to_string(),
+        "embeddings" => "embedding".to_string(),
+        "vectors" => "vector".to_string(),
+        "separately" | "separation" | "separate" | "separating" => "separation".to_string(),
+        "verification" | "verified" | "verifies" | "verify" => "verification".to_string(),
+        "statuses" => "status".to_string(),
+        _ => term,
+    };
+    if term.len() > 4 && term.ends_with('s') && !term.ends_with("ss") {
+        term.pop();
+    }
+    let has_digit = term.chars().any(|ch| ch.is_ascii_digit());
+    if term.len() < 3 && !has_digit {
+        return None;
+    }
+    Some(term)
+}
+
+fn is_semantic_slot_stopword(term: &str) -> bool {
+    matches!(
+        term,
+        "about"
+            | "active"
+            | "add"
+            | "after"
+            | "again"
+            | "against"
+            | "always"
+            | "and"
+            | "are"
+            | "as"
+            | "because"
+            | "before"
+            | "choose"
+            | "current"
+            | "default"
+            | "disable"
+            | "disabled"
+            | "does"
+            | "enable"
+            | "enabled"
+            | "for"
+            | "from"
+            | "has"
+            | "have"
+            | "into"
+            | "keep"
+            | "later"
+            | "must"
+            | "now"
+            | "of"
+            | "only"
+            | "or"
+            | "prefer"
+            | "record"
+            | "remove"
+            | "removed"
+            | "run"
+            | "should"
+            | "stop"
+            | "support"
+            | "supports"
+            | "switch"
+            | "text"
+            | "the"
+            | "this"
+            | "through"
+            | "to"
+            | "use"
+            | "using"
+            | "with"
+            | "without"
+    )
 }
 
 fn is_hash_like_topic_key(topic_key: &str) -> bool {
@@ -250,6 +472,13 @@ fn mentions_codesign_binary(text: &str) -> bool {
             || lower.contains("cp "))
 }
 
+fn is_cjk(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{4E00}'..='\u{9FFF}' | '\u{3400}'..='\u{4DBF}' | '\u{F900}'..='\u{FAFF}'
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -277,6 +506,69 @@ mod tests {
         )
         .expect("semantic preference should derive");
         assert_eq!(decision.state_key, "verification-status-separation");
+    }
+
+    #[test]
+    fn hash_like_decision_uses_semantic_slot_terms() {
+        let Some(decision) = derive_state_key(
+            "decision",
+            Some("decision-deadbeef"),
+            "Optimize CJK search",
+            "Use FTS5 trigram tokenizer for CJK text search support.",
+        ) else {
+            panic!("semantic decision should derive");
+        };
+
+        assert_eq!(
+            decision.state_key,
+            "decision-cjk-fts5-search-tokenizer-trigram"
+        );
+        assert_eq!(decision.reason, "semantic_slot_terms");
+    }
+
+    #[test]
+    fn hash_like_decision_paraphrase_uses_same_semantic_slot() {
+        let Some(first) = derive_state_key(
+            "decision",
+            Some("decision-11111111"),
+            "Optimize CJK search",
+            "Use FTS5 trigram tokenizer for CJK text search support.",
+        ) else {
+            panic!("first decision should derive");
+        };
+        let Some(second) = derive_state_key(
+            "decision",
+            Some("decision-22222222"),
+            "Refine CJK search",
+            "Switch CJK search to FTS5 trigram tokenization.",
+        ) else {
+            panic!("second decision should derive");
+        };
+
+        assert_eq!(first.state_key, second.state_key);
+    }
+
+    #[test]
+    fn hash_like_cjk_decision_paraphrase_uses_same_semantic_slot() {
+        let Some(first) = derive_state_key(
+            "decision",
+            Some("decision-11111111"),
+            "优化中文搜索",
+            "使用三元组分词器支持中文搜索。",
+        ) else {
+            panic!("first CJK decision should derive");
+        };
+        let Some(second) = derive_state_key(
+            "decision",
+            Some("decision-22222222"),
+            "调整中文搜索",
+            "中文搜索改用三元组分词器。",
+        ) else {
+            panic!("second CJK decision should derive");
+        };
+
+        assert_eq!(first.state_key, "decision-cjk-search-tokenizer-trigram");
+        assert_eq!(first.state_key, second.state_key);
     }
 
     #[test]

--- a/src/memory/state_key.rs
+++ b/src/memory/state_key.rs
@@ -69,6 +69,12 @@ pub struct StateKeyDecision {
     pub reason: String,
 }
 
+impl StateKeyDecision {
+    pub fn allows_direct_upsert(&self) -> bool {
+        self.reason != "semantic_slot_terms"
+    }
+}
+
 pub fn derive_state_key(
     memory_type: &str,
     topic_key: Option<&str>,
@@ -274,12 +280,19 @@ fn derive_semantic_state_key(
     content: &str,
 ) -> Option<StateKeyDecision> {
     let prefix = semantic_slot_prefix(memory_type)?;
-    let mut terms = semantic_slot_terms(content);
+    let terms = semantic_slot_terms(content);
     if terms.len() < MIN_SEMANTIC_SLOT_TERMS {
         return None;
     }
-    terms.truncate(MAX_SEMANTIC_SLOT_TERMS);
-    let raw_key = format!("{prefix}-{}", terms.join("-"));
+    let mut key_terms = terms
+        .iter()
+        .take(MAX_SEMANTIC_SLOT_TERMS)
+        .cloned()
+        .collect::<Vec<_>>();
+    if terms.len() > MAX_SEMANTIC_SLOT_TERMS {
+        key_terms.push(semantic_terms_signature(&terms));
+    }
+    let raw_key = format!("{prefix}-{}", key_terms.join("-"));
     let state_key = crate::memory::promote::slugify_for_topic(&raw_key, 120);
     if state_key.is_empty() {
         return None;
@@ -322,16 +335,39 @@ fn add_cjk_semantic_slot_terms(text: &str, terms: &mut BTreeSet<String>) {
     if !text.chars().any(is_cjk) {
         return;
     }
+
+    let mut matches = Vec::new();
     for (cjk, canonical) in CJK_SEMANTIC_SLOT_TERMS {
-        if text.contains(cjk) {
-            let Some(term) = normalize_semantic_slot_term(canonical) else {
-                continue;
-            };
-            if !is_semantic_slot_stopword(&term) {
-                terms.insert(term);
-            }
+        for (start, _) in text.match_indices(cjk) {
+            matches.push((start, start + cjk.len(), cjk.len(), *canonical));
         }
     }
+    matches.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| a.0.cmp(&b.0)));
+
+    let mut claimed = Vec::new();
+    for (start, end, _, canonical) in matches {
+        if claimed
+            .iter()
+            .any(|(claimed_start, claimed_end)| start < *claimed_end && end > *claimed_start)
+        {
+            continue;
+        }
+        claimed.push((start, end));
+        let Some(term) = normalize_semantic_slot_term(canonical) else {
+            continue;
+        };
+        if !is_semantic_slot_stopword(&term) {
+            terms.insert(term);
+        }
+    }
+}
+
+fn semantic_terms_signature(terms: &[String]) -> String {
+    let joined = terms.join("\0");
+    format!(
+        "sig{:08x}",
+        crate::db::deterministic_hash(joined.as_bytes()) as u32
+    )
 }
 
 fn normalize_semantic_slot_term(raw: &str) -> Option<String> {
@@ -569,6 +605,52 @@ mod tests {
 
         assert_eq!(first.state_key, "decision-cjk-search-tokenizer-trigram");
         assert_eq!(first.state_key, second.state_key);
+    }
+
+    #[test]
+    fn truncated_semantic_slot_key_includes_full_term_signature() {
+        let vector = derive_state_key(
+            "decision",
+            Some("decision-11111111"),
+            "Vector rotation",
+            "Use API auth cache migration token rotation vector.",
+        )
+        .expect("vector decision should derive");
+        let workflow = derive_state_key(
+            "decision",
+            Some("decision-22222222"),
+            "Workflow rotation",
+            "Use API auth cache migration token rotation workflow.",
+        )
+        .expect("workflow decision should derive");
+
+        assert!(vector
+            .state_key
+            .starts_with("decision-api-auth-cache-migration-rotation-token-"));
+        assert!(workflow
+            .state_key
+            .starts_with("decision-api-auth-cache-migration-rotation-token-"));
+        assert_ne!(vector.state_key, workflow.state_key);
+    }
+
+    #[test]
+    fn cjk_semantic_slot_terms_use_longest_non_overlapping_matches() {
+        let decision = derive_state_key(
+            "decision",
+            Some("decision-11111111"),
+            "服务器部署",
+            "服务器部署配置端口超时性能验证。",
+        )
+        .expect("CJK decision should derive");
+
+        assert!(decision
+            .state_key
+            .starts_with("decision-config-deploy-performance-port-server-timeout-"));
+        assert!(
+            !decision.state_key.contains("-service-"),
+            "服务器 should not also contribute the shorter 服务 term: {}",
+            decision.state_key
+        );
     }
 
     #[test]

--- a/src/memory/store/write.rs
+++ b/src/memory/store/write.rs
@@ -135,14 +135,16 @@ pub fn insert_memory_full_with_reference_time(
 
     if existing_id.is_none() {
         if let Some(decision) = &state_key {
-            existing_id = state_key::current_memory_id(
-                conn,
-                ownership.owner_scope,
-                ownership.owner_key,
-                memory_type,
-                &decision.state_key,
-                now,
-            )?;
+            if decision.allows_direct_upsert() {
+                existing_id = state_key::current_memory_id(
+                    conn,
+                    ownership.owner_scope,
+                    ownership.owner_key,
+                    memory_type,
+                    &decision.state_key,
+                    now,
+                )?;
+            }
         }
     }
     if existing_id.is_none() {


### PR DESCRIPTION
Refs #381.

## Summary
- Generalize `state_key` derivation for hash-like generated topics across architecture, bugfix, decision, discovery, lesson, preference, and procedure memories.
- Preserve stable explicit topic keys and existing preference compatibility keys.
- Add conservative CJK semantic slot support for common memory/search technical terms so pure Chinese paraphrases can share a state key without arbitrary character n-grams.
- Derive summary-promotion state keys from the raw summary item instead of wrapped candidate text to avoid request/context pollution.
- Add lifecycle coverage proving paraphrased hash-like decision topics supersede through the same semantic state key.
- Bump synced package/plugin version metadata to `0.5.74` for the binary-impacting change.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `python3 scripts/ci/check_version_bump.py origin/main WORKTREE`
- `cargo check`
- `cargo test state_key -- --nocapture`
- `cargo test memory::promote::tests::state_keys -- --nocapture`
- `cargo test semantic_state_key_update_supersedes_hash_like_decision_topic -- --nocapture`
- `REMEM_DATA_DIR=$(mktemp -d /tmp/remem-issue381-final2.XXXXXX) cargo test`
- `REMEM_DATA_DIR=$(mktemp -d /tmp/remem-issue381-final2-eval.XXXXXX) cargo run -- eval-gates --json-out /tmp/remem-issue381-final2-eval-gates.json --json`
  - 47 metrics checked, passed=true

## #381 status
This PR intentionally uses `Refs #381`, not `Closes #381`. The remaining umbrella acceptance item is operational: two consecutive weeks of growing production `memory_facts` counts. Fact writes landed on 2026-06-12, and today is 2026-06-15, so that acceptance item cannot be satisfied yet.
