### PR TITLE
[codex] make install migrate database before hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.73"
+version = "0.5.74"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.73"
+version = "0.5.74"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.73",
+  "version": "0.5.74",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.73",
+  "version": "0.5.74",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.73": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.73",
+    "0.5.74": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.74",
       "assets": {}
     }
   }

--- a/src/db/core.rs
+++ b/src/db/core.rs
@@ -142,7 +142,7 @@ pub fn open_db_no_migrate() -> Result<Connection> {
 
 pub fn open_db_for_hook() -> Result<Connection> {
     let conn = open_db_no_migrate().context(
-        "hook database open requires an existing current schema; run `remem install` or `remem migrate` outside the hook path",
+        "hook database open requires an existing current schema; run `remem install` outside the hook path",
     )?;
     let invariant_errors = crate::migrate::validate_schema_invariants(&conn)?;
     if !invariant_errors.is_empty() {

--- a/src/install/runtime.rs
+++ b/src/install/runtime.rs
@@ -14,6 +14,7 @@ use crate::install::paths::{binary_path, old_hooks_path, remem_data_dir};
 pub(in crate::install) struct RuntimeStoreReady {
     pub(in crate::install) key_path: std::path::PathBuf,
     pub(in crate::install) db_path: std::path::PathBuf,
+    pub(in crate::install) schema_version: i64,
     pub(in crate::install) created_key: bool,
     pub(in crate::install) encrypted_existing_db: bool,
 }
@@ -54,7 +55,7 @@ pub fn install(target: InstallTarget, dry_run: bool, hooks_only: bool) -> Result
             remem_data_dir().join(".key").display()
         );
         eprintln!(
-            "  db     -> {} (initialize encrypted database if missing)",
+            "  db     -> {} (initialize or migrate encrypted database if needed)",
             crate::db::db_path().display()
         );
         print_install_path_warnings(&bin);
@@ -77,13 +78,14 @@ pub fn install(target: InstallTarget, dry_run: bool, hooks_only: bool) -> Result
         }
     );
     eprintln!(
-        "  db     -> {} ({})",
+        "  db     -> {} ({}, schema v{})",
         runtime_store.db_path.display(),
         if runtime_store.encrypted_existing_db {
             "encrypted existing database"
         } else {
             "ready"
-        }
+        },
+        runtime_store.schema_version
     );
 
     let runtime_hosts = hosts
@@ -140,16 +142,16 @@ pub(in crate::install) fn ensure_runtime_store_ready() -> Result<RuntimeStoreRea
 
     if key_path.exists() {
         ensure_env_key_matches_persisted_key_if_set(&key_path)?;
-        let conn = crate::db::open_db().with_context(|| {
+        let schema_version = migrate_runtime_store(&key_path, &db_path).with_context(|| {
             format!(
                 "open remem database with existing SQLCipher key {}; run `remem status` after fixing the reported database/key error",
                 key_path.display()
             )
         })?;
-        drop(conn);
         return Ok(RuntimeStoreReady {
             key_path,
             db_path,
+            schema_version,
             created_key: false,
             encrypted_existing_db: false,
         });
@@ -202,20 +204,37 @@ pub(in crate::install) fn ensure_runtime_store_ready() -> Result<RuntimeStoreRea
         }
     }
 
-    let conn = crate::db::open_db().with_context(|| {
+    let schema_version = migrate_runtime_store(&key_path, &db_path).with_context(|| {
         format!(
             "initialize encrypted remem database {}; run `remem encrypt` manually and rerun `remem install`",
             db_path.display()
         )
     })?;
-    drop(conn);
 
     Ok(RuntimeStoreReady {
         key_path,
         db_path,
+        schema_version,
         created_key: true,
         encrypted_existing_db: db_existed,
     })
+}
+
+fn migrate_runtime_store(key_path: &Path, db_path: &Path) -> Result<i64> {
+    let conn = crate::db::open_db().with_context(|| {
+        format!(
+            "open and migrate remem database {} with SQLCipher key {}",
+            db_path.display(),
+            key_path.display()
+        )
+    })?;
+    crate::migrate::ensure_schema_current(&conn).with_context(|| {
+        format!(
+            "verify remem database {} is hook-safe after install migration",
+            db_path.display()
+        )
+    })?;
+    Ok(crate::migrate::latest_schema_version())
 }
 
 fn env_cipher_key_is_set() -> Result<bool> {

--- a/src/install/tests.rs
+++ b/src/install/tests.rs
@@ -1,8 +1,50 @@
 use serde_json::json;
 
+use anyhow::Context;
+use rusqlite::{params, Connection};
+
 use super::config::{build_hooks, remove_remem_hooks, remove_remem_mcp, HookStrategy};
 use super::runtime::ensure_runtime_store_ready;
 use crate::db::test_support::ScopedTestDataDir;
+
+fn seed_plaintext_runtime_db_through(
+    test_dir: &ScopedTestDataDir,
+    max_migration_version: i64,
+) -> anyhow::Result<()> {
+    std::fs::create_dir_all(&test_dir.path)?;
+    let conn = Connection::open(test_dir.db_path())?;
+    conn.execute_batch(
+        "PRAGMA foreign_keys=ON;
+         CREATE TABLE IF NOT EXISTS _schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_epoch INTEGER NOT NULL
+         );",
+    )?;
+
+    for migration in crate::migrate::MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version <= max_migration_version)
+    {
+        conn.execute_batch(migration.sql).with_context(|| {
+            format!(
+                "seed migration v{:03}_{}",
+                migration.version, migration.name
+            )
+        })?;
+        conn.execute(
+            "INSERT OR IGNORE INTO _schema_migrations (version, name, applied_at_epoch)
+             VALUES (?1, ?2, ?3)",
+            params![migration.version, migration.name, 1_700_000_000_i64],
+        )?;
+    }
+
+    conn.execute_batch(&format!(
+        "PRAGMA user_version = {};",
+        12 + max_migration_version
+    ))?;
+    Ok(())
+}
 
 #[test]
 fn ensure_runtime_store_ready_initializes_encrypted_db_for_status() -> anyhow::Result<()> {
@@ -15,6 +57,10 @@ fn ensure_runtime_store_ready_initializes_encrypted_db_for_status() -> anyhow::R
 
     assert!(ready.created_key);
     assert!(!ready.encrypted_existing_db);
+    assert_eq!(
+        ready.schema_version,
+        crate::migrate::latest_schema_version()
+    );
     assert_eq!(ready.key_path, test_dir.path.join(".key"));
     assert_eq!(ready.db_path, test_dir.db_path());
     let saved_key = std::fs::read_to_string(&ready.key_path)?;
@@ -25,6 +71,56 @@ fn ensure_runtime_store_ready_initializes_encrypted_db_for_status() -> anyhow::R
     let conn = crate::db::open_db_read_only()?;
     let stats = crate::db::query_system_stats(&conn)?;
     assert_eq!(stats.active_memories, 0);
+    Ok(())
+}
+
+#[test]
+fn ensure_runtime_store_ready_migrates_existing_db_before_hooks() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("install-runtime-migrates-db");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::env::remove_var("REMEM_CIPHER_KEY");
+    let latest = crate::migrate::latest_schema_version();
+    seed_plaintext_runtime_db_through(&test_dir, latest - 1)?;
+
+    let ready = ensure_runtime_store_ready()?;
+
+    assert!(ready.created_key);
+    assert!(ready.encrypted_existing_db);
+    assert_eq!(ready.schema_version, latest);
+    let conn = crate::db::open_db_for_hook()?;
+    let latest_rows: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM _schema_migrations WHERE version = ?1",
+        [latest],
+        |row| row.get(0),
+    )?;
+    assert_eq!(latest_rows, 1);
+    let prompt_ref_column: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('graph_candidates')
+         WHERE name = 'prompt_memory_ref_ids'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(prompt_ref_column, 1);
+    Ok(())
+}
+
+#[test]
+fn install_dry_run_does_not_initialize_runtime_store() -> anyhow::Result<()> {
+    let test_dir = ScopedTestDataDir::new("install-dry-run-no-db");
+    std::env::remove_var("REMEM_ALLOW_PLAINTEXT_DB");
+    std::env::remove_var("REMEM_CIPHER_KEY");
+    test_dir.remove_db_files();
+
+    super::runtime::install(super::InstallTarget::Codex, true, false)?;
+
+    assert!(
+        !test_dir.path.join(".key").exists(),
+        "dry-run install must not create a key file"
+    );
+    assert!(
+        !test_dir.db_path().exists(),
+        "dry-run install must not create or migrate the database"
+    );
     Ok(())
 }
 
@@ -43,6 +139,10 @@ fn ensure_runtime_store_ready_encrypts_existing_plaintext_db() -> anyhow::Result
 
     assert!(ready.created_key);
     assert!(ready.encrypted_existing_db);
+    assert_eq!(
+        ready.schema_version,
+        crate::migrate::latest_schema_version()
+    );
     assert!(test_dir.path.join("remem.db.bak").exists());
     let header = std::fs::read(&ready.db_path)?;
     assert_ne!(&header[..16], b"SQLite format 3\0");


### PR DESCRIPTION
## Summary

Make `remem install` explicitly initialize or migrate the runtime database before writing hook/MCP setup, so hook-safe paths can keep refusing migrations without leaving upgraded installs broken.

Closes #490.

## Root Cause

The hook-safe database paths correctly validate the installed schema without running migrations. After a binary upgrade, the install/setup path should guarantee the runtime database is current before those hook-safe paths run, but that behavior was not documented in install output or covered by an install regression test.

## Changes

- Have install runtime setup report the migrated schema version after opening the runtime store through the foreground migration path.
- Verify the database is hook-safe after install migration.
- Keep dry-run install non-mutating while documenting that a real install initializes or migrates the database.
- Remove the stale hook error reference to a non-existent `remem migrate` command.
- Add regression coverage for migrating an existing stale database before hook opens, plus dry-run no-mutation behavior.
- Bump the binary/plugin/npm version metadata to `0.5.74` for this binary-impacting change.

## Validation

- `python3 scripts/ci/check_version_bump.py origin/main HEAD`
- `python3 scripts/ci/check_plugin_version_sync.py`
- `cargo fmt --check`
- `cargo check`
- `cargo test install::tests --lib`
- `cargo test`
