### PR TITLE
[codex] Layer 1: Deduplicate recurring workflow preferences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "remem-ai"
-version = "0.5.74"
+version = "0.5.75"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remem-ai"
-version = "0.5.74"
+version = "0.5.75"
 edition = "2021"
 description = "Persistent memory for Claude Code and Codex — single binary, automatic context"
 license = "MIT"

--- a/npm/remem/package.json
+++ b/npm/remem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@majiayu000/remem",
-  "version": "0.5.74",
+  "version": "0.5.75",
   "description": "Persistent memory for Claude Code and Codex",
   "license": "MIT",
   "homepage": "https://github.com/majiayu000/remem#readme",

--- a/plugins/remem/.codex-plugin/plugin.json
+++ b/plugins/remem/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remem",
-  "version": "0.5.74",
+  "version": "0.5.75",
   "description": "Persistent project memory for Codex through remem MCP and explicit hook activation.",
   "author": {
     "name": "majiayu000",

--- a/plugins/remem/runtimes/remem-releases.json
+++ b/plugins/remem/runtimes/remem-releases.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "0.5.74": {
-      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.74",
+    "0.5.75": {
+      "base_url": "https://github.com/majiayu000/remem/releases/download/v0.5.75",
       "assets": {}
     }
   }

--- a/src/memory/promote/tests/promote.rs
+++ b/src/memory/promote/tests/promote.rs
@@ -319,6 +319,86 @@ fn test_summary_preference_paraphrases_promote_through_same_state_key() -> Resul
 }
 
 #[test]
+fn test_summary_workflow_preference_variants_promote_through_same_state_key() -> Result<()> {
+    let mut conn = setup_conn()?;
+    let project = "test/proj";
+
+    record_summary_evidence(&conn, "session-small-change-a", project)?;
+    promote_summary_to_memory_candidates(
+        &mut conn,
+        "session-small-change-a",
+        project,
+        Some("Capture workflow preference"),
+        None,
+        None,
+        Some("Prefers small, reversible changes (“一处改动一个提交”) with concrete verification output (tests, lint, job IDs); avoids unsafe content fallbacks."),
+    )?;
+    let first_candidate_id: i64 = conn.query_row(
+        "SELECT id FROM memory_candidates WHERE review_status = 'pending_review'",
+        [],
+        |row| row.get(0),
+    )?;
+    let first_memory_id = approve_candidate(&mut conn, first_candidate_id)?
+        .ok_or_else(|| anyhow::anyhow!("first candidate should promote"))?;
+
+    record_summary_evidence(&conn, "session-small-change-b", project)?;
+    promote_summary_to_memory_candidates(
+        &mut conn,
+        "session-small-change-b",
+        project,
+        Some("Capture refined workflow preference"),
+        None,
+        None,
+        Some("Prefers small, reversible changes (“一处改动一个提交”) with concrete verification output (tests, build, job IDs, artifacts); checklist-driven done only with artifact proof."),
+    )?;
+    let second_candidate_id: i64 = conn.query_row(
+        "SELECT id
+         FROM memory_candidates
+         WHERE review_status = 'pending_review'
+         ORDER BY id DESC
+         LIMIT 1",
+        [],
+        |row| row.get(0),
+    )?;
+    let second_topic_key: String = conn.query_row(
+        "SELECT topic_key FROM memory_candidates WHERE id = ?1",
+        [second_candidate_id],
+        |row| row.get(0),
+    )?;
+    let second_memory_id = approve_candidate(&mut conn, second_candidate_id)?
+        .ok_or_else(|| anyhow::anyhow!("second candidate should promote"))?;
+
+    let first_status: String = conn.query_row(
+        "SELECT status FROM memories WHERE id = ?1",
+        [first_memory_id],
+        |row| row.get(0),
+    )?;
+    let (second_status, state_key, current_memory_id): (String, String, i64) = conn.query_row(
+        "SELECT m.status, sk.state_key, sk.current_memory_id
+         FROM memories m
+         JOIN memory_state_keys sk ON sk.id = m.state_key_id
+         WHERE m.id = ?1",
+        [second_memory_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    let active_count: i64 = conn.query_row(
+        "SELECT COUNT(*)
+         FROM memories
+         WHERE memory_type = 'preference' AND status = 'active'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    assert_eq!(second_topic_key, "small-reversible-verified-changes");
+    assert_eq!(first_status, "stale");
+    assert_eq!(second_status, "active");
+    assert_eq!(state_key, "small-reversible-verified-changes");
+    assert_eq!(current_memory_id, second_memory_id);
+    assert_eq!(active_count, 1);
+    Ok(())
+}
+
+#[test]
 fn test_summary_candidates_missing_evidence_fails_closed() -> Result<()> {
     let mut conn = setup_conn()?;
 

--- a/src/memory/state_key.rs
+++ b/src/memory/state_key.rs
@@ -270,6 +270,13 @@ fn derive_compat_preference_state_key(
             reason: "preference_domain_codesign_binary".to_string(),
         });
     }
+    if mentions_small_reversible_changes(&combined) && mentions_concrete_verification(&combined) {
+        return Some(StateKeyDecision {
+            state_key: "small-reversible-verified-changes".to_string(),
+            confidence: 0.95,
+            reason: "preference_domain_small_reversible_verified_changes".to_string(),
+        });
+    }
 
     None
 }
@@ -508,6 +515,34 @@ fn mentions_codesign_binary(text: &str) -> bool {
             || lower.contains("cp "))
 }
 
+fn mentions_small_reversible_changes(text: &str) -> bool {
+    text.contains("一处改动一个提交")
+}
+
+fn mentions_concrete_verification(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    let has_verification =
+        lower.contains("verification") || lower.contains("verify") || text.contains("验证");
+    let has_evidence = [
+        "artifact",
+        "build",
+        "command",
+        "evidence",
+        "job id",
+        "lint",
+        "output",
+        "test",
+        "typecheck",
+    ]
+    .iter()
+    .any(|term| lower.contains(term))
+        || text.contains("证据")
+        || text.contains("输出")
+        || text.contains("测试");
+
+    has_verification && has_evidence
+}
+
 fn is_cjk(ch: char) -> bool {
     matches!(
         ch,
@@ -542,6 +577,33 @@ mod tests {
         )
         .expect("semantic preference should derive");
         assert_eq!(decision.state_key, "verification-status-separation");
+    }
+
+    #[test]
+    fn hash_like_preference_small_reversible_verified_changes_uses_stable_domain() {
+        let Some(first) = derive_state_key(
+            "preference",
+            Some("preference-11111111"),
+            "Preference",
+            "Prefers small, reversible changes (“一处改动一个提交”) with concrete verification output (tests, lint, job IDs); avoids unsafe content fallbacks.",
+        ) else {
+            panic!("first workflow preference should derive");
+        };
+        let Some(second) = derive_state_key(
+            "preference",
+            Some("preference-22222222"),
+            "Preference",
+            "Prefers small, reversible changes (“一处改动一个提交”) with concrete verification output (tests, build, job IDs, artifacts); checklist-driven done only with artifact proof.",
+        ) else {
+            panic!("second workflow preference should derive");
+        };
+
+        assert_eq!(first.state_key, "small-reversible-verified-changes");
+        assert_eq!(first.state_key, second.state_key);
+        assert_eq!(
+            first.reason,
+            "preference_domain_small_reversible_verified_changes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds a stable preference state key for the recurring explicit “一处改动一个提交” plus concrete verification evidence preference family.
- Keeps generic English small reversible preference dedup on the existing semantic path by requiring the explicit Chinese rule phrase for this domain.
- Adds regression coverage for state-key derivation and summary promotion replacing the previous active preference.
- Bumps the crate/plugin/npm/release manifest versions to 0.5.75 for the binary-impacting change gates.

## Root Cause

Summary-promoted preferences with hash-like topic keys only deduplicated when `derive_state_key` produced the same state key. The recurring workflow preference variants differed by words such as lint, build, artifacts, and checklist, so generic semantic keys could diverge and multiple active preferences reached SessionStart context.

## Scope

This PR is the Layer 1 stopgap: high-precision, low-risk consolidation for the confirmed recurring preference family.

Generic preference/procedural-memory consolidation should happen on the write path instead of accumulating more hardcoded state-key domains. That Layer 2 work is tracked in #494.

## Validation

- cargo fmt --check
- cargo test hash_like_preference_small_reversible_verified_changes_uses_stable_domain
- cargo test test_summary_workflow_preference_variants_promote_through_same_state_key
- cargo test semantic_preference_duplicate_logs_update
- cargo check
- cargo test
- python3 scripts/ci/check_version_bump.py origin/main WORKTREE
- python3 scripts/ci/check_plugin_version_sync.py
- GitHub Actions `check` passed

Closes #492
